### PR TITLE
Fix CLI installer to download shared tools

### DIFF
--- a/bin/goose-skills.js
+++ b/bin/goose-skills.js
@@ -67,6 +67,12 @@ function getCodexSkillsRoot() {
   return path.join(home, '.codex', 'skills');
 }
 
+// Map of tool names to their file paths relative to repo root
+const TOOL_FILE_MAP = {
+  apify_guard: ['tools/apify_guard.py'],
+  supabase: ['tools/supabase/__init__.py', 'tools/supabase/supabase_client.py'],
+};
+
 async function downloadSkillFiles(skill, installDir) {
   let downloaded = 0;
   for (const filePath of skill.files) {
@@ -85,6 +91,28 @@ async function downloadSkillFiles(skill, installDir) {
       console.error(`    [FAILED] ${filePath}: ${err.message}`);
     }
   }
+
+  // Download shared tools if requires_tools is declared
+  const requiresTools = skill.metadata?.requires_tools || [];
+  for (const toolName of requiresTools) {
+    const toolFiles = TOOL_FILE_MAP[toolName];
+    if (!toolFiles) continue;
+    for (const toolPath of toolFiles) {
+      const url = `${RAW_BASE}/${toolPath}`;
+      const localPath = path.join(installDir, toolPath);
+      const localDir = path.dirname(localPath);
+      fs.mkdirSync(localDir, { recursive: true });
+      try {
+        const content = await fetch(url);
+        fs.writeFileSync(localPath, content);
+        downloaded++;
+        console.log(`    ${toolPath} (shared tool)`);
+      } catch (err) {
+        console.error(`    [FAILED] ${toolPath}: ${err.message}`);
+      }
+    }
+  }
+
   return downloaded;
 }
 

--- a/bin/goose-skills.js
+++ b/bin/goose-skills.js
@@ -190,6 +190,37 @@ async function installSkill(options) {
     process.exit(1);
   }
 
+  // Auto-install dependency skills (requires_skills)
+  const requiresSkills = skill.metadata?.requires_skills || [];
+  const installedDeps = [];
+  if (requiresSkills.length > 0) {
+    console.log(`\nInstalling ${requiresSkills.length} dependency skill(s) first...\n`);
+    for (const depSlug of requiresSkills) {
+      const depSkill = index.skills.find((s) => s.slug === depSlug);
+      if (!depSkill) {
+        console.error(`  [WARN] Dependency "${depSlug}" not found in index, skipping.`);
+        continue;
+      }
+      const depDir = getInstallDir(depSlug);
+      if (fs.existsSync(path.join(depDir, 'SKILL.md'))) {
+        console.log(`  ${depSlug} — already installed`);
+        installedDeps.push(depSlug);
+        continue;
+      }
+      console.log(`  ${depSlug} → ${depDir}`);
+      fs.mkdirSync(depDir, { recursive: true });
+      await downloadSkillFiles(depSkill, depDir);
+      installedDeps.push(depSlug);
+
+      if (target === 'codex') {
+        placeForCodex(depDir, getCodexSkillsRoot());
+      } else if (target === 'cursor') {
+        placeForCursor(depDir, projectDir);
+      }
+    }
+    console.log('');
+  }
+
   const installDir = getInstallDir(slug);
   console.log(`Installing ${skill.name} to ${installDir}...`);
 
@@ -199,6 +230,9 @@ async function installSkill(options) {
   const downloaded = await downloadSkillFiles(skill, installDir);
 
   console.log(`\nInstalled ${downloaded}/${skill.files.length} files.`);
+  if (installedDeps.length > 0) {
+    console.log(`Dependencies installed: ${installedDeps.join(', ')}`);
+  }
   console.log(`Primary location: ${installDir}`);
 
   if (target === 'codex') {


### PR DESCRIPTION
## Summary

Two gaps in the CLI installer that caused skills to break when installed via `npx goose-skills install`:

1. **Shared tools not downloaded** — 6 skills import shared modules from `tools/` (apify_guard, supabase_client) that live at the repo root. The CLI only downloaded files from the skill's own directory, causing `ModuleNotFoundError` at runtime.

2. **Composite dependencies not installed** — 36 composite skills declare `requires_skills` (e.g. ad-angle-miner needs reddit-post-finder + review-site-scraper + twitter-mention-tracker). The CLI installed only the composite, not its dependencies, so the agent couldn't find the required scripts.

## Fix

### Shared tools (`requires_tools`)
The CLI now reads `requires_tools` from `skill.meta.json` metadata and downloads the corresponding tool files into the skill's install directory:

```js
const TOOL_FILE_MAP = {
  apify_guard: ['tools/apify_guard.py'],
  supabase: ['tools/supabase/__init__.py', 'tools/supabase/supabase_client.py'],
};
```

### Composite dependencies (`requires_skills`)
When installing a composite, the CLI now auto-installs all dependency skills first. Skips already-installed deps. Works with all targets (claude/codex/cursor).

## Why this is needed

Without these fixes, anyone installing skills via `npx goose-skills install` on any platform (Claude Code, Codex, Cursor, or marketplace listings) gets broken skills:
- 6 capability skills crash with `ModuleNotFoundError: No module named 'tools'`
- 36 composite skills can't find their dependency scripts

The GooseWorks platform path (catalog API + sandbox) handles both of these separately, but the open-source CLI install path was missing them entirely.

## Test plan

- [x] `npx goose-skills install pain-language-engagers` — confirms `tools/apify_guard.py (shared tool)` is downloaded
- [x] `npx goose-skills install ad-angle-miner` — confirms 3 dependency skills installed first
- [x] Already-installed deps are skipped (no duplicate downloads)
- [x] `npm run ci` — all 13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)