### PR TITLE
Add goose-graphics composite skill pack; deprecate create-html-carousel/slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,16 @@ npx gooseworks update                      # Update to latest skill version
 | `seo-traffic-analyzer` | Cap | Website traffic and keyword analysis |
 | `tech-stack-teardown` | Cap | Reverse-engineer a company's sales/marketing tech stack |
 
-### Content (10)
+### Content (11)
 | Skill | Type | Description |
 |-------|------|-------------|
 | `blog-feed-monitor` | Cap | Scrape blogs via RSS feeds with Apify fallback |
 | `campaign-brief-generator` | Comp | Generate complete marketing campaign brief |
 | `content-asset-creator` | Cap | Generate branded HTML reports and pages |
 | `content-brief-factory` | Comp | Detailed content briefs at scale with SERP analysis |
-| `create-html-carousel` | Cap | Create LinkedIn carousel posts as PNG images |
-| `create-html-slides` | Cap | Create animation-rich HTML presentations |
+| `create-html-carousel` | Cap | *(deprecated — use `goose-graphics`)* Create LinkedIn carousel posts as PNG images |
+| `create-html-slides` | Cap | *(deprecated — use `goose-graphics`)* Create animation-rich HTML presentations |
+| `goose-graphics` | Comp | 36 aesthetic presets across 7 formats (carousel, story, infographic, slides, poster, chart, tweet) with Unsplash/ASCII sourcing and Playwright PNG export |
 | `create-workflow-diagram` | Cap | Create FigJam/Miro-style workflow diagrams as PNGs |
 | `feature-launch-playbook` | Comp | Generate full launch kit from a feature/update |
 | `help-center-article-generator` | Comp | Generate structured help center articles |

--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-04-20",
+  "generated": "2026-04-21",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -770,6 +770,8 @@
         "tags": [
           "content"
         ],
+        "deprecated": true,
+        "deprecation_note": "Superseded by `goose-graphics` (skills/composites/goose-graphics/). Scheduled for removal after one release cycle.",
         "installation": {
           "base_command": "npx goose-skills install create-html-carousel",
           "supports": [
@@ -799,6 +801,8 @@
         "tags": [
           "content"
         ],
+        "deprecated": true,
+        "deprecation_note": "Superseded by `goose-graphics` (skills/composites/goose-graphics/). Scheduled for removal after one release cycle.",
         "installation": {
           "base_command": "npx goose-skills install create-html-slides",
           "supports": [
@@ -1198,6 +1202,135 @@
         },
         "requires_skills": [
           "seo-domain-analyzer"
+        ]
+      }
+    },
+    {
+      "slug": "goose-graphics",
+      "name": "goose-graphics",
+      "category": "composites",
+      "description": "Portable visual skill pack for the Agent Skills ecosystem (Claude Code, Claude Desktop, Claude Cowork, Claude Design, Goose, Cursor, Codex). Ships 36 aesthetic presets in DESIGN.md format, 7 social-first format specs, extract-style from reference images, and automatic PNG export via Playwright.",
+      "tags": "content, design, graphics, social",
+      "path": "skills/composites/goose-graphics",
+      "files": [
+        "skills/composites/goose-graphics/README.md",
+        "skills/composites/goose-graphics/SKILL.md",
+        "skills/composites/goose-graphics/formats/carousel.md",
+        "skills/composites/goose-graphics/formats/chart.md",
+        "skills/composites/goose-graphics/formats/infographic.md",
+        "skills/composites/goose-graphics/formats/poster.md",
+        "skills/composites/goose-graphics/formats/slides.md",
+        "skills/composites/goose-graphics/formats/story.md",
+        "skills/composites/goose-graphics/formats/tweet.md",
+        "skills/composites/goose-graphics/screenshot/.gitignore",
+        "skills/composites/goose-graphics/screenshot/fetch-full-tweet.js",
+        "skills/composites/goose-graphics/screenshot/fetch-tweet.js",
+        "skills/composites/goose-graphics/screenshot/package-lock.json",
+        "skills/composites/goose-graphics/screenshot/package.json",
+        "skills/composites/goose-graphics/screenshot/screenshot.js",
+        "skills/composites/goose-graphics/skill.meta.json",
+        "skills/composites/goose-graphics/sources/ascii-art.md",
+        "skills/composites/goose-graphics/sources/unsplash.md",
+        "skills/composites/goose-graphics/styles/_full/DESIGN_MD_COVERAGE.md",
+        "skills/composites/goose-graphics/styles/_full/archive-fashion.md",
+        "skills/composites/goose-graphics/styles/_full/aurora-app-launch.md",
+        "skills/composites/goose-graphics/styles/_full/blueprint-sticky.md",
+        "skills/composites/goose-graphics/styles/_full/brutalist.md",
+        "skills/composites/goose-graphics/styles/_full/bw-editorial-drop.md",
+        "skills/composites/goose-graphics/styles/_full/card-toss.md",
+        "skills/composites/goose-graphics/styles/_full/cinematic-romance.md",
+        "skills/composites/goose-graphics/styles/_full/clean-slate.md",
+        "skills/composites/goose-graphics/styles/_full/deep-ocean.md",
+        "skills/composites/goose-graphics/styles/_full/electric-burst.md",
+        "skills/composites/goose-graphics/styles/_full/frosted-lens.md",
+        "skills/composites/goose-graphics/styles/_full/garden-blur.md",
+        "skills/composites/goose-graphics/styles/_full/golden-dusk.md",
+        "skills/composites/goose-graphics/styles/_full/grid-quote-editorial.md",
+        "skills/composites/goose-graphics/styles/_full/heatwave-orange.md",
+        "skills/composites/goose-graphics/styles/_full/highlighter-yellow.md",
+        "skills/composites/goose-graphics/styles/_full/ink-doodle-event.md",
+        "skills/composites/goose-graphics/styles/_full/iridescent-y2k.md",
+        "skills/composites/goose-graphics/styles/_full/magazine-red.md",
+        "skills/composites/goose-graphics/styles/_full/masked-object-editorial.md",
+        "skills/composites/goose-graphics/styles/_full/matt-gray.md",
+        "skills/composites/goose-graphics/styles/_full/midnight-editorial.md",
+        "skills/composites/goose-graphics/styles/_full/mint-pixel-corporate.md",
+        "skills/composites/goose-graphics/styles/_full/paper-and-ink.md",
+        "skills/composites/goose-graphics/styles/_full/pastel-organic-shapes.md",
+        "skills/composites/goose-graphics/styles/_full/peach-pop.md",
+        "skills/composites/goose-graphics/styles/_full/product-minimal.md",
+        "skills/composites/goose-graphics/styles/_full/retro-line-art.md",
+        "skills/composites/goose-graphics/styles/_full/social-post-card.md",
+        "skills/composites/goose-graphics/styles/_full/soft-cloud.md",
+        "skills/composites/goose-graphics/styles/_full/split-yellow-product.md",
+        "skills/composites/goose-graphics/styles/_full/sunburst-editorial.md",
+        "skills/composites/goose-graphics/styles/_full/terminal.md",
+        "skills/composites/goose-graphics/styles/_full/venn-infographic.md",
+        "skills/composites/goose-graphics/styles/_full/vintage-duotone-poster.md",
+        "skills/composites/goose-graphics/styles/_full/warm-earth.md",
+        "skills/composites/goose-graphics/styles/archive-fashion.md",
+        "skills/composites/goose-graphics/styles/aurora-app-launch.md",
+        "skills/composites/goose-graphics/styles/blueprint-sticky.md",
+        "skills/composites/goose-graphics/styles/brutalist.md",
+        "skills/composites/goose-graphics/styles/bw-editorial-drop.md",
+        "skills/composites/goose-graphics/styles/card-toss.md",
+        "skills/composites/goose-graphics/styles/cinematic-romance.md",
+        "skills/composites/goose-graphics/styles/clean-slate.md",
+        "skills/composites/goose-graphics/styles/deep-ocean.md",
+        "skills/composites/goose-graphics/styles/electric-burst.md",
+        "skills/composites/goose-graphics/styles/extract-style.md",
+        "skills/composites/goose-graphics/styles/frosted-lens.md",
+        "skills/composites/goose-graphics/styles/garden-blur.md",
+        "skills/composites/goose-graphics/styles/golden-dusk.md",
+        "skills/composites/goose-graphics/styles/grid-quote-editorial.md",
+        "skills/composites/goose-graphics/styles/heatwave-orange.md",
+        "skills/composites/goose-graphics/styles/highlighter-yellow.md",
+        "skills/composites/goose-graphics/styles/index.json",
+        "skills/composites/goose-graphics/styles/ink-doodle-event.md",
+        "skills/composites/goose-graphics/styles/iridescent-y2k.md",
+        "skills/composites/goose-graphics/styles/magazine-red.md",
+        "skills/composites/goose-graphics/styles/masked-object-editorial.md",
+        "skills/composites/goose-graphics/styles/matt-gray.md",
+        "skills/composites/goose-graphics/styles/midnight-editorial.md",
+        "skills/composites/goose-graphics/styles/mint-pixel-corporate.md",
+        "skills/composites/goose-graphics/styles/paper-and-ink.md",
+        "skills/composites/goose-graphics/styles/pastel-organic-shapes.md",
+        "skills/composites/goose-graphics/styles/peach-pop.md",
+        "skills/composites/goose-graphics/styles/product-minimal.md",
+        "skills/composites/goose-graphics/styles/retro-line-art.md",
+        "skills/composites/goose-graphics/styles/social-post-card.md",
+        "skills/composites/goose-graphics/styles/soft-cloud.md",
+        "skills/composites/goose-graphics/styles/split-yellow-product.md",
+        "skills/composites/goose-graphics/styles/sunburst-editorial.md",
+        "skills/composites/goose-graphics/styles/terminal.md",
+        "skills/composites/goose-graphics/styles/venn-infographic.md",
+        "skills/composites/goose-graphics/styles/vintage-duotone-poster.md",
+        "skills/composites/goose-graphics/styles/warm-earth.md"
+      ],
+      "metadata": {
+        "slug": "goose-graphics",
+        "category": "composites",
+        "tags": [
+          "content",
+          "design",
+          "graphics",
+          "social"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install goose-graphics",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "36 aesthetic style presets",
+          "7 output formats (carousel, story, infographic, slides, poster, chart, tweet)",
+          "Unsplash + ASCII image sourcing",
+          "Playwright PNG export",
+          "Image-to-style extraction",
+          "Args-based slash command invocation"
         ]
       }
     },

--- a/skills/capabilities/create-html-carousel/SKILL.md
+++ b/skills/capabilities/create-html-carousel/SKILL.md
@@ -3,6 +3,8 @@ name: create-html-carousel
 description: Create LinkedIn carousel posts as high-quality PNG images. Design informational multi-slide posts like "5 AI GTM workflows" with consistent styling, then automatically screenshot each slide at LinkedIn's optimal 1080x1080px format.
 ---
 
+> **Deprecated:** This skill is superseded by `goose-graphics`. See `skills/composites/goose-graphics/` (install with `npx goose-skills install goose-graphics`). The carousel format is one of seven formats in the newer skill and supports 36 style presets plus image sourcing and PNG export. This skill is retained for one release cycle before removal.
+
 # LinkedIn Carousel Creator
 
 Create stunning LinkedIn carousel posts as PNG images. This skill generates styled HTML slides optimized for square format (1080×1080px), then automatically screenshots each slide for direct upload to LinkedIn.

--- a/skills/capabilities/create-html-carousel/skill.meta.json
+++ b/skills/capabilities/create-html-carousel/skill.meta.json
@@ -4,6 +4,8 @@
   "tags": [
     "content"
   ],
+  "deprecated": true,
+  "deprecation_note": "Superseded by `goose-graphics` (skills/composites/goose-graphics/). Scheduled for removal after one release cycle.",
   "installation": {
     "base_command": "npx goose-skills install create-html-carousel",
     "supports": [

--- a/skills/capabilities/create-html-slides/SKILL.md
+++ b/skills/capabilities/create-html-slides/SKILL.md
@@ -3,6 +3,8 @@ name: frontend-slides
 description: Create stunning, animation-rich HTML presentations from scratch or by converting PowerPoint files. Use when the user wants to build a presentation, convert a PPT/PPTX to web, or create slides for a talk/pitch. Helps non-designers discover their aesthetic through visual exploration rather than abstract choices.
 ---
 
+> **Deprecated:** This skill is superseded by `goose-graphics`. See `skills/composites/goose-graphics/` (install with `npx goose-skills install goose-graphics`). The slides format is one of seven formats in the newer skill and supports 36 style presets plus image sourcing and PNG export. This skill is retained for one release cycle before removal.
+
 # Frontend Slides Skill
 
 Create zero-dependency, animation-rich HTML presentations that run entirely in the browser. This skill helps non-designers discover their preferred aesthetic through visual exploration ("show, don't tell"), then generates production-quality slide decks.

--- a/skills/capabilities/create-html-slides/skill.meta.json
+++ b/skills/capabilities/create-html-slides/skill.meta.json
@@ -4,6 +4,8 @@
   "tags": [
     "content"
   ],
+  "deprecated": true,
+  "deprecation_note": "Superseded by `goose-graphics` (skills/composites/goose-graphics/). Scheduled for removal after one release cycle.",
   "installation": {
     "base_command": "npx goose-skills install create-html-slides",
     "supports": [

--- a/skills/composites/goose-graphics/README.md
+++ b/skills/composites/goose-graphics/README.md
@@ -1,0 +1,134 @@
+# goose-graphics — Agent Skills pack for visual graphics
+
+`goose-graphics` is a portable visual skill pack for the Agent Skills ecosystem. It bundles 36 aesthetic presets (each authored in the VoltAgent 9-section DESIGN.md format), 7 social-first format specs (carousel, story, infographic, slides, poster, chart, tweet), an extract-style workflow for reference images, and a Playwright-based HTML-to-PNG export pipeline.
+
+Any host that reads `SKILL.md` can load the pack — Claude Code agents calling it for automated render, Goose pipelines wiring it into content generation, Cursor/Codex projects picking it up via `.cursor/rules/` or `~/.codex/skills/`. Individual style files under `styles/_full/<slug>.md` are authored to Claude Design's DESIGN.md spec so they can also be uploaded directly into CD as design-system scaffolds.
+
+## Host compatibility
+
+`SKILL.md` auto-loads on most Agent Skills hosts once the pack is installed at the right path. Claude Design is the one host that does not auto-load skill packs — instead, it consumes individual style files (DESIGN.md) via manual upload from `styles/_full/<slug>.md`.
+
+| Host | Install | Notes |
+|---|---|---|
+| Claude Code | `npx goose-skills install goose-graphics --claude` | Lands at `~/.claude/skills/goose-graphics/` |
+| Claude Desktop | (same install as above) | Auto-shared — Desktop reads `~/.claude/skills/` |
+| Claude Cowork | (same install as above) | Built on Claude Desktop; same skill dir |
+| Goose (Block) | (same install as above) | Auto-discovers `~/.claude/skills/` + `~/.config/goose/skills/` |
+| Cursor | `npx goose-skills install goose-graphics --cursor --project-dir .` | Writes `.cursor/rules/goose-goose-graphics.mdc` |
+| Codex (OpenAI) | `npx goose-skills install goose-graphics --codex` | Writes `~/.codex/skills/goose-graphics/` |
+| Claude Design | Download a DESIGN.md from styles.gooseworks.ai and upload via CD's "Create new design system" | Per-style DESIGN.md upload; no CLI sync |
+
+## Directory Structure
+
+```
+goose-graphics/
+  SKILL.md                        # Entry-point skill (router)
+  README.md                       # This file
+  skill.meta.json                 # Goose-skills installation metadata
+  .claude-plugin/plugin.json      # Claude Code plugin descriptor
+  formats/                        # 7 format specs
+    carousel.md, story.md, infographic.md, slides.md,
+    poster.md, chart.md, tweet.md
+  styles/                         # 36 slim style preset files + tools
+    index.json                    # Canonical list of all 36 presets
+    <slug>.md × 36                # Slim presets (~6-8KB each)
+    extract-style.md              # Derive a custom style from a reference image
+    _full/                        # Full-prose archive (~30KB each)
+      <slug>.md × 36
+  sources/
+    unsplash.md, ascii-art.md
+  screenshot/
+    screenshot.js, package.json   # Playwright HTML-to-PNG export
+  examples/
+    <style-slug>/                 # Per-style example outputs
+    references/canva-figma/       # Canva + Figma reference screenshots
+```
+
+## Formats
+
+| Format | Dimensions | Output |
+|--------|-----------|--------|
+| Carousel | 1080x1080px per slide | One PNG per slide (up to 10) |
+| Story | 1080x1920px per slide | One PNG per slide (up to 10) |
+| Infographic | 1080px wide, variable height | Single PNG |
+| Slides | 1920x1080px per slide | One PNG per slide |
+| Poster | 1080x1350px | Single PNG |
+| Chart | 1080x1080px | Single PNG |
+| Tweet | 1080x1080px | Single PNG |
+
+## Style Presets (36 total)
+
+The single source of truth is `styles/index.json`. The README, SKILL.md, and any consuming tool should read from that file. Presets are grouped into 7 moods:
+
+| Group | Count | Slugs |
+|-------|-------|-------|
+| Dark & Moody | 7 | `midnight-editorial`, `deep-ocean`, `golden-dusk`, `terminal`, `bw-editorial-drop`, `masked-object-editorial`, `grid-quote-editorial` |
+| Light & Editorial | 7 | `clean-slate`, `paper-and-ink`, `matt-gray`, `magazine-red`, `sunburst-editorial`, `product-minimal`, `archive-fashion` |
+| Organic & Warm | 6 | `warm-earth`, `garden-blur`, `soft-cloud`, `peach-pop`, `pastel-organic-shapes`, `aurora-app-launch` |
+| Bold & Energetic | 5 | `electric-burst`, `highlighter-yellow`, `heatwave-orange`, `split-yellow-product`, `blueprint-sticky` |
+| Retro & Cinematic | 5 | `cinematic-romance`, `vintage-duotone-poster`, `retro-line-art`, `iridescent-y2k`, `ink-doodle-event` |
+| Structural & Technical | 5 | `brutalist`, `frosted-lens`, `card-toss`, `venn-infographic`, `social-post-card` |
+| Friendly Corporate | 1 | `mint-pixel-corporate` |
+
+You can also extract a custom style from any reference image via `styles/extract-style.md`.
+
+## Slim vs Full Style Files
+
+Each style ships in two forms:
+
+- **Slim** (`styles/<slug>.md`) — ~6-8KB each. A tight, consistent spec: palette (hex + role), typography rules (fonts, weights, tracking, Google Fonts link), layout rules, do/don't list, and reusable CSS snippets. **This is what the skill loads during generation.** Designed to fit comfortably inside a prompt without ballooning context.
+- **Full** (`styles/_full/<slug>.md`) — ~30KB each. The original atmospheric prose brief with extensive component patterns, format adaptation notes, and detailed rationale. Preserved verbatim from the pre-slim baseline. Use this when you need the long-form voice — for extract-style prompting, when the slim file is ambiguous, or when building net-new related styles.
+
+All 36 styles follow the same slim template so Claude and humans can both reason about them predictably.
+
+## Args-based Invocation
+
+This skill supports three invocation modes. See SKILL.md §2 for full details.
+
+```bash
+# Full args — one-shot generate (fastest)
+/goose-graphics --style matt-gray --format carousel --brief "How founders find their first 100 customers"
+
+# Reference-driven — extract style from image, then build
+/goose-graphics --ref ~/Desktop/mood.png --format poster --brief "Studio open house"
+
+# Partial args — Claude asks only for what's missing
+/goose-graphics --style deep-ocean --format slides
+
+# No args — full interactive flow
+/goose-graphics
+```
+
+Flags:
+
+- `--style <slug>` — any slug in `styles/index.json`
+- `--format <format>` — `carousel` · `story` · `infographic` · `slides` · `poster` · `chart` · `tweet`
+- `--brief "..."` — topic / content description
+- `--ref <image-path>` — use image-to-style extraction instead of a preset
+
+## Image Sourcing
+
+- **Unsplash** — Search and embed high-quality stock photography (requires `UNSPLASH_ACCESS_KEY` environment variable).
+- **ASCII art** — Generate decorative ASCII art elements via CSS/HTML.
+
+## Installation
+
+```bash
+cd screenshot && npm install && npx playwright install chromium
+```
+
+For cross-platform installation via the `goose-skills` CLI:
+
+```bash
+npx goose-skills install goose-graphics
+```
+
+See `skill.meta.json` for installation metadata.
+
+## Usage
+
+Invoke via `/goose-graphics` in Claude Code. The skill walks you through format selection, style choice, image sourcing, and HTML generation, then automatically exports PNGs — or jump straight to generate by passing args (see above).
+
+## Testing
+
+Automated testing harness lives in a separate workstream (GOOSE-1357) — check the `testing/` subdirectory once that lands.

--- a/skills/composites/goose-graphics/SKILL.md
+++ b/skills/composites/goose-graphics/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: goose-graphics
+description: Portable visual skill pack for the Agent Skills ecosystem (Claude Code, Claude Desktop, Claude Cowork, Claude Design, Goose, Cursor, Codex). Ships 36 aesthetic presets in DESIGN.md format, 7 social-first format specs, extract-style from reference images, and automatic PNG export via Playwright.
+---
+
+## 1. Overview
+
+`goose-graphics` is a portable visual skill pack for the Agent Skills ecosystem. It bundles 36 aesthetic presets (each authored in the VoltAgent 9-section DESIGN.md format), 7 social-first format specs (carousel, story, infographic, slides, poster, chart, tweet), an extract-style workflow for reference images, and a Playwright-based HTML-to-PNG export pipeline.
+
+It loads in any host that reads `SKILL.md` — Claude Code agents calling it for automated render, Goose pipelines wiring it into content generation, Cursor/Codex projects picking it up via `.cursor/rules/` or `~/.codex/skills/`. Individual style files under `styles/_full/<slug>.md` are authored to Claude Design's DESIGN.md spec so they can also be uploaded directly into CD as design-system scaffolds.
+
+Everything is self-contained: format templates, style systems, image sourcing instructions, and the screenshot pipeline all live within this skill pack directory.
+
+## 2. Invocation
+
+This skill supports **three invocation modes** — all-args, partial-args, and interactive. Pick the fastest path for the ask.
+
+### 2.1 Full-args invocation (fastest path)
+
+```
+/goose-graphics --style <slug> --format <format> [--brief "..."] [--ref <image-path>]
+```
+
+- `--style <slug>` — one of the 36 preset slugs (see `styles/index.json` or §6). Required for style-selected generation. Omit to let the user pick interactively.
+- `--format <format>` — one of `carousel`, `story`, `infographic`, `slides`, `poster`, `chart`, `tweet`. Required for format-selected generation.
+- `--brief "..."` — the topic / content description. Replaces the Content Discovery phase.
+- `--ref <image-path>` — if present, extract a custom style from the reference image instead of using a preset. When `--ref` is provided, `--style` is ignored.
+
+**Three branches:**
+
+1. **All required args present** (`--style` + `--format` + `--brief` OR `--ref` + `--format` + `--brief`) → skip discovery, skip style selection, proceed directly to §7 (Set Output Path) and §8 (Generate HTML).
+2. **Partial args** → ask only for the missing pieces. If `--style` is set but `--format` is not, ask only for format. If `--brief` is missing, ask only for the topic/content.
+3. **No args** → run the interactive flow from §3 onward.
+
+### 2.2 Examples
+
+```bash
+# Full args — one-shot generate
+/goose-graphics --style matt-gray --format carousel --brief "How founders find their first 100 customers in 2026"
+
+# Reference-driven — extract style from image, then build
+/goose-graphics --ref ~/Desktop/mood.png --format poster --brief "Summer studio open house, August 14"
+
+# Partial — Claude asks for the missing brief
+/goose-graphics --style deep-ocean --format slides
+
+# No args — full interactive flow
+/goose-graphics
+```
+
+### 2.3 Defaults when args are partial but unambiguous
+
+- If `--brief` is missing but clearly inferable from subsequent user text, don't block — proceed.
+- If `--format` is missing, default to asking (there is no safe default across formats).
+- If `--style` is missing and `--ref` is missing, ask — style is load-bearing.
+
+## 3. Host compatibility
+
+`SKILL.md` (this file) auto-loads on most Agent Skills hosts once the pack is installed at the right path. Claude Design is the one host that does not auto-load skill packs — instead, it consumes individual style files (DESIGN.md) via manual upload from `styles/_full/<slug>.md`.
+
+| Host | Install | Notes |
+|---|---|---|
+| Claude Code | `npx goose-skills install goose-graphics --claude` | Lands at `~/.claude/skills/goose-graphics/` |
+| Claude Desktop | (same install as above) | Auto-shared — Desktop reads `~/.claude/skills/` |
+| Claude Cowork | (same install as above) | Built on Claude Desktop; same skill dir |
+| Goose (Block) | (same install as above) | Auto-discovers `~/.claude/skills/` + `~/.config/goose/skills/` |
+| Cursor | `npx goose-skills install goose-graphics --cursor --project-dir .` | Writes `.cursor/rules/goose-goose-graphics.mdc` |
+| Codex (OpenAI) | `npx goose-skills install goose-graphics --codex` | Writes `~/.codex/skills/goose-graphics/` |
+| Claude Design | Download a DESIGN.md from styles.gooseworks.ai and upload via CD's "Create new design system" | Per-style DESIGN.md upload; no CLI sync |
+
+## 4. First-Run Setup
+
+Before first use, check whether the screenshot tool's dependencies are installed. Look for a `node_modules/` directory inside the `screenshot/` folder (relative to this skill file).
+
+If `node_modules/` does **not** exist, run:
+
+```bash
+cd [skill-pack-dir]/screenshot && npm install && npx playwright install chromium
+```
+
+Replace `[skill-pack-dir]` with the absolute path to the directory containing this SKILL.md file.
+
+## 5. Interactive Workflow
+
+```
+1. Discover Intent   --> What format? What content?
+2. Select Style      --> Choose from 36 presets or extract from reference image
+3. Select Sources    --> Unsplash photos? ASCII art? None?
+4. Set Output Path   --> Where to save exports
+5. Generate HTML     --> Using format skill + style preset + sources
+6. Screenshot        --> Playwright PNG export
+7. Deliver           --> Present results with file listing
+```
+
+## 6. Step 1: Discover Intent
+
+Ask the user what they want to create. Present these format options:
+
+| Format | Dimensions | Best For |
+|--------|-----------|----------|
+| **Carousel** | 1080x1080px per slide | LinkedIn, Instagram multi-slide posts |
+| **Story** | 1080x1920px per slide | Instagram/LinkedIn Stories, TikTok, Snapchat |
+| **Infographic** | 1080px wide, variable height | Social media, blog embeds |
+| **Slides** | 1920x1080px per slide | Presentations, webinars |
+| **Poster** | 1080x1350px | Instagram posts, event flyers |
+| **Chart** | 1080x1080px | Single data chart graphic |
+| **Tweet** | 1080x1080px | Tweet-sized square screenshot |
+
+Once the user chooses a format, read the corresponding format skill file:
+
+```
+formats/carousel.md
+formats/story.md
+formats/infographic.md
+formats/slides.md
+formats/poster.md
+formats/chart.md
+formats/tweet.md
+```
+
+Then follow that format skill's **Content Discovery** phase to gather the topic, content, and any other format-specific inputs from the user.
+
+## 7. Step 2: Select Style
+
+Present the **36 style presets**, grouped by mood. The canonical list lives in `styles/index.json` — when in doubt, read that file.
+
+**Dark & Moody**
+1. **Midnight Editorial** — Dark, elegant magazine aesthetic with copper accents.
+2. **Deep Ocean** — Calm cyan glow on deep blue-black.
+3. **Golden Dusk** — Warm gold highlights on dark navy.
+4. **Terminal** — Green-on-dark monospace hacker aesthetic.
+5. **BW Editorial Drop** — Grayscale photo top + yellow Anton display on black drop panel.
+6. **Masked Object Editorial** — Navy + photo clipped into an object silhouette + italic Playfair.
+7. **Grid Quote Editorial** — Royal purple widescreen quote card with pink grid overlay + mint Figtree.
+
+**Light & Editorial**
+8. **Clean Slate** — Ultra-minimal white canvas, single blue accent.
+9. **Paper & Ink** — Classic serif editorial with red accent on cream.
+10. **Matt Gray** — Playfair italic green + yellow pill tags on light gray.
+11. **Magazine Red** — Massive tomato-red condensed headlines on cream paper.
+12. **Sunburst Editorial** — Mid-century book cover feel with serif + collage accents.
+13. **Product Minimal** — Apple-style white canvas, hero product photo, underlined URL.
+14. **Archive Fashion** — Stone beige catalog frame + brown photo inset + pink sticker.
+
+**Organic & Warm**
+15. **Warm Earth** — Organic terracotta and sage on cream.
+16. **Garden Blur** — Soft botanical backgrounds with translucent card overlays.
+17. **Soft Cloud** — Airy pastel gradients with white cards.
+18. **Peach Pop** — DTC beauty: monospace testimonials on peach + blue blocks.
+19. **Pastel Organic Shapes** — Cream canvas with one pistachio circle half off-frame.
+20. **Aurora App Launch** — Rainbow mesh gradient + phone mockup + frosted-glass footer.
+
+**Bold & Energetic**
+21. **Electric Burst** — Bold neon yellow and hot pink on black.
+22. **Highlighter Yellow** — Saturated yellow + heavy black sans + white-rect italic emphasis.
+23. **Heatwave Orange** — Three-variant white/orange/black system + line-wave accents.
+24. **Split Yellow Product** — Vivid mustard 2/3 headline slab + gray body panel + yellow photo.
+25. **Blueprint Sticky** — Cobalt blueprint grid + tilted pink/yellow sticky notes.
+
+**Retro & Cinematic**
+26. **Cinematic Romance** — Portrait photo canvas + hot pink chancery script headlines.
+27. **Vintage Duotone Poster** — Forest green + dusty pink halftone, 1950s letterpress.
+28. **Retro Line Art** — Powder blue + cream hand-drawn cocktail-poster line art.
+29. **Iridescent Y2K** — Brutalist grid + chrome iridescent blob hero, Y2K club poster.
+30. **Ink Doodle Event** — Kraft paper + loose hand-drawn ink character + Yellowtail script.
+
+**Structural & Technical**
+31. **Brutalist** — Raw heavy borders, system fonts, no decoration.
+32. **Frosted Lens** — Glassmorphism + blurred photography backgrounds.
+33. **Card Toss** — Scattered tilted cards with sticky-note energy.
+34. **Venn Infographic** — Translucent three-circle Venn diagrams + floating info cards.
+35. **Social Post Card** — Blurred real scene + simulated Instagram post card as hero.
+
+**Friendly Corporate**
+36. **Mint Pixel Corporate** — Pale mint + lime pixel-staircase corner decorations.
+
+The user may also say: **"I have a reference image"** — in that case, read `styles/extract-style.md` and follow its workflow to derive a custom style from the provided image.
+
+After the user selects a preset, read the corresponding style file from `styles/<slug>.md` (e.g., `styles/midnight-editorial.md`, `styles/heatwave-orange.md`). Each slim style file contains everything you need to generate: palette, typography, layout, do/don'ts, and ready-to-paste CSS snippets. For the full prose deep-dive (rare — use for extract-style prompting or when nuance is missing), read `styles/_full/<slug>.md`.
+
+## 8. Step 3: Image Sources (Optional)
+
+Ask the user: **"Do you want to include images in your graphic?"**
+
+Options:
+
+- **Unsplash photos** — Read `sources/unsplash.md` and follow its search workflow to find and embed high-quality stock photography.
+- **ASCII art decorations** — Read `sources/ascii-art.md` and follow its workflow to generate and embed ASCII art elements.
+- **Both** — Read both source files and incorporate both types.
+- **No images** — Skip this step entirely. The graphic will use pure CSS/HTML styling only.
+
+## 9. Step 4: Output Path
+
+Ask the user: **"Where should I save the exports?"**
+
+Default location: `./goose-graphics-exports/`
+
+Within that directory, create a subfolder using this naming convention:
+
+```
+[YYYY-MM-DD]-[slugified-name]/
+```
+
+For example: `2026-04-17-q2-product-roadmap/`
+
+## 10. Step 5: Generate HTML
+
+Follow the chosen format skill's **HTML Generation** phase. When generating:
+
+- Apply the chosen style preset's CSS variables, typography rules, color palette, and spacing system — the slim style file has everything you need.
+- Incorporate image sources (Unsplash URLs or ASCII art blocks) if the user selected any in Step 3.
+- Follow the format skill's content density limits and structural requirements exactly.
+- Write all HTML files to the output directory established in Step 4.
+
+## 11. Step 6: Screenshot
+
+Run the screenshot script to export HTML files to high-resolution PNGs:
+
+```bash
+node [skill-pack-dir]/screenshot/screenshot.js --format FORMAT --input INPUT_PATH --output OUTPUT_PATH
+```
+
+Where:
+- `[skill-pack-dir]` is the absolute path to this skill pack's directory.
+- `FORMAT` is one of: `carousel`, `story`, `infographic`, `slides`, `poster`, `chart`, `tweet`.
+- `INPUT_PATH` is the directory or file containing the generated HTML.
+- `OUTPUT_PATH` is the directory where PNG files should be saved.
+
+## 12. Step 7: Deliver
+
+Present the results to the user:
+
+- List all generated files (HTML source files and PNG exports) with their file sizes.
+- Provide the full path to the output directory.
+- Suggest how to preview: open the HTML files in a browser, or view the PNG files directly.
+- For carousels and slides, note the slide count and order.
+
+## 13. Special Modes
+
+- **"Surprise me"** — Pick the carousel format and a random style preset from `styles/index.json`. Ask the user only for content/topic, then generate everything else automatically.
+- **Multi-format** — If the user says "make this as both a carousel and an infographic," run the full workflow twice using the same content and style but different format skills. Save outputs in separate subdirectories.
+- **Style preview** — Before committing to full generation, produce a single sample slide or section so the user can approve the visual direction. If they want changes, adjust the style or switch presets before generating the rest.
+
+## 14. File Reference
+
+### Formats
+| File | Description |
+|------|-------------|
+| `formats/carousel.md` | Multi-slide square carousel (1080x1080px). LinkedIn/Instagram. |
+| `formats/story.md` | Vertical 9:16 stories (1080x1920px). Instagram/LinkedIn Stories, TikTok. |
+| `formats/infographic.md` | Tall vertical infographic (1080px wide, variable height). |
+| `formats/slides.md` | Widescreen presentation slides (1920x1080px). |
+| `formats/poster.md` | Portrait poster graphic (1080x1350px). |
+| `formats/chart.md` | Single data chart graphic. |
+| `formats/tweet.md` | Tweet-sized square screenshot. |
+
+### Styles
+
+The canonical list of all 36 style presets lives in `styles/index.json` (slug, display name, mood group, one-line tagline). Individual slim style files at `styles/<slug>.md` give you the full spec (palette, typography, layout, do/don't, CSS snippets). Archived full-prose versions live in `styles/_full/<slug>.md` if you need the deeper atmospheric reference.
+
+### Image Sources
+| File | Description |
+|------|-------------|
+| `sources/unsplash.md` | Search and embed Unsplash stock photography. |
+| `sources/ascii-art.md` | Generate and embed ASCII art decorations. |
+
+### Screenshot Tool
+| File | Description |
+|------|-------------|
+| `screenshot/screenshot.js` | Playwright-based HTML-to-PNG export script. |
+| `screenshot/package.json` | Node.js dependencies for the screenshot tool. |
+
+### Examples
+| Path | Description |
+|------|-------------|
+| `examples/<style-slug>/` | Per-style example output directories. |
+| `examples/references/canva-figma/` | Canva + Figma style reference screenshots. |

--- a/skills/composites/goose-graphics/formats/carousel.md
+++ b/skills/composites/goose-graphics/formats/carousel.md
@@ -1,0 +1,758 @@
+# Format: Carousel
+
+Create multi-slide square carousels optimized for LinkedIn and Instagram. Each slide is an individual HTML file rendered at 1080x1080px, then screenshotted to PNG.
+
+---
+
+## 1. Format Specifications
+
+| Property | Value |
+|----------|-------|
+| Dimensions | 1080 x 1080px per slide (1:1 square) |
+| File structure | Individual HTML file per slide (`slide-01.html`, `slide-02.html`, ...) + `index.html` preview |
+| Max slides | 10 |
+| Ideal slide count | 5-8 (best engagement) |
+| Output format | PNG per slide |
+| Sizing approach | Fixed pixel sizes (NOT responsive) |
+
+### Content Density Limits
+
+Each slide must be scannable in 2-3 seconds on mobile.
+
+| Slide Type | Max Content |
+|------------|-------------|
+| Cover | Title (8 words max) + subtitle (12 words max) + branding element |
+| Numbered item | Number + heading (2 lines max) + body (3 lines / 40 words max) |
+| Stat display | 1 large number + label (5 words) + description (20 words max) |
+| Comparison | 2 columns, 3-4 bullet points each (6 words per point max) |
+| List items | 3-4 items with icon + heading (4 words) + body (15 words each) |
+| Quote | 1 quote (25 words max) + attribution |
+| Framework | Diagram/visual + 2-4 labels (4 words each) |
+| CTA | 1 heading + 1 action line + visual element |
+
+**If content exceeds limits:** Break into multiple slides or simplify.
+
+---
+
+## 2. Workflow Overview
+
+```
+Content Discovery --> Style Selection --> HTML Generation --> Screenshot --> Delivery
+```
+
+1. Gather topic, content type, slide count, and content readiness from the user
+2. Present style presets and let the user choose (or guide them)
+3. Read the chosen style preset from `styles/[name].md`
+4. Generate individual HTML files per slide + an `index.html` preview
+5. Run the screenshot tool to export PNGs
+6. Present the finished files to the user
+
+---
+
+## 3. Content Discovery Phase
+
+Ask the user these questions before generating anything.
+
+**Question 1: Topic**
+- "What is the main topic of this carousel?"
+- Free text input
+
+**Question 2: Content Type**
+- "What type of post is this?"
+- Options:
+  - **Numbered list** -- "5 ways to...", "7 mistakes...", "3 steps to..."
+  - **How-to guide** -- Step-by-step tutorial or process
+  - **Framework** -- Concept explanation with structure
+  - **Comparison** -- Before/after, pros/cons, old way vs new way
+  - **Insights / Tips** -- Collection of advice or learnings
+  - **Case study** -- Results, metrics, transformation story
+
+**Question 3: Slide Count**
+- "How many slides?"
+- Options:
+  - **Short (5-6)** -- Quick, punchy (best for mobile scrolling)
+  - **Medium (7-8)** -- Standard carousel length
+  - **Long (9-10)** -- Maximum allowed
+
+**Question 4: Content Readiness**
+- "Do you have the content ready?"
+- Options:
+  - **Yes, I have all content** -- Paste it in
+  - **I have bullet points** -- Need light formatting
+  - **Just the topic** -- Need help outlining
+
+If the user has content, ask them to share it before proceeding.
+
+---
+
+## 4. Style Selection Phase
+
+Present the 10 available design presets:
+
+| # | Preset | Description |
+|---|--------|-------------|
+| 1 | **Midnight Editorial** | Dark, elegant, magazine-inspired with copper accents |
+| 2 | **Clean Slate** | Ultra-minimal, precise, modern tech aesthetic |
+| 3 | **Warm Earth** | Organic, artisanal, grounded with natural tones |
+| 4 | **Electric Burst** | Bold, energetic, attention-grabbing with vivid color |
+| 5 | **Soft Cloud** | Airy, modern, approachable with gentle pastels |
+| 6 | **Terminal** | Dev/hacker aesthetic, focused and technical |
+| 7 | **Paper & Ink** | Classic editorial, literary, print-inspired |
+| 8 | **Brutalist** | Raw, structural, anti-design with strong geometry |
+| 9 | **Golden Dusk** | Warm, luxurious, premium with rich gold tones |
+| 10 | **Deep Ocean** | Calm, professional, immersive blue-dark palette |
+
+**Additional options:**
+
+- **"I have a reference image"** -- Use the `extract-style` skill at `styles/extract-style.md` to derive a custom palette from the user's image.
+- **Guided discovery** -- If the user is unsure, ask about their audience and tone, then recommend 2-3 presets:
+  - Professional / Corporate --> Midnight Editorial, Clean Slate, Deep Ocean
+  - Creative / Playful --> Electric Burst, Soft Cloud, Warm Earth
+  - Technical / Dev-focused --> Terminal, Brutalist, Clean Slate
+  - Elegant / Premium --> Midnight Editorial, Golden Dusk, Paper & Ink
+
+**After selection:** Read the chosen style preset file from `styles/[name].md` to load all colors, typography, and component patterns. For example, if the user picks "Midnight Editorial", read `styles/midnight-editorial.md`.
+
+---
+
+## 5. HTML Generation Phase
+
+### Base CSS (Mandatory)
+
+Every carousel slide MUST include this dimension-locking CSS. Carousel slides are fixed-size -- no responsive scaling, no viewport units, no clamp(). Everything is in pixels.
+
+```css
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+html, body {
+    width: 1080px;
+    height: 1080px;
+    overflow: hidden;
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 60px;
+}
+```
+
+### Injecting the Style Preset
+
+After reading the style preset file, find its **Section 9 (Agent Prompt Guide)** which contains the CSS `:root` variables. Paste those variables into each slide's `<style>` block:
+
+```css
+:root {
+    /* -- Paste all CSS variables from the preset's Section 9 here -- */
+    /* Example (Midnight Editorial): */
+    /* --color-midnight: #0d0d0d; */
+    /* --font-display: 'Playfair Display', Georgia, serif; */
+    /* ... etc. */
+}
+```
+
+Also add the Google Fonts `<link>` from the preset's Section 9 into the `<head>`.
+
+### Using Component Patterns
+
+The preset's **Section 4 (Component Patterns)** contains ready-to-use HTML snippets for title blocks, numbered items, stat displays, comparison grids, list items, quote blocks, and CTA blocks. Adapt these patterns for the 1080x1080 format.
+
+The preset's **Section 8 (Format Adaptation Notes)** contains carousel-specific typography scale and layout guidance. Always apply these adaptations.
+
+### Complete HTML Template (Single Slide)
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=1080, initial-scale=1.0">
+    <title>Slide 01</title>
+
+    <!-- Google Fonts: paste the link from your chosen preset's Section 9 -->
+    <link href="https://fonts.googleapis.com/css2?family=PRESET_FONTS_HERE&display=swap" rel="stylesheet">
+
+    <style>
+        /* =============================================
+           CAROUSEL SLIDE: 1080x1080px FIXED
+           ============================================= */
+
+        :root {
+            /* -- Paste CSS variables from preset Section 9 -- */
+
+            /* Carousel-specific overrides */
+            --slide-width: 1080px;
+            --slide-height: 1080px;
+            --slide-padding: 60px;
+            --content-max-width: 960px;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        html, body {
+            width: var(--slide-width);
+            height: var(--slide-height);
+            overflow: hidden;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+        }
+
+        body {
+            /* Use preset background variable */
+            background-color: var(--bg-primary, var(--color-midnight, #0d0d0d));
+            color: var(--text-primary, var(--color-cream, #f5f0e8));
+            font-family: var(--font-body);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            padding: var(--slide-padding);
+        }
+
+        .slide-content {
+            width: 100%;
+            max-width: var(--content-max-width);
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+
+        /* =============================================
+           TYPOGRAPHY HIERARCHY
+           Scale down from preset's Section 8 carousel sizes
+           ============================================= */
+
+        .title {
+            font-family: var(--font-display);
+            font-size: 56px;
+            font-weight: 700;
+            line-height: 1.08;
+            letter-spacing: -1px;
+        }
+
+        .subtitle {
+            font-family: var(--font-body);
+            font-size: 24px;
+            font-weight: 300;
+            line-height: 1.50;
+        }
+
+        .heading {
+            font-family: var(--font-display);
+            font-size: 40px;
+            font-weight: 700;
+            line-height: 1.12;
+            letter-spacing: -0.5px;
+        }
+
+        .subheading {
+            font-family: var(--font-display);
+            font-size: 32px;
+            font-weight: 700;
+            line-height: 1.15;
+        }
+
+        .body-text {
+            font-family: var(--font-body);
+            font-size: 22px;
+            font-weight: 400;
+            line-height: 1.55;
+        }
+
+        .small-text {
+            font-family: var(--font-body);
+            font-size: 16px;
+            font-weight: 400;
+            line-height: 1.50;
+        }
+
+        .label {
+            font-family: var(--font-body);
+            font-size: 14px;
+            font-weight: 600;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+        }
+
+        .big-number {
+            font-family: var(--font-display);
+            font-size: 72px;
+            font-weight: 900;
+            line-height: 1.00;
+            letter-spacing: -1px;
+        }
+
+        /* =============================================
+           BRANDING FOOTER
+           ============================================= */
+
+        .brand {
+            position: absolute;
+            bottom: var(--slide-padding);
+            right: var(--slide-padding);
+            font-family: var(--font-body);
+            font-size: 16px;
+            font-weight: 400;
+            opacity: 0.6;
+        }
+
+        /* =============================================
+           SLIDE INDICATOR (optional dots)
+           ============================================= */
+
+        .slide-dots {
+            position: absolute;
+            bottom: var(--slide-padding);
+            left: 50%;
+            transform: translateX(-50%);
+            display: flex;
+            gap: 12px;
+        }
+
+        .slide-dots .dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            opacity: 0.3;
+        }
+
+        .slide-dots .dot.active {
+            opacity: 1.0;
+        }
+    </style>
+</head>
+<body>
+    <div class="slide-content">
+        <!-- Slide content goes here -->
+    </div>
+
+    <div class="brand">@yourbrand</div>
+</body>
+</html>
+```
+
+### File Naming
+
+Slides are numbered sequentially:
+- `slide-01.html`
+- `slide-02.html`
+- `slide-03.html`
+- ...up to `slide-10.html`
+
+---
+
+## 6. Content Templates
+
+All templates use CSS custom properties so they work with any style preset. Adapt colors, fonts, and spacing from the preset's component patterns in Section 4.
+
+### Cover Slide (Slide 1)
+
+```html
+<body>
+    <div class="slide-content" style="text-align: center; justify-content: center; align-items: center;">
+
+        <!-- Decorative accent rule -->
+        <div style="width: 60px; height: 2px; background: var(--color-accent, var(--color-copper, #c17f59));"></div>
+
+        <!-- Title -->
+        <h1 class="title" style="margin-top: 24px;">
+            5 AI Workflows<br>That Actually Work
+        </h1>
+
+        <!-- Subtitle -->
+        <p class="subtitle" style="max-width: 680px; margin-top: 16px; opacity: 0.7;">
+            Practical systems you can deploy this week
+        </p>
+
+        <!-- Bottom accent rule -->
+        <div style="width: 60px; height: 2px; background: var(--color-accent, var(--color-copper, #c17f59)); margin-top: 32px;"></div>
+
+    </div>
+
+    <div class="brand">@yourbrand</div>
+</body>
+```
+
+### Numbered Item
+
+```html
+<body>
+    <div class="slide-content">
+
+        <!-- Number -->
+        <span class="big-number" style="color: var(--color-accent, var(--color-copper, #c17f59));">
+            01
+        </span>
+
+        <!-- Category label -->
+        <p class="label" style="color: var(--color-secondary-accent, var(--color-muted-gold, #a89067)); margin-top: 8px;">
+            SIGNAL-BASED OUTBOUND
+        </p>
+
+        <!-- Heading -->
+        <h2 class="heading" style="margin-top: 12px;">
+            Find buyers before they find you
+        </h2>
+
+        <!-- Body -->
+        <p class="body-text" style="margin-top: 12px; opacity: 0.7; max-width: 800px;">
+            Monitor hiring signals, funding events, and tech stack changes to identify high-intent prospects the moment they enter the market.
+        </p>
+
+    </div>
+
+    <div class="brand">@yourbrand &middot; 1/5</div>
+</body>
+```
+
+### Stat Display
+
+```html
+<body>
+    <div class="slide-content" style="text-align: center; justify-content: center; align-items: center;">
+
+        <!-- Big stat number -->
+        <p class="big-number" style="font-size: 120px; color: var(--color-accent, var(--color-copper, #c17f59));">
+            47%
+        </p>
+
+        <!-- Stat label -->
+        <p class="label" style="margin-top: 16px;">
+            FASTER RESPONSE TIME
+        </p>
+
+        <!-- Context -->
+        <p class="body-text" style="margin-top: 16px; opacity: 0.7; max-width: 640px;">
+            Teams using AI coworkers respond to inbound leads nearly twice as fast as manual workflows.
+        </p>
+
+    </div>
+
+    <div class="brand">@yourbrand &middot; 3/5</div>
+</body>
+```
+
+### Comparison Grid
+
+```html
+<body>
+    <div class="slide-content">
+
+        <!-- Section heading -->
+        <h2 class="heading" style="text-align: center; margin-bottom: 8px;">Before vs After</h2>
+
+        <!-- Two-column comparison -->
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2px; border-radius: 4px; overflow: hidden; margin-top: 24px;">
+
+            <!-- Left: Before -->
+            <div style="background: var(--color-surface, var(--color-charcoal, #1a1a1a)); padding: 40px 32px;">
+                <p class="label" style="opacity: 0.6; margin-bottom: 16px;">BEFORE</p>
+                <h3 class="subheading" style="font-size: 28px; margin-bottom: 16px;">Manual Process</h3>
+                <ul style="list-style: none; display: flex; flex-direction: column; gap: 12px;">
+                    <li class="body-text" style="opacity: 0.7; font-size: 18px; padding-left: 24px; position: relative;">
+                        <span style="position: absolute; left: 0; color: var(--color-accent);">&times;</span>
+                        4 hours per lead
+                    </li>
+                    <li class="body-text" style="opacity: 0.7; font-size: 18px; padding-left: 24px; position: relative;">
+                        <span style="position: absolute; left: 0; color: var(--color-accent);">&times;</span>
+                        Inconsistent quality
+                    </li>
+                    <li class="body-text" style="opacity: 0.7; font-size: 18px; padding-left: 24px; position: relative;">
+                        <span style="position: absolute; left: 0; color: var(--color-accent);">&times;</span>
+                        Doesn't scale
+                    </li>
+                </ul>
+            </div>
+
+            <!-- Right: After -->
+            <div style="background: var(--color-surface, var(--color-charcoal, #1a1a1a)); padding: 40px 32px; border-left: 2px solid var(--color-accent, var(--color-copper, #c17f59));">
+                <p class="label" style="color: var(--color-accent, var(--color-copper, #c17f59)); margin-bottom: 16px;">AFTER</p>
+                <h3 class="subheading" style="font-size: 28px; margin-bottom: 16px;">AI-Powered</h3>
+                <ul style="list-style: none; display: flex; flex-direction: column; gap: 12px;">
+                    <li class="body-text" style="opacity: 0.7; font-size: 18px; padding-left: 24px; position: relative;">
+                        <span style="position: absolute; left: 0; color: var(--color-accent);">&#10003;</span>
+                        15 minutes per lead
+                    </li>
+                    <li class="body-text" style="opacity: 0.7; font-size: 18px; padding-left: 24px; position: relative;">
+                        <span style="position: absolute; left: 0; color: var(--color-accent);">&#10003;</span>
+                        Consistently high quality
+                    </li>
+                    <li class="body-text" style="opacity: 0.7; font-size: 18px; padding-left: 24px; position: relative;">
+                        <span style="position: absolute; left: 0; color: var(--color-accent);">&#10003;</span>
+                        Scales infinitely
+                    </li>
+                </ul>
+            </div>
+
+        </div>
+
+    </div>
+
+    <div class="brand">@yourbrand &middot; 4/5</div>
+</body>
+```
+
+### List Items
+
+```html
+<body>
+    <div class="slide-content">
+
+        <h2 class="heading" style="margin-bottom: 16px;">Key Capabilities</h2>
+
+        <!-- List -->
+        <div style="display: flex; flex-direction: column; gap: 0;">
+
+            <div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                <div style="width: 40px; height: 40px; min-width: 40px; display: flex; align-items: center; justify-content: center; border: 1px solid var(--color-border-accent, rgba(193,127,89,0.3)); border-radius: 4px; color: var(--color-accent); font-size: 18px;">&#9670;</div>
+                <div>
+                    <h4 class="subheading" style="font-size: 24px; margin-bottom: 6px;">Persistent Memory</h4>
+                    <p class="body-text" style="opacity: 0.7; font-size: 18px;">Agents remember context across sessions. Nothing is lost.</p>
+                </div>
+            </div>
+
+            <div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                <div style="width: 40px; height: 40px; min-width: 40px; display: flex; align-items: center; justify-content: center; border: 1px solid var(--color-border-accent, rgba(193,127,89,0.3)); border-radius: 4px; color: var(--color-accent); font-size: 18px;">&#9670;</div>
+                <div>
+                    <h4 class="subheading" style="font-size: 24px; margin-bottom: 6px;">Multi-Channel Access</h4>
+                    <p class="body-text" style="opacity: 0.7; font-size: 18px;">Reach your agents via Slack, Telegram, or web chat.</p>
+                </div>
+            </div>
+
+            <div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0;">
+                <div style="width: 40px; height: 40px; min-width: 40px; display: flex; align-items: center; justify-content: center; border: 1px solid var(--color-border-accent, rgba(193,127,89,0.3)); border-radius: 4px; color: var(--color-accent); font-size: 18px;">&#9670;</div>
+                <div>
+                    <h4 class="subheading" style="font-size: 24px; margin-bottom: 6px;">Tool Integration</h4>
+                    <p class="body-text" style="opacity: 0.7; font-size: 18px;">Connect to any API, database, or SaaS tool your team uses.</p>
+                </div>
+            </div>
+
+        </div>
+
+    </div>
+
+    <div class="brand">@yourbrand &middot; 3/5</div>
+</body>
+```
+
+### Quote Block
+
+```html
+<body>
+    <div class="slide-content" style="justify-content: center;">
+
+        <!-- Quote -->
+        <div style="padding: 48px 40px; border-left: 2px solid var(--color-accent, var(--color-copper, #c17f59)); background: var(--color-surface-inset, #141414);">
+            <p style="font-family: var(--font-display); font-size: 36px; font-weight: 400; font-style: italic; line-height: 1.35; letter-spacing: -0.5px;">
+                "It felt less like configuring software and more like onboarding a new team member."
+            </p>
+            <div style="display: flex; align-items: center; gap: 12px; margin-top: 24px;">
+                <div style="width: 32px; height: 2px; background: var(--color-accent, var(--color-copper, #c17f59));"></div>
+                <p class="label" style="color: var(--color-secondary-accent, var(--color-muted-gold, #a89067));">
+                    SARAH CHEN, VP OPERATIONS
+                </p>
+            </div>
+        </div>
+
+    </div>
+
+    <div class="brand">@yourbrand &middot; 4/5</div>
+</body>
+```
+
+### CTA Slide (Last Slide)
+
+```html
+<body>
+    <div class="slide-content" style="text-align: center; justify-content: center; align-items: center;">
+
+        <!-- Decorative accent rule -->
+        <div style="width: 60px; height: 2px; background: var(--color-accent, var(--color-copper, #c17f59));"></div>
+
+        <!-- Heading -->
+        <h2 class="heading" style="font-size: 48px; margin-top: 24px;">
+            Want more like this?
+        </h2>
+
+        <!-- Body -->
+        <p class="body-text" style="margin-top: 16px; opacity: 0.7; max-width: 640px;">
+            Follow for weekly breakdowns of AI-powered workflows and systems.
+        </p>
+
+        <!-- CTA button -->
+        <div style="margin-top: 32px; display: inline-block; background: var(--color-accent, var(--color-copper, #c17f59)); color: var(--bg-primary, var(--color-midnight, #0d0d0d)); font-family: var(--font-body); font-size: 15px; font-weight: 600; letter-spacing: 0.8px; text-transform: uppercase; padding: 16px 40px; border-radius: 4px;">
+            Follow &rarr;
+        </div>
+
+        <!-- Bottom accent rule -->
+        <div style="width: 60px; height: 2px; background: var(--color-accent, var(--color-copper, #c17f59)); margin-top: 40px;"></div>
+
+    </div>
+
+    <div class="brand">@yourbrand</div>
+</body>
+```
+
+### Index Preview File
+
+Create an `index.html` that shows all slides in a scrollable grid for easy review:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Carousel Preview</title>
+    <style>
+        body {
+            margin: 0;
+            background: #111;
+            color: #fff;
+            font-family: -apple-system, sans-serif;
+            padding: 40px;
+        }
+        h1 { font-size: 24px; margin-bottom: 32px; font-weight: 400; }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+            gap: 24px;
+        }
+        .slide-wrapper {
+            width: 360px;
+            height: 360px;
+            overflow: hidden;
+            border: 1px solid #333;
+            border-radius: 4px;
+            position: relative;
+        }
+        .slide-wrapper iframe {
+            width: 1080px;
+            height: 1080px;
+            border: none;
+            transform: scale(0.333);
+            transform-origin: 0 0;
+        }
+        .slide-label {
+            font-size: 13px;
+            opacity: 0.5;
+            margin-top: 8px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Carousel Preview</h1>
+    <div class="grid">
+        <!-- Repeat for each slide -->
+        <div>
+            <div class="slide-wrapper">
+                <iframe src="slides/slide-01.html" scrolling="no"></iframe>
+            </div>
+            <p class="slide-label">Slide 01</p>
+        </div>
+        <!-- ... additional slides ... -->
+    </div>
+</body>
+</html>
+```
+
+---
+
+## 7. Screenshot Phase
+
+After generating all HTML files, run the screenshot tool:
+
+```bash
+node screenshot/screenshot.js \
+  --format carousel \
+  --input ./EXPORT_DIR/slides \
+  --output ./EXPORT_DIR/exports
+```
+
+Where `EXPORT_DIR` is the export directory (see Section 9).
+
+This will:
+1. Open each slide HTML in a headless Chromium browser
+2. Set the viewport to 1080x1080px with 2x device scale factor
+3. Wait for fonts to load (500ms default; use `--font-delay 1000` for custom fonts)
+4. Capture a PNG screenshot of each slide
+5. Save as `slide-01.png`, `slide-02.png`, etc. in the exports directory
+
+---
+
+## 8. Delivery Phase
+
+After screenshots are generated, present results to the user:
+
+```
+Your carousel is ready!
+
+Location: [EXPORT_DIR]/
+
+Files:
+  slides/        -- 7 HTML source files
+  exports/       -- 7 PNG images (1080x1080px each)
+  index.html     -- Preview all slides in browser
+
+Export details:
+  slide-01.png    287 KB
+  slide-02.png    198 KB
+  slide-03.png    224 KB
+  slide-04.png    312 KB
+  slide-05.png    189 KB
+  slide-06.png    256 KB
+  slide-07.png    201 KB
+  Total:          1.67 MB
+
+Upload instructions:
+  LinkedIn: Create post > Add media > Upload all PNGs in order
+  Instagram: New post > Select multiple > Upload all PNGs in order
+
+Want to make any changes to the slides?
+```
+
+---
+
+## 9. Export Directory Convention
+
+Ask the user: **"Where should I save the exports? (default: ./goose-graphics-exports/)"**
+
+### Directory naming
+- Primary: `[YYYY-MM-DD]-[slugified-name]/` (e.g., `2026-04-04-ai-gtm-workflows/`)
+- Fallback (no name given): `[YYYY-MM-DD]-carousel-[HHMMSS]/`
+
+### Directory structure (carousel = multi-file)
+```
+goose-graphics-exports/
+  2026-04-04-ai-gtm-workflows/
+    slides/
+      slide-01.html
+      slide-02.html
+      slide-03.html
+      ...
+    exports/
+      slide-01.png
+      slide-02.png
+      slide-03.png
+      ...
+    index.html          # Preview file
+```
+
+---
+
+## Design Reminders
+
+- **Fixed pixels only.** Carousel slides are 1080x1080px exactly. Never use `vw`, `vh`, `clamp()`, or responsive units. Everything is defined in `px`.
+- **One concept per slide.** Each slide should communicate a single idea that is scannable in 2-3 seconds.
+- **High contrast.** Most viewers see carousels on small phone screens in bright environments. Ensure strong text/background contrast.
+- **Consistent branding.** Place your handle or branding element in the same position on every slide (typically bottom-right).
+- **Slide indicators.** Optionally include small dots at the bottom center to show progress.
+- **Mobile-first.** Text must be readable at thumbnail size. Minimum body text size: 18px. Minimum heading size: 32px.

--- a/skills/composites/goose-graphics/formats/chart.md
+++ b/skills/composites/goose-graphics/formats/chart.md
@@ -1,0 +1,1283 @@
+# Format: Chart
+
+Create data visualization graphics at 1080x1080px (1:1 square, optimized for social posts). The entire composition is one HTML file with a styled card containing a pure CSS/HTML chart. Think metric dashboards, growth bar charts, before/after comparisons, progress trackers, and timeline visualizations.
+
+---
+
+## 1. Format Specifications
+
+| Property | Value |
+|----------|-------|
+| Dimensions | 1080 x 1080px (1:1 square) |
+| File structure | Single HTML file (`index.html`) |
+| Aspect ratio | 1:1 (universal social media format) |
+| Output format | Single PNG |
+| Sizing approach | Fixed pixel sizes (NOT responsive) |
+| Design approach | Polished data visualization on a styled card -- designed, not raw |
+
+### Content Density Limits
+
+A chart graphic is focused on one key insight. The visualization is the hero -- everything else supports it.
+
+| Element | Max Content |
+|---------|-------------|
+| Title | 1 line, 6 words max |
+| Context label | 1 line (e.g., "Q1 2026 Results", "Monthly Growth") |
+| Data points | 4-8 bars, 3-5 metrics, or 4-6 timeline entries |
+| Value labels | Short numeric labels on each data point |
+| Footnote/source | 1 line attribution or date range |
+| Branding | Logo mark or handle, positioned in bottom zone |
+
+**If content exceeds limits:** Reduce data points. A chart graphic should communicate one insight at a glance, not present a full dataset.
+
+---
+
+## 2. Workflow Overview
+
+```
+Content Discovery --> Style Selection --> HTML Generation --> Screenshot --> Delivery
+```
+
+1. Gather the data, chart type, and context from the user
+2. Present style presets and let the user choose (or guide them)
+3. Read the chosen style preset from `styles/[name].md`
+4. Generate a single HTML file with the full chart composition
+5. Run the screenshot tool to export the PNG
+6. Present the finished file to the user
+
+---
+
+## 3. Content Discovery Phase
+
+Ask the user these questions before generating anything.
+
+**Question 1: Data / Topic**
+- "What data or metric do you want to visualize?"
+- Free text input -- numbers, percentages, growth figures, comparisons
+
+**Question 2: Chart Type**
+- "What kind of chart works best?"
+- Options:
+  - **Bar Chart** -- Vertical bars showing growth or comparison over time
+  - **Metric Card** -- Big hero number with trend indicator and context
+  - **Before/After Comparison** -- Two-column stats showing improvement
+  - **Progress/Goal Tracker** -- Horizontal progress bars toward targets
+  - **Timeline** -- Vertical timeline showing milestones or growth over time
+
+**Question 3: Content Readiness**
+- "Do you have the exact numbers ready?"
+- Options:
+  - **Yes, I have all data** -- Paste it in
+  - **I have rough numbers** -- Need formatting
+  - **Just the topic** -- Need help creating sample data
+
+If the user has data, ask them to share it before proceeding.
+
+---
+
+## 4. Style Selection Phase
+
+Present the 10 available design presets:
+
+| # | Preset | Description |
+|---|--------|-------------|
+| 1 | **Midnight Editorial** | Dark, elegant, magazine-inspired with copper accents |
+| 2 | **Clean Slate** | Ultra-minimal, precise, modern tech aesthetic |
+| 3 | **Warm Earth** | Organic, artisanal, grounded with natural tones |
+| 4 | **Electric Burst** | Bold, energetic, attention-grabbing with vivid color |
+| 5 | **Soft Cloud** | Airy, modern, approachable with gentle pastels |
+| 6 | **Terminal** | Dev/hacker aesthetic, focused and technical |
+| 7 | **Paper & Ink** | Classic editorial, literary, print-inspired |
+| 8 | **Brutalist** | Raw, structural, anti-design with strong geometry |
+| 9 | **Golden Dusk** | Warm, luxurious, premium with rich gold tones |
+| 10 | **Deep Ocean** | Calm, professional, immersive blue-dark palette |
+
+**Additional options:**
+
+- **"I have a reference image"** -- Use the `extract-style` skill at `styles/extract-style.md` to derive a custom palette from the user's image.
+- **Guided discovery** -- If the user is unsure, ask about their audience and tone, then recommend 2-3 presets:
+  - Professional / Corporate --> Clean Slate, Deep Ocean, Midnight Editorial
+  - Creative / Playful --> Electric Burst, Soft Cloud, Warm Earth
+  - Technical / Dev-focused --> Terminal, Brutalist, Clean Slate
+  - Elegant / Premium --> Midnight Editorial, Golden Dusk, Paper & Ink
+
+**After selection:** Read the chosen style preset file from `styles/[name].md` to load all colors, typography, and component patterns. For example, if the user picks "Electric Burst", read `styles/electric-burst.md`.
+
+---
+
+## 5. HTML Generation Phase
+
+### Base CSS (Mandatory)
+
+Charts are fixed-size square compositions. No scrolling, no overflow. Everything fits within 1080x1080px.
+
+```css
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+html, body {
+    width: 1080px;
+    height: 1080px;
+    overflow: hidden;
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+    padding: 48px;
+}
+```
+
+### Injecting the Style Preset
+
+After reading the style preset file, find its **Section 9 (Agent Prompt Guide)** which contains the CSS `:root` variables. Paste those variables into the `<style>` block:
+
+```css
+:root {
+    /* -- Paste all CSS variables from the preset's Section 9 here -- */
+
+    /* Chart-specific overrides */
+    --chart-width: 1080px;
+    --chart-height: 1080px;
+    --chart-padding: 48px;
+    --card-radius: 16px;
+    --bar-radius: 6px;
+    --content-max-width: 984px;
+}
+```
+
+Also add the Google Fonts `<link>` from the preset's Section 9 into the `<head>`.
+
+### Using Component Patterns
+
+The preset's **Section 4 (Component Patterns)** contains ready-to-use HTML snippets. Adapt these for the chart's 1080x1080 square format.
+
+The preset's **Section 8 (Format Adaptation Notes)** contains format-specific guidance. For charts, key rules:
+- Display Hero (big number) at 72px
+- Title at 36px
+- Value labels at 18-24px
+- Body/context at 16px
+- The chart visualization is the dominant element -- it occupies the center of the composition
+- The card container should have rounded corners and a subtle border or shadow
+
+### Chart Composition Zones
+
+A chart graphic is divided into three vertical zones within the overall canvas:
+
+```
++---------------------------+
+|       TOP ZONE            |  ~200px
+|  Title + Context label    |
++---------------------------+
+|       CHART ZONE          |  ~680px
+|  The visualization        |
+|  (bars, numbers, etc.)    |
++---------------------------+
+|       BOTTOM ZONE         |  ~200px
+|  Source/footnote + Brand  |
++---------------------------+
+```
+
+The entire composition sits on a styled background. The chart itself is contained inside a card element with rounded corners, padding, and a distinct surface color.
+
+### Chart-Specific CSS Patterns
+
+These utility classes support the chart templates below. Include them in every chart HTML file.
+
+```css
+/* =============================================
+   CHART CARD
+   ============================================= */
+
+.chart-card {
+    background: var(--color-surface, var(--color-charcoal, #1a1a1a));
+    border: 1px solid var(--color-border, rgba(245,240,232,0.08));
+    border-radius: var(--card-radius);
+    padding: 40px;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}
+
+/* =============================================
+   BAR CHART COMPONENTS
+   ============================================= */
+
+.bar-chart-container {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-around;
+    gap: 16px;
+    flex: 1;
+    padding-top: 24px;
+}
+
+.bar-column {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    flex: 1;
+}
+
+.bar-value {
+    font-family: var(--font-display);
+    font-size: 18px;
+    font-weight: 700;
+    color: var(--text-primary, var(--color-cream, #f5f0e8));
+}
+
+.bar {
+    width: 100%;
+    max-width: 80px;
+    border-radius: var(--bar-radius) var(--bar-radius) 0 0;
+    background: var(--color-accent, var(--color-copper, #c17f59));
+    transition: height 0.3s ease;
+}
+
+.bar.muted {
+    background: var(--color-border, rgba(245,240,232,0.15));
+}
+
+.bar.highlight {
+    background: var(--color-accent, var(--color-copper, #c17f59));
+    box-shadow: 0 0 20px rgba(193, 127, 89, 0.3);
+}
+
+.bar-label {
+    font-family: var(--font-body);
+    font-size: 14px;
+    font-weight: 500;
+    opacity: 0.6;
+    text-align: center;
+}
+
+/* =============================================
+   GRID LINES (decorative)
+   ============================================= */
+
+.chart-grid {
+    position: relative;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+}
+
+.grid-line {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 1px;
+    background: var(--color-border, rgba(245,240,232,0.06));
+}
+
+/* =============================================
+   PROGRESS BAR COMPONENTS
+   ============================================= */
+
+.progress-row {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.progress-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+}
+
+.progress-track {
+    width: 100%;
+    height: 12px;
+    background: var(--color-border, rgba(245,240,232,0.08));
+    border-radius: 6px;
+    overflow: hidden;
+}
+
+.progress-fill {
+    height: 100%;
+    border-radius: 6px;
+    background: var(--color-accent, var(--color-copper, #c17f59));
+}
+
+/* =============================================
+   METRIC / BIG NUMBER
+   ============================================= */
+
+.metric-hero {
+    font-family: var(--font-display);
+    font-size: 96px;
+    font-weight: 900;
+    line-height: 1.00;
+    letter-spacing: -2px;
+    color: var(--color-accent, var(--color-copper, #c17f59));
+}
+
+.trend-arrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-family: var(--font-body);
+    font-size: 18px;
+    font-weight: 600;
+    color: #34d399;
+}
+
+.trend-arrow.down {
+    color: #f87171;
+}
+```
+
+### Complete HTML Template
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=1080, initial-scale=1.0">
+    <title>Chart Title</title>
+
+    <!-- Google Fonts: paste the link from your chosen preset's Section 9 -->
+    <link href="https://fonts.googleapis.com/css2?family=PRESET_FONTS_HERE&display=swap" rel="stylesheet">
+
+    <style>
+        /* =============================================
+           CHART: 1080x1080px FIXED (1:1 Square)
+           ============================================= */
+
+        :root {
+            /* -- Paste CSS variables from preset Section 9 -- */
+
+            /* Chart-specific layout */
+            --chart-width: 1080px;
+            --chart-height: 1080px;
+            --chart-padding: 48px;
+            --card-radius: 16px;
+            --bar-radius: 6px;
+            --content-max-width: 984px;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        html, body {
+            width: var(--chart-width);
+            height: var(--chart-height);
+            overflow: hidden;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+        }
+
+        body {
+            background-color: var(--bg-primary, var(--color-midnight, #0d0d0d));
+            color: var(--text-primary, var(--color-cream, #f5f0e8));
+            font-family: var(--font-body);
+            display: flex;
+            flex-direction: column;
+            padding: var(--chart-padding);
+        }
+
+        /* =============================================
+           CHART ZONES
+           ============================================= */
+
+        .chart-top {
+            flex: 0 0 auto;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            padding-bottom: 24px;
+        }
+
+        .chart-middle {
+            flex: 1 1 auto;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .chart-bottom {
+            flex: 0 0 auto;
+            display: flex;
+            flex-direction: column;
+            justify-content: flex-end;
+            padding-top: 24px;
+        }
+
+        /* =============================================
+           CHART CARD
+           ============================================= */
+
+        .chart-card {
+            background: var(--color-surface, var(--color-charcoal, #1a1a1a));
+            border: 1px solid var(--color-border, rgba(245,240,232,0.08));
+            border-radius: var(--card-radius);
+            padding: 40px;
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+        }
+
+        /* =============================================
+           ZONE DIVIDER
+           ============================================= */
+
+        .zone-divider {
+            width: 60px;
+            height: 2px;
+            background: var(--color-accent, var(--color-copper, #c17f59));
+        }
+
+        .zone-divider-centered {
+            width: 60px;
+            height: 2px;
+            background: var(--color-accent, var(--color-copper, #c17f59));
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        /* =============================================
+           TYPOGRAPHY HIERARCHY
+           ============================================= */
+
+        .display-title {
+            font-family: var(--font-display);
+            font-size: 36px;
+            font-weight: 700;
+            line-height: 1.10;
+            letter-spacing: -1px;
+        }
+
+        .section-heading {
+            font-family: var(--font-display);
+            font-size: 28px;
+            font-weight: 700;
+            line-height: 1.15;
+            letter-spacing: -0.5px;
+        }
+
+        .sub-heading {
+            font-family: var(--font-display);
+            font-size: 22px;
+            font-weight: 700;
+            line-height: 1.20;
+            letter-spacing: -0.3px;
+        }
+
+        .body-large {
+            font-family: var(--font-body);
+            font-size: 20px;
+            font-weight: 300;
+            line-height: 1.60;
+        }
+
+        .body-text {
+            font-family: var(--font-body);
+            font-size: 16px;
+            font-weight: 400;
+            line-height: 1.65;
+        }
+
+        .small-text {
+            font-family: var(--font-body);
+            font-size: 13px;
+            font-weight: 400;
+            line-height: 1.50;
+            letter-spacing: 0.3px;
+        }
+
+        .label {
+            font-family: var(--font-body);
+            font-size: 14px;
+            font-weight: 600;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+        }
+
+        .big-number {
+            font-family: var(--font-display);
+            font-size: 72px;
+            font-weight: 900;
+            line-height: 1.00;
+            letter-spacing: -1px;
+        }
+
+        /* =============================================
+           BAR CHART COMPONENTS
+           ============================================= */
+
+        .bar-chart-container {
+            display: flex;
+            align-items: flex-end;
+            justify-content: space-around;
+            gap: 16px;
+            flex: 1;
+            padding-top: 24px;
+        }
+
+        .bar-column {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 10px;
+            flex: 1;
+        }
+
+        .bar-value {
+            font-family: var(--font-display);
+            font-size: 18px;
+            font-weight: 700;
+            color: var(--text-primary, var(--color-cream, #f5f0e8));
+        }
+
+        .bar {
+            width: 100%;
+            max-width: 80px;
+            border-radius: var(--bar-radius) var(--bar-radius) 0 0;
+            background: var(--color-accent, var(--color-copper, #c17f59));
+        }
+
+        .bar.muted {
+            background: var(--color-border, rgba(245,240,232,0.15));
+        }
+
+        .bar.highlight {
+            background: var(--color-accent, var(--color-copper, #c17f59));
+            box-shadow: 0 0 20px rgba(193, 127, 89, 0.3);
+        }
+
+        .bar-label {
+            font-family: var(--font-body);
+            font-size: 14px;
+            font-weight: 500;
+            opacity: 0.6;
+            text-align: center;
+        }
+
+        /* =============================================
+           GRID LINES (decorative)
+           ============================================= */
+
+        .chart-grid {
+            position: relative;
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            justify-content: flex-end;
+        }
+
+        .grid-line {
+            position: absolute;
+            left: 0;
+            right: 0;
+            height: 1px;
+            background: var(--color-border, rgba(245,240,232,0.06));
+        }
+
+        /* =============================================
+           PROGRESS BAR COMPONENTS
+           ============================================= */
+
+        .progress-row {
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .progress-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+        }
+
+        .progress-track {
+            width: 100%;
+            height: 12px;
+            background: var(--color-border, rgba(245,240,232,0.08));
+            border-radius: 6px;
+            overflow: hidden;
+        }
+
+        .progress-fill {
+            height: 100%;
+            border-radius: 6px;
+            background: var(--color-accent, var(--color-copper, #c17f59));
+        }
+
+        /* =============================================
+           METRIC / BIG NUMBER
+           ============================================= */
+
+        .metric-hero {
+            font-family: var(--font-display);
+            font-size: 96px;
+            font-weight: 900;
+            line-height: 1.00;
+            letter-spacing: -2px;
+            color: var(--color-accent, var(--color-copper, #c17f59));
+        }
+
+        .trend-arrow {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            font-family: var(--font-body);
+            font-size: 18px;
+            font-weight: 600;
+            color: #34d399;
+        }
+
+        .trend-arrow.down {
+            color: #f87171;
+        }
+
+        /* =============================================
+           COMPARISON COLUMNS
+           ============================================= */
+
+        .comparison-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 24px;
+        }
+
+        .comparison-column {
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+        }
+
+        .comparison-stat {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+
+        .comparison-value {
+            font-family: var(--font-display);
+            font-size: 40px;
+            font-weight: 800;
+            line-height: 1.05;
+            letter-spacing: -0.5px;
+        }
+
+        /* =============================================
+           TIMELINE COMPONENTS
+           ============================================= */
+
+        .timeline {
+            display: flex;
+            flex-direction: column;
+            gap: 0;
+            position: relative;
+            padding-left: 32px;
+        }
+
+        .timeline::before {
+            content: '';
+            position: absolute;
+            left: 7px;
+            top: 8px;
+            bottom: 8px;
+            width: 2px;
+            background: var(--color-border, rgba(245,240,232,0.12));
+        }
+
+        .timeline-item {
+            display: flex;
+            align-items: flex-start;
+            gap: 20px;
+            padding: 16px 0;
+            position: relative;
+        }
+
+        .timeline-dot {
+            position: absolute;
+            left: -32px;
+            top: 22px;
+            width: 16px;
+            height: 16px;
+            border-radius: 50%;
+            background: var(--color-surface, var(--color-charcoal, #1a1a1a));
+            border: 2px solid var(--color-border, rgba(245,240,232,0.2));
+        }
+
+        .timeline-dot.active {
+            background: var(--color-accent, var(--color-copper, #c17f59));
+            border-color: var(--color-accent, var(--color-copper, #c17f59));
+            box-shadow: 0 0 12px rgba(193, 127, 89, 0.4);
+        }
+
+        /* =============================================
+           LAYOUT HELPERS
+           ============================================= */
+
+        .two-column {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 24px;
+        }
+
+        .three-column {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr;
+            gap: 20px;
+        }
+
+        .card {
+            background: var(--color-surface, var(--color-charcoal, #1a1a1a));
+            border: 1px solid var(--color-border, rgba(245,240,232,0.1));
+            border-radius: 4px;
+            padding: 32px 24px;
+        }
+
+        .brand {
+            font-family: var(--font-body);
+            font-size: 14px;
+            font-weight: 400;
+            opacity: 0.5;
+        }
+    </style>
+</head>
+<body>
+
+    <!-- TOP ZONE: Title + Context -->
+    <div class="chart-top">
+        <!-- Content here -->
+    </div>
+
+    <!-- CHART ZONE: Visualization -->
+    <div class="chart-middle">
+        <div class="chart-card">
+            <!-- Chart content here -->
+        </div>
+    </div>
+
+    <!-- BOTTOM ZONE: Source + Brand -->
+    <div class="chart-bottom">
+        <!-- Content here -->
+    </div>
+
+</body>
+</html>
+```
+
+---
+
+## 6. Content Templates
+
+All templates use CSS custom properties so they work with any style preset. Each template shows a complete chart graphic with all three zones filled.
+
+### Bar Chart (Growth / Comparison)
+
+Vertical bars showing monthly or categorical data. Inspired by the InferenceCore growth chart reference -- a clean card with bars rising from a baseline, value labels above each bar, and subtle grid lines for context.
+
+```html
+<body>
+
+    <!-- TOP ZONE -->
+    <div class="chart-top">
+        <p class="label" style="color: var(--color-secondary-accent, var(--color-muted-gold, #a89067)); margin-bottom: 12px;">
+            MONTHLY INFERENCE VOLUME
+        </p>
+        <h1 class="display-title">
+            Platform Growth
+        </h1>
+    </div>
+
+    <!-- CHART ZONE -->
+    <div class="chart-middle">
+        <div class="chart-card">
+            <!-- Subtle grid lines -->
+            <div class="chart-grid">
+                <div class="grid-line" style="bottom: 100%;"></div>
+                <div class="grid-line" style="bottom: 75%;"></div>
+                <div class="grid-line" style="bottom: 50%;"></div>
+                <div class="grid-line" style="bottom: 25%;"></div>
+                <div class="grid-line" style="bottom: 0%;"></div>
+
+                <!-- Bars -->
+                <div class="bar-chart-container">
+                    <div class="bar-column">
+                        <span class="bar-value">1.2M</span>
+                        <div class="bar muted" style="height: 120px;"></div>
+                        <span class="bar-label">Jan</span>
+                    </div>
+                    <div class="bar-column">
+                        <span class="bar-value">1.8M</span>
+                        <div class="bar muted" style="height: 180px;"></div>
+                        <span class="bar-label">Feb</span>
+                    </div>
+                    <div class="bar-column">
+                        <span class="bar-value">2.4M</span>
+                        <div class="bar muted" style="height: 240px;"></div>
+                        <span class="bar-label">Mar</span>
+                    </div>
+                    <div class="bar-column">
+                        <span class="bar-value">3.1M</span>
+                        <div class="bar" style="height: 310px;"></div>
+                        <span class="bar-label">Apr</span>
+                    </div>
+                    <div class="bar-column">
+                        <span class="bar-value">4.2M</span>
+                        <div class="bar" style="height: 380px;"></div>
+                        <span class="bar-label">May</span>
+                    </div>
+                    <div class="bar-column">
+                        <span class="bar-value">5.8M</span>
+                        <div class="bar highlight" style="height: 460px;"></div>
+                        <span class="bar-label">Jun</span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Summary stat inline -->
+            <div style="display: flex; align-items: center; gap: 12px; margin-top: 20px; padding-top: 16px; border-top: 1px solid var(--color-border, rgba(245,240,232,0.08));">
+                <span class="trend-arrow">&#9650; 383%</span>
+                <span class="body-text" style="opacity: 0.5;">growth since January</span>
+            </div>
+        </div>
+    </div>
+
+    <!-- BOTTOM ZONE -->
+    <div class="chart-bottom" style="display: flex; flex-direction: row; justify-content: space-between; align-items: flex-end;">
+        <p class="small-text" style="opacity: 0.4;">Source: Internal analytics &middot; Jan-Jun 2026</p>
+        <p class="brand">@yourbrand</p>
+    </div>
+
+</body>
+```
+
+### Metric Card (Hero Number + Trend)
+
+A single dominant metric with trend indicator and supporting context. Great for revenue milestones, user counts, conversion rates -- any moment where one number tells the story.
+
+```html
+<body>
+
+    <!-- TOP ZONE -->
+    <div class="chart-top">
+        <p class="label" style="color: var(--color-secondary-accent, var(--color-muted-gold, #a89067)); margin-bottom: 12px;">
+            REVENUE &middot; Q1 2026
+        </p>
+        <h1 class="display-title">
+            Quarterly Results
+        </h1>
+    </div>
+
+    <!-- CHART ZONE -->
+    <div class="chart-middle">
+        <div class="chart-card" style="justify-content: center; align-items: center; text-align: center;">
+            <!-- Hero metric -->
+            <p class="metric-hero">$2.4M</p>
+            <div style="display: flex; align-items: center; gap: 8px; margin-top: 16px;">
+                <span class="trend-arrow">&#9650; 47%</span>
+                <span class="body-text" style="opacity: 0.5;">vs last quarter</span>
+            </div>
+
+            <!-- Divider -->
+            <div class="zone-divider-centered" style="margin: 32px auto;"></div>
+
+            <!-- Supporting metrics row -->
+            <div class="three-column" style="width: 100%; max-width: 720px;">
+                <div style="text-align: center;">
+                    <p style="font-family: var(--font-display); font-size: 32px; font-weight: 800; color: var(--text-primary, var(--color-cream, #f5f0e8));">1,247</p>
+                    <p class="label" style="margin-top: 6px; font-size: 11px; opacity: 0.5;">NEW CUSTOMERS</p>
+                </div>
+                <div style="text-align: center;">
+                    <p style="font-family: var(--font-display); font-size: 32px; font-weight: 800; color: var(--text-primary, var(--color-cream, #f5f0e8));">94%</p>
+                    <p class="label" style="margin-top: 6px; font-size: 11px; opacity: 0.5;">RETENTION RATE</p>
+                </div>
+                <div style="text-align: center;">
+                    <p style="font-family: var(--font-display); font-size: 32px; font-weight: 800; color: var(--text-primary, var(--color-cream, #f5f0e8));">$1.9K</p>
+                    <p class="label" style="margin-top: 6px; font-size: 11px; opacity: 0.5;">AVG DEAL SIZE</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- BOTTOM ZONE -->
+    <div class="chart-bottom" style="display: flex; flex-direction: row; justify-content: space-between; align-items: flex-end;">
+        <p class="small-text" style="opacity: 0.4;">Fiscal Q1 &middot; Jan 1 - Mar 31, 2026</p>
+        <p class="brand">@yourbrand</p>
+    </div>
+
+</body>
+```
+
+### Before/After Comparison
+
+Two-column layout showing improvement across multiple metrics. A clear visual story: the left column shows the "before" state, the right column shows the "after" with accent color highlighting the wins. A percentage change badge reinforces the improvement.
+
+```html
+<body>
+
+    <!-- TOP ZONE -->
+    <div class="chart-top" style="text-align: center; align-items: center;">
+        <p class="label" style="color: var(--color-secondary-accent, var(--color-muted-gold, #a89067)); margin-bottom: 12px;">
+            CASE STUDY &middot; 90-DAY RESULTS
+        </p>
+        <h1 class="display-title">
+            Before &amp; After AI Agents
+        </h1>
+    </div>
+
+    <!-- CHART ZONE -->
+    <div class="chart-middle">
+        <div class="chart-card">
+            <!-- Column headers -->
+            <div class="comparison-grid" style="margin-bottom: 24px;">
+                <div>
+                    <p class="label" style="font-size: 12px; opacity: 0.4;">BEFORE</p>
+                </div>
+                <div style="text-align: right;">
+                    <p class="label" style="font-size: 12px; color: var(--color-accent, var(--color-copper, #c17f59));">AFTER</p>
+                </div>
+            </div>
+
+            <!-- Metric rows -->
+            <div style="display: flex; flex-direction: column; gap: 0;">
+                <!-- Row 1: Response Time -->
+                <div style="display: grid; grid-template-columns: 1fr auto 1fr; gap: 16px; align-items: center; padding: 20px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.08));">
+                    <div class="comparison-stat">
+                        <p class="comparison-value" style="opacity: 0.4;">4.2h</p>
+                        <p class="body-text" style="opacity: 0.5;">Response Time</p>
+                    </div>
+                    <div style="background: var(--color-accent, var(--color-copper, #c17f59)); color: var(--bg-primary, #0d0d0d); font-family: var(--font-body); font-size: 13px; font-weight: 700; padding: 4px 12px; border-radius: 20px;">
+                        -86%
+                    </div>
+                    <div class="comparison-stat" style="text-align: right;">
+                        <p class="comparison-value" style="color: var(--color-accent, var(--color-copper, #c17f59));">35m</p>
+                        <p class="body-text" style="opacity: 0.5;">Response Time</p>
+                    </div>
+                </div>
+
+                <!-- Row 2: Tasks per Day -->
+                <div style="display: grid; grid-template-columns: 1fr auto 1fr; gap: 16px; align-items: center; padding: 20px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.08));">
+                    <div class="comparison-stat">
+                        <p class="comparison-value" style="opacity: 0.4;">23</p>
+                        <p class="body-text" style="opacity: 0.5;">Tasks / Day</p>
+                    </div>
+                    <div style="background: var(--color-accent, var(--color-copper, #c17f59)); color: var(--bg-primary, #0d0d0d); font-family: var(--font-body); font-size: 13px; font-weight: 700; padding: 4px 12px; border-radius: 20px;">
+                        +287%
+                    </div>
+                    <div class="comparison-stat" style="text-align: right;">
+                        <p class="comparison-value" style="color: var(--color-accent, var(--color-copper, #c17f59));">89</p>
+                        <p class="body-text" style="opacity: 0.5;">Tasks / Day</p>
+                    </div>
+                </div>
+
+                <!-- Row 3: Cost per Lead -->
+                <div style="display: grid; grid-template-columns: 1fr auto 1fr; gap: 16px; align-items: center; padding: 20px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.08));">
+                    <div class="comparison-stat">
+                        <p class="comparison-value" style="opacity: 0.4;">$142</p>
+                        <p class="body-text" style="opacity: 0.5;">Cost per Lead</p>
+                    </div>
+                    <div style="background: var(--color-accent, var(--color-copper, #c17f59)); color: var(--bg-primary, #0d0d0d); font-family: var(--font-body); font-size: 13px; font-weight: 700; padding: 4px 12px; border-radius: 20px;">
+                        -63%
+                    </div>
+                    <div class="comparison-stat" style="text-align: right;">
+                        <p class="comparison-value" style="color: var(--color-accent, var(--color-copper, #c17f59));">$52</p>
+                        <p class="body-text" style="opacity: 0.5;">Cost per Lead</p>
+                    </div>
+                </div>
+
+                <!-- Row 4: Customer Satisfaction -->
+                <div style="display: grid; grid-template-columns: 1fr auto 1fr; gap: 16px; align-items: center; padding: 20px 0;">
+                    <div class="comparison-stat">
+                        <p class="comparison-value" style="opacity: 0.4;">72%</p>
+                        <p class="body-text" style="opacity: 0.5;">CSAT Score</p>
+                    </div>
+                    <div style="background: var(--color-accent, var(--color-copper, #c17f59)); color: var(--bg-primary, #0d0d0d); font-family: var(--font-body); font-size: 13px; font-weight: 700; padding: 4px 12px; border-radius: 20px;">
+                        +24%
+                    </div>
+                    <div class="comparison-stat" style="text-align: right;">
+                        <p class="comparison-value" style="color: var(--color-accent, var(--color-copper, #c17f59));">89%</p>
+                        <p class="body-text" style="opacity: 0.5;">CSAT Score</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- BOTTOM ZONE -->
+    <div class="chart-bottom" style="display: flex; flex-direction: row; justify-content: space-between; align-items: flex-end;">
+        <p class="small-text" style="opacity: 0.4;">Based on 90-day pilot &middot; 12 team members</p>
+        <p class="brand">@yourbrand</p>
+    </div>
+
+</body>
+```
+
+### Progress / Goal Tracker
+
+Horizontal progress bars showing advancement toward targets. Each row is a named goal with a filled track indicating current progress. Perfect for quarterly OKRs, fundraising rounds, product milestones, or any multi-goal status update.
+
+```html
+<body>
+
+    <!-- TOP ZONE -->
+    <div class="chart-top">
+        <p class="label" style="color: var(--color-secondary-accent, var(--color-muted-gold, #a89067)); margin-bottom: 12px;">
+            Q2 2026 OBJECTIVES
+        </p>
+        <h1 class="display-title">
+            Goals &amp; Progress
+        </h1>
+    </div>
+
+    <!-- CHART ZONE -->
+    <div class="chart-middle">
+        <div class="chart-card" style="gap: 32px; justify-content: center;">
+            <!-- Goal 1 -->
+            <div class="progress-row">
+                <div class="progress-header">
+                    <span class="sub-heading" style="font-size: 18px;">Annual Recurring Revenue</span>
+                    <span style="font-family: var(--font-display); font-size: 18px; font-weight: 700; color: var(--color-accent, var(--color-copper, #c17f59));">$3.2M / $5M</span>
+                </div>
+                <div class="progress-track">
+                    <div class="progress-fill" style="width: 64%;"></div>
+                </div>
+                <div style="display: flex; justify-content: space-between;">
+                    <span class="small-text" style="opacity: 0.4;">64% complete</span>
+                    <span class="small-text" style="opacity: 0.4;">Target: Dec 2026</span>
+                </div>
+            </div>
+
+            <!-- Goal 2 -->
+            <div class="progress-row">
+                <div class="progress-header">
+                    <span class="sub-heading" style="font-size: 18px;">Active Workspaces</span>
+                    <span style="font-family: var(--font-display); font-size: 18px; font-weight: 700; color: var(--color-accent, var(--color-copper, #c17f59));">847 / 1,000</span>
+                </div>
+                <div class="progress-track">
+                    <div class="progress-fill" style="width: 85%;"></div>
+                </div>
+                <div style="display: flex; justify-content: space-between;">
+                    <span class="small-text" style="opacity: 0.4;">85% complete</span>
+                    <span class="small-text" style="opacity: 0.4;">Target: Jun 2026</span>
+                </div>
+            </div>
+
+            <!-- Goal 3 -->
+            <div class="progress-row">
+                <div class="progress-header">
+                    <span class="sub-heading" style="font-size: 18px;">Enterprise Clients</span>
+                    <span style="font-family: var(--font-display); font-size: 18px; font-weight: 700; color: var(--color-accent, var(--color-copper, #c17f59));">18 / 50</span>
+                </div>
+                <div class="progress-track">
+                    <div class="progress-fill" style="width: 36%;"></div>
+                </div>
+                <div style="display: flex; justify-content: space-between;">
+                    <span class="small-text" style="opacity: 0.4;">36% complete</span>
+                    <span class="small-text" style="opacity: 0.4;">Target: Dec 2026</span>
+                </div>
+            </div>
+
+            <!-- Goal 4 -->
+            <div class="progress-row">
+                <div class="progress-header">
+                    <span class="sub-heading" style="font-size: 18px;">NPS Score</span>
+                    <span style="font-family: var(--font-display); font-size: 18px; font-weight: 700; color: var(--color-accent, var(--color-copper, #c17f59));">71 / 80</span>
+                </div>
+                <div class="progress-track">
+                    <div class="progress-fill" style="width: 89%;"></div>
+                </div>
+                <div style="display: flex; justify-content: space-between;">
+                    <span class="small-text" style="opacity: 0.4;">89% complete</span>
+                    <span class="small-text" style="opacity: 0.4;">Target: Jun 2026</span>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- BOTTOM ZONE -->
+    <div class="chart-bottom" style="display: flex; flex-direction: row; justify-content: space-between; align-items: flex-end;">
+        <p class="small-text" style="opacity: 0.4;">Updated April 5, 2026 &middot; Board snapshot</p>
+        <p class="brand">@yourbrand</p>
+    </div>
+
+</body>
+```
+
+### Timeline Chart (Milestones / Growth)
+
+A vertical timeline showing key events or growth milestones in chronological order. Each entry has a date, a headline, and a supporting detail. Active dots highlight the most recent or most significant milestone. Great for company timelines, product roadmaps, and growth narratives.
+
+```html
+<body>
+
+    <!-- TOP ZONE -->
+    <div class="chart-top" style="text-align: center; align-items: center;">
+        <p class="label" style="color: var(--color-secondary-accent, var(--color-muted-gold, #a89067)); margin-bottom: 12px;">
+            OUR JOURNEY
+        </p>
+        <h1 class="display-title">
+            Key Milestones
+        </h1>
+    </div>
+
+    <!-- CHART ZONE -->
+    <div class="chart-middle">
+        <div class="chart-card" style="justify-content: center;">
+            <div class="timeline">
+                <!-- Milestone 1 -->
+                <div class="timeline-item">
+                    <div class="timeline-dot"></div>
+                    <div style="display: flex; gap: 20px; align-items: baseline; flex: 1;">
+                        <span class="label" style="font-size: 12px; min-width: 80px; opacity: 0.5;">JAN 2025</span>
+                        <div>
+                            <h3 class="sub-heading" style="font-size: 20px;">Company Founded</h3>
+                            <p class="body-text" style="opacity: 0.5; margin-top: 4px;">Started with 3 founders and a vision for AI coworkers.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Milestone 2 -->
+                <div class="timeline-item">
+                    <div class="timeline-dot"></div>
+                    <div style="display: flex; gap: 20px; align-items: baseline; flex: 1;">
+                        <span class="label" style="font-size: 12px; min-width: 80px; opacity: 0.5;">JUN 2025</span>
+                        <div>
+                            <h3 class="sub-heading" style="font-size: 20px;">First 100 Users</h3>
+                            <p class="body-text" style="opacity: 0.5; margin-top: 4px;">Reached product-market fit with early adopters.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Milestone 3 -->
+                <div class="timeline-item">
+                    <div class="timeline-dot active"></div>
+                    <div style="display: flex; gap: 20px; align-items: baseline; flex: 1;">
+                        <span class="label" style="font-size: 12px; min-width: 80px; color: var(--color-accent, var(--color-copper, #c17f59));">OCT 2025</span>
+                        <div>
+                            <h3 class="sub-heading" style="font-size: 20px; color: var(--color-accent, var(--color-copper, #c17f59));">$2M Seed Round</h3>
+                            <p class="body-text" style="opacity: 0.5; margin-top: 4px;">Raised from top-tier investors to scale the platform.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Milestone 4 -->
+                <div class="timeline-item">
+                    <div class="timeline-dot"></div>
+                    <div style="display: flex; gap: 20px; align-items: baseline; flex: 1;">
+                        <span class="label" style="font-size: 12px; min-width: 80px; opacity: 0.5;">FEB 2026</span>
+                        <div>
+                            <h3 class="sub-heading" style="font-size: 20px;">1,000 Workspaces</h3>
+                            <p class="body-text" style="opacity: 0.5; margin-top: 4px;">Teams across 14 countries deploying AI agents daily.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Milestone 5 -->
+                <div class="timeline-item">
+                    <div class="timeline-dot active"></div>
+                    <div style="display: flex; gap: 20px; align-items: baseline; flex: 1;">
+                        <span class="label" style="font-size: 12px; min-width: 80px; color: var(--color-accent, var(--color-copper, #c17f59));">APR 2026</span>
+                        <div>
+                            <h3 class="sub-heading" style="font-size: 20px; color: var(--color-accent, var(--color-copper, #c17f59));">Series A</h3>
+                            <p class="body-text" style="opacity: 0.5; margin-top: 4px;">Closing our next round to expand into enterprise.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- BOTTOM ZONE -->
+    <div class="chart-bottom" style="display: flex; flex-direction: row; justify-content: space-between; align-items: flex-end;">
+        <p class="small-text" style="opacity: 0.4;">Company timeline &middot; 2025-2026</p>
+        <p class="brand">@yourbrand</p>
+    </div>
+
+</body>
+```
+
+---
+
+## 7. Screenshot Phase
+
+After generating the HTML file, run the screenshot tool:
+
+```bash
+node screenshot/screenshot.js \
+  --format chart \
+  --input ./EXPORT_DIR/index.html \
+  --output ./EXPORT_DIR/export.png
+```
+
+Where `EXPORT_DIR` is the export directory (see Section 9).
+
+This will:
+1. Open the HTML file in a headless Chromium browser
+2. Set the viewport to 1080x1080px with 2x device scale factor
+3. Wait for fonts to load (500ms default; use `--font-delay 1000` for custom fonts)
+4. Capture a PNG screenshot (fixed size, no full-page needed)
+5. Save to the specified output path
+
+---
+
+## 8. Delivery Phase
+
+After the screenshot is generated, present results to the user:
+
+```
+Your chart is ready!
+
+Location: [EXPORT_DIR]/
+
+Files:
+  index.html     -- Chart source (editable)
+  export.png     -- Final chart image
+
+Export details:
+  Dimensions: 1080 x 1080px (1:1 square)
+  File size:  [SIZE] KB
+
+Share on:
+  Instagram, LinkedIn, Twitter/X (1:1 works everywhere)
+  Newsletters, pitch decks, dashboards, reports
+
+Want to make any changes?
+```
+
+---
+
+## 9. Export Directory Convention
+
+Ask the user: **"Where should I save the exports? (default: ./goose-graphics-exports/)"**
+
+### Directory naming
+- Primary: `[YYYY-MM-DD]-[slugified-name]/` (e.g., `2026-04-05-q1-revenue-chart/`)
+- Fallback (no name given): `[YYYY-MM-DD]-chart-[HHMMSS]/`
+
+### Directory structure (chart = single-file)
+```
+goose-graphics-exports/
+  2026-04-05-q1-revenue-chart/
+    index.html          # Chart source
+    export.png          # Final PNG
+```
+
+---
+
+## Design Reminders
+
+- **One insight per graphic.** A chart graphic communicates a single data story. Do not overload it with multiple unrelated datasets. If the user has more data, suggest splitting into multiple graphics.
+- **Three-zone composition.** Structure the chart into a top zone (title + context), chart zone (the visualization inside a card), and bottom zone (source + branding).
+- **Pure CSS/HTML only.** No JavaScript, no canvas, no SVG charting libraries. All bars, progress fills, and visual elements are built with CSS width/height, background colors, and border-radius.
+- **Percentage-based bar sizing.** Calculate bar heights or widths as proportions of the largest value. The tallest bar should be near the maximum available height, and all others scale proportionally.
+- **Fixed pixels only.** Like all graphic formats, charts are fixed-size. No `vw`, `vh`, `clamp()`, or responsive units. Everything in `px`.
+- **Cards contain charts.** The visualization always sits inside a `.chart-card` container with rounded corners, padding, and a surface background. This creates the "dashboard card" look.
+- **Decorative grid lines.** Add subtle horizontal grid lines behind bar charts to give the feel of a real data visualization. Keep them very faint (6-8% opacity).
+- **Highlight the key data point.** Use the accent color and `.highlight` class on the most important bar or number. Mute less important data points with `.muted` to create visual hierarchy.
+- **Designed, not raw.** Charts should look like they belong in a polished pitch deck or social post -- rounded corners on bars, generous spacing, accent color highlights, and clean typography. Never like a spreadsheet or raw data dump.
+- **Readable at small sizes.** Social feeds display images small. Use bold numbers, strong color contrast, and clear labels. The key insight should be visible even at thumbnail size.

--- a/skills/composites/goose-graphics/formats/infographic.md
+++ b/skills/composites/goose-graphics/formats/infographic.md
@@ -1,0 +1,713 @@
+# Format: Infographic
+
+Create single-page vertical infographics at 1080px wide with variable height. The entire infographic is one HTML file with stacking sections, screenshotted as a single full-page PNG.
+
+---
+
+## 1. Format Specifications
+
+| Property | Value |
+|----------|-------|
+| Dimensions | 1080px wide, variable height (typically 2000-6000px) |
+| File structure | Single HTML file (`index.html`) |
+| Aspect ratio | Portrait, typically 1:2 to 1:6 |
+| Output format | Single PNG (full-page capture) |
+| Target file size | Under 5MB for easy sharing |
+| Sizing approach | Fixed pixel widths, natural vertical flow |
+
+### Content Density Limits
+
+Each section should be scannable in 3-5 seconds.
+
+| Section Type | Max Content |
+|--------------|-------------|
+| Header | Title (1-2 lines) + subtitle (1 line) + optional decorative element |
+| Stat block | 1 large number + label (5 words) + description (20 words max) |
+| Comparison | 2-3 items side-by-side, 3-4 bullet points each (6 words per point) |
+| Process step | Step number + title (5 words) + description (25 words max) |
+| List item | Icon/number + heading (5 words) + description (20 words max) |
+| Timeline entry | Year/date + title (5 words) + description (25 words max) |
+| Quote | 1 quote (30 words max) + attribution |
+| Footer | Brand name + tagline (10 words max) + optional CTA |
+
+**If content exceeds limits:** Break into smaller subsections or simplify.
+
+---
+
+## 2. Workflow Overview
+
+```
+Content Discovery --> Style Selection --> HTML Generation --> Screenshot --> Delivery
+```
+
+1. Gather topic, infographic type, and content readiness from the user
+2. Present style presets and let the user choose (or guide them)
+3. Read the chosen style preset from `styles/[name].md`
+4. Generate a single HTML file with all sections stacking vertically
+5. Run the screenshot tool with `fullPage: true` to export the full-height PNG
+6. Present the finished file to the user
+
+---
+
+## 3. Content Discovery Phase
+
+Ask the user these questions before generating anything.
+
+**Question 1: Topic**
+- "What is the main topic of this infographic?"
+- Free text input
+
+**Question 2: Content Type**
+- "What type of infographic do you want to create?"
+- Options:
+  - **Numbered list** -- "Top 10 ...", "5 things you need to know about ..."
+  - **How-to / Process** -- Step-by-step guide, how something works, workflow
+  - **Comparison** -- X vs Y, pros/cons, side-by-side analysis
+  - **Statistics** -- Key metrics, data visualization, numbers that tell a story
+  - **Timeline** -- Chronological events, history, growth journey
+  - **Framework** -- Concept explanation, hierarchy, organizational structure
+
+**Question 3: Section Count**
+- "How many sections should this infographic have?"
+- Options:
+  - **Short (3-4 sections)** -- Quick overview, single concept
+  - **Medium (5-6 sections)** -- Standard infographic depth
+  - **Long (7-8 sections)** -- Comprehensive deep-dive
+
+**Question 4: Content Readiness**
+- "Do you have the content ready?"
+- Options:
+  - **Yes, I have all data/content** -- Paste it in
+  - **I have rough notes** -- Need structuring
+  - **Just the topic** -- Need help outlining
+
+If the user has content, ask them to share it before proceeding.
+
+---
+
+## 4. Style Selection Phase
+
+Present the 10 available design presets:
+
+| # | Preset | Description |
+|---|--------|-------------|
+| 1 | **Midnight Editorial** | Dark, elegant, magazine-inspired with copper accents |
+| 2 | **Clean Slate** | Ultra-minimal, precise, modern tech aesthetic |
+| 3 | **Warm Earth** | Organic, artisanal, grounded with natural tones |
+| 4 | **Electric Burst** | Bold, energetic, attention-grabbing with vivid color |
+| 5 | **Soft Cloud** | Airy, modern, approachable with gentle pastels |
+| 6 | **Terminal** | Dev/hacker aesthetic, focused and technical |
+| 7 | **Paper & Ink** | Classic editorial, literary, print-inspired |
+| 8 | **Brutalist** | Raw, structural, anti-design with strong geometry |
+| 9 | **Golden Dusk** | Warm, luxurious, premium with rich gold tones |
+| 10 | **Deep Ocean** | Calm, professional, immersive blue-dark palette |
+
+**Additional options:**
+
+- **"I have a reference image"** -- Use the `extract-style` skill at `styles/extract-style.md` to derive a custom palette from the user's image.
+- **Guided discovery** -- If the user is unsure, ask about their audience and tone, then recommend 2-3 presets:
+  - Professional / Corporate --> Midnight Editorial, Clean Slate, Deep Ocean
+  - Creative / Playful --> Electric Burst, Soft Cloud, Warm Earth
+  - Technical / Dev-focused --> Terminal, Brutalist, Clean Slate
+  - Elegant / Premium --> Midnight Editorial, Golden Dusk, Paper & Ink
+
+**After selection:** Read the chosen style preset file from `styles/[name].md` to load all colors, typography, and component patterns. For example, if the user picks "Warm Earth", read `styles/warm-earth.md`.
+
+---
+
+## 5. HTML Generation Phase
+
+### Base CSS (Mandatory)
+
+Infographics are fixed-width (1080px) but variable-height. The base CSS locks the width and lets content flow naturally downward.
+
+```css
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+html {
+    width: 1080px;
+}
+
+body {
+    width: 1080px;
+    margin: 0;
+    padding: 0;
+}
+```
+
+### Injecting the Style Preset
+
+After reading the style preset file, find its **Section 9 (Agent Prompt Guide)** which contains the CSS `:root` variables. Paste those variables into the `<style>` block:
+
+```css
+:root {
+    /* -- Paste all CSS variables from the preset's Section 9 here -- */
+    /* Example (Midnight Editorial): */
+    /* --color-midnight: #0d0d0d; */
+    /* --font-display: 'Playfair Display', Georgia, serif; */
+    /* ... etc. */
+}
+```
+
+Also add the Google Fonts `<link>` from the preset's Section 9 into the `<head>`.
+
+### Using Component Patterns
+
+The preset's **Section 4 (Component Patterns)** contains ready-to-use HTML snippets. Adapt these for the infographic's 1080px-wide vertical layout.
+
+The preset's **Section 8 (Format Adaptation Notes)** contains infographic-specific guidance on typography, section spacing, and vertical rhythm. Always apply these adaptations.
+
+### Complete HTML Template
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=1080, initial-scale=1.0">
+    <title>Infographic Title</title>
+
+    <!-- Google Fonts: paste the link from your chosen preset's Section 9 -->
+    <link href="https://fonts.googleapis.com/css2?family=PRESET_FONTS_HERE&display=swap" rel="stylesheet">
+
+    <style>
+        /* =============================================
+           INFOGRAPHIC: 1080px WIDE, VARIABLE HEIGHT
+           ============================================= */
+
+        :root {
+            /* -- Paste CSS variables from preset Section 9 -- */
+
+            /* Infographic-specific layout */
+            --infographic-width: 1080px;
+            --section-padding-x: 60px;
+            --section-padding-y: 80px;
+            --content-max-width: 960px;
+            --section-gap: 0px;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        html {
+            width: var(--infographic-width);
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+        }
+
+        body {
+            width: var(--infographic-width);
+            margin: 0;
+            padding: 0;
+            font-family: var(--font-body);
+            background-color: var(--bg-primary, var(--color-midnight, #0d0d0d));
+            color: var(--text-primary, var(--color-cream, #f5f0e8));
+        }
+
+        /* =============================================
+           INFOGRAPHIC CONTAINER
+           ============================================= */
+
+        .infographic {
+            width: 100%;
+            display: flex;
+            flex-direction: column;
+        }
+
+        /* =============================================
+           SECTION BASE
+           Each section is a full-width block with padding
+           ============================================= */
+
+        .section {
+            width: 100%;
+            padding: var(--section-padding-y) var(--section-padding-x);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+
+        .section-content {
+            width: 100%;
+            max-width: var(--content-max-width);
+        }
+
+        /* =============================================
+           SECTION DIVIDER
+           Copper/accent rule between sections
+           ============================================= */
+
+        .section-divider {
+            width: 60px;
+            height: 2px;
+            background: var(--color-accent, var(--color-copper, #c17f59));
+            margin: 0 auto;
+        }
+
+        /* =============================================
+           ALTERNATING SECTION BACKGROUNDS
+           Create visual distinction between sections
+           ============================================= */
+
+        .section-alt {
+            background-color: var(--color-surface, var(--color-charcoal, #1a1a1a));
+        }
+
+        /* =============================================
+           TYPOGRAPHY HIERARCHY
+           Uses full-scale preset typography
+           ============================================= */
+
+        .display-title {
+            font-family: var(--font-display);
+            font-size: 72px;
+            font-weight: 700;
+            line-height: 1.05;
+            letter-spacing: -1.5px;
+        }
+
+        .section-heading {
+            font-family: var(--font-display);
+            font-size: 48px;
+            font-weight: 700;
+            line-height: 1.10;
+            letter-spacing: -1px;
+            text-align: center;
+            margin-bottom: 40px;
+        }
+
+        .sub-heading {
+            font-family: var(--font-display);
+            font-size: 32px;
+            font-weight: 700;
+            line-height: 1.15;
+            letter-spacing: -0.5px;
+        }
+
+        .body-large {
+            font-family: var(--font-body);
+            font-size: 20px;
+            font-weight: 300;
+            line-height: 1.60;
+        }
+
+        .body-text {
+            font-family: var(--font-body);
+            font-size: 16px;
+            font-weight: 400;
+            line-height: 1.65;
+        }
+
+        .small-text {
+            font-family: var(--font-body);
+            font-size: 13px;
+            font-weight: 400;
+            line-height: 1.50;
+            letter-spacing: 0.3px;
+        }
+
+        .label {
+            font-family: var(--font-body);
+            font-size: 14px;
+            font-weight: 600;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+        }
+
+        .big-number {
+            font-family: var(--font-display);
+            font-size: 96px;
+            font-weight: 900;
+            line-height: 1.00;
+            letter-spacing: -1px;
+        }
+
+        /* =============================================
+           LAYOUT COMPONENTS
+           ============================================= */
+
+        .two-column {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 30px;
+        }
+
+        .three-column {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr;
+            gap: 24px;
+        }
+
+        .stack {
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+
+        .card {
+            background: var(--color-surface, var(--color-charcoal, #1a1a1a));
+            border: 1px solid var(--color-border, rgba(245,240,232,0.1));
+            border-radius: 4px;
+            padding: 40px 32px;
+        }
+    </style>
+</head>
+<body>
+    <div class="infographic">
+
+        <!-- Header Section -->
+        <section class="section" style="min-height: 600px; justify-content: center; text-align: center;">
+            <div class="section-content">
+                <div class="section-divider" style="margin-bottom: 32px;"></div>
+                <h1 class="display-title">Infographic Title</h1>
+                <p class="body-large" style="margin-top: 24px; max-width: 600px; margin-left: auto; margin-right: auto; opacity: 0.7;">
+                    A visual guide to the topic at hand.
+                </p>
+                <div class="section-divider" style="margin-top: 40px;"></div>
+            </div>
+        </section>
+
+        <!-- Content sections go here -->
+
+        <!-- Footer Section -->
+        <section class="section" style="min-height: 300px; justify-content: center; text-align: center;">
+            <div class="section-content">
+                <div class="section-divider" style="margin-bottom: 32px;"></div>
+                <p class="label" style="opacity: 0.5;">@yourbrand</p>
+            </div>
+        </section>
+
+    </div>
+</body>
+</html>
+```
+
+---
+
+## 6. Content Templates
+
+All templates use CSS custom properties so they work with any style preset. Each template is a `<section>` block that slots into the `.infographic` container.
+
+### Header Section
+
+```html
+<section class="section" style="min-height: 600px; justify-content: center; text-align: center;">
+    <div class="section-content">
+        <!-- Accent rule -->
+        <div class="section-divider" style="margin-bottom: 32px;"></div>
+
+        <!-- Title -->
+        <h1 class="display-title">
+            The Complete Guide to<br>AI-Powered Workflows
+        </h1>
+
+        <!-- Subtitle -->
+        <p class="body-large" style="margin-top: 24px; max-width: 640px; margin-left: auto; margin-right: auto; opacity: 0.7;">
+            How modern teams are using AI coworkers to automate research, outreach, and operations.
+        </p>
+
+        <!-- Accent rule -->
+        <div class="section-divider" style="margin-top: 40px;"></div>
+    </div>
+</section>
+```
+
+### Numbered Item Section
+
+```html
+<section class="section">
+    <div class="section-content">
+        <h2 class="section-heading">5 Core Workflows</h2>
+
+        <div class="stack" style="gap: 0;">
+            <!-- Item 1 -->
+            <div style="display: flex; gap: 24px; align-items: flex-start; padding: 32px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                <span style="font-family: var(--font-display); font-size: 48px; font-weight: 700; line-height: 1.00; color: var(--color-accent, var(--color-copper, #c17f59)); min-width: 72px;">01</span>
+                <div>
+                    <p class="label" style="color: var(--color-secondary-accent, var(--color-muted-gold, #a89067)); margin-bottom: 8px;">SIGNAL-BASED OUTBOUND</p>
+                    <h3 class="sub-heading" style="margin-bottom: 12px;">Find buyers before they find you</h3>
+                    <p class="body-text" style="opacity: 0.7;">Monitor hiring signals, funding events, and tech stack changes to identify high-intent prospects the moment they enter the market.</p>
+                </div>
+            </div>
+
+            <!-- Item 2 -->
+            <div style="display: flex; gap: 24px; align-items: flex-start; padding: 32px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                <span style="font-family: var(--font-display); font-size: 48px; font-weight: 700; line-height: 1.00; color: var(--color-accent, var(--color-copper, #c17f59)); min-width: 72px;">02</span>
+                <div>
+                    <p class="label" style="color: var(--color-secondary-accent, var(--color-muted-gold, #a89067)); margin-bottom: 8px;">AUTOMATED RESEARCH</p>
+                    <h3 class="sub-heading" style="margin-bottom: 12px;">Deep-dive every prospect automatically</h3>
+                    <p class="body-text" style="opacity: 0.7;">AI agents compile company profiles, recent news, tech stack data, and competitive landscape in minutes instead of hours.</p>
+                </div>
+            </div>
+
+            <!-- Repeat pattern for additional items -->
+        </div>
+    </div>
+</section>
+```
+
+### Stat Display Section
+
+```html
+<section class="section section-alt">
+    <div class="section-content">
+        <h2 class="section-heading">Key Metrics</h2>
+
+        <div class="three-column">
+            <!-- Stat 1 -->
+            <div class="card" style="text-align: center;">
+                <p class="big-number" style="color: var(--color-accent, var(--color-copper, #c17f59));">47%</p>
+                <p class="label" style="margin-top: 12px;">FASTER RESPONSE</p>
+                <p class="body-text" style="margin-top: 12px; opacity: 0.7;">Teams respond to leads nearly twice as fast with AI assistance.</p>
+            </div>
+
+            <!-- Stat 2 -->
+            <div class="card" style="text-align: center;">
+                <p class="big-number" style="color: var(--color-accent, var(--color-copper, #c17f59));">3.2x</p>
+                <p class="label" style="margin-top: 12px;">MORE PIPELINE</p>
+                <p class="body-text" style="margin-top: 12px; opacity: 0.7;">Average pipeline increase within the first 90 days of deployment.</p>
+            </div>
+
+            <!-- Stat 3 -->
+            <div class="card" style="text-align: center;">
+                <p class="big-number" style="color: var(--color-accent, var(--color-copper, #c17f59));">12h</p>
+                <p class="label" style="margin-top: 12px;">SAVED PER WEEK</p>
+                <p class="body-text" style="margin-top: 12px; opacity: 0.7;">Hours reclaimed from manual research and data entry tasks.</p>
+            </div>
+        </div>
+    </div>
+</section>
+```
+
+### Comparison Grid Section
+
+```html
+<section class="section">
+    <div class="section-content">
+        <h2 class="section-heading">Manual vs AI-Powered</h2>
+
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2px; background: var(--color-border, rgba(245,240,232,0.1)); border-radius: 4px; overflow: hidden;">
+            <!-- Left column -->
+            <div style="background: var(--color-surface, var(--color-charcoal, #1a1a1a)); padding: 40px 32px;">
+                <p class="small-text" style="color: var(--color-secondary-accent, var(--color-muted-gold, #a89067)); margin-bottom: 16px;">Without AI</p>
+                <h3 class="sub-heading" style="margin-bottom: 16px;">Manual & Fragmented</h3>
+                <p class="body-text" style="opacity: 0.7;">Teams juggle Slack threads, spreadsheets, and context-switching between a dozen tabs to coordinate basic workflows.</p>
+            </div>
+
+            <!-- Right column (featured) -->
+            <div style="background: var(--color-surface, var(--color-charcoal, #1a1a1a)); padding: 40px 32px; border-left: 2px solid var(--color-accent, var(--color-copper, #c17f59));">
+                <p class="small-text" style="color: var(--color-accent, var(--color-copper, #c17f59)); margin-bottom: 16px;">With AI</p>
+                <h3 class="sub-heading" style="margin-bottom: 16px;">Orchestrated & Autonomous</h3>
+                <p class="body-text" style="opacity: 0.7;">AI coworkers handle research, drafting, and follow-up autonomously. Your team focuses on decisions, not busywork.</p>
+            </div>
+        </div>
+    </div>
+</section>
+```
+
+### List Items Section
+
+```html
+<section class="section section-alt">
+    <div class="section-content">
+        <h2 class="section-heading">Core Capabilities</h2>
+
+        <div class="stack" style="gap: 0;">
+            <div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                <div style="width: 40px; height: 40px; min-width: 40px; display: flex; align-items: center; justify-content: center; border: 1px solid var(--color-border-accent, rgba(193,127,89,0.3)); border-radius: 4px; color: var(--color-accent); font-size: 18px;">&#9670;</div>
+                <div>
+                    <h4 class="sub-heading" style="font-size: 22px; margin-bottom: 8px;">Persistent Memory</h4>
+                    <p class="body-text" style="opacity: 0.7;">Every agent maintains its own filesystem, notes, and learned preferences across sessions. Context is never lost.</p>
+                </div>
+            </div>
+
+            <div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                <div style="width: 40px; height: 40px; min-width: 40px; display: flex; align-items: center; justify-content: center; border: 1px solid var(--color-border-accent, rgba(193,127,89,0.3)); border-radius: 4px; color: var(--color-accent); font-size: 18px;">&#9670;</div>
+                <div>
+                    <h4 class="sub-heading" style="font-size: 22px; margin-bottom: 8px;">Multi-Channel Access</h4>
+                    <p class="body-text" style="opacity: 0.7;">Reach your agents via Slack, Telegram, WhatsApp, or web chat. They meet you where you already work.</p>
+                </div>
+            </div>
+
+            <div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0;">
+                <div style="width: 40px; height: 40px; min-width: 40px; display: flex; align-items: center; justify-content: center; border: 1px solid var(--color-border-accent, rgba(193,127,89,0.3)); border-radius: 4px; color: var(--color-accent); font-size: 18px;">&#9670;</div>
+                <div>
+                    <h4 class="sub-heading" style="font-size: 22px; margin-bottom: 8px;">Tool Integration</h4>
+                    <p class="body-text" style="opacity: 0.7;">Connect to any API, database, or SaaS tool. Agents use real tools to get real work done.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+```
+
+### Quote Block Section
+
+```html
+<section class="section">
+    <div class="section-content">
+        <div style="padding: 48px 40px; border-left: 2px solid var(--color-accent, var(--color-copper, #c17f59)); background: var(--color-surface-inset, #141414);">
+            <p style="font-family: var(--font-display); font-size: 32px; font-weight: 400; font-style: italic; line-height: 1.35; letter-spacing: -0.5px;">
+                "It felt less like configuring software and more like onboarding a new team member."
+            </p>
+            <div style="display: flex; align-items: center; gap: 12px; margin-top: 24px;">
+                <div style="width: 32px; height: 2px; background: var(--color-accent, var(--color-copper, #c17f59));"></div>
+                <p class="label" style="color: var(--color-secondary-accent, var(--color-muted-gold, #a89067));">
+                    SARAH CHEN, VP OPERATIONS
+                </p>
+            </div>
+        </div>
+    </div>
+</section>
+```
+
+### CTA / Footer Section
+
+```html
+<section class="section section-alt" style="min-height: 400px; justify-content: center; text-align: center;">
+    <div class="section-content" style="display: flex; flex-direction: column; align-items: center;">
+        <!-- Accent rule -->
+        <div class="section-divider" style="margin-bottom: 32px;"></div>
+
+        <h2 class="section-heading" style="margin-bottom: 16px;">Ready to get started?</h2>
+
+        <p class="body-large" style="max-width: 480px; opacity: 0.7; margin-bottom: 32px;">
+            Deploy your first AI coworker in under five minutes.
+        </p>
+
+        <!-- CTA button -->
+        <div style="display: inline-block; background: var(--color-accent, var(--color-copper, #c17f59)); color: var(--bg-primary, var(--color-midnight, #0d0d0d)); font-family: var(--font-body); font-size: 15px; font-weight: 600; letter-spacing: 0.8px; text-transform: uppercase; padding: 16px 40px; border-radius: 4px;">
+            Get Started
+        </div>
+
+        <!-- Accent rule -->
+        <div class="section-divider" style="margin-top: 48px;"></div>
+
+        <!-- Brand -->
+        <p class="small-text" style="margin-top: 24px; opacity: 0.4;">@yourbrand</p>
+    </div>
+</section>
+```
+
+### Process / Timeline Section
+
+```html
+<section class="section">
+    <div class="section-content">
+        <h2 class="section-heading">How It Works</h2>
+
+        <div class="stack" style="gap: 30px;">
+            <!-- Step 1 -->
+            <div style="display: flex; align-items: flex-start; gap: 30px; padding: 40px; background: var(--color-surface, var(--color-charcoal, #1a1a1a)); border-radius: 4px; border: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                <span style="font-family: var(--font-display); font-size: 64px; font-weight: 900; color: var(--color-accent, var(--color-copper, #c17f59)); opacity: 0.3; line-height: 1; flex-shrink: 0; min-width: 80px;">01</span>
+                <div>
+                    <h3 class="sub-heading" style="margin-bottom: 10px;">Define Your Agent</h3>
+                    <p class="body-text" style="opacity: 0.7;">Describe the role, tools, and objectives. Your agent gets its own workspace, memory, and communication channels.</p>
+                </div>
+            </div>
+
+            <!-- Step 2 -->
+            <div style="display: flex; align-items: flex-start; gap: 30px; padding: 40px; background: var(--color-surface, var(--color-charcoal, #1a1a1a)); border-radius: 4px; border: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                <span style="font-family: var(--font-display); font-size: 64px; font-weight: 900; color: var(--color-accent, var(--color-copper, #c17f59)); opacity: 0.3; line-height: 1; flex-shrink: 0; min-width: 80px;">02</span>
+                <div>
+                    <h3 class="sub-heading" style="margin-bottom: 10px;">Connect Your Tools</h3>
+                    <p class="body-text" style="opacity: 0.7;">Link your CRM, email, Slack, and any APIs your agent needs. Everything stays within your security boundary.</p>
+                </div>
+            </div>
+
+            <!-- Step 3 -->
+            <div style="display: flex; align-items: flex-start; gap: 30px; padding: 40px; background: var(--color-surface, var(--color-charcoal, #1a1a1a)); border-radius: 4px; border: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                <span style="font-family: var(--font-display); font-size: 64px; font-weight: 900; color: var(--color-accent, var(--color-copper, #c17f59)); opacity: 0.3; line-height: 1; flex-shrink: 0; min-width: 80px;">03</span>
+                <div>
+                    <h3 class="sub-heading" style="margin-bottom: 10px;">Deploy & Collaborate</h3>
+                    <p class="body-text" style="opacity: 0.7;">Your agent starts working immediately. Message it in Slack, assign tasks in chat, and review outputs as they come in.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+```
+
+---
+
+## 7. Screenshot Phase
+
+After generating the HTML file, run the screenshot tool:
+
+```bash
+node screenshot/screenshot.js \
+  --format infographic \
+  --input ./EXPORT_DIR/index.html \
+  --output ./EXPORT_DIR/export.png
+```
+
+Where `EXPORT_DIR` is the export directory (see Section 9).
+
+This will:
+1. Open the HTML file in a headless Chromium browser
+2. Set the viewport to 1080px wide with 2x device scale factor
+3. Wait for fonts to load (500ms default; use `--font-delay 1000` for custom fonts)
+4. Capture a **full-page** PNG screenshot (variable height)
+5. Save to the specified output path
+
+---
+
+## 8. Delivery Phase
+
+After the screenshot is generated, present results to the user:
+
+```
+Your infographic is ready!
+
+Location: [EXPORT_DIR]/
+
+Files:
+  index.html     -- Full infographic source (editable)
+  export.png     -- Full-page screenshot
+
+Export details:
+  Dimensions: 1080 x 4200px
+  File size:  1.8 MB
+
+Share on:
+  LinkedIn, Twitter/X, Instagram, blog posts, presentations
+
+Want to make any changes?
+```
+
+---
+
+## 9. Export Directory Convention
+
+Ask the user: **"Where should I save the exports? (default: ./goose-graphics-exports/)"**
+
+### Directory naming
+- Primary: `[YYYY-MM-DD]-[slugified-name]/` (e.g., `2026-04-04-ai-workflow-guide/`)
+- Fallback (no name given): `[YYYY-MM-DD]-infographic-[HHMMSS]/`
+
+### Directory structure (infographic = single-file)
+```
+goose-graphics-exports/
+  2026-04-04-ai-workflow-guide/
+    index.html          # Full infographic source
+    export.png          # Full-page PNG screenshot
+```
+
+---
+
+## Design Reminders
+
+- **Fixed width, flowing height.** The infographic is always 1080px wide. Height is determined by content. Do not constrain height.
+- **Section independence.** Each section should be visually distinct and self-contained. Use alternating backgrounds (`section-alt` class) or accent rules between sections to create clear boundaries.
+- **Vertical rhythm.** Maintain consistent spacing: 80px top/bottom padding per section, 64px between major content blocks within a section, 24px between items.
+- **Accent rules as punctuation.** Use 60px-wide centered copper/accent rules as visual dividers between major sections. They serve the same role as em dashes in prose.
+- **Progressive depth.** Alternate between full-width content sections and card-based layouts (stats, comparisons) to keep the scroll interesting.
+- **Scannable structure.** A viewer should be able to scroll the entire infographic in 30-60 seconds and grasp every main point. Use large headings, bold numbers, and short body text.
+- **Footer matters.** Always end with a clean footer section that includes branding and optional CTA. The footer is the last impression.

--- a/skills/composites/goose-graphics/formats/poster.md
+++ b/skills/composites/goose-graphics/formats/poster.md
@@ -1,0 +1,843 @@
+# Format: Poster
+
+Create single-page portrait posters at 1080x1350px (4:5 ratio, optimized for Instagram). The entire composition is one HTML file with a dense, structured layout -- everything on one page. Think event posters, product announcements, promotional graphics, and visual summaries.
+
+---
+
+## 1. Format Specifications
+
+| Property | Value |
+|----------|-------|
+| Dimensions | 1080 x 1350px (4:5 portrait) |
+| File structure | Single HTML file (`index.html`) |
+| Aspect ratio | 4:5 (Instagram recommended portrait) |
+| Output format | Single PNG |
+| Sizing approach | Fixed pixel sizes (NOT responsive) |
+| Design approach | Dense, single-composition layout -- everything on one page |
+
+### Content Density Limits
+
+A poster is dense but must remain readable and visually ordered. Think of it as a single, well-composed page with clear zones.
+
+| Element | Max Content |
+|---------|-------------|
+| Headline | 1-2 lines, 8 words max |
+| Subheadline | 1 line, 15 words max |
+| Body text | 2-3 short paragraphs or 4-6 bullet points (8 words each) |
+| Stats | 1-3 key numbers with labels |
+| CTA | 1 action line + optional URL or handle |
+| Metadata | Date, location, or attribution (1 line) |
+| Branding | Logo mark or handle, positioned consistently |
+
+**If content exceeds limits:** Simplify ruthlessly. A poster is a single glance, not a document.
+
+---
+
+## 2. Workflow Overview
+
+```
+Content Discovery --> Style Selection --> HTML Generation --> Screenshot --> Delivery
+```
+
+1. Gather topic, poster type, and content from the user
+2. Present style presets and let the user choose (or guide them)
+3. Read the chosen style preset from `styles/[name].md`
+4. Generate a single HTML file with the full poster composition
+5. Run the screenshot tool to export the PNG
+6. Present the finished file to the user
+
+---
+
+## 3. Content Discovery Phase
+
+Ask the user these questions before generating anything.
+
+**Question 1: Topic**
+- "What is this poster about?"
+- Free text input
+
+**Question 2: Content Type**
+- "What kind of poster is this?"
+- Options:
+  - **Event / Webinar** -- Date, time, speakers, registration CTA
+  - **Product announcement** -- Feature launch, new release, what's new
+  - **Promotional** -- Sale, offer, limited-time deal
+  - **Summary / Recap** -- Key takeaways, results, highlights
+  - **Quote / Statement** -- Bold message, manifesto, brand statement
+  - **How-to / Tips** -- Quick guide, top 3 tips, checklist
+
+**Question 3: Content Readiness**
+- "Do you have the content ready?"
+- Options:
+  - **Yes, I have all content** -- Paste it in
+  - **I have bullet points** -- Need formatting
+  - **Just the topic** -- Need help writing
+
+If the user has content, ask them to share it before proceeding.
+
+---
+
+## 4. Style Selection Phase
+
+Present the 10 available design presets:
+
+| # | Preset | Description |
+|---|--------|-------------|
+| 1 | **Midnight Editorial** | Dark, elegant, magazine-inspired with copper accents |
+| 2 | **Clean Slate** | Ultra-minimal, precise, modern tech aesthetic |
+| 3 | **Warm Earth** | Organic, artisanal, grounded with natural tones |
+| 4 | **Electric Burst** | Bold, energetic, attention-grabbing with vivid color |
+| 5 | **Soft Cloud** | Airy, modern, approachable with gentle pastels |
+| 6 | **Terminal** | Dev/hacker aesthetic, focused and technical |
+| 7 | **Paper & Ink** | Classic editorial, literary, print-inspired |
+| 8 | **Brutalist** | Raw, structural, anti-design with strong geometry |
+| 9 | **Golden Dusk** | Warm, luxurious, premium with rich gold tones |
+| 10 | **Deep Ocean** | Calm, professional, immersive blue-dark palette |
+
+**Additional options:**
+
+- **"I have a reference image"** -- Use the `extract-style` skill at `styles/extract-style.md` to derive a custom palette from the user's image.
+- **Guided discovery** -- If the user is unsure, ask about their audience and tone, then recommend 2-3 presets:
+  - Professional / Corporate --> Midnight Editorial, Clean Slate, Deep Ocean
+  - Creative / Playful --> Electric Burst, Soft Cloud, Warm Earth
+  - Technical / Dev-focused --> Terminal, Brutalist, Clean Slate
+  - Elegant / Premium --> Midnight Editorial, Golden Dusk, Paper & Ink
+
+**After selection:** Read the chosen style preset file from `styles/[name].md` to load all colors, typography, and component patterns. For example, if the user picks "Electric Burst", read `styles/electric-burst.md`.
+
+---
+
+## 5. HTML Generation Phase
+
+### Base CSS (Mandatory)
+
+Posters are fixed-size single compositions. No scrolling, no overflow. Everything fits within 1080x1350px.
+
+```css
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+html, body {
+    width: 1080px;
+    height: 1350px;
+    overflow: hidden;
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+    padding: 60px 60px 80px 60px;
+}
+```
+
+### Injecting the Style Preset
+
+After reading the style preset file, find its **Section 9 (Agent Prompt Guide)** which contains the CSS `:root` variables. Paste those variables into the `<style>` block:
+
+```css
+:root {
+    /* -- Paste all CSS variables from the preset's Section 9 here -- */
+
+    /* Poster-specific overrides */
+    --poster-width: 1080px;
+    --poster-height: 1350px;
+    --poster-padding-x: 60px;
+    --poster-padding-top: 80px;
+    --poster-padding-bottom: 80px;
+    --content-max-width: 960px;
+}
+```
+
+Also add the Google Fonts `<link>` from the preset's Section 9 into the `<head>`.
+
+### Using Component Patterns
+
+The preset's **Section 4 (Component Patterns)** contains ready-to-use HTML snippets. Adapt these for the poster's 1080x1350 portrait format.
+
+The preset's **Section 8 (Format Adaptation Notes)** contains poster-specific guidance. Key rules:
+- Display Hero at 64px
+- Section Heading at 40px
+- Body at 16px
+- Composition: top third for headline, middle third for content, bottom third for CTA
+- Copper/accent rules separate the three zones
+
+### Poster Composition Zones
+
+A poster is divided into three vertical zones:
+
+```
++---------------------------+
+|       TOP ZONE            |  ~400px
+|  Headline + Subtitle      |
+|  Accent rule below        |
++---------------------------+
+|       MIDDLE ZONE         |  ~550px
+|  Key content: stats,      |
+|  list, comparison, or     |
+|  body text                |
+|  Accent rule below        |
++---------------------------+
+|       BOTTOM ZONE         |  ~400px
+|  CTA, contact info,       |
+|  or closing statement     |
+|  Branding                 |
++---------------------------+
+```
+
+### Complete HTML Template
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=1080, initial-scale=1.0">
+    <title>Poster Title</title>
+
+    <!-- Google Fonts: paste the link from your chosen preset's Section 9 -->
+    <link href="https://fonts.googleapis.com/css2?family=PRESET_FONTS_HERE&display=swap" rel="stylesheet">
+
+    <style>
+        /* =============================================
+           POSTER: 1080x1350px FIXED (4:5 Portrait)
+           ============================================= */
+
+        :root {
+            /* -- Paste CSS variables from preset Section 9 -- */
+
+            /* Poster-specific layout */
+            --poster-width: 1080px;
+            --poster-height: 1350px;
+            --poster-padding-x: 60px;
+            --poster-padding-top: 80px;
+            --poster-padding-bottom: 80px;
+            --content-max-width: 960px;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        html, body {
+            width: var(--poster-width);
+            height: var(--poster-height);
+            overflow: hidden;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+        }
+
+        body {
+            background-color: var(--bg-primary, var(--color-midnight, #0d0d0d));
+            color: var(--text-primary, var(--color-cream, #f5f0e8));
+            font-family: var(--font-body);
+            display: flex;
+            flex-direction: column;
+            padding: var(--poster-padding-top) var(--poster-padding-x) var(--poster-padding-bottom);
+        }
+
+        /* =============================================
+           POSTER ZONES
+           ============================================= */
+
+        .poster-top {
+            flex: 0 0 auto;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            padding-bottom: 32px;
+        }
+
+        .poster-middle {
+            flex: 1 1 auto;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            padding: 32px 0;
+        }
+
+        .poster-bottom {
+            flex: 0 0 auto;
+            display: flex;
+            flex-direction: column;
+            justify-content: flex-end;
+            padding-top: 32px;
+        }
+
+        /* =============================================
+           ZONE DIVIDER
+           ============================================= */
+
+        .zone-divider {
+            width: 60px;
+            height: 2px;
+            background: var(--color-accent, var(--color-copper, #c17f59));
+        }
+
+        .zone-divider-centered {
+            width: 60px;
+            height: 2px;
+            background: var(--color-accent, var(--color-copper, #c17f59));
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        /* =============================================
+           TYPOGRAPHY HIERARCHY
+           ============================================= */
+
+        .display-title {
+            font-family: var(--font-display);
+            font-size: 64px;
+            font-weight: 700;
+            line-height: 1.05;
+            letter-spacing: -1.5px;
+        }
+
+        .section-heading {
+            font-family: var(--font-display);
+            font-size: 40px;
+            font-weight: 700;
+            line-height: 1.10;
+            letter-spacing: -0.75px;
+        }
+
+        .sub-heading {
+            font-family: var(--font-display);
+            font-size: 28px;
+            font-weight: 700;
+            line-height: 1.15;
+            letter-spacing: -0.5px;
+        }
+
+        .body-large {
+            font-family: var(--font-body);
+            font-size: 20px;
+            font-weight: 300;
+            line-height: 1.60;
+        }
+
+        .body-text {
+            font-family: var(--font-body);
+            font-size: 16px;
+            font-weight: 400;
+            line-height: 1.65;
+        }
+
+        .small-text {
+            font-family: var(--font-body);
+            font-size: 13px;
+            font-weight: 400;
+            line-height: 1.50;
+            letter-spacing: 0.3px;
+        }
+
+        .label {
+            font-family: var(--font-body);
+            font-size: 14px;
+            font-weight: 600;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+        }
+
+        .big-number {
+            font-family: var(--font-display);
+            font-size: 72px;
+            font-weight: 900;
+            line-height: 1.00;
+            letter-spacing: -1px;
+        }
+
+        /* =============================================
+           LAYOUT HELPERS
+           ============================================= */
+
+        .two-column {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 24px;
+        }
+
+        .three-column {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr;
+            gap: 20px;
+        }
+
+        .card {
+            background: var(--color-surface, var(--color-charcoal, #1a1a1a));
+            border: 1px solid var(--color-border, rgba(245,240,232,0.1));
+            border-radius: 4px;
+            padding: 32px 24px;
+        }
+
+        .brand {
+            font-family: var(--font-body);
+            font-size: 14px;
+            font-weight: 400;
+            opacity: 0.5;
+        }
+    </style>
+</head>
+<body>
+
+    <!-- TOP ZONE: Headline -->
+    <div class="poster-top">
+        <!-- Content here -->
+    </div>
+
+    <!-- MIDDLE ZONE: Key content -->
+    <div class="poster-middle">
+        <!-- Content here -->
+    </div>
+
+    <!-- BOTTOM ZONE: CTA / Branding -->
+    <div class="poster-bottom">
+        <!-- Content here -->
+    </div>
+
+</body>
+</html>
+```
+
+---
+
+## 6. Content Templates
+
+All templates use CSS custom properties so they work with any style preset. Each template shows a complete poster with all three zones filled.
+
+### Event / Webinar Poster
+
+```html
+<body>
+
+    <!-- TOP ZONE -->
+    <div class="poster-top">
+        <p class="label" style="color: var(--color-secondary-accent, var(--color-muted-gold, #a89067)); margin-bottom: 16px;">
+            LIVE WEBINAR &middot; APRIL 15, 2026
+        </p>
+        <h1 class="display-title">
+            Building AI<br>Coworker Teams
+        </h1>
+        <p class="body-large" style="margin-top: 16px; opacity: 0.7; max-width: 700px;">
+            A practical workshop on deploying autonomous agents that collaborate with your existing team.
+        </p>
+        <div class="zone-divider" style="margin-top: 32px;"></div>
+    </div>
+
+    <!-- MIDDLE ZONE -->
+    <div class="poster-middle">
+        <h2 class="section-heading" style="margin-bottom: 24px;">What You'll Learn</h2>
+
+        <div style="display: flex; flex-direction: column; gap: 0;">
+            <div style="display: flex; gap: 20px; align-items: flex-start; padding: 20px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                <span style="font-family: var(--font-display); font-size: 36px; font-weight: 700; color: var(--color-accent, var(--color-copper, #c17f59)); min-width: 48px; line-height: 1;">01</span>
+                <div>
+                    <h3 class="sub-heading" style="font-size: 22px; margin-bottom: 4px;">Agent Architecture</h3>
+                    <p class="body-text" style="opacity: 0.7;">How to design agents with persistent memory and tool access.</p>
+                </div>
+            </div>
+
+            <div style="display: flex; gap: 20px; align-items: flex-start; padding: 20px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                <span style="font-family: var(--font-display); font-size: 36px; font-weight: 700; color: var(--color-accent, var(--color-copper, #c17f59)); min-width: 48px; line-height: 1;">02</span>
+                <div>
+                    <h3 class="sub-heading" style="font-size: 22px; margin-bottom: 4px;">Multi-Channel Deployment</h3>
+                    <p class="body-text" style="opacity: 0.7;">Connect agents to Slack, Telegram, and web in minutes.</p>
+                </div>
+            </div>
+
+            <div style="display: flex; gap: 20px; align-items: flex-start; padding: 20px 0;">
+                <span style="font-family: var(--font-display); font-size: 36px; font-weight: 700; color: var(--color-accent, var(--color-copper, #c17f59)); min-width: 48px; line-height: 1;">03</span>
+                <div>
+                    <h3 class="sub-heading" style="font-size: 22px; margin-bottom: 4px;">Team Orchestration</h3>
+                    <p class="body-text" style="opacity: 0.7;">Coordinate multiple agents working together on complex tasks.</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="zone-divider" style="margin-top: 32px;"></div>
+    </div>
+
+    <!-- BOTTOM ZONE -->
+    <div class="poster-bottom" style="text-align: center; align-items: center;">
+        <div style="display: inline-block; background: var(--color-accent, var(--color-copper, #c17f59)); color: var(--bg-primary, var(--color-midnight, #0d0d0d)); font-family: var(--font-body); font-size: 15px; font-weight: 600; letter-spacing: 0.8px; text-transform: uppercase; padding: 16px 40px; border-radius: 4px;">
+            Register Free
+        </div>
+        <p class="small-text" style="margin-top: 16px; opacity: 0.5;">2:00 PM EST &middot; 45 minutes &middot; Free</p>
+        <p class="brand" style="margin-top: 12px;">@yourbrand</p>
+    </div>
+
+</body>
+```
+
+### Product Announcement Poster
+
+```html
+<body>
+
+    <!-- TOP ZONE -->
+    <div class="poster-top" style="text-align: center; align-items: center;">
+        <p class="label" style="color: var(--color-accent, var(--color-copper, #c17f59)); margin-bottom: 16px;">
+            NOW AVAILABLE
+        </p>
+        <h1 class="display-title" style="max-width: 800px; margin: 0 auto;">
+            Multi-Agent<br>Workspaces
+        </h1>
+        <p class="body-large" style="margin-top: 16px; opacity: 0.7; max-width: 640px; margin-left: auto; margin-right: auto;">
+            Deploy teams of AI agents that share context, divide work, and collaborate in real time.
+        </p>
+        <div class="zone-divider-centered" style="margin-top: 32px;"></div>
+    </div>
+
+    <!-- MIDDLE ZONE -->
+    <div class="poster-middle">
+        <div class="three-column">
+            <div class="card" style="text-align: center;">
+                <p class="big-number" style="font-size: 56px; color: var(--color-accent, var(--color-copper, #c17f59));">5x</p>
+                <p class="label" style="margin-top: 12px; font-size: 12px;">FASTER OUTPUT</p>
+                <p class="body-text" style="margin-top: 8px; opacity: 0.7; font-size: 14px;">Multiple agents working in parallel on complex tasks.</p>
+            </div>
+
+            <div class="card" style="text-align: center;">
+                <p class="big-number" style="font-size: 56px; color: var(--color-accent, var(--color-copper, #c17f59));">24/7</p>
+                <p class="label" style="margin-top: 12px; font-size: 12px;">ALWAYS ON</p>
+                <p class="body-text" style="margin-top: 8px; opacity: 0.7; font-size: 14px;">Agents work autonomously across time zones and schedules.</p>
+            </div>
+
+            <div class="card" style="text-align: center;">
+                <p class="big-number" style="font-size: 56px; color: var(--color-accent, var(--color-copper, #c17f59));">0</p>
+                <p class="label" style="margin-top: 12px; font-size: 12px;">CONTEXT LOST</p>
+                <p class="body-text" style="margin-top: 8px; opacity: 0.7; font-size: 14px;">Persistent memory means nothing falls through the cracks.</p>
+            </div>
+        </div>
+
+        <div class="zone-divider-centered" style="margin-top: 40px;"></div>
+    </div>
+
+    <!-- BOTTOM ZONE -->
+    <div class="poster-bottom" style="text-align: center; align-items: center;">
+        <h2 class="section-heading" style="font-size: 32px;">Try it today</h2>
+        <p class="body-text" style="margin-top: 12px; opacity: 0.7;">No setup fees. Deploy your first workspace in under 5 minutes.</p>
+        <div style="margin-top: 24px; display: inline-block; background: var(--color-accent, var(--color-copper, #c17f59)); color: var(--bg-primary, var(--color-midnight, #0d0d0d)); font-family: var(--font-body); font-size: 15px; font-weight: 600; letter-spacing: 0.8px; text-transform: uppercase; padding: 16px 40px; border-radius: 4px;">
+            Get Started
+        </div>
+        <p class="brand" style="margin-top: 20px;">@yourbrand</p>
+    </div>
+
+</body>
+```
+
+### Stat Display Poster
+
+```html
+<body>
+
+    <!-- TOP ZONE -->
+    <div class="poster-top">
+        <div class="zone-divider" style="margin-bottom: 24px;"></div>
+        <p class="label" style="color: var(--color-secondary-accent, var(--color-muted-gold, #a89067)); margin-bottom: 12px;">
+            Q1 2026 RESULTS
+        </p>
+        <h1 class="display-title">
+            The Numbers<br>Speak for Themselves
+        </h1>
+        <div class="zone-divider" style="margin-top: 32px;"></div>
+    </div>
+
+    <!-- MIDDLE ZONE -->
+    <div class="poster-middle" style="gap: 24px;">
+        <!-- Large featured stat -->
+        <div class="card" style="text-align: center; padding: 40px;">
+            <p class="big-number" style="font-size: 96px; color: var(--color-accent, var(--color-copper, #c17f59));">47%</p>
+            <p class="label" style="margin-top: 12px;">FASTER RESPONSE TIME</p>
+            <p class="body-text" style="margin-top: 12px; opacity: 0.7; max-width: 500px; margin-left: auto; margin-right: auto;">
+                Teams respond to inbound leads nearly twice as fast with AI-powered workflows.
+            </p>
+        </div>
+
+        <!-- Two smaller stats side by side -->
+        <div class="two-column">
+            <div class="card" style="text-align: center;">
+                <p class="big-number" style="font-size: 56px; color: var(--color-accent, var(--color-copper, #c17f59));">3.2x</p>
+                <p class="label" style="margin-top: 8px; font-size: 12px;">PIPELINE GROWTH</p>
+            </div>
+            <div class="card" style="text-align: center;">
+                <p class="big-number" style="font-size: 56px; color: var(--color-accent, var(--color-copper, #c17f59));">12h</p>
+                <p class="label" style="margin-top: 8px; font-size: 12px;">SAVED PER WEEK</p>
+            </div>
+        </div>
+
+        <div class="zone-divider-centered" style="margin-top: 16px;"></div>
+    </div>
+
+    <!-- BOTTOM ZONE -->
+    <div class="poster-bottom" style="text-align: center; align-items: center;">
+        <p class="body-text" style="opacity: 0.7;">See the full report at yourbrand.com/results</p>
+        <p class="brand" style="margin-top: 12px;">@yourbrand</p>
+    </div>
+
+</body>
+```
+
+### Quote / Statement Poster
+
+```html
+<body>
+
+    <!-- TOP ZONE -->
+    <div class="poster-top" style="flex: 0 0 auto;">
+        <div class="zone-divider" style="margin-bottom: 24px;"></div>
+        <p class="label" style="color: var(--color-secondary-accent, var(--color-muted-gold, #a89067));">
+            ON THE FUTURE OF WORK
+        </p>
+    </div>
+
+    <!-- MIDDLE ZONE (expanded for the quote) -->
+    <div class="poster-middle" style="justify-content: center;">
+        <div style="padding: 0 0 0 32px; border-left: 2px solid var(--color-accent, var(--color-copper, #c17f59));">
+            <p style="font-family: var(--font-display); font-size: 48px; font-weight: 400; font-style: italic; line-height: 1.30; letter-spacing: -0.5px;">
+                "The best teams of the future won't just have the best people. They'll have the best agents working alongside them."
+            </p>
+            <div style="display: flex; align-items: center; gap: 12px; margin-top: 32px;">
+                <div style="width: 32px; height: 2px; background: var(--color-accent, var(--color-copper, #c17f59));"></div>
+                <p class="label" style="color: var(--color-secondary-accent, var(--color-muted-gold, #a89067));">
+                    SARAH CHEN, VP OPERATIONS
+                </p>
+            </div>
+        </div>
+    </div>
+
+    <!-- BOTTOM ZONE -->
+    <div class="poster-bottom" style="align-items: flex-start;">
+        <div class="zone-divider" style="margin-bottom: 16px;"></div>
+        <p class="brand">@yourbrand</p>
+    </div>
+
+</body>
+```
+
+### List / Tips Poster
+
+```html
+<body>
+
+    <!-- TOP ZONE -->
+    <div class="poster-top" style="text-align: center; align-items: center;">
+        <div class="zone-divider-centered" style="margin-bottom: 24px;"></div>
+        <h1 class="display-title" style="font-size: 56px;">
+            5 Rules for Building<br>AI Agent Teams
+        </h1>
+        <div class="zone-divider-centered" style="margin-top: 24px;"></div>
+    </div>
+
+    <!-- MIDDLE ZONE -->
+    <div class="poster-middle">
+        <div style="display: flex; flex-direction: column; gap: 0;">
+            <div style="display: flex; gap: 20px; align-items: baseline; padding: 18px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                <span style="font-family: var(--font-display); font-size: 32px; font-weight: 700; color: var(--color-accent, var(--color-copper, #c17f59)); min-width: 40px;">01</span>
+                <div>
+                    <h3 class="sub-heading" style="font-size: 22px;">Give each agent a clear role</h3>
+                    <p class="body-text" style="opacity: 0.7; margin-top: 4px;">Specialist agents outperform generalists every time.</p>
+                </div>
+            </div>
+
+            <div style="display: flex; gap: 20px; align-items: baseline; padding: 18px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                <span style="font-family: var(--font-display); font-size: 32px; font-weight: 700; color: var(--color-accent, var(--color-copper, #c17f59)); min-width: 40px;">02</span>
+                <div>
+                    <h3 class="sub-heading" style="font-size: 22px;">Persistent memory is non-negotiable</h3>
+                    <p class="body-text" style="opacity: 0.7; margin-top: 4px;">Agents that forget between sessions waste everyone's time.</p>
+                </div>
+            </div>
+
+            <div style="display: flex; gap: 20px; align-items: baseline; padding: 18px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                <span style="font-family: var(--font-display); font-size: 32px; font-weight: 700; color: var(--color-accent, var(--color-copper, #c17f59)); min-width: 40px;">03</span>
+                <div>
+                    <h3 class="sub-heading" style="font-size: 22px;">Connect real tools, not toy APIs</h3>
+                    <p class="body-text" style="opacity: 0.7; margin-top: 4px;">Production value comes from production integrations.</p>
+                </div>
+            </div>
+
+            <div style="display: flex; gap: 20px; align-items: baseline; padding: 18px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                <span style="font-family: var(--font-display); font-size: 32px; font-weight: 700; color: var(--color-accent, var(--color-copper, #c17f59)); min-width: 40px;">04</span>
+                <div>
+                    <h3 class="sub-heading" style="font-size: 22px;">Let agents talk to each other</h3>
+                    <p class="body-text" style="opacity: 0.7; margin-top: 4px;">The best outcomes come from agent-to-agent collaboration.</p>
+                </div>
+            </div>
+
+            <div style="display: flex; gap: 20px; align-items: baseline; padding: 18px 0;">
+                <span style="font-family: var(--font-display); font-size: 32px; font-weight: 700; color: var(--color-accent, var(--color-copper, #c17f59)); min-width: 40px;">05</span>
+                <div>
+                    <h3 class="sub-heading" style="font-size: 22px;">Human-in-the-loop for decisions</h3>
+                    <p class="body-text" style="opacity: 0.7; margin-top: 4px;">Automate execution. Keep humans on strategy and judgment.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- BOTTOM ZONE -->
+    <div class="poster-bottom" style="text-align: center; align-items: center;">
+        <div class="zone-divider-centered" style="margin-bottom: 16px;"></div>
+        <p class="body-text" style="opacity: 0.6;">Save this for later. Follow for more.</p>
+        <p class="brand" style="margin-top: 12px;">@yourbrand</p>
+    </div>
+
+</body>
+```
+
+### Comparison Poster
+
+```html
+<body>
+
+    <!-- TOP ZONE -->
+    <div class="poster-top" style="text-align: center; align-items: center;">
+        <div class="zone-divider-centered" style="margin-bottom: 24px;"></div>
+        <h1 class="display-title" style="font-size: 56px;">
+            Manual Teams vs<br>AI-Augmented Teams
+        </h1>
+        <div class="zone-divider-centered" style="margin-top: 24px;"></div>
+    </div>
+
+    <!-- MIDDLE ZONE -->
+    <div class="poster-middle">
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2px; background: var(--color-border, rgba(245,240,232,0.1)); border-radius: 4px; overflow: hidden;">
+            <!-- Left -->
+            <div style="background: var(--color-surface, var(--color-charcoal, #1a1a1a)); padding: 36px 28px;">
+                <p class="label" style="opacity: 0.5; margin-bottom: 16px; font-size: 12px;">MANUAL</p>
+                <ul style="list-style: none; display: flex; flex-direction: column; gap: 16px;">
+                    <li class="body-text" style="opacity: 0.7; padding-left: 24px; position: relative;">
+                        <span style="position: absolute; left: 0; color: var(--color-accent);">&times;</span>
+                        Hours of manual research
+                    </li>
+                    <li class="body-text" style="opacity: 0.7; padding-left: 24px; position: relative;">
+                        <span style="position: absolute; left: 0; color: var(--color-accent);">&times;</span>
+                        Inconsistent output quality
+                    </li>
+                    <li class="body-text" style="opacity: 0.7; padding-left: 24px; position: relative;">
+                        <span style="position: absolute; left: 0; color: var(--color-accent);">&times;</span>
+                        Limited by headcount
+                    </li>
+                    <li class="body-text" style="opacity: 0.7; padding-left: 24px; position: relative;">
+                        <span style="position: absolute; left: 0; color: var(--color-accent);">&times;</span>
+                        Context lost between tools
+                    </li>
+                </ul>
+            </div>
+
+            <!-- Right (featured) -->
+            <div style="background: var(--color-surface, var(--color-charcoal, #1a1a1a)); padding: 36px 28px; border-left: 2px solid var(--color-accent, var(--color-copper, #c17f59));">
+                <p class="label" style="color: var(--color-accent, var(--color-copper, #c17f59)); margin-bottom: 16px; font-size: 12px;">AI-AUGMENTED</p>
+                <ul style="list-style: none; display: flex; flex-direction: column; gap: 16px;">
+                    <li class="body-text" style="opacity: 0.7; padding-left: 24px; position: relative;">
+                        <span style="position: absolute; left: 0; color: var(--color-accent);">&#10003;</span>
+                        Research done in minutes
+                    </li>
+                    <li class="body-text" style="opacity: 0.7; padding-left: 24px; position: relative;">
+                        <span style="position: absolute; left: 0; color: var(--color-accent);">&#10003;</span>
+                        Consistently high quality
+                    </li>
+                    <li class="body-text" style="opacity: 0.7; padding-left: 24px; position: relative;">
+                        <span style="position: absolute; left: 0; color: var(--color-accent);">&#10003;</span>
+                        Scales without hiring
+                    </li>
+                    <li class="body-text" style="opacity: 0.7; padding-left: 24px; position: relative;">
+                        <span style="position: absolute; left: 0; color: var(--color-accent);">&#10003;</span>
+                        Persistent shared memory
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <!-- BOTTOM ZONE -->
+    <div class="poster-bottom" style="text-align: center; align-items: center;">
+        <div class="zone-divider-centered" style="margin-bottom: 16px;"></div>
+        <p class="body-text" style="opacity: 0.6;">Make the switch. It takes 5 minutes.</p>
+        <p class="brand" style="margin-top: 12px;">@yourbrand</p>
+    </div>
+
+</body>
+```
+
+---
+
+## 7. Screenshot Phase
+
+After generating the HTML file, run the screenshot tool:
+
+```bash
+node screenshot/screenshot.js \
+  --format poster \
+  --input ./EXPORT_DIR/index.html \
+  --output ./EXPORT_DIR/export.png
+```
+
+Where `EXPORT_DIR` is the export directory (see Section 9).
+
+This will:
+1. Open the HTML file in a headless Chromium browser
+2. Set the viewport to 1080x1350px with 2x device scale factor
+3. Wait for fonts to load (500ms default; use `--font-delay 1000` for custom fonts)
+4. Capture a PNG screenshot (fixed size, no full-page needed)
+5. Save to the specified output path
+
+---
+
+## 8. Delivery Phase
+
+After the screenshot is generated, present results to the user:
+
+```
+Your poster is ready!
+
+Location: [EXPORT_DIR]/
+
+Files:
+  index.html     -- Poster source (editable)
+  export.png     -- Final poster image
+
+Export details:
+  Dimensions: 1080 x 1350px (4:5 portrait)
+  File size:  487 KB
+
+Share on:
+  Instagram (recommended -- 4:5 is the optimal portrait ratio)
+  LinkedIn, Twitter/X, Stories, newsletters, print
+
+Want to make any changes?
+```
+
+---
+
+## 9. Export Directory Convention
+
+Ask the user: **"Where should I save the exports? (default: ./goose-graphics-exports/)"**
+
+### Directory naming
+- Primary: `[YYYY-MM-DD]-[slugified-name]/` (e.g., `2026-04-04-ai-webinar-poster/`)
+- Fallback (no name given): `[YYYY-MM-DD]-poster-[HHMMSS]/`
+
+### Directory structure (poster = single-file)
+```
+goose-graphics-exports/
+  2026-04-04-ai-webinar-poster/
+    index.html          # Poster source
+    export.png          # Final PNG
+```
+
+---
+
+## Design Reminders
+
+- **Everything on one page.** A poster is a single fixed composition at 1080x1350px. No scrolling, no overflow. Every element must fit.
+- **Three-zone composition.** Structure the poster into a top zone (headline), middle zone (content), and bottom zone (CTA/branding). Separate zones with accent rules.
+- **Dense but ordered.** Posters are denser than carousels or slides. Every pixel is planned. Use clear visual hierarchy so the eye knows where to go: headline first, key content second, CTA last.
+- **Fixed pixels only.** Like carousels, posters are fixed-size. No `vw`, `vh`, `clamp()`, or responsive units. Everything in `px`.
+- **High contrast is critical.** Posters are often viewed at small sizes in feeds. Bold headlines, strong accent colors, and clear type hierarchy.
+- **CTA in the bottom zone.** The bottom third is always reserved for the call to action and branding. This is the last thing the viewer sees and the most actionable.
+- **Less text, more impact.** A poster should be understood in 5 seconds or less. Every word must earn its place.

--- a/skills/composites/goose-graphics/formats/slides.md
+++ b/skills/composites/goose-graphics/formats/slides.md
@@ -1,0 +1,939 @@
+# Format: Slides
+
+Create widescreen presentation slides at 1920x1080px (16:9). Each slide is an individual HTML file, plus an `index.html` with keyboard navigation and scroll-snap for presenting directly in the browser.
+
+---
+
+## 1. Format Specifications
+
+| Property | Value |
+|----------|-------|
+| Dimensions | 1920 x 1080px per slide (16:9 widescreen) |
+| File structure | Individual HTML file per slide (`slide-01.html`, `slide-02.html`, ...) + `index.html` with navigation |
+| Max slides | No hard limit (10-30 typical) |
+| Output format | PNG per slide |
+| Sizing approach | Fixed pixel base with `clamp()` for browser-presentable index |
+
+### CRITICAL: Viewport Fitting
+
+Every slide MUST fit exactly within 1920x1080px. No scrolling, no overflow, no exceptions.
+
+- `overflow: hidden` on every `.slide` element
+- Content that does not fit must be split across multiple slides
+- Never reduce font size below readable limits to force a fit
+
+### Content Density Limits
+
+Each slide must be readable at a glance during a presentation.
+
+| Slide Type | Max Content |
+|------------|-------------|
+| Title slide | 1 heading (8 words max) + 1 subtitle (15 words max) + branding |
+| Content slide | 1 heading + 4-6 bullet points (10 words each) OR 1 heading + 2 short paragraphs |
+| Stat slide | 1-3 large numbers with labels and brief context |
+| Comparison | 1 heading + 2-column layout, 3-4 points per column |
+| Quote slide | 1 quote (30 words max) + attribution |
+| Code slide | 1 heading + 8-10 lines of code maximum |
+| Feature grid | 1 heading + 6 cards maximum (2x3 or 3x2 grid) |
+| Image slide | 1 heading + 1 image (max 60% of slide height) |
+| CTA slide | 1 heading + 1 action line + contact/link |
+
+**If content exceeds limits:** Split into multiple slides. Never cram.
+
+---
+
+## 2. Workflow Overview
+
+```
+Content Discovery --> Style Selection --> HTML Generation --> Screenshot --> Delivery
+```
+
+1. Gather presentation purpose, slide count, and content readiness from the user
+2. Present style presets and let the user choose (or guide them)
+3. Read the chosen style preset from `styles/[name].md`
+4. Generate individual HTML files per slide + an `index.html` with navigation
+5. Run the screenshot tool to export PNGs
+6. Present the finished files to the user
+
+---
+
+## 3. Content Discovery Phase
+
+Ask the user these questions before generating anything.
+
+**Question 1: Topic**
+- "What is this presentation about?"
+- Free text input
+
+**Question 2: Content Type**
+- "What kind of presentation is this?"
+- Options:
+  - **Pitch deck** -- Selling an idea, product, or company
+  - **Teaching / Tutorial** -- Explaining concepts, how-to guides
+  - **Conference talk** -- Speaking at an event, keynote, tech talk
+  - **Internal presentation** -- Team updates, strategy meetings
+  - **Report / Review** -- Quarterly results, performance review, analysis
+
+**Question 3: Slide Count**
+- "Approximately how many slides?"
+- Options:
+  - **Short (5-10)** -- Lightning talk, quick pitch
+  - **Medium (10-20)** -- Standard presentation
+  - **Long (20-30+)** -- Deep dive, comprehensive talk
+
+**Question 4: Content Readiness**
+- "Do you have the content ready?"
+- Options:
+  - **Yes, I have all content** -- Paste it in
+  - **I have rough notes** -- Need help organizing into slides
+  - **Just the topic** -- Need help creating the full outline
+
+If the user has content, ask them to share it before proceeding.
+
+---
+
+## 4. Style Selection Phase
+
+Present the 10 available design presets:
+
+| # | Preset | Description |
+|---|--------|-------------|
+| 1 | **Midnight Editorial** | Dark, elegant, magazine-inspired with copper accents |
+| 2 | **Clean Slate** | Ultra-minimal, precise, modern tech aesthetic |
+| 3 | **Warm Earth** | Organic, artisanal, grounded with natural tones |
+| 4 | **Electric Burst** | Bold, energetic, attention-grabbing with vivid color |
+| 5 | **Soft Cloud** | Airy, modern, approachable with gentle pastels |
+| 6 | **Terminal** | Dev/hacker aesthetic, focused and technical |
+| 7 | **Paper & Ink** | Classic editorial, literary, print-inspired |
+| 8 | **Brutalist** | Raw, structural, anti-design with strong geometry |
+| 9 | **Golden Dusk** | Warm, luxurious, premium with rich gold tones |
+| 10 | **Deep Ocean** | Calm, professional, immersive blue-dark palette |
+
+**Additional options:**
+
+- **"I have a reference image"** -- Use the `extract-style` skill at `styles/extract-style.md` to derive a custom palette from the user's image.
+- **Guided discovery** -- If the user is unsure, ask about their audience and tone, then recommend 2-3 presets:
+  - Professional / Corporate --> Clean Slate, Deep Ocean, Midnight Editorial
+  - Creative / Playful --> Electric Burst, Soft Cloud, Warm Earth
+  - Technical / Dev-focused --> Terminal, Brutalist, Clean Slate
+  - Elegant / Premium --> Midnight Editorial, Golden Dusk, Paper & Ink
+
+**After selection:** Read the chosen style preset file from `styles/[name].md` to load all colors, typography, and component patterns. For example, if the user picks "Terminal", read `styles/terminal.md`.
+
+---
+
+## 5. HTML Generation Phase
+
+### Base CSS (Mandatory)
+
+Every slide MUST include this dimension-locking CSS. Individual slide files use fixed pixels. The `index.html` presenter uses `clamp()` for browser-responsive viewing.
+
+#### For Individual Slide Files (`slide-XX.html`)
+
+```css
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+html, body {
+    width: 1920px;
+    height: 1080px;
+    overflow: hidden;
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 80px;
+}
+
+.slide {
+    width: 1920px;
+    height: 1080px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    position: relative;
+}
+```
+
+#### For the Index Presenter (`index.html`)
+
+```css
+html {
+    scroll-snap-type: y mandatory;
+    scroll-behavior: smooth;
+    height: 100%;
+    overflow-x: hidden;
+}
+
+body {
+    height: 100%;
+    margin: 0;
+}
+
+.slide {
+    width: 100vw;
+    height: 100vh;
+    height: 100dvh;
+    overflow: hidden;
+    scroll-snap-align: start;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    position: relative;
+    padding: clamp(2rem, 4vw, 80px);
+}
+```
+
+### Injecting the Style Preset
+
+After reading the style preset file, find its **Section 9 (Agent Prompt Guide)** which contains the CSS `:root` variables. Paste those variables into each slide's `<style>` block:
+
+```css
+:root {
+    /* -- Paste all CSS variables from the preset's Section 9 here -- */
+
+    /* Slides-specific overrides */
+    --slide-width: 1920px;
+    --slide-height: 1080px;
+    --slide-padding: 80px;
+    --content-max-width: 1760px;
+}
+```
+
+Also add the Google Fonts `<link>` from the preset's Section 9 into the `<head>`.
+
+### Using Component Patterns
+
+The preset's **Section 4 (Component Patterns)** contains ready-to-use HTML snippets. Scale them up for the 1920x1080 widescreen format.
+
+The preset's **Section 8 (Format Adaptation Notes)** contains slides-specific typography and layout guidance. Always apply these adaptations:
+- Display Hero scales up to 80px
+- Section Heading scales up to 56px
+- Body Large scales up to 22px
+- Left-heavy composition: title and body text in the left 60%, right 40% as breathing room
+
+### Complete HTML Template (Single Slide)
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=1920, initial-scale=1.0">
+    <title>Slide 01</title>
+
+    <!-- Google Fonts: paste the link from your chosen preset's Section 9 -->
+    <link href="https://fonts.googleapis.com/css2?family=PRESET_FONTS_HERE&display=swap" rel="stylesheet">
+
+    <style>
+        /* =============================================
+           PRESENTATION SLIDE: 1920x1080px FIXED
+           ============================================= */
+
+        :root {
+            /* -- Paste CSS variables from preset Section 9 -- */
+
+            /* Slides-specific overrides */
+            --slide-width: 1920px;
+            --slide-height: 1080px;
+            --slide-padding: 80px;
+            --content-max-width: 1760px;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        html, body {
+            width: var(--slide-width);
+            height: var(--slide-height);
+            overflow: hidden;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+        }
+
+        body {
+            background-color: var(--bg-primary, var(--color-midnight, #0d0d0d));
+            color: var(--text-primary, var(--color-cream, #f5f0e8));
+            font-family: var(--font-body);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: flex-start;
+            padding: var(--slide-padding);
+        }
+
+        .slide-content {
+            width: 100%;
+            max-width: var(--content-max-width);
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+
+        /* =============================================
+           TYPOGRAPHY HIERARCHY
+           Scaled up for widescreen from preset Section 8
+           ============================================= */
+
+        .display-title {
+            font-family: var(--font-display);
+            font-size: 80px;
+            font-weight: 700;
+            line-height: 1.05;
+            letter-spacing: -1.5px;
+        }
+
+        .section-heading {
+            font-family: var(--font-display);
+            font-size: 56px;
+            font-weight: 700;
+            line-height: 1.10;
+            letter-spacing: -1px;
+        }
+
+        .sub-heading {
+            font-family: var(--font-display);
+            font-size: 36px;
+            font-weight: 700;
+            line-height: 1.15;
+            letter-spacing: -0.5px;
+        }
+
+        .body-large {
+            font-family: var(--font-body);
+            font-size: 22px;
+            font-weight: 300;
+            line-height: 1.60;
+        }
+
+        .body-text {
+            font-family: var(--font-body);
+            font-size: 18px;
+            font-weight: 400;
+            line-height: 1.65;
+        }
+
+        .small-text {
+            font-family: var(--font-body);
+            font-size: 14px;
+            font-weight: 400;
+            line-height: 1.50;
+            letter-spacing: 0.3px;
+        }
+
+        .label {
+            font-family: var(--font-body);
+            font-size: 16px;
+            font-weight: 600;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+        }
+
+        .big-number {
+            font-family: var(--font-display);
+            font-size: 96px;
+            font-weight: 900;
+            line-height: 1.00;
+            letter-spacing: -1px;
+        }
+
+        /* =============================================
+           LAYOUT HELPERS
+           ============================================= */
+
+        .left-content {
+            max-width: 60%;
+        }
+
+        .two-column {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 40px;
+            width: 100%;
+        }
+
+        .three-column {
+            display: grid;
+            grid-template-columns: 1fr 1fr 1fr;
+            gap: 32px;
+            width: 100%;
+        }
+
+        .card {
+            background: var(--color-surface, var(--color-charcoal, #1a1a1a));
+            border: 1px solid var(--color-border, rgba(245,240,232,0.1));
+            border-radius: 4px;
+            padding: 40px 32px;
+        }
+
+        /* =============================================
+           SLIDE NUMBER
+           ============================================= */
+
+        .slide-number {
+            position: absolute;
+            bottom: var(--slide-padding);
+            right: var(--slide-padding);
+            font-family: var(--font-body);
+            font-size: 14px;
+            font-weight: 400;
+            opacity: 0.4;
+        }
+    </style>
+</head>
+<body>
+    <div class="slide-content">
+        <!-- Slide content goes here -->
+    </div>
+
+    <div class="slide-number">01</div>
+</body>
+</html>
+```
+
+### File Naming
+
+Slides are numbered sequentially:
+- `slide-01.html`
+- `slide-02.html`
+- `slide-03.html`
+- ...and so on
+
+---
+
+## 6. Content Templates
+
+All templates use CSS custom properties so they work with any style preset. For widescreen slides, favor left-aligned layouts with generous whitespace on the right.
+
+### Title Slide (Slide 1)
+
+```html
+<body>
+    <div class="slide-content" style="text-align: center; justify-content: center; align-items: center;">
+
+        <!-- Accent rule -->
+        <div style="width: 60px; height: 2px; background: var(--color-accent, var(--color-copper, #c17f59));"></div>
+
+        <!-- Title -->
+        <h1 class="display-title" style="margin-top: 32px; max-width: 1200px;">
+            The Future of Autonomous Work
+        </h1>
+
+        <!-- Subtitle -->
+        <p class="body-large" style="margin-top: 20px; opacity: 0.7; max-width: 800px;">
+            How AI coworkers are reshaping the way teams operate, collaborate, and deliver results.
+        </p>
+
+        <!-- Accent rule -->
+        <div style="width: 60px; height: 2px; background: var(--color-accent, var(--color-copper, #c17f59)); margin-top: 40px;"></div>
+
+        <!-- Author / date -->
+        <p class="label" style="margin-top: 32px; opacity: 0.5;">
+            YOUR NAME &middot; APRIL 2026
+        </p>
+    </div>
+</body>
+```
+
+### Numbered Item
+
+```html
+<body>
+    <div class="slide-content">
+
+        <div class="left-content">
+            <!-- Number -->
+            <span class="big-number" style="color: var(--color-accent, var(--color-copper, #c17f59));">
+                01
+            </span>
+
+            <!-- Category label -->
+            <p class="label" style="color: var(--color-secondary-accent, var(--color-muted-gold, #a89067)); margin-top: 12px;">
+                SIGNAL-BASED OUTBOUND
+            </p>
+
+            <!-- Heading -->
+            <h2 class="section-heading" style="margin-top: 16px;">
+                Find buyers before they find you
+            </h2>
+
+            <!-- Body -->
+            <p class="body-large" style="margin-top: 16px; opacity: 0.7; max-width: 800px;">
+                Monitor hiring signals, funding events, and tech stack changes to identify high-intent prospects the moment they enter the market.
+            </p>
+        </div>
+
+    </div>
+
+    <div class="slide-number">03</div>
+</body>
+```
+
+### Stat Display (Up to 3 Stats)
+
+```html
+<body>
+    <div class="slide-content">
+
+        <h2 class="section-heading" style="text-align: center; margin-bottom: 16px;">Impact at a Glance</h2>
+
+        <div class="three-column" style="margin-top: 24px;">
+            <!-- Stat 1 -->
+            <div class="card" style="text-align: center;">
+                <p class="big-number" style="color: var(--color-accent, var(--color-copper, #c17f59));">47%</p>
+                <p class="label" style="margin-top: 16px;">FASTER RESPONSE</p>
+                <p class="body-text" style="margin-top: 12px; opacity: 0.7;">Teams respond to leads nearly twice as fast with AI-powered workflows.</p>
+            </div>
+
+            <!-- Stat 2 -->
+            <div class="card" style="text-align: center;">
+                <p class="big-number" style="color: var(--color-accent, var(--color-copper, #c17f59));">3.2x</p>
+                <p class="label" style="margin-top: 16px;">PIPELINE GROWTH</p>
+                <p class="body-text" style="margin-top: 12px; opacity: 0.7;">Average pipeline increase within the first 90 days of deployment.</p>
+            </div>
+
+            <!-- Stat 3 -->
+            <div class="card" style="text-align: center;">
+                <p class="big-number" style="color: var(--color-accent, var(--color-copper, #c17f59));">12h</p>
+                <p class="label" style="margin-top: 16px;">SAVED WEEKLY</p>
+                <p class="body-text" style="margin-top: 12px; opacity: 0.7;">Hours reclaimed from manual research and data entry per team member.</p>
+            </div>
+        </div>
+
+    </div>
+
+    <div class="slide-number">05</div>
+</body>
+```
+
+### Comparison Grid
+
+```html
+<body>
+    <div class="slide-content">
+
+        <h2 class="section-heading" style="text-align: center; margin-bottom: 16px;">Old Way vs New Way</h2>
+
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2px; background: var(--color-border, rgba(245,240,232,0.1)); border-radius: 4px; overflow: hidden; margin-top: 24px;">
+            <!-- Left -->
+            <div style="background: var(--color-surface, var(--color-charcoal, #1a1a1a)); padding: 48px 40px;">
+                <p class="small-text" style="color: var(--color-secondary-accent, var(--color-muted-gold, #a89067)); margin-bottom: 20px;">Without AI</p>
+                <h3 class="sub-heading" style="margin-bottom: 20px;">Manual & Fragmented</h3>
+                <p class="body-text" style="opacity: 0.7;">Teams juggle Slack threads, spreadsheets, and context-switching between a dozen tabs to coordinate basic workflows.</p>
+            </div>
+
+            <!-- Right (featured) -->
+            <div style="background: var(--color-surface, var(--color-charcoal, #1a1a1a)); padding: 48px 40px; border-left: 2px solid var(--color-accent, var(--color-copper, #c17f59));">
+                <p class="small-text" style="color: var(--color-accent, var(--color-copper, #c17f59)); margin-bottom: 20px;">With AI</p>
+                <h3 class="sub-heading" style="margin-bottom: 20px;">Orchestrated & Autonomous</h3>
+                <p class="body-text" style="opacity: 0.7;">AI coworkers handle research, drafting, and follow-up autonomously. Your team focuses on decisions, not busywork.</p>
+            </div>
+        </div>
+
+    </div>
+
+    <div class="slide-number">06</div>
+</body>
+```
+
+### List Items
+
+```html
+<body>
+    <div class="slide-content">
+
+        <h2 class="section-heading" style="margin-bottom: 16px;">Core Capabilities</h2>
+
+        <div class="two-column" style="margin-top: 16px;">
+            <!-- Left column items -->
+            <div style="display: flex; flex-direction: column; gap: 0;">
+                <div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                    <div style="width: 40px; height: 40px; min-width: 40px; display: flex; align-items: center; justify-content: center; border: 1px solid var(--color-border-accent, rgba(193,127,89,0.3)); border-radius: 4px; color: var(--color-accent); font-size: 18px;">&#9670;</div>
+                    <div>
+                        <h4 class="sub-heading" style="font-size: 24px; margin-bottom: 6px;">Persistent Memory</h4>
+                        <p class="body-text" style="opacity: 0.7;">Agents remember context across sessions.</p>
+                    </div>
+                </div>
+
+                <div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                    <div style="width: 40px; height: 40px; min-width: 40px; display: flex; align-items: center; justify-content: center; border: 1px solid var(--color-border-accent, rgba(193,127,89,0.3)); border-radius: 4px; color: var(--color-accent); font-size: 18px;">&#9670;</div>
+                    <div>
+                        <h4 class="sub-heading" style="font-size: 24px; margin-bottom: 6px;">Multi-Channel Access</h4>
+                        <p class="body-text" style="opacity: 0.7;">Slack, Telegram, WhatsApp, or web chat.</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Right column items -->
+            <div style="display: flex; flex-direction: column; gap: 0;">
+                <div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                    <div style="width: 40px; height: 40px; min-width: 40px; display: flex; align-items: center; justify-content: center; border: 1px solid var(--color-border-accent, rgba(193,127,89,0.3)); border-radius: 4px; color: var(--color-accent); font-size: 18px;">&#9670;</div>
+                    <div>
+                        <h4 class="sub-heading" style="font-size: 24px; margin-bottom: 6px;">Tool Integration</h4>
+                        <p class="body-text" style="opacity: 0.7;">Connect any API, CRM, or SaaS tool.</p>
+                    </div>
+                </div>
+
+                <div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0; border-bottom: 1px solid var(--color-border, rgba(245,240,232,0.1));">
+                    <div style="width: 40px; height: 40px; min-width: 40px; display: flex; align-items: center; justify-content: center; border: 1px solid var(--color-border-accent, rgba(193,127,89,0.3)); border-radius: 4px; color: var(--color-accent); font-size: 18px;">&#9670;</div>
+                    <div>
+                        <h4 class="sub-heading" style="font-size: 24px; margin-bottom: 6px;">Autonomous Execution</h4>
+                        <p class="body-text" style="opacity: 0.7;">Agents work independently on assigned tasks.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+    <div class="slide-number">07</div>
+</body>
+```
+
+### Quote Block
+
+```html
+<body>
+    <div class="slide-content" style="justify-content: center; align-items: center;">
+
+        <div style="max-width: 1200px; padding: 60px 48px; border-left: 2px solid var(--color-accent, var(--color-copper, #c17f59)); background: var(--color-surface-inset, #141414);">
+            <p style="font-family: var(--font-display); font-size: 40px; font-weight: 400; font-style: italic; line-height: 1.35; letter-spacing: -0.5px;">
+                "It felt less like configuring software and more like onboarding a new team member."
+            </p>
+            <div style="display: flex; align-items: center; gap: 12px; margin-top: 32px;">
+                <div style="width: 32px; height: 2px; background: var(--color-accent, var(--color-copper, #c17f59));"></div>
+                <p class="label" style="color: var(--color-secondary-accent, var(--color-muted-gold, #a89067));">
+                    SARAH CHEN, VP OPERATIONS
+                </p>
+            </div>
+        </div>
+
+    </div>
+
+    <div class="slide-number">08</div>
+</body>
+```
+
+### CTA / Closing Slide
+
+```html
+<body>
+    <div class="slide-content" style="text-align: center; justify-content: center; align-items: center;">
+
+        <!-- Accent rule -->
+        <div style="width: 60px; height: 2px; background: var(--color-accent, var(--color-copper, #c17f59));"></div>
+
+        <!-- Heading -->
+        <h2 class="display-title" style="font-size: 64px; margin-top: 32px; max-width: 1000px;">
+            Ready to meet your team?
+        </h2>
+
+        <!-- Body -->
+        <p class="body-large" style="margin-top: 20px; opacity: 0.7; max-width: 600px;">
+            Deploy your first AI coworker in under five minutes. No setup fees, no long-term commitments.
+        </p>
+
+        <!-- CTA button -->
+        <div style="margin-top: 40px; display: inline-block; background: var(--color-accent, var(--color-copper, #c17f59)); color: var(--bg-primary, var(--color-midnight, #0d0d0d)); font-family: var(--font-body); font-size: 16px; font-weight: 600; letter-spacing: 0.8px; text-transform: uppercase; padding: 18px 48px; border-radius: 4px;">
+            Get Started
+        </div>
+
+        <!-- Accent rule -->
+        <div style="width: 60px; height: 2px; background: var(--color-accent, var(--color-copper, #c17f59)); margin-top: 48px;"></div>
+    </div>
+</body>
+```
+
+### Index Presenter File
+
+Create an `index.html` with full keyboard navigation and scroll-snap for presenting directly in the browser:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Presentation Title</title>
+
+    <!-- Google Fonts: same as individual slides -->
+    <link href="https://fonts.googleapis.com/css2?family=PRESET_FONTS_HERE&display=swap" rel="stylesheet">
+
+    <style>
+        :root {
+            /* -- Same preset CSS variables as individual slides -- */
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        html {
+            scroll-snap-type: y mandatory;
+            scroll-behavior: smooth;
+            height: 100%;
+            overflow-x: hidden;
+        }
+
+        body {
+            font-family: var(--font-body);
+            background: var(--bg-primary, #0d0d0d);
+            color: var(--text-primary, #f5f0e8);
+            height: 100%;
+            overflow-x: hidden;
+        }
+
+        .slide {
+            width: 100vw;
+            height: 100vh;
+            height: 100dvh;
+            overflow: hidden;
+            scroll-snap-align: start;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: flex-start;
+            position: relative;
+            padding: clamp(2rem, 4vw, 80px);
+        }
+
+        /* Typography scales for browser viewing */
+        .display-title { font-size: clamp(2rem, 5vw, 80px); }
+        .section-heading { font-size: clamp(1.5rem, 3.5vw, 56px); }
+        .sub-heading { font-size: clamp(1.1rem, 2.5vw, 36px); }
+        .body-large { font-size: clamp(0.875rem, 1.5vw, 22px); }
+        .body-text { font-size: clamp(0.75rem, 1.2vw, 18px); }
+
+        /* Navigation dots */
+        .nav-dots {
+            position: fixed;
+            right: 24px;
+            top: 50%;
+            transform: translateY(-50%);
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            z-index: 100;
+        }
+
+        .nav-dots .dot {
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            background: var(--text-primary, #f5f0e8);
+            opacity: 0.2;
+            cursor: pointer;
+            transition: opacity 0.3s;
+        }
+
+        .nav-dots .dot.active {
+            opacity: 0.8;
+        }
+
+        /* Progress bar */
+        .progress-bar {
+            position: fixed;
+            top: 0;
+            left: 0;
+            height: 2px;
+            background: var(--color-accent, #c17f59);
+            z-index: 100;
+            transition: width 0.3s;
+        }
+
+        /* Keyboard hint */
+        .keyboard-hint {
+            position: fixed;
+            bottom: 24px;
+            left: 50%;
+            transform: translateX(-50%);
+            font-size: 12px;
+            opacity: 0.3;
+            z-index: 100;
+        }
+
+        @media (max-height: 600px) {
+            .nav-dots, .keyboard-hint { display: none; }
+        }
+    </style>
+</head>
+<body>
+    <div class="progress-bar" id="progress" style="width: 0%;"></div>
+    <nav class="nav-dots" id="nav-dots"></nav>
+
+    <!-- Paste all slide content here as <section class="slide"> blocks -->
+    <section class="slide" id="slide-1">
+        <!-- ... slide 1 content ... -->
+    </section>
+
+    <section class="slide" id="slide-2">
+        <!-- ... slide 2 content ... -->
+    </section>
+
+    <!-- ... more slides ... -->
+
+    <p class="keyboard-hint">Arrow keys or scroll to navigate</p>
+
+    <script>
+        // Navigation controller
+        const slides = document.querySelectorAll('.slide');
+        const progress = document.getElementById('progress');
+        const navDots = document.getElementById('nav-dots');
+        let currentSlide = 0;
+
+        // Create nav dots
+        slides.forEach((_, i) => {
+            const dot = document.createElement('div');
+            dot.className = 'dot' + (i === 0 ? ' active' : '');
+            dot.addEventListener('click', () => goToSlide(i));
+            navDots.appendChild(dot);
+        });
+
+        function goToSlide(index) {
+            if (index < 0 || index >= slides.length) return;
+            currentSlide = index;
+            slides[index].scrollIntoView({ behavior: 'smooth' });
+            updateUI();
+        }
+
+        function updateUI() {
+            const pct = ((currentSlide + 1) / slides.length) * 100;
+            progress.style.width = pct + '%';
+
+            navDots.querySelectorAll('.dot').forEach((dot, i) => {
+                dot.classList.toggle('active', i === currentSlide);
+            });
+        }
+
+        // Keyboard navigation
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'ArrowDown' || e.key === 'ArrowRight' || e.key === ' ') {
+                e.preventDefault();
+                goToSlide(currentSlide + 1);
+            } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+                e.preventDefault();
+                goToSlide(currentSlide - 1);
+            }
+        });
+
+        // Track scroll position
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    const index = Array.from(slides).indexOf(entry.target);
+                    if (index !== -1) {
+                        currentSlide = index;
+                        updateUI();
+                    }
+                }
+            });
+        }, { threshold: 0.5 });
+
+        slides.forEach(slide => observer.observe(slide));
+    </script>
+</body>
+</html>
+```
+
+---
+
+## 7. Screenshot Phase
+
+After generating all HTML files, run the screenshot tool:
+
+```bash
+node screenshot/screenshot.js \
+  --format slides \
+  --input ./EXPORT_DIR/slides \
+  --output ./EXPORT_DIR/exports
+```
+
+Where `EXPORT_DIR` is the export directory (see Section 9).
+
+This will:
+1. Open each slide HTML in a headless Chromium browser
+2. Set the viewport to 1920x1080px with 2x device scale factor
+3. Wait for fonts to load (500ms default; use `--font-delay 1000` for custom fonts)
+4. Capture a PNG screenshot of each slide
+5. Save as `slide-01.png`, `slide-02.png`, etc. in the exports directory
+
+---
+
+## 8. Delivery Phase
+
+After screenshots are generated, present results to the user:
+
+```
+Your presentation is ready!
+
+Location: [EXPORT_DIR]/
+
+Files:
+  slides/        -- 12 HTML source files
+  exports/       -- 12 PNG images (1920x1080px each)
+  index.html     -- Browser-based presentation with keyboard navigation
+
+Present directly:
+  Open index.html in any browser and use arrow keys to navigate.
+  Works in full-screen mode (F11) for actual presentations.
+
+Export details:
+  slide-01.png    412 KB
+  slide-02.png    287 KB
+  ...
+  slide-12.png    198 KB
+  Total:          3.8 MB
+
+Navigation controls:
+  Arrow keys (left/right or up/down) to move between slides
+  Space bar to advance
+  Click the dots on the right to jump to any slide
+  Scroll also works (with snap)
+
+Want to make any changes?
+```
+
+---
+
+## 9. Export Directory Convention
+
+Ask the user: **"Where should I save the exports? (default: ./goose-graphics-exports/)"**
+
+### Directory naming
+- Primary: `[YYYY-MM-DD]-[slugified-name]/` (e.g., `2026-04-04-future-of-autonomous-work/`)
+- Fallback (no name given): `[YYYY-MM-DD]-slides-[HHMMSS]/`
+
+### Directory structure (slides = multi-file)
+```
+goose-graphics-exports/
+  2026-04-04-future-of-autonomous-work/
+    slides/
+      slide-01.html
+      slide-02.html
+      slide-03.html
+      ...
+    exports/
+      slide-01.png
+      slide-02.png
+      slide-03.png
+      ...
+    index.html          # Browser-based presenter
+```
+
+---
+
+## Design Reminders
+
+- **Viewport fitting is non-negotiable.** Every slide must fit exactly in 1920x1080px. Content that overflows must be split across slides. `overflow: hidden` on every slide.
+- **Left-heavy composition.** On widescreen slides, anchor the primary content (title, body text) to the left 60% of the frame. The right 40% is breathing room or for supporting visuals (stats, illustrations).
+- **One idea per slide.** Presentations work best when each slide makes a single point clearly. Dense slides lose the audience.
+- **Scaled-up typography.** Widescreen gives you room for large, confident type. Use 80px for display titles, 56px for section headings. These sizes feel right when projected.
+- **Slide numbers.** Place small, low-opacity slide numbers in the bottom-right corner of every slide for reference during Q&A.
+- **Consistent transitions.** The `index.html` presenter uses scroll-snap for smooth slide transitions. Individual PNG exports can be loaded into Google Slides, Keynote, or PowerPoint as image slides.

--- a/skills/composites/goose-graphics/formats/story.md
+++ b/skills/composites/goose-graphics/formats/story.md
@@ -1,0 +1,673 @@
+# Format: Story
+
+Create vertical 9:16 story slides optimized for Instagram Stories, LinkedIn Stories, TikTok slides, and Snapchat. Each slide is an individual HTML file rendered at 1080x1920px, then screenshotted to PNG.
+
+---
+
+## 1. Format Specifications
+
+| Property | Value |
+|----------|-------|
+| Dimensions | 1080 x 1920px per slide (9:16 vertical) |
+| File structure | Individual HTML file per slide (`story-01.html`, `story-02.html`, ...) + `index.html` preview |
+| Max slides | 10 |
+| Ideal slide count | 3-6 (best completion rate) |
+| Output format | PNG per slide |
+| Sizing approach | Fixed pixel sizes (NOT responsive) |
+| Safe zones | 160px top + 160px bottom reserved for platform UI |
+
+### Content Density Limits
+
+Stories are watched at full-screen on a phone, typically in 3-5 seconds per frame. Every slide must communicate a single idea with ONE focal element.
+
+| Slide Type | Max Content |
+|------------|-------------|
+| Cover | Title (6 words max) + subtitle (10 words max) + branding element |
+| Hook / Question | 1 question (10 words max) |
+| Single stat | 1 big number + label (4 words) + 1-line context (15 words max) |
+| Quote | 1 quote (20 words max) + attribution |
+| Numbered item | Number + heading (2 lines max) + body (25 words max) |
+| Visual / Photo | 1 full-bleed image + 1 headline overlay (6 words max) |
+| CTA | 1 action heading + 1 support line + swipe/tap element |
+
+**If content exceeds limits:** Break into multiple slides. Stories are meant to be tapped through quickly; cramming kills completion rate.
+
+### Platform Safe Zones
+
+Platform UI (profile avatar, reply bar, progress segments) overlays the top and bottom of every story. Reserve:
+
+- **Top 160px** -- profile avatar, progress bar, close button
+- **Bottom 160px** -- reply input, swipe-up indicator, reaction bar
+
+All critical content (headlines, CTAs, big numbers) must sit inside the middle 1600px safe zone (from y=160 to y=1760). Decorative background elements (gradients, photos, textures) can extend into the safe zones; text and interactive UI cannot.
+
+---
+
+## 2. Workflow Overview
+
+```
+Content Discovery --> Style Selection --> HTML Generation --> Screenshot --> Delivery
+```
+
+1. Gather topic, content type, slide count, and content readiness from the user
+2. Present style presets and let the user choose (or guide them)
+3. Read the chosen style preset from `styles/[name].md`
+4. Generate individual HTML files per slide + an `index.html` preview
+5. Run the screenshot tool to export PNGs
+6. Present the finished files to the user
+
+---
+
+## 3. Content Discovery Phase
+
+Ask the user these questions before generating anything.
+
+**Question 1: Topic**
+- "What is the main topic of this story?"
+- Free text input
+
+**Question 2: Content Type**
+- "What type of story is this?"
+- Options:
+  - **Hook -> Insight -> CTA** -- The classic 3-slide story sequence
+  - **Numbered list** -- "3 ways to...", "5 reasons..."
+  - **Before / After** -- Transformation or comparison
+  - **Announcement** -- Launch, release, event
+  - **Quote / Testimonial** -- Featured customer voice
+  - **Behind-the-scenes** -- Narrative sequence
+
+**Question 3: Slide Count**
+- "How many story slides?"
+- Options:
+  - **Short (3)** -- Hook + Insight + CTA. Best for announcements.
+  - **Medium (4-6)** -- Standard story sequence.
+  - **Long (7-10)** -- Maximum allowed. Use only for strong narrative arcs.
+
+**Question 4: Content Readiness**
+- "Do you have the content ready?"
+- Same options as carousel format.
+
+---
+
+## 4. Style Selection Phase
+
+Present the available design presets (see SKILL.md §5 for the full list). After selection, read the chosen style preset file from `styles/[name].md`.
+
+**Guided discovery** -- if the user is unsure, ask about their platform and audience, then recommend 2-3 presets:
+- Instagram / lifestyle brand --> cinematic-romance, peach-pop, pastel-organic-shapes, warm-earth
+- LinkedIn / B2B --> matt-gray, midnight-editorial, heatwave-orange
+- Tech / developer --> terminal, brutalist, deep-ocean, iridescent-y2k
+- Editorial / magazine --> paper-and-ink, sunburst-editorial, magazine-red
+
+**After selection:** Read the chosen style preset file. Look specifically at **Section 8 (Format Adaptation Notes) -> Story (1080x1920)** for the format-specific typography scale and layout guidance.
+
+---
+
+## 5. HTML Generation Phase
+
+### Base CSS (Mandatory)
+
+Every story slide MUST include this dimension-locking CSS. Stories are fixed-size -- no responsive scaling, no viewport units, no clamp(). Everything is in pixels.
+
+```css
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+html, body {
+    width: 1080px;
+    height: 1920px;
+    overflow: hidden;
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    padding: 120px 60px;  /* top/bottom bigger to respect safe zones */
+}
+```
+
+### Safe Zone Variables
+
+```css
+:root {
+    --story-width: 1080px;
+    --story-height: 1920px;
+    --story-padding-x: 60px;
+    --story-padding-y: 120px;
+    --safe-top: 160px;
+    --safe-bottom: 160px;
+    --content-max-width: 960px;
+}
+```
+
+### Injecting the Style Preset
+
+After reading the style preset file, find its **Section 9 (Agent Prompt Guide)** CSS `:root` variables and paste them into each slide's `<style>` block. Then look at **Section 8 (Story 1080x1920)** for the preset's specific Story typography scale and apply those sizes.
+
+Also add the Google Fonts `<link>` from the preset's Section 9 into the `<head>`.
+
+### Complete HTML Template (Single Slide)
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=1080, initial-scale=1.0">
+    <title>Story 01</title>
+
+    <!-- Google Fonts: paste the link from your chosen preset's Section 9 -->
+    <link href="https://fonts.googleapis.com/css2?family=PRESET_FONTS_HERE&display=swap" rel="stylesheet">
+
+    <style>
+        /* =============================================
+           STORY SLIDE: 1080x1920px FIXED
+           ============================================= */
+
+        :root {
+            /* -- Paste CSS variables from preset Section 9 -- */
+
+            /* Story-specific overrides */
+            --story-width: 1080px;
+            --story-height: 1920px;
+            --story-padding-x: 60px;
+            --story-padding-y: 120px;
+            --safe-top: 160px;
+            --safe-bottom: 160px;
+            --content-max-width: 960px;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        html, body {
+            width: var(--story-width);
+            height: var(--story-height);
+            overflow: hidden;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+        }
+
+        body {
+            /* Use preset background variable */
+            background-color: var(--bg-primary);
+            color: var(--text-primary);
+            font-family: var(--font-body);
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            align-items: center;
+            padding: var(--story-padding-y) var(--story-padding-x);
+            position: relative;
+        }
+
+        .story-content {
+            width: 100%;
+            max-width: var(--content-max-width);
+            display: flex;
+            flex-direction: column;
+            gap: 32px;
+        }
+
+        /* =============================================
+           TYPOGRAPHY HIERARCHY (Story scale)
+           Typically ~30% larger than carousel scale -- stories
+           are viewed at full-screen phone size where headlines
+           need to carry the frame on their own.
+           ============================================= */
+
+        .title {
+            font-family: var(--font-display);
+            font-size: 96px;
+            font-weight: 700;
+            line-height: 1.05;
+            letter-spacing: -1.5px;
+        }
+
+        .subtitle {
+            font-family: var(--font-body);
+            font-size: 32px;
+            font-weight: 400;
+            line-height: 1.40;
+        }
+
+        .heading {
+            font-family: var(--font-display);
+            font-size: 72px;
+            font-weight: 700;
+            line-height: 1.10;
+            letter-spacing: -0.8px;
+        }
+
+        .body-text {
+            font-family: var(--font-body);
+            font-size: 28px;
+            font-weight: 400;
+            line-height: 1.50;
+        }
+
+        .label {
+            font-family: var(--font-body);
+            font-size: 18px;
+            font-weight: 600;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+        }
+
+        .big-number {
+            font-family: var(--font-display);
+            font-size: 180px;
+            font-weight: 900;
+            line-height: 1.00;
+            letter-spacing: -2px;
+        }
+
+        /* =============================================
+           SAFE ZONES (visual debug only -- remove in production)
+           ============================================= */
+
+        /*
+        body::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: var(--safe-top);
+            background: rgba(255,0,0,0.1);
+            pointer-events: none;
+        }
+
+        body::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            height: var(--safe-bottom);
+            background: rgba(255,0,0,0.1);
+            pointer-events: none;
+        }
+        */
+
+        /* =============================================
+           BRANDING FOOTER (sits inside content area, above bottom safe zone)
+           ============================================= */
+
+        .brand {
+            position: absolute;
+            bottom: calc(var(--safe-bottom) + 40px);
+            left: 50%;
+            transform: translateX(-50%);
+            font-family: var(--font-body);
+            font-size: 20px;
+            font-weight: 500;
+            opacity: 0.7;
+            text-align: center;
+        }
+
+        /* =============================================
+           PROGRESS SEGMENTS (optional, at top inside safe zone)
+           ============================================= */
+
+        .progress {
+            position: absolute;
+            top: 60px;
+            left: var(--story-padding-x);
+            right: var(--story-padding-x);
+            display: flex;
+            gap: 6px;
+        }
+
+        .progress .segment {
+            flex: 1;
+            height: 3px;
+            background: rgba(255,255,255,0.3);
+            border-radius: 2px;
+        }
+
+        .progress .segment.active {
+            background: var(--text-primary);
+        }
+
+        /* =============================================
+           SWIPE-UP INDICATOR (optional, above bottom safe zone)
+           ============================================= */
+
+        .swipe-up {
+            position: absolute;
+            bottom: calc(var(--safe-bottom) + 80px);
+            left: 50%;
+            transform: translateX(-50%);
+            font-family: var(--font-body);
+            font-size: 16px;
+            font-weight: 600;
+            letter-spacing: 1.5px;
+            text-transform: uppercase;
+            opacity: 0.8;
+        }
+    </style>
+</head>
+<body>
+    <!-- Optional progress bar -->
+    <div class="progress">
+        <div class="segment active"></div>
+        <div class="segment"></div>
+        <div class="segment"></div>
+    </div>
+
+    <div class="story-content">
+        <!-- Slide content goes here -->
+    </div>
+
+    <div class="brand">@yourbrand</div>
+</body>
+</html>
+```
+
+### File Naming
+
+Slides are numbered sequentially:
+- `story-01.html`
+- `story-02.html`
+- `story-03.html`
+- ...up to `story-10.html`
+
+---
+
+## 6. Content Templates
+
+All templates use CSS custom properties so they work with any style preset. Adapt colors, fonts, and spacing from the preset's component patterns in Section 4.
+
+### Cover Slide (Slide 1)
+
+```html
+<body>
+    <div class="story-content" style="text-align: center; justify-content: center; align-items: center;">
+
+        <!-- Small label -->
+        <p class="label" style="margin-bottom: 40px; opacity: 0.7;">
+            THE GOOSE GUIDE
+        </p>
+
+        <!-- Title -->
+        <h1 class="title">
+            5 AI Workflows<br>That Actually Work
+        </h1>
+
+        <!-- Subtitle -->
+        <p class="subtitle" style="margin-top: 32px; opacity: 0.7; max-width: 720px;">
+            Tap to see the full list.
+        </p>
+
+    </div>
+
+    <div class="brand">@yourbrand</div>
+</body>
+```
+
+### Hook / Question Slide
+
+```html
+<body>
+    <div class="story-content" style="justify-content: center;">
+
+        <p class="label" style="margin-bottom: 32px; opacity: 0.6;">
+            ASK YOURSELF
+        </p>
+
+        <h2 class="heading">
+            Why does your<br>AI workflow<br>feel so manual?
+        </h2>
+
+    </div>
+
+    <div class="brand">@yourbrand</div>
+    <p class="swipe-up">Swipe up for the answer &uarr;</p>
+</body>
+```
+
+### Stat Display
+
+```html
+<body>
+    <div class="story-content" style="text-align: center; justify-content: center; align-items: center;">
+
+        <!-- Big stat number -->
+        <p class="big-number" style="color: var(--color-accent);">
+            47%
+        </p>
+
+        <!-- Stat label -->
+        <p class="label" style="margin-top: 24px;">
+            FASTER RESPONSE
+        </p>
+
+        <!-- Context -->
+        <p class="body-text" style="margin-top: 32px; opacity: 0.7; max-width: 720px;">
+            Teams using AI coworkers respond to inbound leads nearly twice as fast as manual workflows.
+        </p>
+
+    </div>
+
+    <div class="brand">@yourbrand &middot; 3/5</div>
+</body>
+```
+
+### Quote Slide
+
+```html
+<body>
+    <div class="story-content" style="justify-content: center;">
+
+        <div style="padding: 64px 48px; border-left: 4px solid var(--color-accent);">
+            <p style="font-family: var(--font-display); font-size: 54px; font-weight: 400; font-style: italic; line-height: 1.30; letter-spacing: -0.5px;">
+                "It felt less like configuring software and more like onboarding a new team member."
+            </p>
+            <div style="display: flex; align-items: center; gap: 16px; margin-top: 40px;">
+                <div style="width: 48px; height: 3px; background: var(--color-accent);"></div>
+                <p class="label" style="opacity: 0.8;">
+                    SARAH CHEN, VP OPS
+                </p>
+            </div>
+        </div>
+
+    </div>
+
+    <div class="brand">@yourbrand &middot; 4/5</div>
+</body>
+```
+
+### CTA Slide (Last Slide)
+
+```html
+<body>
+    <div class="story-content" style="text-align: center; justify-content: center; align-items: center;">
+
+        <p class="label" style="opacity: 0.7; margin-bottom: 32px;">
+            READY?
+        </p>
+
+        <h2 class="heading" style="font-size: 84px;">
+            Meet your<br>AI coworker.
+        </h2>
+
+        <p class="body-text" style="margin-top: 32px; opacity: 0.7; max-width: 720px;">
+            Tap the link in bio to get started.
+        </p>
+
+        <div style="margin-top: 56px; display: inline-block; background: var(--color-accent); color: var(--bg-primary); font-family: var(--font-body); font-size: 24px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; padding: 24px 56px; border-radius: 8px;">
+            Tap the Link &rarr;
+        </div>
+
+    </div>
+
+    <div class="brand">@yourbrand</div>
+</body>
+```
+
+### Index Preview File
+
+Create an `index.html` that shows all story slides in a horizontal scroll for easy review:
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Story Preview</title>
+    <style>
+        body {
+            margin: 0;
+            background: #111;
+            color: #fff;
+            font-family: -apple-system, sans-serif;
+            padding: 40px;
+        }
+        h1 { font-size: 24px; margin-bottom: 32px; font-weight: 400; }
+        .row {
+            display: flex;
+            gap: 24px;
+            overflow-x: auto;
+            padding-bottom: 24px;
+        }
+        .slide-wrapper {
+            width: 270px;
+            height: 480px;
+            min-width: 270px;
+            overflow: hidden;
+            border: 1px solid #333;
+            border-radius: 12px;
+            position: relative;
+        }
+        .slide-wrapper iframe {
+            width: 1080px;
+            height: 1920px;
+            border: none;
+            transform: scale(0.25);
+            transform-origin: 0 0;
+        }
+        .slide-label {
+            font-size: 13px;
+            opacity: 0.5;
+            margin-top: 8px;
+        }
+    </style>
+</head>
+<body>
+    <h1>Story Preview</h1>
+    <div class="row">
+        <div>
+            <div class="slide-wrapper">
+                <iframe src="slides/story-01.html" scrolling="no"></iframe>
+            </div>
+            <p class="slide-label">Story 01</p>
+        </div>
+        <!-- ... additional slides ... -->
+    </div>
+</body>
+</html>
+```
+
+---
+
+## 7. Screenshot Phase
+
+After generating all HTML files, run the screenshot tool:
+
+```bash
+node screenshot/screenshot.js \
+  --format story \
+  --input ./EXPORT_DIR/slides \
+  --output ./EXPORT_DIR/exports
+```
+
+Where `EXPORT_DIR` is the export directory (see Section 9).
+
+This will:
+1. Open each slide HTML in a headless Chromium browser
+2. Set the viewport to 1080x1920px with 2x device scale factor
+3. Wait for fonts to load (500ms default; use `--font-delay 1000` for custom fonts)
+4. Capture a PNG screenshot of each slide
+5. Save as `story-01.png`, `story-02.png`, etc. in the exports directory
+
+If the current `screenshot/screenshot.js` does not yet support `story` as a format flag, add a case that sets `viewport: { width: 1080, height: 1920 }` and uses the output naming pattern `story-##.png`.
+
+---
+
+## 8. Delivery Phase
+
+After screenshots are generated, present results to the user:
+
+```
+Your story is ready!
+
+Location: [EXPORT_DIR]/
+
+Files:
+  slides/        -- 4 HTML source files
+  exports/       -- 4 PNG images (1080x1920px each)
+  index.html     -- Preview all slides in browser
+
+Export details:
+  story-01.png    512 KB
+  story-02.png    478 KB
+  story-03.png    491 KB
+  story-04.png    356 KB
+  Total:          1.8 MB
+
+Upload instructions:
+  Instagram: Stories > + > Upload each PNG as a separate story
+  LinkedIn: Add story > Upload each PNG in sequence
+  TikTok: Upload as photo carousel
+
+Want to make any changes to the slides?
+```
+
+---
+
+## 9. Export Directory Convention
+
+Ask the user: **"Where should I save the exports? (default: ./goose-graphics-exports/)"**
+
+### Directory naming
+- Primary: `[YYYY-MM-DD]-[slugified-name]-story/` (e.g., `2026-04-15-ai-gtm-story/`)
+- Fallback (no name given): `[YYYY-MM-DD]-story-[HHMMSS]/`
+
+### Directory structure (story = multi-file)
+```
+goose-graphics-exports/
+  2026-04-15-ai-gtm-story/
+    slides/
+      story-01.html
+      story-02.html
+      story-03.html
+      ...
+    exports/
+      story-01.png
+      story-02.png
+      story-03.png
+      ...
+    index.html          # Preview file
+```
+
+---
+
+## Design Reminders
+
+- **Fixed pixels only.** Story slides are 1080x1920px exactly. Never use `vw`, `vh`, `clamp()`, or responsive units. Everything is defined in `px`.
+- **One focal element per slide.** Stories are viewed full-screen for 3-5 seconds. If the viewer has to pick which thing to read first, you've already lost them.
+- **Respect the safe zones.** Keep all critical text between y=160 and y=1760. Decorative backgrounds can extend edge-to-edge; readable content cannot.
+- **Big type, big margins.** Story hero type is typically ~30% larger than carousel hero type. 96px title, 72px heading, 180px big-number. Anything smaller gets lost on a phone.
+- **Center the gravity.** Stories feel right when content clusters in the vertical middle (y=400 to y=1500). Top and bottom are for labels and chrome.
+- **Sparse is strong.** Four lines of body text is the ceiling for any content slide. More than that, split into two slides.
+- **High contrast.** Most viewers watch stories outdoors or on low brightness. Strong text/background contrast is non-negotiable. Minimum 4.5:1.
+- **Consistent branding.** Place your handle in the same position on every slide -- bottom center just above the safe zone is the convention.
+- **Progress segments.** If your story is 3+ slides, include progress segments at the top (inside the safe zone, y=60). Each segment is 3px tall, flex-equal-width, with the current slide's segment fully filled.

--- a/skills/composites/goose-graphics/formats/tweet.md
+++ b/skills/composites/goose-graphics/formats/tweet.md
@@ -1,0 +1,1010 @@
+# Format: Tweet
+
+Create social proof and testimonial graphics at 1080x1080px (1:1 square). A tweet, review, or quote is displayed as a card floating on a decorative background -- perfect for customer testimonials, social proof screenshots, notable quotes from Twitter/X or LinkedIn, and reviews presented as beautiful standalone graphics.
+
+---
+
+## 1. Format Specifications
+
+| Property | Value |
+|----------|-------|
+| Dimensions | 1080 x 1080px (1:1 square) |
+| File structure | Single HTML file (`index.html`) |
+| Aspect ratio | 1:1 (works on Instagram, LinkedIn, Twitter/X) |
+| Output format | Single PNG |
+| Sizing approach | Fixed pixel sizes (NOT responsive) |
+| Design approach | Testimonial card centered on decorative background |
+
+### Content Density Limits
+
+The tweet card must look like a real social media post -- clean and readable. The background is decorative but should not compete with the card.
+
+| Element | Max Content |
+|---------|-------------|
+| Display name | 1 line, 30 characters max |
+| Handle / title | 1 line, 40 characters max |
+| Post body text | Full tweet text -- do NOT truncate or compress |
+| Engagement metrics | 3-4 numbers (likes, retweets, replies, views) |
+| Star rating | 1-5 stars |
+| Timestamp | 1 line |
+| Attribution | Name + role/company, 1-2 lines |
+| Brand watermark | Small mark in bottom corner of overall graphic |
+
+**IMPORTANT -- Show the full text:** Always display the complete tweet/testimonial text. Do NOT truncate, summarize, or compress the body text. If the text is long, increase the card height to accommodate it -- the card should grow vertically as needed within the 1080x1080 frame. Use `font-size: 18-20px` for body text and `line-height: 1.6` for comfortable reading. The card width stays fixed (~800px), but height is flexible.
+
+**If content truly exceeds the frame** (very rare -- would need 500+ characters): Only then trim with an ellipsis, but try font-size reduction first (minimum 16px).
+
+---
+
+## 2. Workflow Overview
+
+```
+Content Discovery --> Style Selection --> HTML Generation --> Screenshot --> Delivery
+```
+
+1. Gather the testimonial content, source type, and attribution from the user
+2. Present style presets and let the user choose (or guide them)
+3. Read the chosen style preset from `styles/[name].md`
+4. Generate a single HTML file with the card-on-background composition
+5. Run the screenshot tool to export the PNG
+6. Present the finished file to the user
+
+---
+
+## 3. Content Discovery Phase
+
+Ask the user these questions before generating anything.
+
+**Question 1: Content**
+- "What testimonial or quote do you want to feature?"
+- Free text input -- could be a tweet URL, pasted text, or a description
+
+**Question 2: Content Type**
+- "What kind of testimonial is this?"
+- Options:
+  - **Twitter/X Post** -- Tweet with profile, handle, text, engagement metrics
+  - **LinkedIn Post** -- Professional post with name, title, company, reactions
+  - **Customer Review** -- Star rating, review text, reviewer name + company
+  - **Quote Testimonial** -- Large editorial quote with attribution
+  - **Chat Message** -- Slack/iMessage-style conversation thread (2-3 messages)
+
+**Question 3: Attribution**
+- "Who said this? (Name, handle, role, company)"
+- Needed for the profile area of the card
+
+**Question 4: Content Readiness**
+- "Do you have the exact text ready?"
+- Options:
+  - **Yes, use this exact text** -- Paste it in
+  - **Paraphrase this** -- Need help cleaning up
+  - **Just the gist** -- Need help writing a compelling testimonial
+
+If the user has content, ask them to share it before proceeding.
+
+### Auto-Fetching from Tweet URLs
+
+**If the user provides a tweet URL (x.com or twitter.com),** use the tweet fetcher tool to automatically extract all data:
+
+```bash
+node [skill-pack-dir]/screenshot/fetch-tweet.js <tweet-url>
+```
+
+This returns JSON with:
+- `text` -- Full tweet text (cleaned of t.co URLs)
+- `author.name` -- Display name
+- `author.handle` -- @handle
+- `author.profileImage` -- 400x400 profile photo URL (use in `<img>` tag)
+- `author.isVerified` -- Blue checkmark status
+- `metrics.likes`, `metrics.retweets`, etc. -- Engagement counts
+- `metrics.likesFormatted` -- Human-readable counts (e.g., "1.2K")
+- `date.formatted` -- Formatted timestamp (e.g., "11:45 AM · April 5, 2026")
+
+**When tweet data is fetched:**
+- Skip Questions 2-4 (auto-detected as Twitter/X Post)
+- Use the real profile photo URL in an `<img>` tag (NOT CSS initials)
+- Use the full tweet text (do NOT truncate or compress)
+- Use the real engagement metrics
+- Use the real timestamp
+
+---
+
+## 4. Style Selection Phase
+
+Present the 10 available design presets. For tweet graphics, the preset controls the **background** behind the card (gradients, colors, patterns) and the accent colors on the card itself.
+
+| # | Preset | Description |
+|---|--------|-------------|
+| 1 | **Midnight Editorial** | Dark, elegant, magazine-inspired with copper accents |
+| 2 | **Clean Slate** | Ultra-minimal, precise, modern tech aesthetic |
+| 3 | **Warm Earth** | Organic, artisanal, grounded with natural tones |
+| 4 | **Electric Burst** | Bold, energetic, attention-grabbing with vivid color |
+| 5 | **Soft Cloud** | Airy, modern, approachable with gentle pastels |
+| 6 | **Terminal** | Dev/hacker aesthetic, focused and technical |
+| 7 | **Paper & Ink** | Classic editorial, literary, print-inspired |
+| 8 | **Brutalist** | Raw, structural, anti-design with strong geometry |
+| 9 | **Golden Dusk** | Warm, luxurious, premium with rich gold tones |
+| 10 | **Deep Ocean** | Calm, professional, immersive blue-dark palette |
+
+**Additional options:**
+
+- **"I have a reference image"** -- Use the `extract-style` skill at `styles/extract-style.md` to derive a custom palette from the user's image.
+- **Guided discovery** -- If the user is unsure, ask about their audience and tone, then recommend 2-3 presets:
+  - Professional / Corporate --> Clean Slate, Deep Ocean, Midnight Editorial
+  - Creative / Playful --> Electric Burst, Soft Cloud, Warm Earth
+  - Technical / Dev-focused --> Terminal, Brutalist, Clean Slate
+  - Elegant / Premium --> Midnight Editorial, Golden Dusk, Paper & Ink
+  - Friendly / Approachable --> Soft Cloud, Warm Earth, Clean Slate
+
+**After selection:** Read the chosen style preset file from `styles/[name].md` to load all colors, typography, and component patterns. For example, if the user picks "Soft Cloud", read `styles/soft-cloud.md`.
+
+---
+
+## 5. HTML Generation Phase
+
+### Base CSS (Mandatory)
+
+Tweet graphics are fixed-size 1080x1080 square compositions. The card floats centered on a full-bleed decorative background.
+
+```css
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+html, body {
+    width: 1080px;
+    height: 1080px;
+    overflow: hidden;
+}
+
+body {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+}
+```
+
+### Injecting the Style Preset
+
+After reading the style preset file, find its **Section 9 (Agent Prompt Guide)** which contains the CSS `:root` variables. Paste those variables into the `<style>` block:
+
+```css
+:root {
+    /* -- Paste all CSS variables from the preset's Section 9 here -- */
+
+    /* Tweet-specific overrides */
+    --tweet-width: 1080px;
+    --tweet-height: 1080px;
+    --card-width: 800px;
+    --card-padding: 48px;
+    --card-radius: 18px;
+    --card-bg: #ffffff;
+    --card-text: #0f1419;
+    --card-text-secondary: #536471;
+    --card-border: rgba(0, 0, 0, 0.04);
+}
+```
+
+Also add the Google Fonts `<link>` from the preset's Section 9 into the `<head>`.
+
+### Using Component Patterns
+
+The preset's **Section 4 (Component Patterns)** contains ready-to-use HTML snippets. Adapt these for the tweet card's internal elements (avatars, names, text).
+
+The preset's **Section 8 (Format Adaptation Notes)** contains format-specific guidance. For tweets, the preset primarily controls the **background** and **accent colors**. The card itself stays white/light with dark text to maintain readability and the "social media post" feel.
+
+### Card-on-Background Composition
+
+The tweet format uses a two-layer composition: a decorative full-bleed background, and a centered card on top.
+
+```
++----------------------------------+
+|                                  |
+|    [DECORATIVE BACKGROUND]       |   Full 1080x1080
+|    gradient / color / pattern    |
+|    from style preset             |
+|                                  |
+|    +------------------------+    |
+|    |                        |    |
+|    |    TWEET CARD           |    |   Card: ~800px wide
+|    |    White/light bg       |    |   Centered vertically
+|    |    Rounded corners      |    |   and horizontally
+|    |    Subtle shadow        |    |
+|    |                        |    |
+|    |    - Avatar + Name     |    |
+|    |    - Post content      |    |
+|    |    - Metadata/metrics  |    |
+|    |                        |    |
+|    +------------------------+    |
+|                                  |
+|                   @yourbrand     |   Brand watermark
++----------------------------------+
+```
+
+### Component Patterns
+
+#### Avatar
+
+**When a real profile photo URL is available** (from the tweet fetcher), use an `<img>` tag:
+
+```html
+<img class="avatar" src="https://pbs.twimg.com/profile_images/.../photo_400x400.jpg" alt="Profile photo">
+```
+
+**Fallback** (when no image URL is available), use CSS initials:
+
+```html
+<div class="avatar avatar-fallback" style="background: var(--color-accent, #1da1f2);">
+    <span class="avatar-initials">JD</span>
+</div>
+```
+
+```css
+.avatar {
+    width: 52px;
+    height: 52px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    object-fit: cover;
+}
+
+.avatar-fallback {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.avatar-initials {
+    font-family: var(--font-body);
+    font-size: 20px;
+    font-weight: 700;
+    color: #ffffff;
+    letter-spacing: 0.5px;
+}
+```
+
+#### Engagement Metrics Row
+
+```html
+<div class="metrics">
+    <span class="metric"><span class="metric-icon">&#9825;</span> 2,847</span>
+    <span class="metric"><span class="metric-icon">&#8635;</span> 391</span>
+    <span class="metric"><span class="metric-icon">&#128172;</span> 84</span>
+</div>
+```
+
+```css
+.metrics {
+    display: flex;
+    gap: 28px;
+}
+
+.metric {
+    font-family: var(--font-body);
+    font-size: 14px;
+    color: var(--card-text-secondary);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.metric-icon {
+    font-size: 16px;
+}
+```
+
+#### Star Rating
+
+```html
+<div class="stars">
+    <span class="star filled">&#9733;</span>
+    <span class="star filled">&#9733;</span>
+    <span class="star filled">&#9733;</span>
+    <span class="star filled">&#9733;</span>
+    <span class="star filled">&#9733;</span>
+</div>
+```
+
+```css
+.stars {
+    display: flex;
+    gap: 4px;
+}
+
+.star {
+    font-size: 22px;
+    color: #d1d5db;
+}
+
+.star.filled {
+    color: #f59e0b;
+}
+```
+
+### Complete HTML Template
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=1080, initial-scale=1.0">
+    <title>Tweet Graphic</title>
+
+    <!-- Google Fonts: paste the link from your chosen preset's Section 9 -->
+    <link href="https://fonts.googleapis.com/css2?family=PRESET_FONTS_HERE&display=swap" rel="stylesheet">
+
+    <style>
+        /* =============================================
+           TWEET: 1080x1080px FIXED (1:1 Square)
+           ============================================= */
+
+        :root {
+            /* -- Paste CSS variables from preset Section 9 -- */
+
+            /* Tweet-specific layout */
+            --tweet-width: 1080px;
+            --tweet-height: 1080px;
+            --card-width: 800px;
+            --card-padding: 48px;
+            --card-radius: 18px;
+            --card-bg: #ffffff;
+            --card-text: #0f1419;
+            --card-text-secondary: #536471;
+            --card-border: rgba(0, 0, 0, 0.04);
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        html, body {
+            width: var(--tweet-width);
+            height: var(--tweet-height);
+            overflow: hidden;
+            -webkit-font-smoothing: antialiased;
+            -moz-osx-font-smoothing: grayscale;
+        }
+
+        body {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            position: relative;
+        }
+
+        /* =============================================
+           DECORATIVE BACKGROUND
+           ============================================= */
+
+        .background {
+            position: absolute;
+            inset: 0;
+            /* Default: gradient using preset colors.
+               Override per-preset with solid, gradient, or pattern. */
+            background: linear-gradient(
+                135deg,
+                var(--bg-primary, #0d0d0d) 0%,
+                var(--color-surface, #1a1a1a) 50%,
+                var(--bg-primary, #0d0d0d) 100%
+            );
+            z-index: 0;
+        }
+
+        /* Optional: subtle pattern overlay */
+        .background::after {
+            content: '';
+            position: absolute;
+            inset: 0;
+            background: radial-gradient(
+                circle at 30% 40%,
+                var(--color-accent, rgba(193, 127, 89, 0.15)) 0%,
+                transparent 60%
+            );
+        }
+
+        /* =============================================
+           TWEET CARD
+           ============================================= */
+
+        .card {
+            position: relative;
+            z-index: 1;
+            width: var(--card-width);
+            background: var(--card-bg);
+            border-radius: var(--card-radius);
+            padding: var(--card-padding);
+            box-shadow:
+                0 4px 6px rgba(0, 0, 0, 0.04),
+                0 10px 40px rgba(0, 0, 0, 0.08),
+                0 0 0 1px var(--card-border);
+        }
+
+        /* =============================================
+           CARD HEADER (Avatar + Name)
+           ============================================= */
+
+        .card-header {
+            display: flex;
+            align-items: center;
+            gap: 14px;
+            margin-bottom: 20px;
+        }
+
+        .avatar {
+            width: 52px;
+            height: 52px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            flex-shrink: 0;
+        }
+
+        .avatar-initials {
+            font-family: var(--font-body);
+            font-size: 20px;
+            font-weight: 700;
+            color: #ffffff;
+            letter-spacing: 0.5px;
+        }
+
+        .author-info {
+            display: flex;
+            flex-direction: column;
+            gap: 2px;
+        }
+
+        .author-name {
+            font-family: var(--font-body);
+            font-size: 17px;
+            font-weight: 700;
+            color: var(--card-text);
+            line-height: 1.2;
+        }
+
+        .author-handle {
+            font-family: var(--font-body);
+            font-size: 15px;
+            font-weight: 400;
+            color: var(--card-text-secondary);
+            line-height: 1.2;
+        }
+
+        /* =============================================
+           CARD BODY
+           ============================================= */
+
+        .card-body {
+            font-family: var(--font-body);
+            font-size: 20px;
+            font-weight: 400;
+            line-height: 1.55;
+            color: var(--card-text);
+            margin-bottom: 24px;
+        }
+
+        /* =============================================
+           CARD FOOTER (Metrics / Timestamp)
+           ============================================= */
+
+        .card-footer {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .timestamp {
+            font-family: var(--font-body);
+            font-size: 14px;
+            color: var(--card-text-secondary);
+        }
+
+        .divider {
+            width: 100%;
+            height: 1px;
+            background: #eff3f4;
+        }
+
+        .metrics {
+            display: flex;
+            gap: 28px;
+        }
+
+        .metric {
+            font-family: var(--font-body);
+            font-size: 14px;
+            color: var(--card-text-secondary);
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .metric-icon {
+            font-size: 16px;
+        }
+
+        .metric-count {
+            font-weight: 700;
+            color: var(--card-text);
+        }
+
+        /* =============================================
+           STAR RATING
+           ============================================= */
+
+        .stars {
+            display: flex;
+            gap: 4px;
+            margin-bottom: 16px;
+        }
+
+        .star {
+            font-size: 22px;
+            color: #d1d5db;
+        }
+
+        .star.filled {
+            color: #f59e0b;
+        }
+
+        /* =============================================
+           QUOTE MARKS
+           ============================================= */
+
+        .quote-mark {
+            font-family: Georgia, 'Times New Roman', serif;
+            font-size: 80px;
+            line-height: 0.6;
+            color: var(--color-accent, #c17f59);
+            opacity: 0.3;
+        }
+
+        /* =============================================
+           CHAT BUBBLES
+           ============================================= */
+
+        .chat-bubble {
+            padding: 14px 20px;
+            border-radius: 18px;
+            font-family: var(--font-body);
+            font-size: 17px;
+            line-height: 1.45;
+            max-width: 85%;
+        }
+
+        .chat-bubble-incoming {
+            background: #f0f0f0;
+            color: var(--card-text);
+            border-bottom-left-radius: 4px;
+            align-self: flex-start;
+        }
+
+        .chat-bubble-outgoing {
+            background: var(--color-accent, #1da1f2);
+            color: #ffffff;
+            border-bottom-right-radius: 4px;
+            align-self: flex-end;
+        }
+
+        /* =============================================
+           BRAND WATERMARK
+           ============================================= */
+
+        .brand-watermark {
+            position: absolute;
+            bottom: 28px;
+            right: 36px;
+            z-index: 2;
+            font-family: var(--font-body);
+            font-size: 14px;
+            font-weight: 500;
+            color: var(--text-primary, #f5f0e8);
+            opacity: 0.4;
+        }
+    </style>
+</head>
+<body>
+
+    <!-- DECORATIVE BACKGROUND -->
+    <div class="background"></div>
+
+    <!-- TWEET CARD -->
+    <div class="card">
+        <!-- Card content goes here (see Content Templates) -->
+    </div>
+
+    <!-- BRAND WATERMARK -->
+    <div class="brand-watermark">@yourbrand</div>
+
+</body>
+</html>
+```
+
+---
+
+## 6. Content Templates
+
+All templates use CSS custom properties so they work with any style preset. Each template shows a complete `<body>` with the background, card, and watermark.
+
+### Twitter/X Post
+
+A tweet displayed as a card with avatar, handle, body text, timestamp, and engagement metrics. The most common social proof format.
+
+```html
+<body>
+
+    <!-- DECORATIVE BACKGROUND -->
+    <div class="background"></div>
+
+    <!-- TWEET CARD -->
+    <div class="card">
+
+        <!-- Header: Avatar + Author -->
+        <div class="card-header">
+            <div class="avatar" style="background: #1da1f2;">
+                <span class="avatar-initials">JD</span>
+            </div>
+            <div class="author-info">
+                <span class="author-name">Jane Doe</span>
+                <span class="author-handle">@janedoe</span>
+            </div>
+        </div>
+
+        <!-- Body: Tweet text -->
+        <div class="card-body">
+            We switched to @yourbrand three weeks ago and our response time dropped from 4 hours to 12 minutes. Not exaggerating. The AI agents handle 80% of inbound automatically and the quality is better than what we were doing manually.
+        </div>
+
+        <!-- Footer: Timestamp + Metrics -->
+        <div class="card-footer">
+            <span class="timestamp">2:47 PM &middot; Mar 28, 2026</span>
+            <div class="divider"></div>
+            <div class="metrics">
+                <span class="metric">
+                    <span class="metric-icon">&#9825;</span>
+                    <span class="metric-count">2,847</span>
+                </span>
+                <span class="metric">
+                    <span class="metric-icon">&#8635;</span>
+                    <span class="metric-count">391</span>
+                </span>
+                <span class="metric">
+                    <span class="metric-icon">&#128172;</span>
+                    <span class="metric-count">84</span>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+    <!-- BRAND WATERMARK -->
+    <div class="brand-watermark">@yourbrand</div>
+
+</body>
+```
+
+### LinkedIn Post
+
+A professional testimonial styled as a LinkedIn post with name, title/company, post text, and reaction count.
+
+```html
+<body>
+
+    <!-- DECORATIVE BACKGROUND -->
+    <div class="background"></div>
+
+    <!-- TWEET CARD -->
+    <div class="card">
+
+        <!-- Header: Avatar + Author + Title -->
+        <div class="card-header">
+            <div class="avatar" style="background: #0a66c2;">
+                <span class="avatar-initials">MR</span>
+            </div>
+            <div class="author-info">
+                <span class="author-name">Marcus Rodriguez</span>
+                <span class="author-handle" style="font-size: 14px;">VP of Operations at Meridian Labs</span>
+            </div>
+        </div>
+
+        <!-- Body: Post text -->
+        <div class="card-body">
+            We've been testing AI agent teams for the last quarter and I have to say -- the results exceeded every projection we had. Our ops team went from spending 60% of their day on repetitive coordination to focusing almost entirely on strategy.
+            <br><br>
+            The key insight: it's not about replacing people. It's about giving your best people the leverage to do their best work.
+        </div>
+
+        <!-- Footer: Reactions -->
+        <div class="card-footer">
+            <div class="divider"></div>
+            <div class="metrics">
+                <span class="metric">
+                    <span style="font-size: 14px;">&#128077;&#10084;&#65039;&#128079;</span>
+                    <span class="metric-count" style="margin-left: 4px;">1,243</span>
+                </span>
+                <span class="metric">
+                    <span style="font-size: 13px;">86 comments</span>
+                </span>
+                <span class="metric">
+                    <span style="font-size: 13px;">34 reposts</span>
+                </span>
+            </div>
+        </div>
+
+    </div>
+
+    <!-- BRAND WATERMARK -->
+    <div class="brand-watermark">@yourbrand</div>
+
+</body>
+```
+
+### Customer Review
+
+A product review with star rating, review text, and reviewer attribution. Great for social proof on landing pages and ads.
+
+```html
+<body>
+
+    <!-- DECORATIVE BACKGROUND -->
+    <div class="background"></div>
+
+    <!-- TWEET CARD -->
+    <div class="card">
+
+        <!-- Star Rating -->
+        <div class="stars">
+            <span class="star filled">&#9733;</span>
+            <span class="star filled">&#9733;</span>
+            <span class="star filled">&#9733;</span>
+            <span class="star filled">&#9733;</span>
+            <span class="star filled">&#9733;</span>
+        </div>
+
+        <!-- Review Title -->
+        <div style="font-family: var(--font-body); font-size: 22px; font-weight: 700; color: var(--card-text); margin-bottom: 16px; line-height: 1.3;">
+            "Game changer for our support team"
+        </div>
+
+        <!-- Body: Review text -->
+        <div class="card-body">
+            We were drowning in support tickets -- 200+ per day with a 3-person team. After deploying AI agents through this platform, our first-response time went from 6 hours to under 5 minutes. The agents handle tier-1 issues completely on their own and escalate complex cases with full context. Our CSAT score jumped from 3.2 to 4.7 in the first month.
+        </div>
+
+        <!-- Footer: Attribution -->
+        <div class="card-footer">
+            <div class="divider"></div>
+            <div class="card-header" style="margin-bottom: 0; padding-top: 8px;">
+                <div class="avatar" style="background: #10b981; width: 44px; height: 44px;">
+                    <span class="avatar-initials" style="font-size: 16px;">AK</span>
+                </div>
+                <div class="author-info">
+                    <span class="author-name" style="font-size: 15px;">Aisha Kapoor</span>
+                    <span class="author-handle" style="font-size: 13px;">Head of Support, CloudStack Inc.</span>
+                </div>
+            </div>
+        </div>
+
+    </div>
+
+    <!-- BRAND WATERMARK -->
+    <div class="brand-watermark">@yourbrand</div>
+
+</body>
+```
+
+### Quote Testimonial
+
+A large editorial-style quote with decorative quote marks and clean attribution. The most design-forward option -- great for hero sections, pitch decks, and brand content.
+
+```html
+<body>
+
+    <!-- DECORATIVE BACKGROUND -->
+    <div class="background"></div>
+
+    <!-- TWEET CARD -->
+    <div class="card" style="text-align: center; padding: 56px 52px;">
+
+        <!-- Decorative Quote Mark -->
+        <div class="quote-mark" style="margin-bottom: 16px;">&ldquo;</div>
+
+        <!-- Quote Text -->
+        <div class="card-body" style="font-size: 24px; line-height: 1.55; font-weight: 400; margin-bottom: 32px; max-width: 640px; margin-left: auto; margin-right: auto;">
+            The best teams of the next decade won't just have the best people. They'll have the best agents working alongside them. This platform made that real for us in a single afternoon.
+        </div>
+
+        <!-- Attribution Divider -->
+        <div style="width: 48px; height: 2px; background: var(--color-accent, #c17f59); margin: 0 auto 24px;"></div>
+
+        <!-- Attribution -->
+        <div style="display: flex; flex-direction: column; align-items: center; gap: 4px;">
+            <div class="avatar" style="background: var(--color-accent, #c17f59); width: 48px; height: 48px; margin-bottom: 8px;">
+                <span class="avatar-initials" style="font-size: 18px;">SC</span>
+            </div>
+            <span class="author-name" style="font-size: 16px;">Sarah Chen</span>
+            <span class="author-handle" style="font-size: 14px;">VP of Operations, Nexus Partners</span>
+        </div>
+
+    </div>
+
+    <!-- BRAND WATERMARK -->
+    <div class="brand-watermark">@yourbrand</div>
+
+</body>
+```
+
+### Chat Message
+
+A Slack or iMessage-style conversation snippet showing 2-3 messages in a thread. Perfect for showing real user reactions, internal team praise, or conversational social proof.
+
+```html
+<body>
+
+    <!-- DECORATIVE BACKGROUND -->
+    <div class="background"></div>
+
+    <!-- TWEET CARD -->
+    <div class="card" style="padding: 40px 44px;">
+
+        <!-- Chat Header -->
+        <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 28px; padding-bottom: 16px; border-bottom: 1px solid #eff3f4;">
+            <div style="width: 10px; height: 10px; border-radius: 50%; background: #22c55e;"></div>
+            <span style="font-family: var(--font-body); font-size: 15px; font-weight: 600; color: var(--card-text);">#team-wins</span>
+            <span style="font-family: var(--font-body); font-size: 13px; color: var(--card-text-secondary); margin-left: auto;">Today</span>
+        </div>
+
+        <!-- Message Thread -->
+        <div style="display: flex; flex-direction: column; gap: 20px;">
+
+            <!-- Message 1 -->
+            <div style="display: flex; gap: 12px; align-items: flex-start;">
+                <div class="avatar" style="background: #6366f1; width: 36px; height: 36px;">
+                    <span class="avatar-initials" style="font-size: 13px;">TW</span>
+                </div>
+                <div>
+                    <div style="display: flex; gap: 8px; align-items: baseline; margin-bottom: 4px;">
+                        <span style="font-family: var(--font-body); font-size: 15px; font-weight: 700; color: var(--card-text);">Tom Walsh</span>
+                        <span style="font-family: var(--font-body); font-size: 12px; color: var(--card-text-secondary);">10:32 AM</span>
+                    </div>
+                    <div class="chat-bubble chat-bubble-incoming" style="border-radius: 4px 18px 18px 18px; max-width: 100%;">
+                        Just checked the numbers from last week. The AI agent handled 847 support tickets completely autonomously. Zero escalations on tier-1.
+                    </div>
+                </div>
+            </div>
+
+            <!-- Message 2 -->
+            <div style="display: flex; gap: 12px; align-items: flex-start;">
+                <div class="avatar" style="background: #ec4899; width: 36px; height: 36px;">
+                    <span class="avatar-initials" style="font-size: 13px;">RP</span>
+                </div>
+                <div>
+                    <div style="display: flex; gap: 8px; align-items: baseline; margin-bottom: 4px;">
+                        <span style="font-family: var(--font-body); font-size: 15px; font-weight: 700; color: var(--card-text);">Rachel Park</span>
+                        <span style="font-family: var(--font-body); font-size: 12px; color: var(--card-text-secondary);">10:33 AM</span>
+                    </div>
+                    <div class="chat-bubble chat-bubble-incoming" style="border-radius: 4px 18px 18px 18px; max-width: 100%;">
+                        Wait, 847?! We used to cap out at maybe 200 a week with the full team.
+                    </div>
+                </div>
+            </div>
+
+            <!-- Message 3 -->
+            <div style="display: flex; gap: 12px; align-items: flex-start;">
+                <div class="avatar" style="background: #6366f1; width: 36px; height: 36px;">
+                    <span class="avatar-initials" style="font-size: 13px;">TW</span>
+                </div>
+                <div>
+                    <div style="display: flex; gap: 8px; align-items: baseline; margin-bottom: 4px;">
+                        <span style="font-family: var(--font-body); font-size: 15px; font-weight: 700; color: var(--card-text);">Tom Walsh</span>
+                        <span style="font-family: var(--font-body); font-size: 12px; color: var(--card-text-secondary);">10:34 AM</span>
+                    </div>
+                    <div class="chat-bubble chat-bubble-incoming" style="border-radius: 4px 18px 18px 18px; max-width: 100%;">
+                        Yep. And CSAT went UP. 4.8 average. This thing is unreal.
+                    </div>
+                </div>
+            </div>
+
+        </div>
+
+        <!-- Reaction -->
+        <div style="margin-top: 16px; padding-left: 48px;">
+            <span style="display: inline-block; background: #f0f0f0; border-radius: 12px; padding: 4px 10px; font-size: 13px;">
+                &#127881; 6 &nbsp; &#128293; 4 &nbsp; &#128588; 3
+            </span>
+        </div>
+
+    </div>
+
+    <!-- BRAND WATERMARK -->
+    <div class="brand-watermark">@yourbrand</div>
+
+</body>
+```
+
+---
+
+## 7. Screenshot Phase
+
+After generating the HTML file, run the screenshot tool:
+
+```bash
+node screenshot/screenshot.js \
+  --format tweet \
+  --input ./EXPORT_DIR/index.html \
+  --output ./EXPORT_DIR/export.png
+```
+
+Where `EXPORT_DIR` is the export directory (see Section 9).
+
+This will:
+1. Open the HTML file in a headless Chromium browser
+2. Set the viewport to 1080x1080px with 2x device scale factor
+3. Wait for fonts to load (500ms default; use `--font-delay 1000` for custom fonts)
+4. Capture a PNG screenshot (fixed size, no full-page needed)
+5. Save to the specified output path
+
+---
+
+## 8. Delivery Phase
+
+After the screenshot is generated, present results to the user:
+
+```
+Your tweet graphic is ready!
+
+Location: [EXPORT_DIR]/
+
+Files:
+  index.html     -- Graphic source (editable)
+  export.png     -- Final image
+
+Export details:
+  Dimensions: 1080 x 1080px (1:1 square)
+  File size:  [SIZE] KB
+
+Share on:
+  Instagram, LinkedIn, Twitter/X (1:1 works natively on all three)
+  Also great for: pitch decks, landing pages, newsletters, ads
+
+Want to make any changes?
+```
+
+---
+
+## 9. Export Directory Convention
+
+Ask the user: **"Where should I save the exports? (default: ./goose-graphics-exports/)"**
+
+### Directory naming
+- Primary: `[YYYY-MM-DD]-[slugified-name]/` (e.g., `2026-04-05-customer-testimonial-tweet/`)
+- Fallback (no name given): `[YYYY-MM-DD]-tweet-[HHMMSS]/`
+
+### Directory structure (tweet = single-file)
+```
+goose-graphics-exports/
+  2026-04-05-customer-testimonial-tweet/
+    index.html          # Graphic source
+    export.png          # Final PNG
+```
+
+---
+
+## 10. Design Reminders
+
+- **Card on background.** The testimonial card is the focal point. It floats centered on a full-bleed decorative background. The background uses the style preset's palette; the card stays white/light for readability.
+- **Fixed pixels only.** Like all graphic formats, tweet graphics are fixed at 1080x1080px. No `vw`, `vh`, `clamp()`, or responsive units. Everything in `px`.
+- **Use real profile photos.** When a tweet URL is provided, use the fetcher tool to get the real profile image URL and display it with an `<img>` tag. Only fall back to CSS initials when no image URL is available.
+- **Show the FULL tweet text.** Never truncate, summarize, or compress the body text. The card should grow vertically to fit all content. Use 18-20px font size with 1.6 line-height. If the tweet is long, the card gets taller — that's fine.
+- **Card must look real.** The card should feel like a genuine social media post -- correct typography hierarchy, realistic metadata, real engagement numbers from the fetcher. Do not over-design the card interior; the design expression lives in the background and accent colors.
+- **Readability over style.** The card text is dark on light. The decorative background can be expressive, but the card itself prioritizes legibility. Minimum 18px for body text on the card.
+- **One testimonial per graphic.** Each graphic features a single post, review, or quote. If the user has multiple testimonials, generate multiple graphics.
+- **Subtle shadow sells it.** The card's box-shadow creates depth against the background. Keep it subtle -- the goal is to look elevated, not floating in space.
+- **Brand watermark is quiet.** The @yourbrand watermark sits in the bottom-right corner of the overall graphic (not inside the card). Low opacity, small size, never competing with the testimonial.
+- **Engagement numbers should be plausible.** If the user provides real metrics, use them. If not, use realistic but not outrageous numbers. A tweet with 50M likes looks fake.
+- **Square works everywhere.** 1080x1080 is the safest format across Instagram, LinkedIn, Twitter/X, and Facebook. No cropping, no letterboxing.

--- a/skills/composites/goose-graphics/screenshot/.gitignore
+++ b/skills/composites/goose-graphics/screenshot/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/skills/composites/goose-graphics/screenshot/fetch-full-tweet.js
+++ b/skills/composites/goose-graphics/screenshot/fetch-full-tweet.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+/**
+ * Fetches full tweet text (including long-form notes) by loading the actual tweet page.
+ * Uses Playwright to render x.com and extract the complete text.
+ *
+ * Usage:
+ *   node fetch-full-tweet.js <tweet-url-or-id>
+ *
+ * Output: JSON with { text, author, handle } to stdout.
+ */
+
+const { chromium } = require('playwright');
+
+function extractTweetId(input) {
+    if (/^\d+$/.test(input)) return input;
+    const match = input.match(/(?:x\.com|twitter\.com)\/(\w+)\/status\/(\d+)/);
+    if (match) return match[2];
+    console.error(`Error: Could not extract tweet ID from "${input}"`);
+    process.exit(1);
+}
+
+function extractHandle(input) {
+    const match = input.match(/(?:x\.com|twitter\.com)\/(\w+)\/status/);
+    return match ? match[1] : null;
+}
+
+async function fetchFullTweet(tweetId, handle) {
+    const browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({
+        viewport: { width: 1280, height: 2400 },
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    });
+    const page = await context.newPage();
+
+    try {
+        const url = handle
+            ? `https://x.com/${handle}/status/${tweetId}`
+            : `https://x.com/i/status/${tweetId}`;
+
+        await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15000 });
+
+        // Wait for tweet content to load
+        await page.waitForTimeout(5000);
+
+        // Extract tweet text from the page
+        const tweetData = await page.evaluate(() => {
+            // On x.com, the main tweet text is in [data-testid="tweetText"]
+            // The first one on the page is usually the main tweet
+            const tweetTextEls = document.querySelectorAll('[data-testid="tweetText"]');
+
+            if (tweetTextEls.length > 0) {
+                // Get the first (main) tweet text
+                const mainText = tweetTextEls[0].innerText;
+
+                // Also try to get the author info
+                const userNameEl = document.querySelector('[data-testid="User-Name"]');
+                let authorName = null;
+                let authorHandle = null;
+                if (userNameEl) {
+                    const spans = userNameEl.querySelectorAll('span');
+                    for (const span of spans) {
+                        const text = span.textContent.trim();
+                        if (text.startsWith('@')) {
+                            authorHandle = text;
+                        } else if (text.length > 1 && !text.includes('·') && !text.match(/^\d/)) {
+                            if (!authorName) authorName = text;
+                        }
+                    }
+                }
+
+                return {
+                    text: mainText,
+                    author: authorName,
+                    handle: authorHandle,
+                    source: 'x.com',
+                };
+            }
+
+            // Fallback
+            return { text: document.body.innerText.substring(0, 2000), source: 'body-fallback' };
+        });
+
+        await browser.close();
+        return tweetData;
+    } catch (error) {
+        await browser.close();
+        return { text: null, error: error.message };
+    }
+}
+
+async function main() {
+    const input = process.argv[2];
+    if (!input) {
+        console.error('Usage: node fetch-full-tweet.js <tweet-url-or-id>');
+        process.exit(1);
+    }
+
+    const tweetId = extractTweetId(input);
+    const handle = extractHandle(input);
+    const result = await fetchFullTweet(tweetId, handle);
+    console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch(e => { console.error(e.message); process.exit(1); });

--- a/skills/composites/goose-graphics/screenshot/fetch-tweet.js
+++ b/skills/composites/goose-graphics/screenshot/fetch-tweet.js
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+
+/**
+ * Tweet Data Fetcher for Graphic Design Skill Pack
+ *
+ * Fetches tweet data including full text (even for long-form notes/threads).
+ * Uses two sources:
+ *   1. Twitter syndication API — for profile photo, metrics, date (fast, no auth)
+ *   2. Playwright render of x.com — for the full untruncated tweet text
+ *
+ * Usage:
+ *   node fetch-tweet.js <tweet-url-or-id>
+ *
+ * Examples:
+ *   node fetch-tweet.js https://x.com/shivsakhuja/status/2039963598244716919
+ *   node fetch-tweet.js 2039963598244716919
+ *
+ * Output: JSON object with tweet data printed to stdout.
+ */
+
+const path = require('path');
+
+function extractTweetId(input) {
+    if (/^\d+$/.test(input)) return input;
+    const match = input.match(/(?:x\.com|twitter\.com)\/\w+\/status\/(\d+)/);
+    if (match) return match[1];
+    console.error(`Error: Could not extract tweet ID from "${input}"`);
+    process.exit(1);
+}
+
+function extractHandle(input) {
+    const match = input.match(/(?:x\.com|twitter\.com)\/(\w+)\/status/);
+    return match ? match[1] : null;
+}
+
+// ---------------------------------------------------------------------------
+// Source 1: Syndication API (fast — profile photo, metrics, date, short text)
+// ---------------------------------------------------------------------------
+
+async function fetchSyndicationData(tweetId) {
+    const url = `https://cdn.syndication.twimg.com/tweet-result?id=${tweetId}&token=x`;
+    const response = await fetch(url);
+    if (!response.ok) return null;
+
+    const data = await response.json();
+    if (!data || !data.user) return null;
+
+    const profileImageSmall = data.user.profile_image_url_https || '';
+    const profileImage = profileImageSmall.replace('_normal.', '_400x400.');
+
+    let text = data.text || '';
+    text = text.replace(/\s*https:\/\/t\.co\/\w+\s*$/g, '').trim();
+
+    const date = new Date(data.created_at);
+    const formattedDate = date.toLocaleDateString('en-US', {
+        year: 'numeric', month: 'long', day: 'numeric',
+    });
+    const formattedTime = date.toLocaleTimeString('en-US', {
+        hour: 'numeric', minute: '2-digit', hour12: true,
+    });
+
+    // Detect if tweet is truncated (has note_tweet field)
+    const isLongForm = !!(data.note_tweet && data.note_tweet.id);
+
+    return {
+        id: data.id_str,
+        text,
+        isLongForm,
+        author: {
+            name: data.user.name,
+            handle: `@${data.user.screen_name}`,
+            profileImage,
+            profileImageSmall,
+            isVerified: data.user.is_blue_verified || data.user.verified || false,
+            verifiedType: data.user.verified_type || null,
+        },
+        metrics: {
+            likes: data.favorite_count || 0,
+            retweets: data.retweet_count || 0,
+            replies: data.reply_count || 0,
+            quotes: data.quote_count || 0,
+            bookmarks: data.bookmark_count || 0,
+            views: data.views_count || null,
+        },
+        date: {
+            iso: data.created_at,
+            formatted: `${formattedTime} · ${formattedDate}`,
+            dateOnly: formattedDate,
+        },
+        media: (data.mediaDetails || []).map(m => ({
+            type: m.type || 'photo',
+            url: m.media_url_https,
+        })),
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Source 2: Playwright render of x.com (slow — full untruncated text)
+// ---------------------------------------------------------------------------
+
+async function fetchFullText(tweetId, handle) {
+    let chromium;
+    try {
+        ({ chromium } = require('playwright'));
+    } catch {
+        console.error('Warning: Playwright not available, cannot fetch full tweet text');
+        return null;
+    }
+
+    const browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({
+        viewport: { width: 1280, height: 2400 },
+        userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+    });
+    const page = await context.newPage();
+
+    try {
+        const url = handle
+            ? `https://x.com/${handle}/status/${tweetId}`
+            : `https://x.com/i/status/${tweetId}`;
+
+        await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15000 });
+        await page.waitForTimeout(5000);
+
+        const tweetData = await page.evaluate(() => {
+            const tweetTextEls = document.querySelectorAll('[data-testid="tweetText"]');
+            if (tweetTextEls.length > 0) {
+                let text = tweetTextEls[0].innerText;
+                text = text.replace(/\n?Show more\s*$/, '').replace(/\n?Show less\s*$/, '').trim();
+                return text;
+            }
+            return null;
+        });
+
+        await browser.close();
+        return tweetData;
+    } catch (error) {
+        await browser.close();
+        console.error('Warning: Failed to fetch full text from x.com:', error.message);
+        return null;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Format helpers
+// ---------------------------------------------------------------------------
+
+function formatCount(n) {
+    if (n === null || n === undefined) return null;
+    if (n >= 1000000) return (n / 1000000).toFixed(1).replace(/\.0$/, '') + 'M';
+    if (n >= 1000) return (n / 1000).toFixed(1).replace(/\.0$/, '') + 'K';
+    return String(n);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+    const input = process.argv[2];
+    if (!input) {
+        console.error('Usage: node fetch-tweet.js <tweet-url-or-id>');
+        process.exit(1);
+    }
+
+    const tweetId = extractTweetId(input);
+    const handle = extractHandle(input);
+
+    // Step 1: Fast syndication API for metadata
+    console.error('Fetching tweet metadata...');
+    const tweet = await fetchSyndicationData(tweetId);
+
+    if (!tweet) {
+        console.error('Error: Could not fetch tweet data from syndication API');
+        process.exit(1);
+    }
+
+    // Step 2: If long-form, use Playwright to get full text
+    if (tweet.isLongForm) {
+        console.error('Long-form tweet detected, fetching full text via Playwright...');
+        const fullText = await fetchFullText(tweetId, handle);
+        if (fullText && fullText.length > tweet.text.length) {
+            tweet.text = fullText;
+            tweet.textSource = 'x.com (full)';
+        } else {
+            tweet.textSource = 'syndication (truncated)';
+        }
+    } else {
+        tweet.textSource = 'syndication';
+    }
+
+    // Add formatted metric strings
+    tweet.metrics.likesFormatted = formatCount(tweet.metrics.likes);
+    tweet.metrics.retweetsFormatted = formatCount(tweet.metrics.retweets);
+    tweet.metrics.repliesFormatted = formatCount(tweet.metrics.replies);
+    tweet.metrics.quotesFormatted = formatCount(tweet.metrics.quotes);
+    tweet.metrics.bookmarksFormatted = formatCount(tweet.metrics.bookmarks);
+    tweet.metrics.viewsFormatted = formatCount(tweet.metrics.views);
+
+    // Output to stdout (logs go to stderr)
+    console.log(JSON.stringify(tweet, null, 2));
+}
+
+main().catch(error => {
+    console.error('Failed to fetch tweet:', error.message);
+    process.exit(1);
+});

--- a/skills/composites/goose-graphics/screenshot/package-lock.json
+++ b/skills/composites/goose-graphics/screenshot/package-lock.json
@@ -1,0 +1,59 @@
+{
+  "name": "graphic-design-screenshot",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "graphic-design-screenshot",
+      "version": "1.0.0",
+      "dependencies": {
+        "playwright": "^1.40.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/skills/composites/goose-graphics/screenshot/package.json
+++ b/skills/composites/goose-graphics/screenshot/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "goose-graphics-screenshot",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Unified screenshot tool for graphic design skill pack",
+  "main": "screenshot.js",
+  "dependencies": {
+    "playwright": "^1.40.0"
+  }
+}

--- a/skills/composites/goose-graphics/screenshot/screenshot.js
+++ b/skills/composites/goose-graphics/screenshot/screenshot.js
@@ -1,0 +1,306 @@
+#!/usr/bin/env node
+
+/**
+ * Unified Screenshot Tool for Graphic Design Skill Pack
+ *
+ * Captures HTML files as PNG images at format-specific dimensions.
+ *
+ * Usage:
+ *   node screenshot.js --format <carousel|infographic|slides|poster|story|chart|tweet> --input <path> --output <path> [--font-delay <ms>]
+ *
+ * Formats:
+ *   carousel     1080x1080px per slide, directory of HTML files -> numbered PNGs
+ *   infographic  1080px wide, variable height, single HTML file -> single PNG
+ *   slides       1920x1080px per slide, directory of HTML files -> numbered PNGs
+ *   poster       1080x1350px, single HTML file -> single PNG
+ *   story        1080x1920px per slide, directory of HTML files -> numbered PNGs
+ *   chart        1080x1080px, single HTML file -> single PNG
+ *   tweet        1080x1080px, single HTML file -> single PNG
+ */
+
+const path = require('path');
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+// ---------------------------------------------------------------------------
+// Format configurations
+// ---------------------------------------------------------------------------
+
+const FORMAT_CONFIGS = {
+    carousel: {
+        width: 1080,
+        height: 1080,
+        deviceScaleFactor: 2,
+        fullPage: false,
+        multiFile: true,
+    },
+    infographic: {
+        width: 1080,
+        height: 1080, // initial viewport; fullPage captures actual height
+        deviceScaleFactor: 2,
+        fullPage: true,
+        multiFile: false,
+    },
+    slides: {
+        width: 1920,
+        height: 1080,
+        deviceScaleFactor: 2,
+        fullPage: false,
+        multiFile: true,
+    },
+    poster: {
+        width: 1080,
+        height: 1350,
+        deviceScaleFactor: 2,
+        fullPage: false,
+        multiFile: false,
+    },
+    story: {
+        width: 1080,
+        height: 1920,
+        deviceScaleFactor: 2,
+        fullPage: false,
+        multiFile: true,
+    },
+    chart: {
+        width: 1080,
+        height: 1080,
+        deviceScaleFactor: 2,
+        fullPage: false,
+        multiFile: false,
+    },
+    tweet: {
+        width: 1080,
+        height: 1080,
+        deviceScaleFactor: 2,
+        fullPage: false,
+        multiFile: false,
+    },
+};
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+    const args = {};
+    for (let i = 2; i < argv.length; i++) {
+        if (argv[i] === '--format' && argv[i + 1]) {
+            args.format = argv[++i];
+        } else if (argv[i] === '--input' && argv[i + 1]) {
+            args.input = argv[++i];
+        } else if (argv[i] === '--output' && argv[i + 1]) {
+            args.output = argv[++i];
+        } else if (argv[i] === '--font-delay' && argv[i + 1]) {
+            args.fontDelay = parseInt(argv[++i], 10);
+        }
+    }
+    return args;
+}
+
+function validateArgs(args) {
+    if (!args.format) {
+        console.error('Error: Missing required --format flag.');
+        console.error('Usage: node screenshot.js --format <carousel|infographic|slides|poster|story|chart|tweet> --input <path> --output <path> [--font-delay <ms>]');
+        process.exit(1);
+    }
+    if (!FORMAT_CONFIGS[args.format]) {
+        console.error(`Error: Invalid format "${args.format}". Must be one of: ${Object.keys(FORMAT_CONFIGS).join(', ')}`);
+        process.exit(1);
+    }
+    if (!args.input) {
+        console.error('Error: Missing required --input flag.');
+        process.exit(1);
+    }
+    if (!args.output) {
+        console.error('Error: Missing required --output flag.');
+        process.exit(1);
+    }
+
+    const inputPath = path.resolve(args.input);
+    if (!fs.existsSync(inputPath)) {
+        console.error(`Error: Input path not found: ${inputPath}`);
+        process.exit(1);
+    }
+
+    return {
+        format: args.format,
+        input: inputPath,
+        output: path.resolve(args.output),
+        fontDelay: args.fontDelay || 500,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Chromium auto-install check
+// ---------------------------------------------------------------------------
+
+async function ensureChromium() {
+    try {
+        const { chromium } = require('playwright');
+        // Try to get the executable path; throws if not installed
+        chromium.executablePath();
+    } catch {
+        console.log('Chromium not found. Installing via Playwright...');
+        execSync('npx playwright install chromium', { stdio: 'inherit' });
+        console.log('Chromium installed successfully.\n');
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Screenshot helpers
+// ---------------------------------------------------------------------------
+
+async function screenshotMultiFile(config, inputDir, outputDir, fontDelay) {
+    const htmlFiles = fs.readdirSync(inputDir)
+        .filter(f => f.endsWith('.html'))
+        .sort();
+
+    if (htmlFiles.length === 0) {
+        console.error(`Error: No HTML files found in ${inputDir}`);
+        process.exit(1);
+    }
+
+    // Ensure output directory exists
+    if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
+        console.log(`Created output directory: ${outputDir}`);
+    }
+
+    console.log(`\nStarting screenshot capture for ${htmlFiles.length} files (${config.width}x${config.height}px)...\n`);
+
+    const { chromium } = require('playwright');
+    const browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({
+        viewport: { width: config.width, height: config.height },
+        deviceScaleFactor: config.deviceScaleFactor,
+    });
+    const page = await context.newPage();
+
+    let totalSize = 0;
+
+    for (let i = 0; i < htmlFiles.length; i++) {
+        const htmlFile = htmlFiles[i];
+        const slideNum = String(i + 1).padStart(2, '0');
+        const outputName = `slide-${slideNum}.png`;
+        const outputPath = path.join(outputDir, outputName);
+
+        process.stdout.write(`  Capturing ${i + 1}/${htmlFiles.length}: ${htmlFile}...`);
+
+        try {
+            await page.goto(`file://${path.join(inputDir, htmlFile)}`, {
+                waitUntil: 'networkidle',
+                timeout: 15000,
+            });
+
+            await page.waitForTimeout(fontDelay);
+
+            await page.screenshot({
+                path: outputPath,
+                type: 'png',
+                fullPage: config.fullPage,
+            });
+
+            const stats = fs.statSync(outputPath);
+            const fileSizeKB = Math.round(stats.size / 1024);
+            totalSize += stats.size;
+
+            console.log(` done (${fileSizeKB} KB)`);
+        } catch (error) {
+            console.log(` FAILED`);
+            console.error(`    Error: ${error.message}`);
+        }
+    }
+
+    await browser.close();
+
+    return { fileCount: htmlFiles.length, totalSize };
+}
+
+async function screenshotSingleFile(config, inputFile, outputPath, fontDelay) {
+    // Ensure output directory exists
+    const outputDir = path.dirname(outputPath);
+    if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
+        console.log(`Created output directory: ${outputDir}`);
+    }
+
+    console.log(`\nStarting screenshot capture (${config.width}x${config.fullPage ? 'auto' : config.height}px)...\n`);
+
+    const { chromium } = require('playwright');
+    const browser = await chromium.launch({ headless: true });
+    const context = await browser.newContext({
+        viewport: { width: config.width, height: config.height },
+        deviceScaleFactor: config.deviceScaleFactor,
+    });
+    const page = await context.newPage();
+
+    process.stdout.write(`  Capturing: ${path.basename(inputFile)}...`);
+
+    try {
+        await page.goto(`file://${inputFile}`, {
+            waitUntil: 'networkidle',
+            timeout: 15000,
+        });
+
+        await page.waitForTimeout(fontDelay);
+
+        await page.screenshot({
+            path: outputPath,
+            type: 'png',
+            fullPage: config.fullPage,
+        });
+
+        const stats = fs.statSync(outputPath);
+        const fileSizeKB = Math.round(stats.size / 1024);
+
+        console.log(` done (${fileSizeKB} KB)`);
+
+        await browser.close();
+
+        return { fileCount: 1, totalSize: stats.size };
+    } catch (error) {
+        console.log(` FAILED`);
+        console.error(`    Error: ${error.message}`);
+        await browser.close();
+        process.exit(1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+    const rawArgs = parseArgs(process.argv);
+    const args = validateArgs(rawArgs);
+    const config = FORMAT_CONFIGS[args.format];
+
+    await ensureChromium();
+
+    console.log(`Format: ${args.format}`);
+    console.log(`Input:  ${args.input}`);
+    console.log(`Output: ${args.output}`);
+    console.log(`Font delay: ${args.fontDelay}ms`);
+
+    let result;
+
+    if (config.multiFile) {
+        result = await screenshotMultiFile(config, args.input, args.output, args.fontDelay);
+    } else {
+        result = await screenshotSingleFile(config, args.input, args.output, args.fontDelay);
+    }
+
+    const totalKB = Math.round(result.totalSize / 1024);
+
+    console.log('\n--- Summary ---');
+    console.log(`  Files exported: ${result.fileCount}`);
+    console.log(`  Total size:     ${totalKB} KB`);
+    console.log(`  Output:         ${args.output}`);
+    console.log('');
+}
+
+main().catch(error => {
+    console.error('Screenshot capture failed:', error.message);
+    process.exit(1);
+});

--- a/skills/composites/goose-graphics/skill.meta.json
+++ b/skills/composites/goose-graphics/skill.meta.json
@@ -1,0 +1,26 @@
+{
+  "slug": "goose-graphics",
+  "category": "composites",
+  "tags": [
+    "content",
+    "design",
+    "graphics",
+    "social"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install goose-graphics",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "36 aesthetic style presets",
+    "7 output formats (carousel, story, infographic, slides, poster, chart, tweet)",
+    "Unsplash + ASCII image sourcing",
+    "Playwright PNG export",
+    "Image-to-style extraction",
+    "Args-based slash command invocation"
+  ]
+}

--- a/skills/composites/goose-graphics/sources/ascii-art.md
+++ b/skills/composites/goose-graphics/sources/ascii-art.md
@@ -1,0 +1,436 @@
+# ASCII Art as a Design Element
+
+## Overview
+
+ASCII art is not just retro decoration -- it is a legitimate design tool that adds texture, personality, and visual structure to HTML graphics. When used intentionally, ASCII art can serve as borders, section dividers, background textures, decorative headers, and abstract visual elements.
+
+This skill teaches you to generate and embed ASCII art within HTML graphics, not as standalone art but as integrated design elements that complement typography, color, and layout.
+
+**When to use ASCII art:**
+- Tech, developer, or hacker-themed content
+- Retro or nostalgic aesthetics
+- Abstract textures and patterns where illustration is not available
+- Section dividers and visual separators
+- Decorative borders and frames
+- When you want to add visual interest without relying on stock photos
+
+## HTML/CSS Rendering
+
+ASCII art must be rendered in a monospace font with precise control over spacing. Here is the base pattern:
+
+```html
+<pre style="
+  font-family: 'Courier New', 'Consolas', 'Monaco', monospace;
+  font-size: 14px;
+  line-height: 1;
+  letter-spacing: 0;
+  margin: 0;
+  padding: 0;
+  white-space: pre;
+  color: #e0e0e0;
+">ASCII ART CONTENT HERE</pre>
+```
+
+### Critical CSS Properties
+
+| Property | Value | Why It Matters |
+|---|---|---|
+| `font-family` | monospace stack | Characters must be equal width for alignment |
+| `line-height` | `1` | **Critical.** Any other value breaks vertical alignment of multi-line art |
+| `letter-spacing` | `0` | Prevents horizontal drift |
+| `white-space` | `pre` | Preserves all spaces and line breaks exactly |
+| `margin` / `padding` | `0` | Prevents unexpected offsets |
+
+### Positioning Methods
+
+**Inline placement** (section divider, header decoration):
+
+```html
+<div style="text-align: center; margin: 24px 0;">
+  <pre style="
+    font-family: 'Courier New', monospace;
+    font-size: 12px;
+    line-height: 1;
+    color: #666;
+    display: inline-block;
+  ">===== * ===== * ===== * =====</pre>
+</div>
+```
+
+**Absolute overlay** (background texture, watermark):
+
+```html
+<div style="position: relative; width: 1080px; height: 1080px;">
+  <!-- Background ASCII texture -->
+  <pre style="
+    position: absolute;
+    top: 40px;
+    left: 40px;
+    font-family: 'Courier New', monospace;
+    font-size: 10px;
+    line-height: 1;
+    color: rgba(255, 255, 255, 0.06);
+    z-index: 0;
+    pointer-events: none;
+  ">REPEATING PATTERN HERE</pre>
+
+  <!-- Foreground content -->
+  <div style="position: relative; z-index: 1;">
+    <!-- Your actual content -->
+  </div>
+</div>
+```
+
+**Contained block** (featured art element):
+
+```html
+<div style="
+  background: #1a1a1a;
+  border-radius: 8px;
+  padding: 24px;
+  overflow: hidden;
+">
+  <pre style="
+    font-family: 'Courier New', monospace;
+    font-size: 13px;
+    line-height: 1;
+    color: #00ff88;
+    text-align: center;
+  ">ASCII ART HERE</pre>
+</div>
+```
+
+## Pattern Library
+
+### Borders and Frames
+
+**Single-line box (light):**
+```
+┌──────────────────────────────────────┐
+│                                      │
+│          Your content here           │
+│                                      │
+└──────────────────────────────────────┘
+```
+
+**Double-line box (heavy emphasis):**
+```
+╔══════════════════════════════════════╗
+║                                      ║
+║          Your content here           ║
+║                                      ║
+╚══════════════════════════════════════╝
+```
+
+**Decorative corner frame:**
+```
++------======------+
+|                   |
+|                   |
++------======------+
+```
+
+**Rounded frame:**
+```
+.-------------------------------------------.
+|                                           |
+|            Your content here              |
+|                                           |
+'-------------------------------------------'
+```
+
+### Dividers
+
+**Simple horizontal rules:**
+```
+────────────────────────────────────────
+════════════════════════════════════════
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+**Wave pattern:**
+```
+~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~^~
+```
+
+**Dot patterns:**
+```
+. . . . . . . . . . . . . . . . . . .
+ . . . . . . . . . . . . . . . . . .
+· · · · · · · · · · · · · · · · · · ·
+```
+
+**Arrow patterns:**
+```
+>>>----->>>>>----->>>>>----->>>>>----->
+<<<<< ===== >>>>> ===== >>>>> ===== >
+->->->->->->->->->->->->->->->->->->
+```
+
+**Diamond chain:**
+```
+<>--<>--<>--<>--<>--<>--<>--<>--<>--<>
+```
+
+### Geometric Shapes
+
+**Diamond:**
+```
+    /\
+   /  \
+  /    \
+ /      \
+ \      /
+  \    /
+   \  /
+    \/
+```
+
+**Triangle:**
+```
+      /\
+     /  \
+    /    \
+   /      \
+  /        \
+ /          \
+/____________\
+```
+
+**Approximate circle:**
+```
+      ****
+    **    **
+   *        *
+  *          *
+  *          *
+   *        *
+    **    **
+      ****
+```
+
+**Star:**
+```
+        *
+       /|\
+      / | \
+*----*  |  *----*
+ \   \  |  /   /
+  \   \ | /   /
+   \   \|/   /
+    *---*---*
+   /   /|\   \
+  /   / | \   \
+ /   /  |  \   \
+*----*  |  *----*
+      \ | /
+       \|/
+        *
+```
+
+**Hexagon:**
+```
+   ___
+  /   \
+ /     \
+ \     /
+  \___/
+```
+
+### Abstract Textures
+
+**Dot matrix (light):**
+```
+.   .   .   .   .   .   .   .   .   .
+  .   .   .   .   .   .   .   .   .
+.   .   .   .   .   .   .   .   .   .
+  .   .   .   .   .   .   .   .   .
+.   .   .   .   .   .   .   .   .   .
+```
+
+**Hash pattern (medium density):**
+```
+# . # . # . # . # . # . # . # . # .
+. # . # . # . # . # . # . # . # . #
+# . # . # . # . # . # . # . # . # .
+. # . # . # . # . # . # . # . # . #
+```
+
+**Gradient fill using character density (light to dense):**
+```
+.     .     .     .     .     .
+ .   . .   . .   . .   . .   .
+. . . . . . . . . . . . . . . .
+.:;:.:;:.:;:.:;:.:;:.:;:.:;:.:;
+:;%:;%:;%:;%:;%:;%:;%:;%:;%:;%
+%#@%#@%#@%#@%#@%#@%#@%#@%#@%#@%
+```
+
+Characters ordered by visual density (light to heavy):
+`. - : ; = + * # % @`
+
+**Cross-hatch:**
+```
+/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\
+\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/
+/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\
+\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/\/
+```
+
+**Binary rain (good for tech themes):**
+```
+01 10 01 11 00 10 01 10 11 00
+10 01 10 00 11 01 10 01 00 11
+01 10 01 11 00 10 01 10 11 00
+10 01 10 00 11 01 10 01 00 11
+```
+
+### Decorative Headers
+
+Large block letters are built from repeated characters. The technique: use a 5-7 line tall grid where each letter is 5-8 characters wide.
+
+**Block letter technique (example: "HI"):**
+```
+██  ██  ██
+██  ██  ██
+██████  ██
+██  ██  ██
+██  ██  ██
+```
+
+**Hash letter technique (example: "GO"):**
+```
+ ####   ####
+#      #    #
+#  ##  #    #
+#    #  #    #
+ ####   ####
+```
+
+**Slim letter technique (example: "HELLO"):**
+```
+|_| _  |  |  _
+| ||_ |_| |_|_|
+```
+
+When generating block text for a specific word, construct each letter on a fixed grid and space them consistently. Do not attempt to memorize full alphabets -- build each letter from simple geometric logic.
+
+## Integration with Style Presets
+
+### Dark Themes
+- Use light-colored ASCII (`#e0e0e0`, `#aaa`, `rgba(255,255,255,0.1)`) on dark backgrounds
+- Lower opacity for background textures (`rgba(255,255,255,0.04)` to `0.08`)
+- Full brightness for featured/foreground art elements
+
+```html
+<pre style="color: rgba(255, 255, 255, 0.06); font-size: 10px; line-height: 1;">
+<!-- Subtle background texture -->
+</pre>
+```
+
+### Light Themes
+- Use muted grays (`#ccc`, `#ddd`, `rgba(0,0,0,0.08)`) as subtle texture
+- ASCII should recede into the background, never compete with content
+- Thin-line characters (`.`, `-`, `|`) work better than heavy ones (`#`, `@`, `%`)
+
+```html
+<pre style="color: rgba(0, 0, 0, 0.06); font-size: 10px; line-height: 1;">
+<!-- Barely-visible texture layer -->
+</pre>
+```
+
+### Terminal / Hacker Theme
+- Green ASCII on black/very dark green background
+- Fully visible, not subtle -- embrace the aesthetic
+- Use `#00ff41` (classic terminal green) or `#0f0` for high contrast
+- Add a slight text-shadow glow for CRT effect
+
+```html
+<pre style="
+  color: #00ff41;
+  font-size: 14px;
+  line-height: 1;
+  text-shadow: 0 0 5px rgba(0, 255, 65, 0.4);
+  font-family: 'Courier New', monospace;
+">
+╔══════════════════════════════════╗
+║   SYSTEM STATUS: OPERATIONAL     ║
+╚══════════════════════════════════╝
+</pre>
+```
+
+### Editorial / Minimal Styles
+- Use only thin-line ASCII: single-line box drawing (`─`, `│`, `┌`, `┐`, `└`, `┘`)
+- Keep it functional: section dividers, light borders only
+- Never use block fills or dense textures
+- Color should match the body text color at reduced opacity
+
+```html
+<pre style="color: #bbb; font-size: 11px; line-height: 1;">
+───────────────────────────────
+</pre>
+```
+
+## Sizing Guidelines
+
+The number of characters that fit depends on font size and the graphic's pixel width. Here are recommended ranges:
+
+### Carousel / Square Post (1080px wide)
+
+| Font Size | Characters Wide | Use Case |
+|---|---|---|
+| 10px | ~130 chars | Dense background textures |
+| 12px | ~110 chars | Background patterns, subtle elements |
+| 14px | ~80 chars | Featured art, borders |
+| 16px | ~70 chars | Prominent decorative elements |
+| 20px | ~55 chars | Large headers, bold statements |
+
+Height: match the graphic height. At 14px font-size with `line-height: 1`, each row is 14px tall. A 1080px graphic fits ~77 rows.
+
+### Infographic (1080px wide, tall)
+
+Same width as carousel. The vertical dimension can extend as long as the infographic requires.
+
+| Font Size | Characters Wide | Characters Tall (per 1000px) |
+|---|---|---|
+| 10px | ~130 chars | ~100 rows |
+| 12px | ~110 chars | ~83 rows |
+| 14px | ~80 chars | ~71 rows |
+
+### Presentation Slide (1920px wide)
+
+| Font Size | Characters Wide | Use Case |
+|---|---|---|
+| 10px | ~230 chars | Extremely dense texture |
+| 12px | ~190 chars | Background patterns |
+| 14px | ~140 chars | Featured art |
+| 16px | ~120 chars | Prominent elements |
+| 20px | ~100 chars | Large decorative headers |
+
+### Poster (1080px wide)
+
+Same width calculations as carousel. Use larger font sizes (16-24px) since posters are viewed from a distance and need more visual weight.
+
+**General rule of thumb:** At 14px monospace, one character is approximately 8.4px wide. Divide your graphic's content width (total width minus padding) by 8.4 to get your character count.
+
+## Do's and Don'ts
+
+### Do
+
+- **Use ASCII as supporting texture**, not the main attraction (unless the theme demands it)
+- **Keep it subtle** -- background ASCII at 4-8% opacity adds depth without clutter
+- **Match the density to the theme** -- minimal themes get thin lines, tech themes can go heavier
+- **Use box-drawing characters** (Unicode range U+2500-U+257F) for clean borders -- they connect seamlessly
+- **Test vertical alignment** by checking that line-height is exactly `1` and no extra padding is present
+- **Use ASCII dividers** between sections to add rhythm to long-form graphics like infographics
+- **Limit the palette** -- ASCII art should use one color (or one color at varying opacities), never rainbow
+
+### Don't
+
+- **Don't fill the entire graphic** with dense ASCII unless it is a deliberate full-texture background
+- **Don't use ASCII art as the sole visual** in a professional/corporate context -- it reads as unserious
+- **Don't mix too many ASCII styles** in one graphic (pick one border style, one divider style, stick with them)
+- **Don't use ASCII for body text** -- it should decorate, frame, or texture, not replace readable typography
+- **Don't assume perfect character alignment** across all renderers -- test with `line-height: 1` and a known monospace font
+- **Don't use wide Unicode characters** (CJK, emoji) mixed with ASCII -- they are double-width and break alignment
+- **Don't forget `white-space: pre`** -- without it, browsers collapse your carefully placed spaces

--- a/skills/composites/goose-graphics/sources/unsplash.md
+++ b/skills/composites/goose-graphics/sources/unsplash.md
@@ -1,0 +1,321 @@
+# Unsplash Photo Sourcing
+
+## Overview
+
+This skill teaches you to search for and embed high-quality stock photos from Unsplash into HTML graphics. Use this whenever a graphic needs real photography -- product shots, backgrounds, lifestyle imagery, textures, or any visual element that benefits from a photograph rather than illustration or CSS-only decoration.
+
+Unsplash provides a free API with access to millions of professionally shot, freely licensed photos.
+
+## Setup
+
+You need an Unsplash API key stored in the environment variable `UNSPLASH_ACCESS_KEY`.
+
+**How to get a key:**
+
+1. Go to https://unsplash.com/developers
+2. Click "Register as a developer" and create an account (free)
+3. Click "Your apps" and then "New Application"
+4. Accept the API guidelines and terms
+5. Give your app a name (e.g., "Graphic Design Agent") and description
+6. Copy the **Access Key** (not the Secret Key) from the app dashboard
+
+The key should be available as:
+
+```
+export UNSPLASH_ACCESS_KEY="your-access-key-here"
+```
+
+The free tier allows 50 requests per hour, which is more than enough for graphic design work.
+
+## Search Workflow
+
+### Step 1: Determine Search Keywords
+
+Analyze the graphic's content and purpose to pick effective search terms. Use concrete, descriptive nouns rather than abstract concepts.
+
+| Graphic Topic | Good Keywords | Weak Keywords |
+|---|---|---|
+| SaaS product launch | "laptop workspace modern" | "technology" |
+| Fitness blog header | "running trail sunrise" | "health" |
+| Restaurant menu | "fresh ingredients kitchen" | "food" |
+| Travel newsletter | "mountain landscape hiking" | "travel" |
+| Finance dashboard | "office desk charts" | "money" |
+
+Tips:
+- Use 1-3 words per query. More specific is better.
+- Try multiple queries if the first results are poor.
+- Add aesthetic modifiers like "minimal", "dark", "aerial", "closeup" to refine style.
+- Match the mood of your graphic -- a corporate piece needs different imagery than an indie brand.
+
+### Step 2: Search the API
+
+```bash
+curl -s "https://api.unsplash.com/search/photos?query=KEYWORD&per_page=5&orientation=landscape" \
+  -H "Authorization: Client-ID $UNSPLASH_ACCESS_KEY"
+```
+
+**Parameters you can adjust:**
+
+| Parameter | Options | When to Use |
+|---|---|---|
+| `orientation` | `landscape`, `portrait`, `squarish` | Match your graphic's aspect ratio |
+| `per_page` | 1-30 (default 10) | 5 is usually enough to find a good match |
+| `color` | `black_and_white`, `black`, `white`, `yellow`, `orange`, `red`, `purple`, `magenta`, `green`, `teal`, `blue` | When you need a specific color palette |
+| `order_by` | `relevant` (default), `latest` | Keep `relevant` for best matches |
+
+### Step 3: Parse the JSON Response
+
+The response contains a `results` array. Each result has:
+
+```
+results[i].urls.raw       -- Original resolution (very large, avoid)
+results[i].urls.full      -- Full resolution (use for print or high-DPI)
+results[i].urls.regular   -- 1080px wide (best for most web graphics)
+results[i].urls.small     -- 400px wide (thumbnails, previews)
+results[i].urls.thumb     -- 200px wide (tiny thumbnails)
+
+results[i].user.name      -- Photographer's display name (for attribution)
+results[i].user.links.html -- Photographer's Unsplash profile URL
+
+results[i].links.html     -- Photo page on Unsplash (for attribution link)
+
+results[i].alt_description -- Alt text for accessibility
+results[i].description     -- Photographer's description (may be null)
+results[i].color           -- Dominant color hex (useful for placeholder/fallback)
+```
+
+**Use `.urls.regular` for standard web graphics.** Use `.urls.full` only when the graphic will be displayed at very high resolution or printed.
+
+### Step 4: Select the Best Match
+
+Review the top 3-5 results and select based on:
+- Relevance to the graphic's message
+- Composition that works with your layout (consider where text overlays will go)
+- Color harmony with your style preset
+- Sufficient empty/blurred areas if you need to overlay text
+
+## Embedding in HTML
+
+### Full-Bleed Background Image
+
+Use when the photo should fill the entire graphic or a major section.
+
+```html
+<div style="
+  width: 1080px;
+  height: 1080px;
+  background-image: url('IMAGE_URL');
+  background-size: cover;
+  background-position: center;
+  position: relative;
+">
+  <!-- Content goes here, on top of the image -->
+</div>
+```
+
+### Contained Image with Caption
+
+Use for featured images that sit within the layout, not behind it.
+
+```html
+<figure style="
+  margin: 0;
+  width: 100%;
+  max-width: 900px;
+">
+  <img src="IMAGE_URL"
+       alt="ALT_DESCRIPTION"
+       style="
+         width: 100%;
+         height: 400px;
+         object-fit: cover;
+         border-radius: 8px;
+         display: block;
+       " />
+  <figcaption style="
+    font-size: 13px;
+    color: #888;
+    margin-top: 8px;
+    font-style: italic;
+  ">
+    Caption text here
+  </figcaption>
+</figure>
+```
+
+### Image Grid (2-3 Images)
+
+Use for comparison layouts, multi-topic visuals, or visual variety.
+
+```html
+<!-- Two-image grid -->
+<div style="
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  width: 100%;
+">
+  <img src="IMAGE_URL_1" alt="..." style="width: 100%; height: 300px; object-fit: cover; border-radius: 8px;" />
+  <img src="IMAGE_URL_2" alt="..." style="width: 100%; height: 300px; object-fit: cover; border-radius: 8px;" />
+</div>
+
+<!-- Three-image grid -->
+<div style="
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 12px;
+  width: 100%;
+">
+  <img src="IMAGE_URL_1" alt="..." style="width: 100%; height: 250px; object-fit: cover; border-radius: 8px;" />
+  <img src="IMAGE_URL_2" alt="..." style="width: 100%; height: 250px; object-fit: cover; border-radius: 8px;" />
+  <img src="IMAGE_URL_3" alt="..." style="width: 100%; height: 250px; object-fit: cover; border-radius: 8px;" />
+</div>
+```
+
+### Overlay Text on Image
+
+Use for hero sections, title cards, and quote graphics. The gradient overlay is critical for text readability.
+
+```html
+<div style="
+  width: 1080px;
+  height: 1080px;
+  background-image: url('IMAGE_URL');
+  background-size: cover;
+  background-position: center;
+  position: relative;
+">
+  <!-- Gradient overlay for readability -->
+  <div style="
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(
+      to bottom,
+      rgba(0, 0, 0, 0.1) 0%,
+      rgba(0, 0, 0, 0.6) 60%,
+      rgba(0, 0, 0, 0.85) 100%
+    );
+  "></div>
+
+  <!-- Text content -->
+  <div style="
+    position: absolute;
+    bottom: 80px;
+    left: 60px;
+    right: 60px;
+    color: #ffffff;
+    z-index: 1;
+  ">
+    <h1 style="font-size: 48px; font-weight: 700; margin: 0 0 16px 0; line-height: 1.1;">
+      Your Headline Here
+    </h1>
+    <p style="font-size: 20px; margin: 0; opacity: 0.9; line-height: 1.5;">
+      Supporting text or description goes here.
+    </p>
+  </div>
+</div>
+```
+
+**Gradient overlay variations:**
+
+| Use Case | Gradient |
+|---|---|
+| Text at bottom | `linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.8) 100%)` |
+| Text at top | `linear-gradient(to top, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.8) 100%)` |
+| Text centered | `radial-gradient(ellipse at center, rgba(0,0,0,0.7) 0%, rgba(0,0,0,0.3) 100%)` |
+| Full dim | `rgba(0, 0, 0, 0.5)` (no gradient, uniform overlay) |
+| Light overlay (dark text) | `rgba(255, 255, 255, 0.75)` |
+
+## Attribution
+
+Unsplash's license is generous (free for commercial and non-commercial use, no attribution required by law), but **attribution is expected and good practice**, especially for AI-generated content. Always include attribution unless space absolutely does not permit it.
+
+### Attribution HTML Pattern
+
+Place this at the bottom of the graphic or in a credits section:
+
+```html
+<div style="
+  font-size: 11px;
+  color: #999;
+  margin-top: 12px;
+">
+  Photo by <a href="PHOTOGRAPHER_PROFILE_URL" style="color: #999; text-decoration: underline;">PHOTOGRAPHER_NAME</a>
+  on <a href="PHOTO_URL" style="color: #999; text-decoration: underline;">Unsplash</a>
+</div>
+```
+
+For graphics where the attribution is overlaid on the image:
+
+```html
+<div style="
+  position: absolute;
+  bottom: 8px;
+  right: 12px;
+  font-size: 10px;
+  color: rgba(255, 255, 255, 0.6);
+  z-index: 2;
+">
+  Photo by PHOTOGRAPHER_NAME on Unsplash
+</div>
+```
+
+## Fallback Strategy
+
+If `UNSPLASH_ACCESS_KEY` is not set or the API is unavailable:
+
+1. **Ask the user** if they have image URLs they want to use. This is the best fallback.
+2. **Use CSS-only decorative alternatives** instead of photos:
+   - Gradient backgrounds (linear, radial, conic)
+   - CSS patterns using `repeating-linear-gradient`
+   - Geometric shapes with CSS `clip-path`
+   - Solid color blocks with strong typography (often looks more professional than a bad stock photo)
+
+Example CSS-only gradient background:
+
+```html
+<div style="
+  width: 1080px;
+  height: 1080px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+">
+  <!-- Content here -->
+</div>
+```
+
+Example CSS pattern background:
+
+```html
+<div style="
+  width: 1080px;
+  height: 1080px;
+  background-color: #1a1a2e;
+  background-image:
+    radial-gradient(circle at 25% 25%, rgba(255,255,255,0.05) 1px, transparent 1px),
+    radial-gradient(circle at 75% 75%, rgba(255,255,255,0.05) 1px, transparent 1px);
+  background-size: 60px 60px;
+">
+  <!-- Content here -->
+</div>
+```
+
+3. **Never invent or hallucinate image URLs.** If you cannot source a real image, use CSS graphics or tell the user.
+
+## Image Sizing Guide
+
+Select the appropriate Unsplash URL parameter and `object-fit` based on format:
+
+| Format | Dimensions | Recommended URL | Notes |
+|---|---|---|---|
+| Instagram Carousel | 1080 x 1080 px | `.urls.regular` | Square crop; use `object-fit: cover` |
+| Instagram Story | 1080 x 1920 px | `.urls.regular` | Portrait; search with `orientation=portrait` |
+| LinkedIn Post | 1200 x 627 px | `.urls.regular` | Landscape; keep subjects centered for crop |
+| Twitter/X Post | 1200 x 675 px | `.urls.regular` | Similar to LinkedIn |
+| Blog Header | 1200 x 630 px | `.urls.regular` | Landscape |
+| Presentation Slide | 1920 x 1080 px | `.urls.full` | Use full for sharpness at this size |
+| Infographic | 1080 x 1920+ px | `.urls.regular` | Use as section backgrounds, not full-bleed |
+| Poster/Flyer | 1080 x 1440 px | `.urls.full` | Use full if printing |
+| Email Header | 600 x 200 px | `.urls.small` | Small is sufficient |
+| Thumbnail | 400 x 400 px | `.urls.small` | Square crop |
+
+When using `background-size: cover`, the image will be cropped to fill the container. Use `background-position` to control which part of the image is visible -- `center` works in most cases, but use `top` for portraits with faces or `bottom` for landscapes with foreground interest.

--- a/skills/composites/goose-graphics/styles/_full/DESIGN_MD_COVERAGE.md
+++ b/skills/composites/goose-graphics/styles/_full/DESIGN_MD_COVERAGE.md
@@ -1,0 +1,88 @@
+# DESIGN.md Compliance Coverage
+
+Generated audit of all 36 `styles/_full/<slug>.md` files against the VoltAgent / Claude Design 9-section DESIGN.md spec.
+
+**Result: 36/36 files fully compliant.**
+
+
+## Required sections
+
+1. Visual Theme & Atmosphere
+2. Color Palette & Roles
+3. Typography Rules
+4. Component Stylings
+5. Layout Principles
+6. Depth & Elevation
+7. Do's and Don'ts
+8. Responsive Behavior
+9. Agent Prompt Guide
+
+## Section aliases honoured
+
+Sections are detected by case-insensitive substring match on `##` headings. Close variants count as covered (do not require literal match):
+
+- `Component Stylings` satisfied by `Component Patterns` or `Components`
+- `Color Palette & Roles` satisfied by `Color Palette` / `Palette`
+- `Typography Rules` satisfied by `Typography`
+- `Do's and Don'ts` satisfied by `Do and Don'ts`, `Dos and Don'ts`, etc.
+
+## Coverage matrix
+
+| Style | Visual Theme & Atmosphere | Color Palette & Roles | Typography Rules | Component Stylings | Layout Principles | Depth & Elevation | Do's and Don'ts | Responsive Behavior | Agent Prompt Guide |
+|---|---|---|---|---|---|---|---|---|---|
+| archive-fashion | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| aurora-app-launch | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| blueprint-sticky | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| brutalist | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| bw-editorial-drop | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| card-toss | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| cinematic-romance | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| clean-slate | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| deep-ocean | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| electric-burst | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| frosted-lens | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| garden-blur | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| golden-dusk | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| grid-quote-editorial | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| heatwave-orange | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| highlighter-yellow | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| ink-doodle-event | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| iridescent-y2k | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| magazine-red | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| masked-object-editorial | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| matt-gray | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| midnight-editorial | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| mint-pixel-corporate | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| paper-and-ink | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| pastel-organic-shapes | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| peach-pop | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| product-minimal | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| retro-line-art | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| social-post-card | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| soft-cloud | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| split-yellow-product | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| sunburst-editorial | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| terminal | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| venn-infographic | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| vintage-duotone-poster | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| warm-earth | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+## Per-section totals
+
+| Section | Coverage |
+|---|---|
+| Visual Theme & Atmosphere | 36/36 |
+| Color Palette & Roles | 36/36 |
+| Typography Rules | 36/36 |
+| Component Stylings | 36/36 |
+| Layout Principles | 36/36 |
+| Depth & Elevation | 36/36 |
+| Do's and Don'ts | 36/36 |
+| Responsive Behavior | 36/36 |
+| Agent Prompt Guide | 36/36 |
+
+## Notes
+
+- Pre-existing structure: every file already shipped with §1–§7 and an Agent Prompt Guide section. The VoltAgent Responsive Behavior section was uniformly missing across all 36 files.
+- Gap fill: a compact §8 Responsive Behavior was inserted in each file covering format-driven responsive principles (type ramps by frame size, padding scales, safe zones on Story, one-idea-per-frame, signature-component invariance, aspect-ratio aware composition, PNG raster export). Subsequent sections (Format Adaptation Notes, Agent Prompt Guide) were renumbered to §9 and §10.
+- No existing content was modified or removed.

--- a/skills/composites/goose-graphics/styles/_full/archive-fashion.md
+++ b/skills/composites/goose-graphics/styles/_full/archive-fashion.md
@@ -1,0 +1,483 @@
+# Design Style: Archive Fashion
+
+## 1. Visual Theme & Atmosphere
+
+Archive Fashion is the design language of a curated boutique catalog -- the visual equivalent of a mailed lookbook from a quiet Parisian concept store that happens to be running an end-of-season sale. Inspired by editorial fashion catalogs, vintage department store mailers, and the minimal-but-warm aesthetic of independent fashion labels, this style frames a photographic hero inside a stone-beige paper border and stops the scroll with exactly one tilted pink sticker in the corner. The stone background (`#E6DCC8`) is not white and not cream -- it is the muted, slightly dusty tone of raw linen, unbleached card stock, or the matte paper used in high-end catalogs. It feels tactile, physical, mailed.
+
+The typography layers three distinct voices. **Cormorant Garamond** handles the small italic "Galerie" wordmark at the top of the frame -- thin, refined, almost a whisper, the way a legacy brand letterhead signs itself. **Inter** at weight 700 carries the main catalog headline ("ARCHIVE DESIGN SALE") in a medium-tall sans that feels confident but never loud, stacked on two lines and centered like a department store banner. **Caveat**, the handwritten italic script, lives exclusively on the tilted pink sticker -- it is the personal note scrawled over a printed catalog, the Post-it stuck to a page in the mailroom. The script is intimate; the sans is the brand; the italic serif is the heritage. Together they tell a story that the photo alone cannot: this is vintage, this is curated, this is on sale right now.
+
+The signature move is the **tilted candy-pink sticker** -- a speech-bubble or price-tag shape (`#F4B8D4`) rotated about -8 degrees in the bottom-left corner of the composition, with a curved inner border and a soft drop shadow so it reads as an object stuck onto the catalog page rather than rendered into it. It is the ONE decorative element the style permits. Everything else is quiet. The stone frame insets the photograph with a generous ~50px margin all around, and the photograph itself lives in a darker brown/taupe environment that keeps the composition warm and enveloping. No gradients, no icons, no flourishes -- just a photographic frame, centered type, and the one tilted pink note.
+
+**Key Characteristics:**
+- Stone beige (`#E6DCC8`) as the dominant outer frame -- warm, unbleached, physical
+- Deep taupe brown (`#4A352A`) as the photographic environment inside the frame
+- Near-black (`#1A1410`) for all primary text -- never pure black
+- Candy pink (`#F4B8D4`) reserved exclusively for the sticker -- one use per composition
+- Cormorant Garamond italic 400-500 for the small "Galerie"-style wordmark
+- Inter 700 at 44px+ for the stacked catalog headline, centered, 2 lines
+- Cormorant Garamond uppercase tracked caps for dates and small labels
+- Caveat handwritten italic for sticker copy only -- never for headlines
+- Photo inset inside the stone frame with a consistent ~50px all-around margin
+- Tilted pink sticker rotated -5 to -10deg in the bottom-left corner, one per composition
+- No gradients, no icons, no background patterns -- pure editorial calm
+- Soft drop shadow on the sticker only, ~4px y-offset, 12px blur, pink-tinted
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Stone Beige** (`#E6DCC8`): Primary outer frame background. The raw linen / unbleached card stock tone of a premium mailed catalog.
+- **Near-Black** (`#1A1410`): Primary text color. Deep warm near-black tuned to the stone background, never pure black.
+- **Taupe Brown** (`#4A352A`): Inset photo environment. The darker brown/taupe surround that cradles the hero photograph.
+
+### Accent
+- **Candy Pink** (`#F4B8D4`): The sticker fill. Used exclusively for the single tilted pink sticker element -- never as a general accent.
+- **Deep Pink Ink** (`#8B3A5C`): Text color for sticker copy when contrast is needed -- a muted rose ink that reads on the candy-pink fill.
+
+### Neutral Scale
+- **Stone Deeper** (`#D8C9B0`): Slightly darker stone for subtle borders, dividers, and secondary surfaces.
+- **Stone Lighter** (`#EFE6D6`): Slightly lighter stone for inset highlights inside the frame.
+- **Warm Brown** (`#6B4C3B`): Mid-tone warm brown, used for secondary text within photo environments.
+- **Muted Text** (`#7A6B5D`): Metadata, subtle labels inside the stone frame.
+- **Ink Trace** (`rgba(26,20,16,0.45)`): Low-contrast supporting text.
+- **Divider Rule** (`rgba(26,20,16,0.12)`): Hairline dividers on the stone surface.
+
+### Surface & Borders
+- **Surface Stone** (`#E6DCC8`): The outer frame canvas.
+- **Surface Photo Frame** (`#4A352A`): The inset photo container background.
+- **Surface Sticker** (`#F4B8D4`): The candy-pink sticker fill.
+- **Border Hairline** (`rgba(26,20,16,0.12)`): Quietest separator for labels and dates.
+- **Border Sticker Inner** (`rgba(139,58,92,0.35)`): The inner curved rose line running just inside the sticker edge.
+- **Border Sticker Outer** (`rgba(26,20,16,0.06)`): Barely-there outer pink border definition.
+
+### Shadow Colors
+- **Shadow Whisper** (`rgba(74,53,42,0.06)`): Ambient, for the photo inset subtle lift.
+- **Shadow Sticker** (`rgba(139,58,92,0.18)`): Pink-tinted drop shadow beneath the tilted sticker.
+- **Shadow Deep** (`rgba(26,20,16,0.14)`): Medium depth for featured sticker hover states.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500;1,600&family=Inter:wght@400;500;600;700;800&family=Caveat:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Wordmark (Galerie logo)**: `'Cormorant Garamond', Georgia, 'Times New Roman', serif` (italic 500)
+- **Display (catalog headline)**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Label (dates, tracked caps)**: `'Cormorant Garamond', Georgia, 'Times New Roman', serif` (uppercase 500, wide tracking)
+- **Sticker script**: `'Caveat', 'Brush Script MT', cursive`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Wordmark | Cormorant Garamond | 28px | 500 italic | 1.0 | 0.5px | The small "Galerie" logo at top center |
+| Display Hero | Inter | 72px | 700 | 1.05 | -1.5px | Catalog headline, stacked on 2 lines |
+| Display (1:1) | Inter | 56px | 700 | 1.05 | -1px | Same headline scaled to square formats |
+| Tracked Caps Date | Cormorant Garamond | 14px | 500 | 1.2 | 2.5px | "FEBRUARY 13 - 16" small uppercase |
+| Section Heading | Inter | 32px | 600 | 1.15 | -0.5px | Inside-frame secondary headings |
+| Body Large | Inter | 20px | 500 | 1.55 | 0px | Supporting paragraphs |
+| Body | Inter | 17px | 500 | 1.55 | 0px | Standard body text |
+| Small / Caption | Inter | 13px | 500 | 1.45 | 0.3px | Metadata, attributions |
+| Sticker Headline | Caveat | 32px | 700 | 1.1 | 0px | "SPECIAL OFFER" on the tilted sticker |
+| Sticker Body | Caveat | 20px | 500 | 1.25 | 0px | Promo code + terms handwritten on sticker |
+| Sticker Foot | Caveat | 16px | 600 | 1.2 | 0.5px | "ENDS JUNE 10TH, 12PM EST" |
+
+### Principles
+- **Three-voice layering**: Thin italic serif (heritage wordmark) + bold sans (catalog headline) + handwritten script (personal note). Never collapse any two into one voice.
+- **Centered catalog header**: The top third of any composition stacks the wordmark, the 2-line sans headline, and the tracked-caps date, all center-aligned. This is the catalog masthead pattern -- do not left-align it.
+- **Tracked caps for dates only**: Dates, editions, and small labels use Cormorant Garamond uppercase with ~2.5px tracking. Never use this treatment for body text.
+- **Caveat stays on the sticker**: The handwritten Caveat font appears ONLY inside the tilted pink sticker. Using it elsewhere breaks the spell.
+- **Bold sans at scale**: The main catalog headline is always Inter 700 at 44-72px depending on format, stacked across 2 lines, centered, with slightly negative letter-spacing for density.
+- **No italic sans**: Italic treatment belongs to Cormorant Garamond (wordmark, dates) and Caveat (sticker). Inter is never italicized.
+
+## 4. Component Patterns
+
+### Stone Frame Container (the core structural component)
+
+```html
+<div style="background-color: var(--color-stone); padding: 50px; width: 100%; max-width: 1080px; aspect-ratio: 1 / 1; position: relative; font-family: var(--font-body);">
+  <!-- Inset photo container -->
+  <div style="position: absolute; inset: 50px; background-color: var(--color-taupe); overflow: hidden;">
+    <!-- photo or content -->
+  </div>
+  <!-- Centered catalog header overlay sits above the inset, in the stone band -->
+  <div style="position: relative; z-index: 2; text-align: center; padding: 30px 40px 0;">
+    <!-- wordmark / headline / date stack goes here -->
+  </div>
+</div>
+```
+
+### Centered Catalog Header
+
+```html
+<div style="text-align: center; padding: 20px 40px 36px;">
+  <div style="font-family: var(--font-display-serif); font-size: 28px; font-weight: 500; font-style: italic; color: var(--color-near-black); letter-spacing: 0.5px; line-height: 1.0; margin: 0 0 24px;">Galerie</div>
+  <h1 style="font-family: var(--font-body); font-size: 56px; font-weight: 700; line-height: 1.05; letter-spacing: -1px; color: var(--color-near-black); margin: 0 0 18px; text-transform: uppercase;">ARCHIVE<br>DESIGN SALE</h1>
+  <p style="font-family: var(--font-display-serif); font-size: 14px; font-weight: 500; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-near-black); margin: 0;">FEBRUARY 13 - 16</p>
+</div>
+```
+
+### Inset Brown Photo Container
+
+```html
+<div style="position: relative; width: 100%; aspect-ratio: 1 / 1; background-color: var(--color-stone); padding: 50px;">
+  <div style="position: absolute; inset: 50px; background-color: var(--color-taupe); overflow: hidden; box-shadow: var(--shadow-photo);">
+    <img src="hero.jpg" alt="" style="width: 100%; height: 100%; object-fit: cover; display: block;" />
+  </div>
+</div>
+```
+
+### Tilted Pink Sticker (the signature move)
+
+```html
+<div style="position: absolute; left: 70px; bottom: 90px; transform: rotate(-8deg); background-color: var(--color-pink); padding: 26px 36px; border-radius: 120px 140px 110px 130px / 90px 100px 80px 110px; box-shadow: 0 8px 24px rgba(139,58,92,0.18), 0 2px 6px rgba(26,20,16,0.08); text-align: center; max-width: 260px; z-index: 10; font-family: var(--font-script);">
+  <!-- Inner curved rose border to suggest double-line sticker -->
+  <div style="position: absolute; inset: 8px; border: 1.5px solid rgba(139,58,92,0.35); border-radius: 110px 130px 100px 120px / 82px 92px 72px 100px; pointer-events: none;"></div>
+  <div style="position: relative;">
+    <p style="font-family: var(--font-script); font-size: 28px; font-weight: 700; line-height: 1.05; color: var(--color-near-black); margin: 0 0 10px; font-style: italic;">SPECIAL OFFER</p>
+    <p style="font-family: var(--font-script); font-size: 18px; font-weight: 500; line-height: 1.25; color: var(--color-near-black); margin: 0 0 4px; font-style: italic;">Use code <span style="text-decoration: underline;">DESIGN20</span></p>
+    <p style="font-family: var(--font-script); font-size: 18px; font-weight: 500; line-height: 1.25; color: var(--color-near-black); margin: 0 0 12px; font-style: italic;">at checkout for 20% off</p>
+    <p style="font-family: var(--font-script); font-size: 14px; font-weight: 600; line-height: 1.2; letter-spacing: 0.3px; color: var(--color-near-black); margin: 0; font-style: italic;">ENDS JUNE 10TH, 12PM EST</p>
+  </div>
+</div>
+```
+
+### Numbered Item (inside the stone frame for multi-card compositions)
+
+```html
+<div style="padding: 24px 0; border-bottom: 1px solid var(--color-border-hairline);">
+  <p style="font-family: var(--font-display-serif); font-size: 13px; font-weight: 500; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-muted-text); margin: 0 0 10px;">EDITION 01</p>
+  <h3 style="font-family: var(--font-body); font-size: 28px; font-weight: 700; line-height: 1.15; letter-spacing: -0.5px; color: var(--color-near-black); margin: 0;">The Sweater, Reimagined</h3>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="text-align: center; padding: 40px 32px; background-color: var(--color-stone-lighter); border: 1px solid var(--color-border-hairline);">
+  <p style="font-family: var(--font-body); font-size: 64px; font-weight: 700; line-height: 1.0; letter-spacing: -2px; color: var(--color-near-black); margin: 0 0 12px;">20%</p>
+  <p style="font-family: var(--font-display-serif); font-size: 13px; font-weight: 500; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-near-black); margin: 0;">OFF ARCHIVE PIECES</p>
+</div>
+```
+
+### Comparison Grid
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 40px;">
+  <div style="background-color: var(--color-taupe); aspect-ratio: 3 / 4; position: relative;">
+    <div style="position: absolute; bottom: 24px; left: 24px; right: 24px;">
+      <p style="font-family: var(--font-display-serif); font-size: 12px; font-weight: 500; letter-spacing: 2px; text-transform: uppercase; color: var(--color-stone); margin: 0 0 6px;">COLLECTION I</p>
+      <h3 style="font-family: var(--font-body); font-size: 22px; font-weight: 700; line-height: 1.2; color: var(--color-stone); margin: 0;">Winter Archive</h3>
+    </div>
+  </div>
+  <div style="background-color: var(--color-taupe); aspect-ratio: 3 / 4; position: relative;">
+    <div style="position: absolute; bottom: 24px; left: 24px; right: 24px;">
+      <p style="font-family: var(--font-display-serif); font-size: 12px; font-weight: 500; letter-spacing: 2px; text-transform: uppercase; color: var(--color-stone); margin: 0 0 6px;">COLLECTION II</p>
+      <h3 style="font-family: var(--font-body); font-size: 22px; font-weight: 700; line-height: 1.2; color: var(--color-stone); margin: 0;">Atelier Edit</h3>
+    </div>
+  </div>
+</div>
+```
+
+### Quote Block
+
+```html
+<div style="padding: 40px 50px; background-color: var(--color-stone-lighter); border-left: 2px solid var(--color-near-black);">
+  <p style="font-family: var(--font-display-serif); font-size: 28px; font-weight: 500; font-style: italic; line-height: 1.35; color: var(--color-near-black); margin: 0 0 20px;">"Every piece tells a story the season almost forgot."</p>
+  <p style="font-family: var(--font-display-serif); font-size: 12px; font-weight: 500; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-muted-text); margin: 0;">THE GALERIE EDITORS</p>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="text-align: center; padding: 48px 40px; position: relative;">
+  <p style="font-family: var(--font-display-serif); font-size: 13px; font-weight: 500; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-near-black); margin: 0 0 20px;">LIMITED RELEASE</p>
+  <h2 style="font-family: var(--font-body); font-size: 48px; font-weight: 700; line-height: 1.05; letter-spacing: -1px; color: var(--color-near-black); margin: 0 0 32px; text-transform: uppercase;">Shop<br>The Archive</h2>
+  <a style="display: inline-block; background: var(--color-near-black); color: var(--color-stone); font-family: var(--font-body); font-size: 14px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; text-decoration: none; padding: 18px 44px; border-radius: 0;">Enter Galerie</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- inside tracked-caps labels.
+- **8px**: Tight gap -- between wordmark baseline and first hairline.
+- **12px**: Small gap -- between headline lines and subheadings.
+- **18px**: Stack gap -- between headline and tracked-caps date below.
+- **24px**: Header internal -- between wordmark and main headline.
+- **32px**: Section internal -- inside the stone frame between content blocks.
+- **40px**: Grid gap -- between paired photo cards in comparison layouts.
+- **50px**: Frame inset -- the signature stone-to-photo margin (the core structural unit).
+- **80px**: Section divider -- between major vertical blocks on taller formats.
+
+### Format Padding
+| Format | Outer Stone Frame | Inner Photo Inset | Content Max-Width |
+|--------|------------------|-------------------|-------------------|
+| Carousel (1080x1080) | 50px all sides | 50px additional | 980px |
+| Infographic (1080xN) | 60px L/R, 80px T/B | 50px additional | 960px |
+| Slides (1920x1080) | 80px all sides | 60px additional | 1760px |
+| Poster (1080x1350) | 60px L/R, 80px T/B | 50px additional | 960px |
+| Story (1080x1920) | 60px L/R, 120px T/B | 50px additional | 960px |
+
+### Alignment & Grid
+- **Primary alignment**: Center-aligned for catalog headers, wordmark, and date labels. Left-aligned inside secondary content cards only.
+- **Frame inset rule**: The photo container is always inset from the stone frame by ~50px on all sides. This margin is non-negotiable -- it is the visual signature that makes the composition feel like a mailed catalog page.
+- **Sticker placement**: Bottom-left corner, with roughly 60-80px offset from the stone frame's inner photo edge. Always one sticker, never two, always rotated -5 to -10deg.
+- **Vertical rhythm**: Top third is the catalog header band (in stone). Middle + bottom two-thirds is the inset photo environment. The sticker straddles the bottom-left edge between the two.
+- **Content gravity**: Heavy top-center (catalog header), heavy bottom-left (sticker). The rest is photo quiet.
+- **No grid patterns**: No dot grids, no stripes, no decorative background textures. The stone canvas is the only texture.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, stone `#E6DCC8` | Outer frame canvas |
+| Photo Inset (Level 1) | `inset 0 1px 2px rgba(26,20,16,0.04)` + taupe bg | The darker photo container |
+| Sticker Rest (Level 2) | `0 8px 24px rgba(139,58,92,0.18), 0 2px 6px rgba(26,20,16,0.08)` | The tilted pink sticker (default) |
+| Sticker Lifted (Level 3) | `0 14px 36px rgba(139,58,92,0.24), 0 3px 8px rgba(26,20,16,0.12)` | Hover / featured state for the sticker |
+| Overlay (Level 4) | `0 24px 56px rgba(26,20,16,0.22)` | Modals and overlays (rare) |
+
+### Border Treatments
+- **Hairline divider**: `1px solid rgba(26,20,16,0.12)` -- used beneath catalog headers and between list items inside the frame.
+- **Photo frame border**: No explicit border -- the color contrast between stone beige and taupe brown IS the border.
+- **Sticker outer shape**: Asymmetric `border-radius` like `120px 140px 110px 130px / 90px 100px 80px 110px` to suggest a hand-cut speech bubble rather than a perfect ellipse.
+- **Sticker inner rose line**: `1.5px solid rgba(139,58,92,0.35)` positioned 8px inside the sticker shape with a matching asymmetric radius -- this is the double-line detail that sells the sticker illusion.
+- **CTA button border**: None. CTAs are solid near-black blocks with no border-radius.
+
+### Surface Hierarchy
+1. **Stone Frame** (`#E6DCC8`) -- the outermost canvas, the paper itself.
+2. **Photo Environment** (`#4A352A`) -- the inset taupe container, warmer and recessed.
+3. **Photo Content** -- the actual imagery, living inside the taupe container.
+4. **Sticker** (`#F4B8D4`) -- the singular raised element, tilted and drop-shadowed, breaking the frame.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use stone beige (`#E6DCC8`) as the outer frame color on every composition -- it is the visual signature of the style.
+- Inset the photo with a generous ~50px margin all around -- the stone band is what makes this feel like a catalog, not a poster.
+- Use the tilted pink sticker (`#F4B8D4`) as the ONE decorative focal point -- rotate it -5 to -10deg in the bottom-left corner.
+- Use Caveat handwritten italic for sticker copy -- it is the personal-note voice that counters the formal catalog header.
+- Use Cormorant Garamond italic at 28px for the small "Galerie"-style wordmark at top center.
+- Use Inter 700 at 44-72px for the main catalog headline, stacked on 2 lines, centered.
+- Use tracked caps (Cormorant Garamond, 2.5px letter-spacing, uppercase) for dates and small labels like "FEBRUARY 13 - 16".
+- Add a pink-tinted drop shadow (`0 8px 24px rgba(139,58,92,0.18)`) beneath the sticker so it reads as a physical object stuck to the page.
+- Use an asymmetric `border-radius` on the sticker to suggest a hand-cut speech bubble rather than a perfect ellipse.
+- Keep the photo environment warm and dark (taupe brown `#4A352A`) -- cool backgrounds break the catalog mood.
+- Leave the stone frame empty except for the catalog header and the sticker -- silence is part of the style.
+
+### Don't
+- Don't center photos edge-to-edge -- always inset them from the stone frame with the ~50px margin.
+- Don't use more than 1 sticker per composition -- the singular pink note is the scroll-stopper, two stickers dilute it.
+- Don't straighten the sticker -- the -8deg tilt IS the personality. A rotation of 0deg is dead on arrival.
+- Don't use Caveat anywhere except on the sticker -- it belongs to the handwritten note voice and nowhere else.
+- Don't use pure white (`#FFFFFF`) or pure black (`#000000`) -- always use stone (`#E6DCC8`) and warm near-black (`#1A1410`).
+- Don't use rounded corners on CTA buttons or cards -- this style is editorial and flat-cornered except for the sticker.
+- Don't use Inter italic for anything -- italic belongs to Cormorant Garamond (heritage) and Caveat (handwritten).
+- Don't add dot grids, stripes, gradients, icons, or decorative patterns -- the stone canvas is the only texture.
+- Don't color the catalog headline anything but near-black (`#1A1410`) -- the pink stays on the sticker.
+- Don't stack more than 2 lines in the main headline -- the catalog banner is always 2 lines, centered.
+- Don't place the sticker anywhere except bottom-left -- bottom-right, top-left, and top-right all break the convention.
+- Don't use cool or blue-tinted photography -- source warm, brown, stone-friendly imagery to match the palette.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale**: Display Hero becomes 56px Inter 700 (from 72px). Wordmark stays 28px Cormorant Garamond italic. Tracked date stays 14px. Sticker headline stays Caveat 28-32px.
+- **Frame**: 50px outer stone frame padding. Photo container is inset with an additional 50px margin, leaving an inner photo area of approximately 880x880px.
+- **Cover slide**: Stone frame at 50px. Top ~30% of the frame is the catalog header (wordmark + stacked headline + tracked date). Bottom ~70% is the inset taupe photo container. Pink sticker rotated -8deg sits in the bottom-left, approximately 70px from the left edge and 90px from the bottom.
+- **Content slides**: Same stone frame. Replace the photo container with a stone-lighter content card holding numbered items, stats, or grid layouts. Omit the sticker on purely informational slides -- it is reserved for hero/cover and promo slides.
+- **Promo slide**: Always includes the tilted pink sticker, always with Caveat script copy, always in the bottom-left.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Full scale -- Display Hero at 72px, Section Heading at 48px. Wordmark at 32px for the masthead.
+- **Padding**: 60px left/right, 80px top/bottom outer. Inner photo / content zones maintain the 50px inset rule.
+- **Masthead**: Catalog header stacks at the top (wordmark + 2-line headline + tracked date) with a hairline divider below.
+- **Vertical rhythm**: Alternate between inset photo sections (taupe) and stone-lighter content cards. 80px vertical gaps between sections.
+- **Sticker**: Exactly one sticker per infographic, placed beside the hero photo zone in the top third of the layout.
+- **Footer**: Tracked-caps label, hairline divider, small Cormorant Garamond italic sign-off.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 96px Inter 700. Section Heading at 56px. Wordmark at 36px Cormorant Garamond italic. Tracked date at 16px with 3px letter-spacing.
+- **Padding**: 80px outer stone frame. Photo inset at 60-80px additional.
+- **Layout**: Horizontal split -- left 40% stone band with centered catalog header; right 60% inset taupe photo container. Sticker rotated -8deg sits on the seam between the two bands, in the bottom-left of the photo zone.
+- **Content slides**: Two-column -- left column for catalog header + tracked caps + numbered items, right column for photo or data visualization in the taupe frame.
+- **CTA slide**: Centered catalog header treatment, no sticker, dark near-black pill button with Inter 600 tracked caps label.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 64px Inter 700. Wordmark at 30px Cormorant Garamond italic. Tracked date at 14px.
+- **Padding**: 60px left/right, 80px top/bottom outer stone frame. Photo inset at 50px additional.
+- **Composition**: Top ~25% for catalog header (wordmark, stacked headline, tracked date). Middle ~60% for the inset taupe photo container. Bottom ~15% for secondary tracked-caps label or small CTA.
+- **Sticker placement**: Bottom-left corner of the photo zone, rotated -8deg, overlapping the photo edge into the bottom stone band.
+- **Vertical flow**: Reads top-to-bottom -- catalog masthead, photo hero, tracked-caps footer.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Hero becomes 80px Inter 700 (slightly larger than Carousel 56px). Wordmark at 34px Cormorant Garamond italic. Tracked date at 15px with 3px letter-spacing. Sticker copy: Caveat 36px for the headline, Caveat 22px for the body, Caveat 16px for the footer line.
+- **Padding**: 120px top/bottom + 60px left/right outer stone frame. Safe zones: 180px top and 200px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical content must sit inside y=180 to y=1720. Photo inset at 50px additional inside the stone frame.
+- **Layout**: Single centered column. Content max-width 960px. Vertical center of gravity -- catalog masthead in y=220 to y=620, inset taupe photo container from y=640 to y=1700, pink sticker overlapping the bottom-left corner of the photo zone around y=1500-1700.
+- **Cover slide**: Stone frame edge-to-edge. Catalog header stacks at the top (Cormorant Garamond italic "Galerie" wordmark, then Inter 700 80px headline on 2 lines, then Cormorant Garamond tracked-caps date). Inset taupe photo container fills the remaining vertical space. Tilted pink sticker rotated -8deg at approximately left=80px, bottom=260px, with asymmetric border-radius and the pink-tinted drop shadow.
+- **Content slides**: Same stone frame and masthead. Replace the photo with a stone-lighter content card containing numbered items or stats. Sticker omitted unless the slide is a promo slide.
+- **CTA slide**: Catalog header at top. Centered near-black pill button (no border-radius, tracked-caps label) in the lower-middle of the frame. Optional sticker in bottom-left with a final call ("Last Chance").
+- **Progress indicator**: Thin segments at y=60 (inside the safe zone) -- inactive in `rgba(26,20,16,0.15)`, active in near-black (`#1A1410`). Keeps the catalog aesthetic without competing with the sticker.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Stone Beige | `#E6DCC8` | Outer frame background |
+| Near-Black | `#1A1410` | Primary text, CTA button fill |
+| Taupe Brown | `#4A352A` | Inset photo container background |
+| Candy Pink | `#F4B8D4` | Sticker fill (one use only) |
+| Deep Pink Ink | `#8B3A5C` | Sticker inner border, accent text |
+| Stone Deeper | `#D8C9B0` | Subtle borders, secondary surfaces |
+| Stone Lighter | `#EFE6D6` | Content card highlights |
+| Warm Brown | `#6B4C3B` | Secondary text on photo environments |
+| Muted Text | `#7A6B5D` | Metadata inside the stone frame |
+
+### Font Declarations
+
+```css
+/* Display serif (wordmark, tracked dates, quotes) */
+font-family: 'Cormorant Garamond', Georgia, 'Times New Roman', serif;
+
+/* Body sans (catalog headline, body text, CTAs) */
+font-family: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+/* Script (sticker copy only) */
+font-family: 'Caveat', 'Brush Script MT', cursive;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500;1,600&family=Inter:wght@400;500;600;700;800&family=Caveat:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-stone: #E6DCC8;
+  --color-near-black: #1A1410;
+  --color-taupe: #4A352A;
+
+  /* Colors -- Accent */
+  --color-pink: #F4B8D4;
+  --color-pink-ink: #8B3A5C;
+
+  /* Colors -- Neutral Scale */
+  --color-stone-deeper: #D8C9B0;
+  --color-stone-lighter: #EFE6D6;
+  --color-warm-brown: #6B4C3B;
+  --color-muted-text: #7A6B5D;
+  --color-ink-trace: rgba(26, 20, 16, 0.45);
+  --color-divider: rgba(26, 20, 16, 0.12);
+
+  /* Colors -- Surfaces */
+  --color-surface-stone: #E6DCC8;
+  --color-surface-photo: #4A352A;
+  --color-surface-sticker: #F4B8D4;
+  --color-surface-card: #EFE6D6;
+
+  /* Colors -- Borders */
+  --color-border-hairline: rgba(26, 20, 16, 0.12);
+  --color-border-sticker-inner: rgba(139, 58, 92, 0.35);
+  --color-border-sticker-outer: rgba(26, 20, 16, 0.06);
+
+  /* Colors -- Shadows */
+  --shadow-whisper: rgba(74, 53, 42, 0.06);
+  --shadow-sticker: rgba(139, 58, 92, 0.18);
+  --shadow-deep: rgba(26, 20, 16, 0.14);
+
+  /* Composed Shadows */
+  --shadow-photo: inset 0 1px 2px rgba(26, 20, 16, 0.04);
+  --shadow-sticker-rest: 0 8px 24px rgba(139, 58, 92, 0.18), 0 2px 6px rgba(26, 20, 16, 0.08);
+  --shadow-sticker-lift: 0 14px 36px rgba(139, 58, 92, 0.24), 0 3px 8px rgba(26, 20, 16, 0.12);
+  --shadow-overlay: 0 24px 56px rgba(26, 20, 16, 0.22);
+
+  /* Typography -- Families */
+  --font-display-serif: 'Cormorant Garamond', Georgia, 'Times New Roman', serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-script: 'Caveat', 'Brush Script MT', cursive;
+
+  /* Typography -- Sizes */
+  --text-wordmark: 28px;
+  --text-display-hero: 72px;
+  --text-display-square: 56px;
+  --text-section-heading: 32px;
+  --text-body-large: 20px;
+  --text-body: 17px;
+  --text-small: 13px;
+  --text-tracked-date: 14px;
+  --text-sticker-headline: 32px;
+  --text-sticker-body: 20px;
+  --text-sticker-foot: 16px;
+
+  /* Typography -- Weights */
+  --weight-wordmark: 500;
+  --weight-display: 700;
+  --weight-heading: 600;
+  --weight-body: 500;
+  --weight-body-bold: 700;
+  --weight-tracked: 500;
+  --weight-script: 700;
+
+  /* Typography -- Line Heights */
+  --leading-display: 1.05;
+  --leading-heading: 1.15;
+  --leading-body: 1.55;
+  --leading-tracked: 1.2;
+  --leading-script: 1.1;
+  --leading-number: 1.0;
+
+  /* Typography -- Letter Spacing */
+  --tracking-display: -1.5px;
+  --tracking-display-square: -1px;
+  --tracking-heading: -0.5px;
+  --tracking-body: 0px;
+  --tracking-tracked-date: 2.5px;
+  --tracking-cta: 2px;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-stack: 18px;
+  --space-header-internal: 24px;
+  --space-section-internal: 32px;
+  --space-grid-gap: 40px;
+  --space-frame-inset: 50px;
+  --space-section-divider: 80px;
+
+  /* Borders */
+  --radius-card: 0px;
+  --radius-cta: 0px;
+  --radius-sticker: 120px 140px 110px 130px / 90px 100px 80px 110px;
+  --radius-sticker-inner: 110px 130px 100px 120px / 82px 92px 72px 100px;
+
+  /* Sticker rotation */
+  --sticker-rotate: -8deg;
+}
+```
+
+### System Font Fallbacks
+- **Display serif (if Cormorant Garamond fails to load):** `Georgia, 'Times New Roman', serif`
+- **Sans-serif (if Inter fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Script (if Caveat fails to load):** `'Brush Script MT', 'Lucida Handwriting', cursive`

--- a/skills/composites/goose-graphics/styles/_full/aurora-app-launch.md
+++ b/skills/composites/goose-graphics/styles/_full/aurora-app-launch.md
@@ -1,0 +1,581 @@
+# Design Style: Aurora App Launch
+
+## 1. Visual Theme & Atmosphere
+
+Aurora App Launch is the design language of a modern mindfulness-app reveal -- the visual equivalent of a Mac Big Sur wallpaper that has been carefully composed into a product poster. It is built around a single hero move: a soft, dreamy rainbow mesh gradient that flows across the entire canvas, starting in sky blue on the left, blooming through warm peach-coral in the centre, and resolving into a dusty pink-lavender on the right. Multiple blurry radial colour blobs stack on top of each other with mix-blend modes to create that unmistakable Figma-mesh-gradient feel -- a living, tactile atmosphere that looks like light filtered through stained glass at dawn. This gradient is not a background; it IS the style.
+
+The hero composition is deliberately simple and emotionally loaded: a white-outlined phone mockup sits dead-centre over the upper half of the canvas, showing a meditation app screen. The app inside the phone uses Fraunces -- a modern display serif with warmth and gentle curves -- for the brand name ("Inara") and Inter for everything else. The Fraunces-on-gradient combination feels like a wellness brand out of Copenhagen or Melbourne: considered, warm, and unmistakably premium. The bottom ~45% of the canvas is covered by a large translucent frosted-glass card (`backdrop-filter: blur(40px)` over `rgba(255,255,255,0.2)`) holding a small "Download the app" label and a heavy, two-line Inter 700 headline in near-white. The frosted card is the CTA container -- it interrupts the gradient without killing it, because you can still see the aurora glowing through the glass.
+
+The feel is dreamy, tactile, and unmistakably app-launch. Think: the marketing page for a Calm competitor, the Apple event slide that reveals a new wellness feature, the App Store feature graphic for a meditation app that just won Editor's Choice. It is aspirational without being cold, modern without being sterile, and soft without being boring. The entire style rests on the interplay between atmospheric colour and structural frosted glass.
+
+**Key Characteristics:**
+- Rainbow mesh gradient background built from 3-4 layered `radial-gradient` functions -- sky blue (`#A8C4E8`) + peach-coral (`#F2A87C`) + dusty pink (`#D4A8C4`) + soft lavender (`#C8B8E0`)
+- White-outlined phone mockup as the centre-of-gravity hero visual (`border: 3px solid rgba(255,255,255,0.8)`, `border-radius: 48px`)
+- Frosted-glass footer card occupying bottom ~45% (`backdrop-filter: blur(40px)`, `background: rgba(255,255,255,0.2)`)
+- Fraunces display serif for the in-app brand name only -- the single warm editorial moment
+- Inter 400/500/700 for everything else -- labels, body, headlines
+- 95% white (`rgba(255,255,255,0.95)`) for text on gradient -- never pure `#ffffff` which burns out
+- Small caps label above a heavy 2-line headline -- the signature CTA pattern
+- Square 1:1 hero format, split roughly 55/45 between gradient-hero and frosted-footer
+- No dark text on the light gradient -- the style demands white-on-soft-colour
+- Progress bar inside the phone uses a translucent white fill -- matches the overall glass language
+
+**How this differs from Frosted Lens:** Frosted Lens is built on blurred *photography* as the background layer -- a lifestyle image pushed out of focus behind a glass card. Aurora App Launch is built on *generated* colour -- a CSS-native rainbow mesh gradient with no photo at all. Frosted Lens is a generic content container; Aurora App Launch is structured around a specific hero pattern (phone mockup above, frosted footer below) and tuned for app-launch and product-reveal use cases. The fonts differ too: Aurora uses Fraunces as its editorial serif moment (reserved for in-app brand marks), while Frosted Lens uses its own pairing.
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Sky Blue** (`#A8C4E8`): Gradient origin -- the cool top-left anchor of the mesh. Soft, dusty, slightly desaturated.
+- **Peach Coral** (`#F2A87C`): Gradient centre -- the warm middle bloom that gives the style its sunrise feel.
+- **Dusty Pink** (`#D4A8C4`): Gradient terminus -- the muted rose-lavender on the right side of the mesh.
+
+### Accent
+- **Soft Lavender** (`#C8B8E0`): Fourth mesh blob, placed bottom-right to add depth and dimensional shift.
+- **Warm Cream** (`#F5E6D8`): Occasional highlight bloom at the peach-blue transition; also usable as a subtle card tint.
+- **Deep Navy** (`#2A3551`): The single reserved dark colour -- used ONLY for the Fraunces brand mark inside the phone mockup (to contrast against the app's internal gradient).
+
+### Neutral Scale (mostly whites/translucencies -- this is a light style)
+- **Near-White** (`rgba(255,255,255,0.95)`): Primary text colour on gradient. Almost white but with just enough softness to never burn out.
+- **Soft White** (`rgba(255,255,255,0.80)`): Secondary text, labels, subtitles on gradient.
+- **Muted White** (`rgba(255,255,255,0.60)`): Captions, metadata, progress-bar background fills.
+- **Dim White** (`rgba(255,255,255,0.40)`): Dividers, inactive UI elements inside the phone mockup.
+- **Phone Frame White** (`rgba(255,255,255,0.80)`): The outline stroke for the phone mockup container.
+
+### Surface & Borders
+- **Frosted Glass Surface** (`rgba(255,255,255,0.20)`): The bottom-footer card fill. Combined with `backdrop-filter: blur(40px)` to produce the signature glass effect.
+- **Frosted Glass Inset** (`rgba(255,255,255,0.12)`): Secondary glass surface for nested cards and inner containers.
+- **Phone Screen Tint** (`rgba(168, 196, 232, 0.25)`): The internal gradient layer on the phone app screen -- matches the parent mesh in colour but more saturated.
+- **Glass Border** (`rgba(255,255,255,0.30)`): Thin white border on frosted cards for definition.
+- **Phone Border** (`rgba(255,255,255,0.80)`): The 3px stroke that defines the phone mockup.
+- **Divider Rule** (`rgba(255,255,255,0.15)`): Faint horizontal rules inside cards.
+
+### Shadow Colors
+- **Shadow Soft** (`rgba(42, 53, 81, 0.08)`): Ambient lift on the phone mockup -- tinted with navy to stay on-palette.
+- **Shadow Medium** (`rgba(42, 53, 81, 0.14)`): Standard elevation for the phone and frosted card.
+- **Shadow Deep** (`rgba(42, 53, 81, 0.22)`): High-contrast elevation for hero elements.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,800;1,9..144,400;1,9..144,500;1,9..144,600;1,9..144,700&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+```
+
+- **Display Serif (in-app brand only)**: `'Fraunces', Georgia, 'Times New Roman', serif`
+- **Body / Everything Else**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| App Brand Mark | Fraunces | 64px | 600 | 1.00 | -1px | Inside phone mockup only. Navy `#2A3551`. Use `font-optical-sizing: auto`. |
+| Display Headline | Inter | 60px | 700 | 1.05 | -1.5px | 2-line frosted-footer headline. 95% white. |
+| Display Hero XL | Inter | 72px | 700 | 1.05 | -2px | Upsized for larger formats (Slides, Story). |
+| Section Heading | Inter | 40px | 700 | 1.15 | -0.8px | Subsection titles on content slides. |
+| Small Caps Label | Inter | 16px | 500 | 1.00 | 0.3px | "Download the app" label above the headline. Not uppercase -- mixed case. 80% white. |
+| Body Large | Inter | 22px | 500 | 1.55 | 0px | Lead paragraphs and supporting copy. 80% white. |
+| Body | Inter | 18px | 500 | 1.55 | 0px | Standard body text. |
+| App UI Title | Inter | 22px | 700 | 1.20 | -0.3px | "Evening Meditation" inside the phone. 95% white. |
+| App UI Subtitle | Inter | 16px | 500 | 1.30 | 0px | "Stress relief" inside the phone. 70% white. |
+| App UI Time | Inter | 12px | 500 | 1.00 | 0.2px | Progress bar timestamps. 60% white. |
+| Small / Caption | Inter | 14px | 400 | 1.50 | 0.2px | Metadata, footnotes. 70% white. |
+| CTA Text | Inter | 16px | 700 | 1.00 | 0.3px | Button text. |
+
+### Principles
+- **Fraunces is a precious resource**: Use it ONLY for the in-app brand mark inside the phone mockup. It is the single editorial-serif moment in the whole style. Using it elsewhere breaks the signature.
+- **Inter does the heavy lifting**: 400 for light body, 500 for standard body and labels, 700 for headlines and CTA. Never use 300 (too thin on a busy gradient) and rarely use 800 (the 700 already reads heavy enough against the soft background).
+- **95% white, never 100%**: Pure `#ffffff` burns out against the soft pastel gradient. Always use `rgba(255,255,255,0.95)` for primary text and `rgba(255,255,255,0.80)` for secondary. This is the single most important rule for readability.
+- **Tight tracking on display**: Large Inter 700 headlines use `-1.5px` letter-spacing to feel dense and modern. Labels and body stay at 0px.
+- **Left-aligned in the frosted footer**: The 2-line CTA headline always stacks left-aligned inside the frosted card -- never centred. The asymmetry creates the wellness-product poster feel.
+- **Mixed case throughout**: No uppercase. Even the small caps label stays mixed case ("Download the app", not "DOWNLOAD THE APP"). Softness is the brand.
+
+## 4. Component Patterns
+
+### Aurora Mesh Gradient Background
+
+The signature component. Layer 3-4 radial gradients to produce the mesh effect. Include a fallback linear gradient for reduced rendering paths.
+
+```html
+<div style="
+  position: relative;
+  width: 100%;
+  min-height: 100vh;
+  /* Fallback linear gradient (for simpler rendering or older browsers) */
+  background: linear-gradient(110deg, #A8C4E8 0%, #F2A87C 50%, #D4A8C4 100%);
+  /* Mesh: layered radial gradients */
+  background-image:
+    radial-gradient(circle at 15% 30%, #A8C4E8 0%, transparent 55%),
+    radial-gradient(circle at 55% 45%, #F2A87C 0%, transparent 50%),
+    radial-gradient(circle at 85% 35%, #D4A8C4 0%, transparent 55%),
+    radial-gradient(circle at 75% 80%, #C8B8E0 0%, transparent 60%),
+    linear-gradient(110deg, #A8C4E8 0%, #F2A87C 50%, #D4A8C4 100%);
+  background-blend-mode: screen, screen, screen, normal, normal;
+  overflow: hidden;
+">
+  <!-- Optional: extra blurred colour blob for depth -->
+  <div style="
+    position: absolute;
+    top: 10%;
+    left: 40%;
+    width: 600px;
+    height: 600px;
+    background: radial-gradient(circle, #F5E6D8 0%, transparent 70%);
+    filter: blur(80px);
+    mix-blend-mode: screen;
+    pointer-events: none;
+  "></div>
+  <!-- ...hero content goes here... -->
+</div>
+```
+
+### Phone Mockup Container (Hero Visual)
+
+A white-outlined phone frame sized ~280x560px with a pill notch at the top, holding a gentle inner gradient and the app UI.
+
+```html
+<div style="
+  width: 280px;
+  height: 560px;
+  border: 3px solid rgba(255,255,255,0.80);
+  border-radius: 48px;
+  background: linear-gradient(180deg, rgba(168,196,232,0.35) 0%, rgba(242,168,124,0.25) 100%);
+  box-shadow: 0 24px 60px rgba(42,53,81,0.14);
+  position: relative;
+  padding: 32px 24px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+">
+  <!-- Top UI row: back chevron + menu dots -->
+  <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 40px;">
+    <div style="width: 32px; height: 32px; border: 1.5px solid rgba(255,255,255,0.80); border-radius: 50%; display: flex; align-items: center; justify-content: center;">
+      <span style="color: rgba(255,255,255,0.95); font-family: var(--font-body); font-size: 14px;">&lsaquo;</span>
+    </div>
+    <div style="width: 32px; height: 32px; border: 1.5px solid rgba(255,255,255,0.80); border-radius: 50%; display: flex; align-items: center; justify-content: center;">
+      <span style="color: rgba(255,255,255,0.95); font-family: var(--font-body); font-size: 14px;">&#8942;</span>
+    </div>
+  </div>
+
+  <!-- Brand mark (Fraunces) -->
+  <div style="flex: 1; display: flex; align-items: center; justify-content: center;">
+    <h2 style="
+      font-family: var(--font-display);
+      font-size: 64px;
+      font-weight: 600;
+      font-optical-sizing: auto;
+      line-height: 1.00;
+      letter-spacing: -1px;
+      color: #2A3551;
+      margin: 0;
+    ">Inara</h2>
+  </div>
+
+  <!-- App UI title + progress bar -->
+  <div style="text-align: center; padding-bottom: 16px;">
+    <p style="font-family: var(--font-body); font-size: 22px; font-weight: 700; line-height: 1.20; letter-spacing: -0.3px; color: rgba(255,255,255,0.95); margin: 0 0 6px;">Evening Meditation</p>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 500; line-height: 1.30; color: rgba(255,255,255,0.70); margin: 0 0 20px;">Stress relief</p>
+
+    <!-- Progress bar -->
+    <div style="height: 3px; background: rgba(255,255,255,0.30); border-radius: 2px; position: relative; margin-bottom: 8px;">
+      <div style="position: absolute; top: 0; left: 0; height: 100%; width: 35%; background: rgba(255,255,255,0.95); border-radius: 2px;"></div>
+    </div>
+    <div style="display: flex; justify-content: space-between;">
+      <span style="font-family: var(--font-body); font-size: 12px; font-weight: 500; letter-spacing: 0.2px; color: rgba(255,255,255,0.60);">4:15</span>
+      <span style="font-family: var(--font-body); font-size: 12px; font-weight: 500; letter-spacing: 0.2px; color: rgba(255,255,255,0.60);">15:28</span>
+    </div>
+  </div>
+</div>
+```
+
+### Frosted-Glass Footer Card
+
+The bottom ~45% of the canvas. A large translucent card with heavy blur, holding the small label and the 2-line heavy headline.
+
+```html
+<div style="
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 45%;
+  background: rgba(255,255,255,0.20);
+  backdrop-filter: blur(40px);
+  -webkit-backdrop-filter: blur(40px);
+  border-top: 1px solid rgba(255,255,255,0.30);
+  padding: 60px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+">
+  <p style="
+    font-family: var(--font-body);
+    font-size: 16px;
+    font-weight: 500;
+    letter-spacing: 0.3px;
+    color: rgba(255,255,255,0.80);
+    margin: 0 0 20px;
+  ">Download the app</p>
+  <h1 style="
+    font-family: var(--font-body);
+    font-size: 60px;
+    font-weight: 700;
+    line-height: 1.05;
+    letter-spacing: -1.5px;
+    color: rgba(255,255,255,0.95);
+    margin: 0;
+  ">Little rituals.<br>Big shifts.</h1>
+</div>
+```
+
+### Label + Heavy Headline Block (Standalone)
+
+The signature CTA pattern -- small caps label above a left-aligned 2-line Inter 700 headline. Use inside frosted cards or on content slides.
+
+```html
+<div style="padding: 48px 0;">
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 500; letter-spacing: 0.3px; color: rgba(255,255,255,0.80); margin: 0 0 18px;">Start your practice</p>
+  <h2 style="font-family: var(--font-body); font-size: 52px; font-weight: 700; line-height: 1.05; letter-spacing: -1.3px; color: rgba(255,255,255,0.95); margin: 0;">Five minutes.<br>New mind.</h2>
+</div>
+```
+
+### Content Card (Nested Frosted)
+
+For secondary content inside or beside the phone mockup.
+
+```html
+<div style="
+  background: rgba(255,255,255,0.12);
+  backdrop-filter: blur(30px);
+  -webkit-backdrop-filter: blur(30px);
+  border: 1px solid rgba(255,255,255,0.25);
+  border-radius: 24px;
+  padding: 32px 28px;
+">
+  <p style="font-family: var(--font-body); font-size: 14px; font-weight: 500; letter-spacing: 0.2px; color: rgba(255,255,255,0.70); margin: 0 0 12px;">Feature</p>
+  <h3 style="font-family: var(--font-body); font-size: 28px; font-weight: 700; line-height: 1.15; letter-spacing: -0.5px; color: rgba(255,255,255,0.95); margin: 0 0 12px;">Guided breathwork</h3>
+  <p style="font-family: var(--font-body); font-size: 18px; font-weight: 500; line-height: 1.55; color: rgba(255,255,255,0.80); margin: 0;">Short, targeted sessions for the moments that matter most.</p>
+</div>
+```
+
+### CTA Button
+
+Frosted pill button for in-app-style CTAs.
+
+```html
+<a style="
+  display: inline-block;
+  background: rgba(255,255,255,0.95);
+  color: #2A3551;
+  font-family: var(--font-body);
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  text-decoration: none;
+  padding: 18px 44px;
+  border-radius: 40px;
+  box-shadow: 0 8px 24px rgba(42,53,81,0.14);
+">Download now</a>
+```
+
+### Stat Display
+
+```html
+<div style="padding: 32px 0;">
+  <p style="font-family: var(--font-body); font-size: 72px; font-weight: 700; line-height: 1.00; letter-spacing: -2px; color: rgba(255,255,255,0.95); margin: 0 0 8px;">2M+</p>
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 500; letter-spacing: 0.3px; color: rgba(255,255,255,0.80); margin: 0;">Moments of calm, delivered daily</p>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- progress-bar tick offset.
+- **8px**: Tight -- app UI subtitle gap.
+- **12px**: Small -- inside-card label-to-body.
+- **16px**: Base -- between body paragraphs.
+- **20px**: Label-to-headline -- the label sits 20px above the 2-line headline inside the frosted footer.
+- **24px**: Medium -- between components.
+- **32px**: Card internal padding.
+- **40px**: App UI intro-to-brand gap inside the phone.
+- **48px**: Phone border-radius and section dividers.
+- **60px**: Frosted footer internal padding.
+- **80px**: Maximum outer section padding.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 960px |
+| Story (1080x1920) | 60px left/right, 120px top/bottom | 960px |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned inside the frosted footer. Centered for the phone mockup hero.
+- **55/45 split**: Hero slides divide vertically -- top ~55% holds the gradient with the phone mockup; bottom ~45% is the frosted footer with the label + headline.
+- **Phone mockup centering**: Always horizontally centered in the top zone, slightly overlapping into the frosted footer (~10-15% of its height dips into the glass for depth).
+- **Headline wrap**: The 2-line frosted-footer headline is always hand-broken to produce a deliberate 2-line stack. Avoid orphan words.
+- **No three-column layouts**: This style uses single-column verticals or 2-column splits. Three columns overwhelm the soft gradient.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | Aurora mesh gradient canvas, no shadow | Base layer, backgrounds |
+| Subtle (Level 1) | `0 4px 12px rgba(42,53,81,0.08)` | Nested cards, soft lifts |
+| Card (Level 2) | `0 12px 32px rgba(42,53,81,0.10)` + frosted glass | Content cards |
+| Elevated (Level 3) | `0 24px 60px rgba(42,53,81,0.14)` | Phone mockup, featured hero elements |
+| Overlay (Level 4) | `0 32px 80px rgba(42,53,81,0.22)` | Modals and peak elements |
+
+### Border Treatments
+- **Phone frame**: `3px solid rgba(255,255,255,0.80)` + `border-radius: 48px`. The hero stroke.
+- **Frosted card (large)**: `1px solid rgba(255,255,255,0.30)` on the top edge only (`border-top`), seamless elsewhere. For the footer.
+- **Frosted card (nested)**: `1px solid rgba(255,255,255,0.25)` all sides + `border-radius: 24px`. For content cards inside the gradient.
+- **Divider rule**: `1px solid rgba(255,255,255,0.15)` for horizontal divisions inside cards.
+- **No sharp corners**: Everything is rounded -- minimum 16px, typical 24-48px.
+
+### Surface Hierarchy
+Depth comes from translucency, blur, and soft navy-tinted shadow -- never from solid opaque layers:
+1. **Aurora mesh** -- the atmospheric base layer.
+2. **Frosted surface 12%** -- nested cards, inset containers.
+3. **Frosted surface 20%** -- the large footer card, primary glass surface.
+4. **Phone frame** -- a bordered translucent container holding the app UI gradient.
+5. **Opaque CTA button** -- the single 95%-white element that anchors the page.
+
+## 7. Do's and Don'ts
+
+### Do
+- **Use layered radial gradients to build the mesh** -- combine 3-4 `radial-gradient` functions at different positions with `background-blend-mode: screen` for the signature rainbow bloom.
+- **Use the phone mockup as the visual center of hero slides** -- centered horizontally, dipping slightly into the frosted footer for depth.
+- **Use the frosted-glass footer for CTAs and main headlines** -- it is the CTA container and the place where the heavy headline lives.
+- **Use Fraunces for the app brand name and Inter for everything else** -- Fraunces is a reserved editorial moment, not a general-purpose serif.
+- **Always use `rgba(255,255,255,0.95)` for primary text on gradient** -- never pure `#ffffff`.
+- **Keep the 55/45 vertical split on hero slides** -- top 55% gradient + phone, bottom 45% frosted footer.
+- **Use `-1.5px` letter-spacing on the big 2-line headline** -- tight tracking is what makes the Inter 700 feel premium.
+- **Include the fallback linear gradient in CSS** -- renders cleanly even when `backdrop-filter` or `background-blend-mode` fails.
+- **Use navy (`#2A3551`) sparingly and only for the Fraunces brand mark inside the phone** -- it is the only dark element in the style.
+- **Round everything** -- 48px phone, 40px button, 24px cards, 16px minimum.
+
+### Don't
+- **Don't use a solid background** -- the mesh IS the style. A flat blue or flat peach defeats the entire composition.
+- **Don't use pure white text (`#ffffff`)** -- it burns out against the soft pastel gradient. Always use 95% white for readability.
+- **Don't skip the frosted-glass footer** -- it's the CTA container. Without it the composition has nowhere for the headline to land.
+- **Don't use dark text on light sections** -- the exception is the Fraunces brand mark inside the phone (navy), and nothing else.
+- **Don't use Fraunces for body text or non-brand headlines** -- it's reserved for the in-app brand mark only.
+- **Don't use saturated or vivid colours** -- everything is soft, dusty, and desaturated. Vivid neon pinks or electric blues break the wellness feel.
+- **Don't use sharp corners** -- 0px radius has no place here. Minimum 16px everywhere.
+- **Don't centre the frosted-footer headline** -- it must be left-aligned to preserve the asymmetric poster feel.
+- **Don't nest too many frosted cards** -- two levels of glass max. More becomes visually noisy.
+- **Don't place the phone mockup off-center** -- symmetry is the anchor that lets the asymmetric footer work.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale**: Display Headline at 60px (default). App Brand Mark at 64px. Body at 18px.
+- **Padding**: 60px on all sides.
+- **Cover slide**: Full aurora mesh + centered phone mockup in top 55% + frosted footer bottom 45% with label + 2-line headline.
+- **Content slides**: Mesh background. Left-aligned label + headline block. Optional nested frosted card for detail content.
+- **Swipe indicator**: Small dots at the very bottom of the frosted footer -- `rgba(255,255,255,0.4)` inactive, `rgba(255,255,255,0.95)` active. 8px diameter.
+- **CTA slide**: Hero pattern repeated with the CTA button replacing the subtitle below the headline.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Display Headline at 60-72px on the hero. Section Heading at 40px. Body at 18-22px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Hero block at the top with the full phone + footer pattern. Below, alternating content sections with nested frosted cards on the mesh background. No second frosted footer -- the mesh runs edge-to-edge after the hero.
+- **Section spacing**: 80px vertical gaps between major sections. Use nested frosted cards (24px radius) to group related content.
+- **Footer**: Small CTA block with frosted card + label + headline + button.
+
+### Slides (1920x1080px)
+- **Typography scale**: Display Hero XL at 72-88px. Section Heading at 48px. Body Large at 24px. App Brand Mark scales to 80px.
+- **Padding**: 80px on all sides.
+- **Layout**: 55/45 vertical split preserved but widescreen: the phone mockup sits left-of-center in the hero zone, with a label + 2-line headline to its right. Frosted footer spans full width at bottom with a CTA button aligned right.
+- **Title slides**: Full hero pattern -- phone centered, frosted footer with label + headline.
+- **Content slides**: Mesh gradient + nested frosted cards in a 2-column layout. Left column: label + headline. Right column: content card.
+- **CTA slides**: Phone mockup left, right column has full label + headline + button stack.
+
+### Poster (1080x1350px)
+- **Typography**: Display Headline at 56px. App Brand Mark at 72px (larger for vertical prominence). Body at 20px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top 55% holds the phone mockup centered on the mesh. Bottom 45% is the frosted footer with label + headline. The 55/45 split stretches naturally in the taller format.
+- **Vertical flow**: All content reads top-to-bottom. The phone is the emotional anchor; the frosted footer is the landing zone.
+- **CTA placement**: CTA button sits 32px below the headline inside the frosted footer, left-aligned.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Headline becomes 72px in Inter 700. Section Heading becomes 56px. Body Large becomes 24px in Inter 500. App Brand Mark scales to 88px for the vertical prominence. Small caps label stays at 16-18px.
+- **Padding**: 60px left/right, 120px top/bottom. Safe zones: 160px top and 180px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical content must sit inside y=160 to y=1740.
+- **Layout**: Single centered column. Aurora mesh runs full-bleed edge-to-edge. Vertical rhythm: top third has the phone mockup, middle third keeps breathing gradient, bottom third is the frosted footer covering ~40% of the full 1920 height.
+- **Cover slide**: Full aurora mesh. Phone mockup sits centered around y=450-1050 (roughly 280x560 scales up to 380x760 here). Frosted footer runs from y=1180 to y=1920 holding a small label at ~y=1320 and the 2-line Inter 700 headline at ~y=1400-1560. Leave room below the headline for the safe-zone platform UI.
+- **Content slides**: Mesh background. Nested frosted card (24px radius) centered in the vertical middle, holding a label + headline + body. Optional small phone mockup icon or mini-illustration above the card.
+- **CTA slide**: Hero pattern repeated. Large CTA button inside the frosted footer, below the 2-line headline, left-aligned.
+- **Progress indicator**: Thin segments at y=100 -- inactive `rgba(255,255,255,0.30)`, active `rgba(255,255,255,0.95)`. Keeps the glass language consistent.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex / RGBA | Usage |
+|------|------------|-------|
+| Sky Blue | `#A8C4E8` | Gradient origin (top-left mesh blob) |
+| Peach Coral | `#F2A87C` | Gradient centre (warm bloom) |
+| Dusty Pink | `#D4A8C4` | Gradient terminus (right side) |
+| Soft Lavender | `#C8B8E0` | Fourth mesh blob (bottom-right) |
+| Warm Cream | `#F5E6D8` | Highlight bloom accent |
+| Deep Navy | `#2A3551` | Fraunces brand mark inside phone ONLY |
+| Near-White | `rgba(255,255,255,0.95)` | Primary text on gradient |
+| Soft White | `rgba(255,255,255,0.80)` | Secondary text, labels |
+| Muted White | `rgba(255,255,255,0.60)` | Captions, metadata |
+| Frosted Surface | `rgba(255,255,255,0.20)` | Footer glass card fill |
+| Frosted Inset | `rgba(255,255,255,0.12)` | Nested glass cards |
+| Glass Border | `rgba(255,255,255,0.30)` | Frosted card border |
+| Phone Border | `rgba(255,255,255,0.80)` | Phone mockup stroke |
+| Shadow Soft | `rgba(42,53,81,0.08)` | Subtle elevation |
+| Shadow Medium | `rgba(42,53,81,0.14)` | Standard card shadow |
+| Shadow Deep | `rgba(42,53,81,0.22)` | Hero elevation |
+
+### Font Declarations
+
+```css
+/* Display serif (in-app brand mark ONLY) */
+font-family: 'Fraunces', Georgia, 'Times New Roman', serif;
+font-optical-sizing: auto;
+
+/* Body (everything else) */
+font-family: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;0,9..144,800;1,9..144,400;1,9..144,500;1,9..144,600;1,9..144,700&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary (mesh gradient stops) */
+  --color-sky-blue: #A8C4E8;
+  --color-peach-coral: #F2A87C;
+  --color-dusty-pink: #D4A8C4;
+
+  /* Colors -- Accent */
+  --color-soft-lavender: #C8B8E0;
+  --color-warm-cream: #F5E6D8;
+  --color-deep-navy: #2A3551;
+
+  /* Colors -- Whites / Neutrals */
+  --color-white-95: rgba(255, 255, 255, 0.95);
+  --color-white-80: rgba(255, 255, 255, 0.80);
+  --color-white-60: rgba(255, 255, 255, 0.60);
+  --color-white-40: rgba(255, 255, 255, 0.40);
+  --color-white-30: rgba(255, 255, 255, 0.30);
+
+  /* Colors -- Surfaces */
+  --color-frosted-surface: rgba(255, 255, 255, 0.20);
+  --color-frosted-inset: rgba(255, 255, 255, 0.12);
+  --color-phone-screen-tint: rgba(168, 196, 232, 0.25);
+
+  /* Colors -- Borders */
+  --color-glass-border: rgba(255, 255, 255, 0.30);
+  --color-phone-border: rgba(255, 255, 255, 0.80);
+  --color-divider: rgba(255, 255, 255, 0.15);
+
+  /* Colors -- Shadows (navy-tinted) */
+  --shadow-soft: rgba(42, 53, 81, 0.08);
+  --shadow-medium: rgba(42, 53, 81, 0.14);
+  --shadow-deep: rgba(42, 53, 81, 0.22);
+
+  /* Composed shadows */
+  --shadow-card: 0 12px 32px rgba(42, 53, 81, 0.10);
+  --shadow-phone: 0 24px 60px rgba(42, 53, 81, 0.14);
+  --shadow-overlay: 0 32px 80px rgba(42, 53, 81, 0.22);
+
+  /* Aurora mesh gradient (the signature background) */
+  --aurora-mesh:
+    radial-gradient(circle at 15% 30%, #A8C4E8 0%, transparent 55%),
+    radial-gradient(circle at 55% 45%, #F2A87C 0%, transparent 50%),
+    radial-gradient(circle at 85% 35%, #D4A8C4 0%, transparent 55%),
+    radial-gradient(circle at 75% 80%, #C8B8E0 0%, transparent 60%),
+    linear-gradient(110deg, #A8C4E8 0%, #F2A87C 50%, #D4A8C4 100%);
+  --aurora-fallback: linear-gradient(110deg, #A8C4E8 0%, #F2A87C 50%, #D4A8C4 100%);
+  --aurora-blend-mode: screen, screen, screen, normal, normal;
+
+  /* Frosted glass */
+  --glass-blur: blur(40px);
+  --glass-blur-nested: blur(30px);
+
+  /* Typography -- Families */
+  --font-display: 'Fraunces', Georgia, 'Times New Roman', serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-xl: 72px;
+  --text-display: 60px;
+  --text-section: 40px;
+  --text-brand-mark: 64px;
+  --text-body-large: 22px;
+  --text-body: 18px;
+  --text-label: 16px;
+  --text-small: 14px;
+  --text-app-title: 22px;
+  --text-app-subtitle: 16px;
+  --text-app-time: 12px;
+  --text-cta: 16px;
+
+  /* Typography -- Weights */
+  --weight-display-serif: 600;
+  --weight-body-regular: 400;
+  --weight-body-medium: 500;
+  --weight-body-bold: 700;
+
+  /* Typography -- Line Heights */
+  --leading-display: 1.05;
+  --leading-heading: 1.15;
+  --leading-body: 1.55;
+  --leading-tight: 1.00;
+
+  /* Typography -- Letter Spacing */
+  --tracking-display: -1.5px;
+  --tracking-heading: -0.8px;
+  --tracking-brand: -1px;
+  --tracking-body: 0px;
+  --tracking-label: 0.3px;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-label-headline: 20px;
+  --space-medium: 24px;
+  --space-card-padding: 32px;
+  --space-large: 40px;
+  --space-section: 48px;
+  --space-footer-padding: 60px;
+  --space-max: 80px;
+
+  /* Borders */
+  --radius-phone: 48px;
+  --radius-cta: 40px;
+  --radius-card: 24px;
+  --radius-small: 16px;
+}
+```
+
+### System Font Fallbacks
+- **Serif (if Fraunces fails to load):** `Georgia, 'Times New Roman', serif`
+- **Sans-serif (if Inter fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/_full/blueprint-sticky.md
+++ b/skills/composites/goose-graphics/styles/_full/blueprint-sticky.md
@@ -1,0 +1,485 @@
+# Design Style: Blueprint Sticky
+
+## 1. Visual Theme & Atmosphere
+
+Blueprint Sticky is the design language of a product launch caught mid-draft -- the visual equivalent of taking a screenshot of the Figma canvas right before the team ships. A saturated cobalt blue (`#2450F5`) floods the entire composition edge-to-edge, but the blue is never empty: a faint blueprint grid of thin lighter-blue lines crosshatches the whole background, evoking the dotted canvas of Figma, the guide rails of Notion, or an architect's technical drawing. The grid is the signature; it transforms a flat blue rectangle into a workspace, a surface on which ideas are still being pinned. This is not the calm navy of corporate finance or the sky blue of SaaS pastels -- it is the pure, electric, high-chroma blue of a design tool loading up for the first time.
+
+The content sits on top of this grid as if it were dropped onto a digital desk. Two tilted sticky notes -- one candy pink (`#F4B8D4`), one bright highlighter yellow (`#F4E34A`) -- overlap at opposing angles, their rotations set just enough off-axis to feel physically placed but never enough to feel chaotic. The stickies carry the body copy in a handwritten-feeling sans serif, giving the composition a human annotation on top of the machined grid. Corner date labels in white Inter 600 anchor the composition top-left and top-right like a calendar event, while a massive bottom-left headline in Inter 900 at 80-100px -- "Product Launch" -- punches through in pure white with a small yellow curved underline accenting one key word. A tiny underlined URL (`www.zentime.com`) floats below the sticky stack, the sort of detail you'd type into a presenter note.
+
+The result is a hybrid: half Figma launch-page screenshot, half scattered desk. It reads as contemporary, tool-native, and slightly handmade -- the design language of an indie SaaS launch tweet, a Notion release note, or a Product Hunt coming-soon page for a design-forward app. It differs sharply from Card Toss (which scatters cards on a black void with pastel-friendly confidence) through four explicit moves: (a) saturated cobalt blue is the identity -- no black canvas, no pastel tints, just pure `#2450F5`; (b) the blueprint grid overlay is mandatory and pervasive, not decorative; (c) the vibe is a Figma-launch-page / canvas screenshot, not an App Store press kit; (d) the composition uses underlined URLs and small curved yellow underline accents as structural punctuation, where Card Toss uses floating off-white circles.
+
+**Key Characteristics:**
+- Saturated cobalt blue background (`#2450F5`) edge-to-edge -- not navy, not sky, pure electric cobalt
+- Blueprint grid overlay in lighter cobalt (`#4870F8` at 30% opacity), 80px spacing, across the entire canvas
+- Two sticky notes per composition: pink (`#F4B8D4`) tilted -3 to -8deg and yellow (`#F4E34A`) tilted +4 to +8deg
+- Sticky notes use soft shadows and rounded corners (`12px` radius) with torn-edge feel
+- Handwritten-feeling Inter 400/500 body copy on stickies at 18-22px
+- Massive Inter 900 white headline, 80-100px, anchored bottom-left
+- Small yellow curved SVG underline accent below one word of the headline
+- Corner date labels: "16 February" top-left and "17" top-right, Inter 600 white at 36-48px
+- Underlined URL in pale blue or white below the sticky stack (e.g. `www.zentime.com`)
+- Maximum of 2 sticky notes per slide -- three is the absolute upper bound, never more
+- Inter as the single typeface -- weights 400, 500, 600, and 900 only
+- Pure white (`#FFFFFF`) for all text on the cobalt canvas -- no cream, no off-white
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Cobalt Blue** (`#2450F5`): Primary background. A saturated, electric cobalt that sits between pure blue and true violet-blue. This is the identity color.
+- **Blueprint White** (`#FFFFFF`): Primary text color on the cobalt canvas. Used for headlines, corner dates, and URL labels.
+- **Sticky Pink** (`#F4B8D4`): Primary sticky note surface color. Candy pink, leaning slightly warm.
+
+### Accent
+- **Sticky Yellow** (`#F4E34A`): Secondary sticky note color and underline accent color. Bright highlighter yellow.
+- **Cobalt Grid Line** (`#4870F8`): Blueprint grid overlay line color at 30% opacity.
+- **Cobalt Deep** (`#1F4AF0`): Alternate cobalt for gradients or deepening the canvas edge.
+- **Hover Pink** (`#E89FBF`): Pressed/hover state for pink sticky interactions.
+- **Hover Yellow** (`#E5D23A`): Pressed/hover state for yellow sticky interactions.
+
+### Neutral Scale
+- **Sticky Text** (`#1A1A1A`): Near-black for body copy on sticky note surfaces -- always dark on bright sticky colors.
+- **Muted White** (`rgba(255,255,255,0.70)`): Secondary white for URL labels and quieter marks.
+- **Faint White** (`rgba(255,255,255,0.40)`): Metadata, footnotes, and decorative inline marks.
+- **Sticky Edge Warm** (`#EBDDD0`): Subtle warm tint for sticky note torn-edge highlight.
+- **Sticky Shadow Color** (`rgba(20,40,120,0.35)`): Blue-tinted shadow for sticky notes on cobalt background.
+
+### Surface & Borders
+- **Surface Canvas** (`#2450F5`): The cobalt blue background.
+- **Surface Sticky Pink** (`#F4B8D4`): Pink sticky note fill.
+- **Surface Sticky Yellow** (`#F4E34A`): Yellow sticky note fill.
+- **Border Sticky** (`none`): Sticky notes have no borders -- the saturated fill against cobalt defines the edge.
+- **Border Faint** (`rgba(255,255,255,0.18)`): Rare thin dividers on cobalt.
+- **Divider Grid** (`rgba(72,112,248,0.30)`): Blueprint grid line color.
+- **URL Underline** (`rgba(255,255,255,0.70)`): Underline under URL labels.
+
+### Shadow Colors
+- **Shadow Sticky** (`rgba(20,40,120,0.35)`): Primary sticky note drop shadow -- blue-tinted to sit naturally on cobalt.
+- **Shadow Sticky Deep** (`rgba(15,30,100,0.45)`): Heavier shadow for the overlapping sticky corner.
+- **Shadow Ambient** (`rgba(20,40,120,0.20)`): Subtle lift for decorative elements.
+- **Shadow Headline Glow** (`rgba(255,255,255,0.05)`): Optional faint white aura behind the headline for extra presence.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Body**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Inter | 96px | 900 | 0.95 | -3px | Massive bottom-left headline. Pure white on cobalt. |
+| Section Heading | Inter | 64px | 900 | 1.00 | -2px | Secondary large headlines for multi-slide formats |
+| Sub-heading | Inter | 36px | 800 | 1.10 | -1px | Card-level headings on sticky notes |
+| Date Label Big | Inter | 48px | 600 | 1.00 | -1px | Corner date number ("16", "17") |
+| Date Label Small | Inter | 20px | 600 | 1.10 | 0.3px | Month name next to big date number ("February") |
+| Sticky Body Large | Inter | 22px | 500 | 1.45 | 0px | Primary sticky note body copy |
+| Sticky Body | Inter | 18px | 400 | 1.50 | 0px | Standard sticky note body text |
+| Sticky Bold | Inter | 18px | 600 | 1.45 | 0px | Emphasis words within sticky body |
+| URL Label | Inter | 16px | 500 | 1.20 | 0.5px | Underlined URLs (e.g. "www.zentime.com") |
+| Caption | Inter | 13px | 500 | 1.45 | 0.4px | Metadata and footnote marks |
+| Big Numbers | Inter | 140px | 900 | 0.90 | -4px | Oversized stats for content slides |
+| CTA Text | Inter | 18px | 700 | 1.00 | 0.3px | Button and CTA label text |
+
+### Principles
+- **Single-family system**: Inter handles everything -- display, body, labels, CTAs. The tension comes entirely from weight contrast (400 for sticky body, 900 for the headline) rather than font pairing. This is deliberate: Blueprint Sticky is a tool-native style, and tools ship with one typeface.
+- **Weight 900 is the signature**: The bottom-left headline is always Inter 900 at the largest size the format allows. This is the anchor element -- nothing else competes with it for weight.
+- **Sticky body reads handwritten**: On sticky notes, body copy uses weight 400 or 500 at a relaxed 1.45-1.50 line height. The goal is legibility with a slightly soft, annotated feel -- not bold corporate body copy.
+- **Tight negative tracking on big type**: Headlines at 80-100px use -2px to -3px letter spacing. Inter 900 is wide by default, and negative tracking keeps the headline feeling poster-weight rather than webpage-weight.
+- **Mixed case always for headlines**: "Product Launch" not "PRODUCT LAUNCH". Uppercase is reserved only for short tracked labels under 14px.
+- **White on cobalt is the only headline treatment**: Headlines are pure white. Sticky body is near-black on pink/yellow. These two contrast modes are fixed -- never invert.
+
+## 4. Component Patterns
+
+### Blueprint Grid Overlay
+
+The grid is applied as a CSS background on the canvas element using a repeating linear-gradient pair. This is applied to every slide -- it is the blueprint.
+
+```html
+<div style="background-color: var(--color-cobalt); background-image: linear-gradient(to right, var(--color-grid-line) 1px, transparent 1px), linear-gradient(to bottom, var(--color-grid-line) 1px, transparent 1px); background-size: 80px 80px; position: relative; padding: 60px; min-height: 1080px;">
+  <!-- slide content -->
+</div>
+```
+
+For a more Figma-canvas feel, an SVG variant with dashed guides can be used:
+
+```html
+<svg style="position: absolute; inset: 0; width: 100%; height: 100%; pointer-events: none;" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <pattern id="blueprint-grid" x="0" y="0" width="80" height="80" patternUnits="userSpaceOnUse">
+      <path d="M 80 0 L 0 0 0 80" fill="none" stroke="#4870F8" stroke-width="1" stroke-opacity="0.30" />
+    </pattern>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#blueprint-grid)" />
+</svg>
+```
+
+### Tilted Sticky Note (Pink)
+
+```html
+<div style="background-color: var(--color-sticky-pink); padding: 40px 36px; border-radius: 12px; transform: rotate(-6deg); max-width: 460px; box-shadow: 0 20px 48px var(--shadow-sticky), 0 6px 16px var(--shadow-sticky-deep); position: relative;">
+  <p style="font-family: var(--font-body); font-size: 22px; font-weight: 500; line-height: 1.45; color: var(--color-sticky-text); margin: 0;">Your calendar's about to get smarter.<br><br>No more back-and-forth, just clean scheduling. Join the waitlist for early access.</p>
+</div>
+```
+
+### Tilted Sticky Note (Yellow)
+
+```html
+<div style="background-color: var(--color-sticky-yellow); padding: 36px 32px; border-radius: 12px; transform: rotate(4deg); max-width: 420px; box-shadow: 0 20px 48px var(--shadow-sticky), 0 6px 16px var(--shadow-sticky-deep); position: relative;">
+  <p style="font-family: var(--font-body); font-size: 20px; font-weight: 500; line-height: 1.45; color: var(--color-sticky-text); margin: 0;">Ships Feb 17. Built for founders who hate calendar tetris.</p>
+</div>
+```
+
+### Corner Date Labels
+
+```html
+<!-- Top-left: "16 February" stacked -->
+<div style="position: absolute; top: 56px; left: 60px; color: var(--color-white); font-family: var(--font-body);">
+  <div style="font-size: 48px; font-weight: 600; line-height: 1.00; letter-spacing: -1px;">16</div>
+  <div style="font-size: 20px; font-weight: 600; line-height: 1.10; letter-spacing: 0.3px; margin-top: 4px;">February</div>
+</div>
+
+<!-- Top-right: "17" standalone -->
+<div style="position: absolute; top: 56px; right: 60px; color: var(--color-white); font-family: var(--font-body); font-size: 48px; font-weight: 600; line-height: 1.00; letter-spacing: -1px;">17</div>
+```
+
+### Massive White Headline
+
+```html
+<div style="position: absolute; bottom: 80px; left: 60px; color: var(--color-white); font-family: var(--font-body);">
+  <h1 style="font-size: 96px; font-weight: 900; line-height: 0.95; letter-spacing: -3px; color: var(--color-white); margin: 0;">Product<br>Launch</h1>
+  <!-- Yellow curved underline SVG sits below one word -->
+  <svg width="220" height="16" viewBox="0 0 220 16" style="display: block; margin-top: 4px; margin-left: 0;" xmlns="http://www.w3.org/2000/svg">
+    <path d="M 4 10 Q 110 2 216 10" stroke="#F4E34A" stroke-width="4" fill="none" stroke-linecap="round" />
+  </svg>
+</div>
+```
+
+### Curved Underline Accent (Standalone)
+
+```html
+<svg width="180" height="14" viewBox="0 0 180 14" xmlns="http://www.w3.org/2000/svg">
+  <path d="M 4 9 Q 90 1 176 9" stroke="#F4E34A" stroke-width="4" fill="none" stroke-linecap="round" />
+</svg>
+```
+
+### Underlined URL Label
+
+```html
+<a style="display: inline-block; color: var(--color-white); font-family: var(--font-body); font-size: 16px; font-weight: 500; letter-spacing: 0.5px; text-decoration: underline; text-decoration-color: rgba(255,255,255,0.70); text-underline-offset: 4px; text-decoration-thickness: 1px;">www.zentime.com</a>
+```
+
+### Stat Display on Sticky
+
+```html
+<div style="background-color: var(--color-sticky-yellow); padding: 48px 40px; border-radius: 12px; transform: rotate(-3deg); max-width: 420px; box-shadow: 0 20px 48px var(--shadow-sticky); text-align: center;">
+  <p style="font-family: var(--font-body); font-size: 140px; font-weight: 900; line-height: 0.90; letter-spacing: -4px; color: var(--color-sticky-text); margin: 0 0 8px;">2.3x</p>
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 500; line-height: 1.45; color: var(--color-sticky-text); margin: 0;">faster scheduling than calendar apps</p>
+</div>
+```
+
+### CTA Block on Cobalt
+
+```html
+<div style="position: relative; padding: 60px; text-align: left;">
+  <h2 style="font-family: var(--font-body); font-size: 80px; font-weight: 900; line-height: 0.95; letter-spacing: -2.5px; color: var(--color-white); margin: 0 0 24px;">Join the<br>waitlist</h2>
+  <a style="display: inline-block; background: var(--color-white); color: var(--color-cobalt); font-family: var(--font-body); font-size: 18px; font-weight: 700; letter-spacing: 0.3px; text-decoration: none; padding: 18px 40px; border-radius: 40px;">Get early access</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between date number and month label.
+- **8px**: Tight gap -- between headline and curved underline.
+- **12px**: Small gap -- between sticky body lines when tightening.
+- **16px**: Base gap -- between heading and supporting label.
+- **24px**: Medium gap -- between headline and CTA button.
+- **32px**: Content gap -- between stacked content blocks.
+- **40px**: Sticky vertical padding -- standard internal padding top/bottom inside sticky notes.
+- **56px**: Corner inset -- distance from canvas edge for corner date labels.
+- **60px**: Scene padding -- outer canvas padding on all sides.
+- **80px**: Grid cell size -- blueprint overlay spacing, also bottom-anchor inset for headline.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 960px |
+| Story (1080x1920) | 60px left/right, 120px top/bottom | 920px |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned, bottom-anchored. The massive headline lives in the bottom-left quadrant. Stickies cluster in the upper-right to middle-right zone.
+- **Grid spacing**: The blueprint grid is 80px x 80px across every format. Never change the grid cell size -- it is the blueprint identity.
+- **Sticky rotation range**: Pink stickies rotate -3deg to -8deg (left lean). Yellow stickies rotate +4deg to +8deg (right lean). Never exceed +/- 10deg. The opposing tilts are mandatory.
+- **Sticky overlap**: The yellow sticky tucks under the pink sticky by 30-60px at one corner. Pink always sits on top (higher z-index).
+- **Corner date labels**: Always at 56-60px inset from top edge. "DD Month" stacked top-left. Standalone "DD" top-right.
+- **Headline placement**: Always bottom-left, 80px from the bottom edge and 60px from the left edge. Two-line headline max.
+- **URL label**: Sits 16-24px below the sticky stack, left-aligned under the stickies, in pale white with solid or dashed underline.
+- **Content gravity**: The composition reads as a diagonal from bottom-left (headline) to upper-right (stickies and top-right date). The curved yellow underline under the headline pulls the eye into the stickies.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, background `#2450F5` with grid overlay | Canvas base layer |
+| Subtle (Level 1) | `0 4px 12px rgba(20,40,120,0.20)` | URL labels, small decorative marks |
+| Sticky (Level 2) | `0 20px 48px rgba(20,40,120,0.35), 0 6px 16px rgba(15,30,100,0.45)` | Standard tilted sticky notes |
+| Featured (Level 3) | `0 28px 64px rgba(20,40,120,0.40), 0 10px 24px rgba(15,30,100,0.50)` | Primary/hero sticky with heaviest lift |
+| Overlay (Level 4) | `0 32px 80px rgba(15,30,100,0.55)` | Modals or popups (rare) |
+
+### Border Treatments
+- **Sticky note**: `border: none; border-radius: 12px` -- the saturated fill against cobalt defines the edge. No stroke.
+- **URL underline**: `text-decoration: underline; text-decoration-color: rgba(255,255,255,0.70); text-underline-offset: 4px; text-decoration-thickness: 1px` -- a thin pale line beneath URL labels.
+- **Grid line**: `1px solid rgba(72,112,248,0.30)` -- the blueprint grid is rendered as 1px lines on an 80px cadence.
+- **Divider (rare)**: `1px solid rgba(255,255,255,0.18)` -- for rare content dividers on cobalt outside sticky notes.
+
+### Surface Hierarchy
+On the cobalt canvas with blueprint grid, depth is communicated through three layers:
+1. **Canvas + Grid** (`#2450F5` + `#4870F8` grid lines) -- the flat blueprint floor. Nothing else lives at this level.
+2. **Sticky notes** (`#F4B8D4` pink, `#F4E34A` yellow) -- elevated objects with strong blue-tinted shadows, always rotated, always overlapping in pairs.
+3. **Headline + corner dates** (`#FFFFFF`) -- pure white type floats above everything, with the headline anchored bottom-left and dates anchored in the top corners. Type is flat (no shadow) -- it is graphic, not objecty.
+
+Shadows are always blue-tinted (`rgba(20,40,120,*)`) rather than neutral black, so sticky notes feel like they belong on the cobalt surface rather than being dropped onto it from a different scene.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use saturated cobalt blue (`#2450F5`) as the background on every slide -- this is the identity and it is non-negotiable.
+- Apply the blueprint grid overlay (`#4870F8` at 30% opacity, 80px spacing) on every slide -- it IS the blueprint.
+- Use sticky notes in opposing tilt angles: pink at -3 to -8deg (left lean) and yellow at +4 to +8deg (right lean).
+- Use Inter 900 for the massive bottom-left headline at 80-100px with -2px to -3px letter spacing.
+- Use a small yellow (`#F4E34A`) curved SVG underline to accent one key word of the headline.
+- Keep text on sticky notes at near-black (`#1A1A1A`) for maximum readability on bright sticky colors.
+- Place corner date labels in the top-left and top-right corners (Inter 600 white, stacked "DD Month" style).
+- Include a small underlined URL (Inter 500, pale white, 16px) below the sticky stack for the Figma-launch-page feel.
+- Overlap the pink and yellow sticky notes by 30-60px at the corner where they meet, pink on top.
+- Use blue-tinted shadows (`rgba(20,40,120,0.35)`) on stickies -- not neutral black shadows.
+- Keep sticky notes at `border-radius: 12px` -- slightly rounded, slightly tactile.
+
+### Don't
+- Don't use pastel backgrounds -- cobalt (`#2450F5`) is the identity. No navy, no sky blue, no light blue tints.
+- Don't skip the grid overlay -- a cobalt slide without the blueprint grid is off-brand. The grid IS the blueprint.
+- Don't use more than 3 sticky notes in a single composition -- two is the ideal count, three is the absolute maximum.
+- Don't over-rotate stickies -- keep all rotations between -10deg and +10deg. Anything beyond that reads chaotic, not annotated.
+- Don't use neutral black shadows -- sticky shadows must be blue-tinted to sit naturally on the cobalt canvas.
+- Don't use a second typeface -- Inter is the only family. Weight contrast (400 vs 900) carries the hierarchy.
+- Don't place the headline anywhere other than bottom-left. The bottom-left anchor is fixed.
+- Don't use uppercase for the main headline -- "Product Launch" is always mixed case. Uppercase is only for 14px-and-below tracked labels.
+- Don't invert the sticky contrast -- text on stickies is always near-black, never white.
+- Don't add gradients to the background -- flat cobalt with grid overlay only. No mesh gradients, no radial fades.
+- Don't use more than two sticky colors per composition -- pink and yellow are the only sticky surface colors.
+- Don't use thin headline weights (under 800) -- Inter 900 is the signature. Inter 800 is acceptable only as a fallback.
+- Don't decorate with icons, emoji, or illustrations -- the sticky notes and curved underline are the only decorative elements.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale**: Display Hero drops to 88px. Section Heading drops to 56px. Sticky body stays 18-22px.
+- **Padding**: 60px on all sides. Content area 960x960.
+- **Grid overlay**: Full 80px blueprint grid across the canvas.
+- **Cover slide**: Corner date labels top-left ("16 February") and top-right ("17"). One pink sticky (-6deg) and one yellow sticky (+4deg) overlapping in the upper-right to middle zone. Massive Inter 900 headline bottom-left, two lines max. Curved yellow underline under one word. Small underlined URL below the sticky stack.
+- **Content slides**: One sticky per slide for single-focus content, or the two-sticky cluster for denser slides. Headline can shrink to 64-72px on content slides to make room for sticky content.
+- **Swipe indicator**: Small white dots (`#FFFFFF`, 8px, 12px gap) at bottom center, active dot fully opaque, inactive at 40% opacity.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Full scale. Display Hero at 96px for the top section.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Grid overlay**: Extends the full height of the variable canvas.
+- **Section flow**: Alternate sticky clusters down the page. Each section has one pink + one yellow sticky pair with a small headline label above and optional URL below. Between sections, the grid breathes for 80-120px of empty cobalt.
+- **Top section**: Corner dates + massive headline + hero sticky pair.
+- **Footer**: Small centered URL label and a tiny Inter 500 caption line.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 120px. Section Heading becomes 80px. Sticky body scales to 24px.
+- **Padding**: 80px on all sides. Content area 1760x920.
+- **Grid overlay**: 80px blueprint grid across the wide canvas.
+- **Layout**: Headline anchors bottom-left. Sticky pair clusters in the right-center zone with more horizontal breathing room. Corner dates top-left and top-right.
+- **Title slides**: Massive Inter 900 headline bottom-left, two stickies right of center, corner dates, curved underline.
+- **Content slides**: Smaller headline (80px) top-left, sticky cluster center-right, support copy in a third small sticky or inline on the cobalt with tight white text.
+- **CTA slides**: Single large white headline, white pill button on cobalt, single pink sticky as emphasis element.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 88px. Section Heading at 56px. Sticky body at 20px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top third: corner dates and sticky pair. Middle third: breathing grid with optional URL label. Bottom third: massive Inter 900 headline anchored bottom-left with curved yellow underline.
+- **Vertical flow**: The poster reads top-to-bottom: dates set the scene, stickies deliver the content, headline closes the deal.
+- **CTA placement**: Optional white pill button at the very bottom, centered or below the headline on the left.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Hero becomes 104px in Inter 900 (approximately 18% larger than Carousel 88px) with -3px letter spacing. Section Heading becomes 68px. Sticky Body Large becomes 24px in Inter 500. Date Label Big becomes 56px in Inter 600. URL label stays at 16px Inter 500.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical text must sit inside y=160 to y=1760.
+- **Layout**: Single centered column feel, but asymmetric inside. Content max-width 920px. Vertical center of gravity -- cluster sticky content in y=500 to y=1300 range. Grid overlay runs edge-to-edge across the full 1080x1920 canvas at 80px spacing so the blueprint is always visible.
+- **Cover slide**: Corner date labels at y=160 (top-left "16 February" stacked, top-right "17"). Pink sticky (-6deg) centered around y=620 at 460px wide. Yellow sticky (+5deg) tucked under pink at y=780 at 420px wide, offset right by 40-60px. Small underlined URL (`www.zentime.com`) at y=1080 centered under the sticky stack. Massive Inter 900 headline at y=1300 to y=1500, bottom-left anchored, 104px, two lines ("Product" / "Launch"). Yellow curved underline at y=1520 under one word. All of this sits inside the safe zone.
+- **Content slides**: One hero sticky per slide with rotation -6deg to +6deg. Headline above or below the sticky depending on content weight. Corner dates remain at y=160. Optional single secondary sticky tucked under the primary by 40-60px. Grid overlay runs the full canvas.
+- **CTA slide**: Massive Inter 900 headline ("Join the waitlist") at y=700 to y=1000, left-aligned. White pill button (`#FFFFFF` fill, cobalt text, 40px radius) at y=1100 with Inter 700 CTA text. Small pink sticky at y=1280 with a one-line supporting message, tilted -4deg. Underlined URL at y=1500.
+- **Progress indicator**: Thin white segments at the top of the safe zone (y=120) -- inactive at `rgba(255,255,255,0.30)`, active at pure white. 4-6px height, 14px gaps.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Cobalt Blue | `#2450F5` | Primary background, the identity color |
+| Cobalt Deep | `#1F4AF0` | Alternate cobalt for depth |
+| Cobalt Grid Line | `#4870F8` | Blueprint grid overlay lines (30% opacity) |
+| Blueprint White | `#FFFFFF` | Headlines, corner dates, URL labels |
+| Sticky Pink | `#F4B8D4` | Pink sticky note fill |
+| Sticky Yellow | `#F4E34A` | Yellow sticky note fill + curved underline accent |
+| Sticky Text | `#1A1A1A` | Body copy on sticky notes |
+| Hover Pink | `#E89FBF` | Pressed/hover state for pink |
+| Hover Yellow | `#E5D23A` | Pressed/hover state for yellow |
+| Muted White | `rgba(255,255,255,0.70)` | Secondary white for URLs |
+| Faint White | `rgba(255,255,255,0.40)` | Metadata and footnotes |
+| Sticky Edge Warm | `#EBDDD0` | Torn-edge highlight tint |
+
+### Font Declarations
+
+```css
+/* Display and body (single family) */
+font-family: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-cobalt: #2450F5;
+  --color-cobalt-deep: #1F4AF0;
+  --color-white: #FFFFFF;
+  --color-sticky-pink: #F4B8D4;
+  --color-sticky-yellow: #F4E34A;
+
+  /* Colors -- Accent */
+  --color-grid-line: rgba(72, 112, 248, 0.30);
+  --color-grid-line-solid: #4870F8;
+  --color-hover-pink: #E89FBF;
+  --color-hover-yellow: #E5D23A;
+  --color-sticky-text: #1A1A1A;
+
+  /* Colors -- Neutral Scale */
+  --color-muted-white: rgba(255, 255, 255, 0.70);
+  --color-faint-white: rgba(255, 255, 255, 0.40);
+  --color-sticky-edge-warm: #EBDDD0;
+
+  /* Colors -- Surfaces */
+  --color-surface-canvas: #2450F5;
+  --color-surface-sticky-pink: #F4B8D4;
+  --color-surface-sticky-yellow: #F4E34A;
+
+  /* Colors -- Borders */
+  --color-border-faint: rgba(255, 255, 255, 0.18);
+  --color-url-underline: rgba(255, 255, 255, 0.70);
+
+  /* Colors -- Shadows */
+  --shadow-sticky: rgba(20, 40, 120, 0.35);
+  --shadow-sticky-deep: rgba(15, 30, 100, 0.45);
+  --shadow-ambient: rgba(20, 40, 120, 0.20);
+  --shadow-headline-glow: rgba(255, 255, 255, 0.05);
+
+  /* Typography -- Families */
+  --font-display: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 96px;
+  --text-section-heading: 64px;
+  --text-sub-heading: 36px;
+  --text-date-big: 48px;
+  --text-date-small: 20px;
+  --text-sticky-large: 22px;
+  --text-sticky-body: 18px;
+  --text-url: 16px;
+  --text-caption: 13px;
+  --text-big-number: 140px;
+  --text-cta: 18px;
+
+  /* Typography -- Weights */
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --weight-bold: 700;
+  --weight-extrabold: 800;
+  --weight-black: 900;
+
+  /* Typography -- Line Heights */
+  --leading-hero: 0.95;
+  --leading-heading: 1.00;
+  --leading-sub-heading: 1.10;
+  --leading-sticky: 1.45;
+  --leading-body: 1.50;
+  --leading-number: 0.90;
+
+  /* Typography -- Letter Spacing */
+  --tracking-hero: -3px;
+  --tracking-heading: -2px;
+  --tracking-sub: -1px;
+  --tracking-label: 0.3px;
+  --tracking-url: 0.5px;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-medium: 24px;
+  --space-large: 32px;
+  --space-sticky-padding: 40px;
+  --space-corner-inset: 56px;
+  --space-scene: 60px;
+  --space-grid: 80px;
+
+  /* Borders */
+  --radius-sticky: 12px;
+  --radius-button: 40px;
+
+  /* Shadows -- Composed */
+  --shadow-sticky-default: 0 20px 48px rgba(20,40,120,0.35), 0 6px 16px rgba(15,30,100,0.45);
+  --shadow-sticky-featured: 0 28px 64px rgba(20,40,120,0.40), 0 10px 24px rgba(15,30,100,0.50);
+  --shadow-ambient-lift: 0 4px 12px rgba(20,40,120,0.20);
+  --shadow-overlay: 0 32px 80px rgba(15,30,100,0.55);
+
+  /* Blueprint Grid */
+  --grid-cell: 80px;
+  --grid-image: linear-gradient(to right, rgba(72,112,248,0.30) 1px, transparent 1px), linear-gradient(to bottom, rgba(72,112,248,0.30) 1px, transparent 1px);
+
+  /* Sticky Rotations */
+  --rotate-pink-default: rotate(-6deg);
+  --rotate-pink-soft: rotate(-3deg);
+  --rotate-pink-strong: rotate(-8deg);
+  --rotate-yellow-default: rotate(4deg);
+  --rotate-yellow-soft: rotate(2deg);
+  --rotate-yellow-strong: rotate(8deg);
+}
+```
+
+### System Font Fallbacks
+- **Inter (if Inter fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/_full/brutalist.md
+++ b/skills/composites/goose-graphics/styles/_full/brutalist.md
@@ -1,0 +1,412 @@
+# Design Style: Brutalist
+
+## 1. Visual Theme & Atmosphere
+
+Brutalist design is the anti-design movement made intentional -- a deliberate rejection of polish, decoration, and visual comfort in favour of raw structural honesty. The name borrows from brutalist architecture, where raw concrete (beton brut) is left exposed, where structural columns are celebrated rather than hidden behind drywall, where the building's skeleton IS the aesthetic. In digital form, this translates to heavy black borders on white surfaces, oversized type that crowds its container, exposed grid lines, and a total refusal of decorative flourish. Nothing is rounded. Nothing is softened. Nothing is hidden.
+
+The palette is binary: white (`#ffffff`) and black (`#000000`), with red (`#ff0000`) as the sole accent -- pure, unblended, straight from the hexadecimal extremes. There is no secondary colour. There is no gradient. There is no shadow. The absence of these conventions is not a limitation but a manifesto. Every border is 3-4px solid black. Every corner is 0px radius. Every heading screams in uppercase at 100px or larger. The style strips away the entire vocabulary of "professional" web design -- the subtle shadows, the 8px border-radius, the tasteful colour palettes -- and replaces it with the raw materials of visual communication: type, line, and contrast.
+
+System fonts only. Arial, Helvetica, monospace. No Google Fonts, no Fontshare, no CDN links. The fonts that ship with every operating system are the concrete and steel of this style. Arial and Helvetica in heavy weights deliver blunt, industrial headlines. Monospace (Courier New, monospace) provides the exposed-infrastructure feel for labels and metadata -- like reading the building's blueprints stamped directly onto the facade. The deliberate use of "ugly" fonts is central to the philosophy: beauty is found in function, not ornament.
+
+**Key Characteristics:**
+- Pure white background (`#ffffff`) -- no off-whites, no creams, no warmth. Clinical, stark, honest.
+- Pure black (`#000000`) for all text and structural borders -- maximum contrast, zero ambiguity.
+- Red (`#ff0000`) as the only accent -- used sparingly for emphasis, warnings, and focal points. No secondary colour exists.
+- Heavy borders EVERYWHERE: 3-4px solid black on cards, containers, images, and section dividers.
+- Zero border-radius on all elements -- sharp 90-degree corners without exception.
+- No shadows, no gradients, no blurs -- depth is communicated through borders and overlap only.
+- Uppercase headers at extreme sizes (100px+) with heavy weight (800-900).
+- System fonts exclusively: Arial, Helvetica for sans-serif; Courier New, monospace for code/labels.
+- Asymmetric layouts that deliberately break grid expectations.
+- Exposed grid lines and structural borders visible as design elements.
+
+## 2. Color Palette & Roles
+
+### Primary
+- **White** (`#ffffff`): Primary background. Pure, unmodified white. The raw canvas.
+- **Black** (`#000000`): Primary text and all structural borders. The ink and the steel.
+- **Red** (`#ff0000`): The sole accent colour. Used for emphasis, active states, and focal points. Pure red, no mixing.
+
+### Accent
+- **Red** (`#ff0000`): There is only one accent. It is used for underlines, active borders, highlight bars, and CTA buttons.
+- **No Secondary**: This style deliberately omits a secondary colour. If you need hierarchy below red, use black at reduced opacity.
+
+### Neutral Scale
+- **White** (`#ffffff`): Primary background and empty space.
+- **Light Gray** (`#f0f0f0`): Alternate background for zebra-striped rows or inset panels.
+- **Medium Gray** (`#cccccc`): Exposed grid lines and structural guides.
+- **Dark Gray** (`#333333`): Secondary text for descriptions and body copy when contrast reduction is needed.
+- **Black** (`#000000`): Primary text, borders, and structural elements.
+
+### Surface & Borders
+- **Surface Primary** (`#ffffff`): All cards and containers sit on white.
+- **Surface Alternate** (`#f0f0f0`): Alternate panels for visual separation.
+- **Border Standard** (`3px solid #000000`): The default border treatment. Heavy, visible, structural.
+- **Border Heavy** (`4px solid #000000`): Emphasis border for featured containers and outer frames.
+- **Border Accent** (`3px solid #ff0000`): Red border for active or highlighted elements.
+- **Divider Rule** (`3px solid #000000`): Horizontal structural dividers between sections.
+
+### Shadow Colors
+- **None**: This style uses no shadows. Depth is communicated exclusively through borders, layering, and overlap. If an element needs to feel elevated, give it a heavier border or offset it with visible displacement.
+
+## 3. Typography Rules
+
+### Font Families
+
+**No CDN required -- system fonts only:**
+
+- **Display**: `Arial, Helvetica, sans-serif`
+- **Body**: `Arial, Helvetica, sans-serif`
+- **Mono**: `'Courier New', Courier, monospace`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Transform | Notes |
+|------|------|------|--------|-------------|----------------|-----------|-------|
+| Display Hero | Arial | 120px | 900 | 0.90 | -2px | uppercase | Massive, crowding the container edges |
+| Section Heading | Arial | 80px | 900 | 0.95 | -1px | uppercase | Dominant section markers |
+| Sub-heading | Arial | 48px | 800 | 1.00 | -0.5px | uppercase | Subsection titles |
+| Body Large | Arial | 20px | 400 | 1.55 | 0px | none | Lead paragraphs |
+| Body | Arial | 16px | 400 | 1.60 | 0px | none | Standard reading text |
+| Small / Caption | Courier New | 12px | 400 | 1.40 | 1px | uppercase | Metadata, labels, timestamps |
+| Big Numbers | Arial | 100px | 900 | 1.00 | -2px | none | Statistics, metrics |
+| Structural Label | Courier New | 14px | 400 | 1.00 | 3px | uppercase | Category markers ("01 -- STRATEGY") |
+| CTA Text | Arial | 18px | 800 | 1.00 | 2px | uppercase | Button text, calls to action |
+
+### Principles
+- **One family, two faces**: Arial/Helvetica handles all display and body text. Courier New/monospace handles labels and metadata. This two-track system mirrors the structural vs. informational divide.
+- **Extreme size contrast**: Headers run 100px+ while body sits at 16px. The ratio (6:1 or higher) creates the visual tension that defines brutalism.
+- **Uppercase for all headings**: Every heading from Sub-heading up is uppercase. Mixed case is reserved for body text only.
+- **Tight line height for display**: 0.90-1.00 for headlines creates intentional crowding -- letters overlap, descenders collide. This is deliberate.
+- **Monospace for exposed structure**: Labels, timestamps, and metadata use Courier New to look like system output or architectural notations stamped on the design.
+- **Heavy weight only at display sizes**: Body text stays at 400 (regular). The weight jump from 400 body to 900 display reinforces the brutalist hierarchy.
+
+## 4. Component Patterns
+
+### Title Block (Cover / Header Section)
+
+```html
+<div style="background-color: #ffffff; padding: 60px; border: 4px solid #000000;">
+  <div style="width: 100%; height: 4px; background: #000000; margin: 0 0 40px;"></div>
+  <h1 style="font-family: Arial, Helvetica, sans-serif; font-size: 120px; font-weight: 900; line-height: 0.90; letter-spacing: -2px; text-transform: uppercase; color: #000000; margin: 0 0 24px;">THE FUTURE<br>OF WORK</h1>
+  <p style="font-family: Arial, Helvetica, sans-serif; font-size: 20px; font-weight: 400; line-height: 1.55; color: #333333; max-width: 600px; margin: 0 0 32px;">How AI coworkers are reshaping the way teams operate, collaborate, and deliver results.</p>
+  <div style="width: 100%; height: 4px; background: #000000;"></div>
+</div>
+```
+
+### Numbered Item
+
+```html
+<div style="display: flex; gap: 24px; align-items: flex-start; padding: 32px 0; border-bottom: 3px solid #000000;">
+  <span style="font-family: Arial, Helvetica, sans-serif; font-size: 80px; font-weight: 900; line-height: 1.00; color: #ff0000; min-width: 120px;">01</span>
+  <div>
+    <p style="font-family: 'Courier New', Courier, monospace; font-size: 14px; font-weight: 400; letter-spacing: 3px; text-transform: uppercase; color: #000000; margin: 0 0 8px;">SIGNAL-BASED OUTBOUND</p>
+    <h3 style="font-family: Arial, Helvetica, sans-serif; font-size: 48px; font-weight: 800; line-height: 1.00; letter-spacing: -0.5px; text-transform: uppercase; color: #000000; margin: 0 0 12px;">FIND BUYERS FIRST</h3>
+    <p style="font-family: Arial, Helvetica, sans-serif; font-size: 16px; font-weight: 400; line-height: 1.60; color: #333333; margin: 0;">Monitor hiring signals, funding events, and tech stack changes to identify high-intent prospects the moment they enter the market.</p>
+  </div>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="text-align: center; padding: 40px 24px; background: #ffffff; border: 4px solid #000000;">
+  <p style="font-family: Arial, Helvetica, sans-serif; font-size: 100px; font-weight: 900; line-height: 1.00; letter-spacing: -2px; color: #ff0000; margin: 0 0 8px;">47%</p>
+  <p style="font-family: 'Courier New', Courier, monospace; font-size: 14px; font-weight: 400; letter-spacing: 3px; text-transform: uppercase; color: #000000; margin: 0 0 12px;">FASTER RESPONSE</p>
+  <p style="font-family: Arial, Helvetica, sans-serif; font-size: 16px; font-weight: 400; line-height: 1.60; color: #333333; max-width: 280px; margin: 0 auto;">Teams using AI coworkers respond to inbound leads nearly twice as fast as manual workflows.</p>
+</div>
+```
+
+### Comparison Grid
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0; border: 4px solid #000000;">
+  <div style="background: #ffffff; padding: 40px 32px; border-right: 3px solid #000000;">
+    <p style="font-family: 'Courier New', Courier, monospace; font-size: 12px; font-weight: 400; letter-spacing: 1px; text-transform: uppercase; color: #333333; margin: 0 0 16px;">WITHOUT GOOSE</p>
+    <h3 style="font-family: Arial, Helvetica, sans-serif; font-size: 48px; font-weight: 800; line-height: 1.00; text-transform: uppercase; color: #000000; margin: 0 0 16px;">MANUAL</h3>
+    <p style="font-family: Arial, Helvetica, sans-serif; font-size: 16px; font-weight: 400; line-height: 1.60; color: #333333; margin: 0;">Teams juggle Slack threads, spreadsheets, and context-switching between a dozen tabs to coordinate basic workflows.</p>
+  </div>
+  <div style="background: #f0f0f0; padding: 40px 32px; border-left: 4px solid #ff0000;">
+    <p style="font-family: 'Courier New', Courier, monospace; font-size: 12px; font-weight: 400; letter-spacing: 1px; text-transform: uppercase; color: #ff0000; margin: 0 0 16px;">WITH GOOSE</p>
+    <h3 style="font-family: Arial, Helvetica, sans-serif; font-size: 48px; font-weight: 800; line-height: 1.00; text-transform: uppercase; color: #000000; margin: 0 0 16px;">AUTONOMOUS</h3>
+    <p style="font-family: Arial, Helvetica, sans-serif; font-size: 16px; font-weight: 400; line-height: 1.60; color: #333333; margin: 0;">AI coworkers handle research, drafting, and follow-up autonomously. Your team focuses on decisions, not busywork.</p>
+  </div>
+</div>
+```
+
+### List Item
+
+```html
+<div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0; border-bottom: 3px solid #000000;">
+  <div style="width: 40px; height: 40px; min-width: 40px; display: flex; align-items: center; justify-content: center; border: 3px solid #000000; background: #ff0000; color: #ffffff; font-family: Arial, Helvetica, sans-serif; font-size: 20px; font-weight: 900;">+</div>
+  <div>
+    <h4 style="font-family: Arial, Helvetica, sans-serif; font-size: 28px; font-weight: 800; line-height: 1.05; text-transform: uppercase; color: #000000; margin: 0 0 8px;">PERSISTENT MEMORY</h4>
+    <p style="font-family: Arial, Helvetica, sans-serif; font-size: 16px; font-weight: 400; line-height: 1.60; color: #333333; margin: 0;">Every agent maintains its own filesystem, notes, and learned preferences across sessions. Context is never lost.</p>
+  </div>
+</div>
+```
+
+### Quote Block
+
+```html
+<div style="padding: 48px 40px; border-left: 4px solid #ff0000; border-top: 3px solid #000000; border-bottom: 3px solid #000000; background: #f0f0f0;">
+  <p style="font-family: Arial, Helvetica, sans-serif; font-size: 36px; font-weight: 900; line-height: 1.15; text-transform: uppercase; color: #000000; margin: 0 0 24px;">"IT FELT LESS LIKE CONFIGURING SOFTWARE AND MORE LIKE ONBOARDING A NEW TEAM MEMBER."</p>
+  <div style="display: flex; align-items: center; gap: 12px;">
+    <div style="width: 40px; height: 3px; background: #ff0000;"></div>
+    <p style="font-family: 'Courier New', Courier, monospace; font-size: 14px; font-weight: 400; letter-spacing: 3px; text-transform: uppercase; color: #000000; margin: 0;">SARAH CHEN // VP OPERATIONS</p>
+  </div>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="text-align: center; padding: 60px 40px; background: #000000; border: 4px solid #000000;">
+  <h2 style="font-family: Arial, Helvetica, sans-serif; font-size: 80px; font-weight: 900; line-height: 0.95; letter-spacing: -1px; text-transform: uppercase; color: #ffffff; margin: 0 0 16px;">GET STARTED</h2>
+  <p style="font-family: Arial, Helvetica, sans-serif; font-size: 18px; font-weight: 400; line-height: 1.55; color: #cccccc; max-width: 480px; margin: 0 auto 32px;">Deploy your first AI coworker in under five minutes. No setup fees. No long-term commitments.</p>
+  <a style="display: inline-block; background: #ff0000; color: #ffffff; font-family: Arial, Helvetica, sans-serif; font-size: 18px; font-weight: 800; letter-spacing: 2px; text-transform: uppercase; text-decoration: none; padding: 20px 48px; border: 3px solid #ffffff;">START NOW</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **0px**: No gap. Elements touching or overlapping is acceptable and even encouraged.
+- **8px**: Micro gap -- minimal separation between tightly related elements.
+- **16px**: Base gap -- between body paragraphs, between compact list items.
+- **24px**: Medium gap -- between components within a section.
+- **32px**: Standard padding inside containers and cards.
+- **48px**: Section divider -- vertical space between major content blocks.
+- **60px**: Section padding -- top/bottom padding for hero areas and major sections.
+- **80px**: Maximum section padding -- cover slides and high-impact areas.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 48px all sides | 984px |
+| Infographic (1080xN) | 48px left/right, 60px top/bottom | 984px |
+| Slides (1920x1080) | 60px all sides | 1800px |
+| Poster (1080x1350) | 48px left/right, 60px top/bottom | 984px |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned for all text. Center-alignment is used only for CTA blocks and single stat displays.
+- **Grid**: Visible grid lines encouraged. Use `border-right` and `border-bottom` to show the grid structure. 2-column for comparisons, single-column for narrative. No gap between grid cells -- use borders as separators.
+- **Horizontal rules**: 3-4px solid black, full-width, used as structural dividers between every major section.
+- **Vertical rhythm**: Deliberately uneven. Some sections pack tightly while others have generous space. The inconsistency is intentional.
+- **Asymmetric layouts**: Headers may extend beyond the content area. Numbers may be oversized and overlap other elements. Text blocks may be intentionally misaligned.
+- **Content overflow**: It is acceptable and desirable for oversized type to be clipped by container edges. This reinforces the raw, structural feel.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No treatment, white background | Default state for all elements |
+| Bordered (Level 1) | `3px solid #000000` border, no shadow | Standard containers, cards, and content blocks |
+| Heavy (Level 2) | `4px solid #000000` border, no shadow | Featured containers, outer frames, hero sections |
+| Accent (Level 3) | `4px solid #ff0000` border, no shadow | Active or highlighted elements, featured cards |
+| Inverted (Level 4) | Black background, white text, heavy border | Maximum emphasis: CTAs, critical callouts |
+
+### Border Treatments
+- **Standard border**: `3px solid #000000` -- the workhorse. Used on every container, card, and content block.
+- **Heavy border**: `4px solid #000000` -- outer frames, hero sections, and high-emphasis containers.
+- **Accent border**: `3px solid #ff0000` -- red border for active, featured, or "preferred" elements.
+- **Accent heavy**: `4px solid #ff0000` -- left-border treatment on quote blocks and highlighted sections.
+- **Divider**: `3px solid #000000` -- full-width horizontal rules between sections.
+
+### Surface Hierarchy
+Brutalism communicates hierarchy through borders and inversion, not through shadow or subtle surface shifts:
+1. **White** (`#ffffff`) -- the default surface. Most content lives here.
+2. **Light Gray** (`#f0f0f0`) -- alternate panels for zebra-striping or inset areas.
+3. **Black** (`#000000`) -- inverted surfaces for maximum contrast. Used for CTAs and high-emphasis blocks.
+4. **Red on White** -- red borders or red text on white surface for accent emphasis.
+
+There are no shadows. There are no gradients. There are no blurs. Elevation is a border, and importance is a colour inversion.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use heavy borders (3-4px solid black) on EVERY container, card, and content block -- borders are the structural skeleton of this style.
+- Use uppercase for all headings and labels -- mixed case is reserved for body text only.
+- Use extreme font sizes (100px+) for hero headlines -- the type should feel like it barely fits.
+- Use red (`#ff0000`) as the only accent colour -- it is the only chromatic relief in a binary palette.
+- Use system fonts only (Arial, Helvetica, Courier New, monospace) -- no web fonts, no CDN links.
+- Use 0px border-radius everywhere -- sharp corners without exception.
+- Use monospace (Courier New) for labels, metadata, and structural annotations.
+- Use black backgrounds with white text for CTA blocks and maximum-emphasis sections.
+- Let oversized type crowd or clip at container edges -- this is intentional, not a bug.
+- Use full-width horizontal rules (3px black) as section dividers.
+
+### Don't
+- Don't use any shadows -- no box-shadow, no text-shadow, no drop-shadow. Zero.
+- Don't use any gradients -- no linear-gradient, no radial-gradient. Flat colour only.
+- Don't use border-radius -- not 2px, not 4px, not 1px. The value is 0px, always.
+- Don't introduce a secondary colour -- no blues, no greens, no oranges. Only black, white, and red.
+- Don't use web fonts or CDN links -- system fonts are the raw material of this style.
+- Don't use Inter, Playfair Display, DM Sans, Satoshi, or any other web font.
+- Don't use light font weights (300) for headings -- display type is 800-900 weight only.
+- Don't center-align body paragraphs -- left-alignment is the default for all text.
+- Don't use opacity or transparency for decorative effect -- elements are either fully visible or absent.
+- Don't soften anything -- no hover transitions, no easing, no animation. State changes are instant.
+- Don't use decorative icons or illustrations -- if a visual is needed, use geometric shapes (squares, lines, plus signs) in black or red.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale**: Display Hero at 80px (from 120px). Section Heading at 60px. Sub-heading at 40px. Body stays 16px.
+- **Padding**: 48px on all sides. Content area is 984x984px.
+- **Cover slide**: Title left-aligned, uppercase, running nearly edge to edge. Full-width black rules top and bottom. Red accent on a single word or number.
+- **Content slides**: Left-aligned. One idea per slide. Oversized number in red at top; content below with heavy bottom border.
+- **Stat slides**: Single stat centered. Number at 80px in red. Label in Courier New below. Heavy black border framing the entire slide.
+- **Navigation**: No swipe dots -- instead, a Courier New page counter in the corner ("03/07").
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Full-scale hierarchy. Display Hero at 120px for the title block.
+- **Padding**: 48px left/right. 60px top/bottom margins.
+- **Section spacing**: Sections separated by full-width 3px black rules. No whitespace as separator -- always a visible rule.
+- **Vertical rhythm**: Alternate between full-width sections and 2-column grids with visible grid borders. Use numbered items for sequences, stat blocks for metrics, and quote blocks for testimonials.
+- **Structure**: Expose the grid. Every section has visible borders. The infographic should look like an architectural blueprint or a newspaper broadsheet.
+- **Footer**: Black bar, full width, white text in Courier New.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero at 140px. Section Heading at 100px. Body Large at 22px.
+- **Padding**: 60px on all sides. Content area is 1800x960px.
+- **Layout**: Asymmetric. Title and body text may occupy only 60% of the frame, with the remaining space intentionally empty or containing a single oversized number/graphic.
+- **Title slides**: Massive uppercase headline, left-aligned, with full-width black rules.
+- **Content slides**: 2-column with visible border separator. No gap between columns.
+- **Stat slides**: Up to 3 stats in a row, each in its own bordered cell with no gap.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 100px. Section Heading at 60px. Body at 16px.
+- **Padding**: 48px left/right, 60px top/bottom.
+- **Composition**: Top section for headline (takes up as much space as needed). Middle for content. Bottom for CTA in inverted black block.
+- **Vertical flow**: Heavy black rules divide the three zones. Each zone is a distinct bordered section.
+- **CTA placement**: Always in a full-width inverted (black background, white text) block at the bottom with a red-bordered button.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Hero becomes 104px (approximately 30% larger than Carousel). Section Heading becomes 80px. Body Large becomes 22px. Big Numbers push to 140px.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical text must sit inside y=160 to y=1760.
+- **Layout**: Single centered column. Content max-width 960px. Vertical center of gravity -- cluster hero content in y=400 to y=1500 range. Asymmetric rules may deliberately extend past the 960px column to reinforce the brutalist grid break.
+- **Cover slide**: Massive uppercase headline crowding the horizontal bounds of the safe zone, letters tight at 0.90 line-height so descenders collide. Full-width 4px black rule above and below the headline. A single word or the hero number in red (`#ff0000`) carries the accent -- everything else is pure black-on-white. The signature "barely fits" feeling translates vertically: let the headline stack three or four lines deep.
+- **Content slides**: One idea per slide with a massive numbered marker (`01`, `02`) in red at 140px+ anchored upper-left, and the content block below bounded by a 3px black rule on top and bottom. Courier New structural label (uppercase, wide tracking) sits immediately above each heading like a blueprint annotation.
+- **CTA slide**: Full-frame inverted block -- black background, white Arial uppercase headline at 80px, and a red-bordered button (`3px solid #ff0000`) at the bottom of the safe zone with `START NOW` in Arial 800.
+- **Progress indicator**: Courier New page counter (`03 / 07`) in the top-right corner inside the safe zone at 14px with 3px letter-spacing. No dots, no bars -- the exposed monospace counter IS the indicator.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| White | `#ffffff` | Primary background |
+| Black | `#000000` | Primary text, all borders |
+| Red | `#ff0000` | Accent: numbers, active borders, CTAs, emphasis |
+| Light Gray | `#f0f0f0` | Alternate surface, inset panels |
+| Medium Gray | `#cccccc` | Exposed grid lines, structural guides |
+| Dark Gray | `#333333` | Secondary body text, descriptions |
+
+### Font Declarations
+
+```css
+font-family: Arial, Helvetica, sans-serif;
+font-family: 'Courier New', Courier, monospace;
+```
+
+### System Fonts Only
+
+No CDN link required. This style uses system fonts exclusively. Do not add any `<link>` tags for fonts.
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-white: #ffffff;
+  --color-black: #000000;
+  --color-red: #ff0000;
+
+  /* Colors -- Neutral Scale */
+  --color-light-gray: #f0f0f0;
+  --color-medium-gray: #cccccc;
+  --color-dark-gray: #333333;
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: #ffffff;
+  --color-surface-alternate: #f0f0f0;
+  --color-surface-inverted: #000000;
+
+  /* Colors -- Borders */
+  --color-border-standard: #000000;
+  --color-border-accent: #ff0000;
+  --border-standard: 3px solid #000000;
+  --border-heavy: 4px solid #000000;
+  --border-accent: 3px solid #ff0000;
+  --border-accent-heavy: 4px solid #ff0000;
+  --border-divider: 3px solid #000000;
+
+  /* Colors -- Shadows */
+  /* None. This style uses no shadows. */
+
+  /* Typography -- Families */
+  --font-display: Arial, Helvetica, sans-serif;
+  --font-body: Arial, Helvetica, sans-serif;
+  --font-mono: 'Courier New', Courier, monospace;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 120px;
+  --text-section-heading: 80px;
+  --text-sub-heading: 48px;
+  --text-body-large: 20px;
+  --text-body: 16px;
+  --text-small: 12px;
+  --text-big-number: 100px;
+  --text-label: 14px;
+  --text-cta: 18px;
+
+  /* Typography -- Weights */
+  --weight-display: 900;
+  --weight-display-medium: 800;
+  --weight-body: 400;
+
+  /* Typography -- Line Heights */
+  --leading-display: 0.90;
+  --leading-heading: 0.95;
+  --leading-sub-heading: 1.00;
+  --leading-body-large: 1.55;
+  --leading-body: 1.60;
+  --leading-small: 1.40;
+  --leading-number: 1.00;
+
+  /* Spacing */
+  --space-none: 0px;
+  --space-micro: 8px;
+  --space-base: 16px;
+  --space-medium: 24px;
+  --space-large: 32px;
+  --space-section: 48px;
+  --space-hero: 60px;
+  --space-max: 80px;
+
+  /* Borders */
+  --radius-standard: 0px;
+
+  /* Shadows -- None */
+  --shadow-card: none;
+  --shadow-featured: none;
+}
+```
+
+### System Font Fallbacks
+- **Sans-serif:** `Arial, Helvetica, sans-serif` -- this IS the primary font, no fallback needed.
+- **Monospace:** `'Courier New', Courier, monospace` -- for labels, metadata, and structural text.

--- a/skills/composites/goose-graphics/styles/_full/bw-editorial-drop.md
+++ b/skills/composites/goose-graphics/styles/_full/bw-editorial-drop.md
@@ -1,0 +1,461 @@
+# Design Style: BW Editorial Drop
+
+## 1. Visual Theme & Atmosphere
+
+BW Editorial Drop is the visual language of a contemporary luxury fashion house reimagined as an Instagram product drop. It is the poster you'd tape up on the back wall of a SoHo eyewear boutique the day a new collaboration lands -- half campaign photography, half product-launch announcement, all attitude. The frame is cut cleanly in two: the **top ~60% is a full-bleed black-and-white high-contrast photograph** (think silver-gelatin print, crushed shadows, specular chrome highlights), and the **bottom ~40% is a near-black drop panel** (`#0A0A0A`) carrying a two-line display headline in saturated highlighter yellow. The composition reads like the closing frame of a music-video bumper or the back cover of a 90s fashion zine -- no gradient, no ornament, just photograph-on-top, typography-on-bottom, separated by a hard horizon line.
+
+The typographic signature is a single massive **Anton ALL CAPS headline** set in highlighter yellow (`#F4ED2B`) at 92-120px, with aggressively tight negative tracking so the letters brick up against each other. Anton is a condensed heavy sans in the lineage of Alternate Gothic and Impact -- chunky, narrow, unapologetic. At display size it reads less like typography and more like silkscreen graffiti pressed into the black panel. The headline always runs to two lines ("OUR NEW / CRUSH", "FALL / DROP 2026") -- never one long line, never three -- because the two-line stack is the shape of this style. Below or flanking the headline, **Inter 500/600 in tracked white uppercase** handles all the metadata: product specs in the bottom-left ("100% UV SCRATCH-RESISTANT"), a CTA in the bottom-right ("SHOP NOW TO ELEVATE YOUR LOOK"). The metadata is kept deliberately small (11-13px) and wide-tracked (0.12em), mimicking the fine print stamped on a product label.
+
+The photograph is the other half of the identity, and it must be **true black-and-white** -- not duotone, not sepia, not a color image with grayscale filter laid on top as an afterthought. When an image is imported, it gets piped through `filter: grayscale(100%) contrast(1.2) brightness(0.95)` to crush the midtones toward a silver-print tonal range. The subject should be editorial: a face, a hand, a product held against skin, a piece of chrome catching light -- never a landscape, never a flat-lay. The hard horizon where the photograph meets the black panel is the most important compositional line in the entire frame, and it is always dead-straight, always unblurred, always uncompromised. The analogies: Helmut Lang archive, Calvin Klein 1996, Arca album art, a Kendrick cover drop, a Hood By Air lookbook. The mood is luxury-fashion-house confidence welded to 90s-music-video restraint.
+
+**Key Characteristics:**
+- True black-and-white photography occupying the top ~60% of the frame, full-bleed, hard edges
+- Near-black drop panel (`#0A0A0A`) occupying the bottom ~40%, flat fill, no gradient
+- Massive Anton 900 display headline in highlighter yellow (`#F4ED2B`) at 92-120px, two lines, ALL CAPS
+- Aggressively tight tracking on the display (-0.02em to -0.04em) so letters brick together
+- Inter 500/600 tracked-uppercase metadata in white, 11-13px, `letter-spacing: 0.12em`, in bottom-left and bottom-right corners
+- Exactly two metadata labels per frame: product spec (bottom-left) and CTA micro-copy (bottom-right)
+- Photograph filter stack: `grayscale(100%) contrast(1.2) brightness(0.95)` for silver-print tonal range
+- Zero decorative elements -- no icons, no rules, no badges, no gradients, no rounded corners
+- Zero use of color anywhere except the yellow display headline -- photograph is BW, panel is black, metadata is white
+- Hard horizon line between photograph and black panel -- always straight, always pixel-sharp
+- Vertical 4:5 poster (1080x1350) or 9:16 story (1080x1920) as the native formats
+- Left-aligned or centered headline, never right-aligned -- the yellow block always sits flush left or centered in the drop panel
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Drop Black** (`#0A0A0A`): The near-black drop panel that carries the headline. Slightly warmer than pure black to avoid digital flatness, but still reads as black on every screen. The dominant surface of the bottom 40% and the canvas color for single-panel variants.
+- **Highlighter Yellow** (`#F4ED2B`): The sole chromatic color in the entire style. Used exclusively for the massive Anton display headline. Reads as fluorescent, electric, almost radioactive against the drop black. Reserved for display only -- never for body, never for metadata, never for anything else.
+- **Signal White** (`#FFFFFF`): Used exclusively for tracked-uppercase metadata in the corners. The photograph remains grayscale, but the white metadata labels sit on top of the black panel as pure `#FFFFFF`.
+
+### Accent
+- **Yellow Hover** (`#F8F34A`): A slightly brighter variant of highlighter yellow for hover/active states on interactive elements. Used rarely -- this style is primarily static.
+- **Yellow Shadow** (`#D4CD1F`): A slightly darker variant used for optional 1-2px text shadow on the display headline when it sits over particularly bright photograph regions in hybrid layouts. Used sparingly.
+- **Deep Black** (`#000000`): The only time true `#000000` appears -- inside the photograph's crushed shadows after the contrast filter. Never used as a background fill.
+
+### Neutral Scale
+- **Panel Black** (`#0A0A0A`): The drop panel fill.
+- **Sub Panel** (`#0F0F0F`): A barely-lighter variant for rare recessed areas (spec plates, secondary info strips). 5% lift.
+- **Photo Black** (`#000000`): Crushed shadows inside the BW photograph only.
+- **Photo Mid** (`#6A6A6A`): The mid-gray range of the photograph -- flesh tones and mid-value fabric.
+- **Photo Highlight** (`#EEEEEE`): The photograph's brightest specular highlights (chrome, catch-lights).
+- **Metadata White** (`#FFFFFF`): Corner label text.
+- **Metadata Muted** (`rgba(255, 255, 255, 0.6)`): Secondary metadata (slide counters, very rare).
+
+### Surface & Borders
+- **Surface Drop** (`#0A0A0A`): The black drop panel -- the primary surface for all typography.
+- **Surface Sub** (`#0F0F0F`): Rare secondary strip under the headline for a secondary label (used in the Story format only).
+- **Border Default** (`rgba(255, 255, 255, 0.12)`): A faint hairline rule used exclusively to separate stacked metadata columns in the Story format. 1px only.
+- **Border None** (`transparent`): The default. This style has no card borders -- the horizon line between photograph and black panel is the only structural edge.
+- **Divider Rule** (`rgba(255, 255, 255, 0.08)`): An even fainter hairline for the rare inline divider.
+
+### Shadow Colors
+- **Shadow None** (`transparent`): The default. This style uses no drop shadows anywhere. All depth comes from the photograph itself.
+- **Photo Vignette** (`rgba(0, 0, 0, 0.35)`): An optional soft vignette applied to the photograph's bottom edge to blend into the black drop panel when the horizon line is too abrupt. Linear gradient, 60px tall.
+- **Display Glow** (`rgba(244, 237, 43, 0.0)`): Reserved at 0 opacity. This style does not glow its headline. Kept in the palette as a guardrail.
+
+### Texture
+- **Grayscale Filter**: `grayscale(100%) contrast(1.2) brightness(0.95)` -- applied as a CSS filter to any imported photograph to force the silver-print tonal range.
+- **No Grain**: Unlike vintage styles, this is a clean digital black-and-white. No halftone dots, no film grain overlay, no noise. The photograph's own tonal range carries all the texture.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Anton&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Anton', 'Oswald', Impact, 'Arial Narrow', sans-serif`
+- **Body / Metadata**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Anton | 120px | 400 | 0.92 | -0.03em | Two-line yellow headline in the drop panel. Anton only ships a single weight (400) but reads as 900. ALL CAPS. |
+| Display Large | Anton | 108px | 400 | 0.92 | -0.03em | Poster variant headline. |
+| Display Medium | Anton | 92px | 400 | 0.94 | -0.025em | Carousel headline. |
+| Display Small | Anton | 72px | 400 | 0.94 | -0.02em | Tight format or secondary slide headline. |
+| Metadata Label | Inter | 12px | 600 | 1.30 | 0.12em | The bottom-left / bottom-right tracked-uppercase corner labels. ALL CAPS. |
+| Metadata Small | Inter | 11px | 500 | 1.30 | 0.14em | The smallest fine-print label (credits, counters). ALL CAPS. |
+| Body Cap | Inter | 14px | 500 | 1.45 | 0.08em | Rare secondary copy in the Story format sub-panel. ALL CAPS. Hard cap -- never exceed 16px. |
+| Credit / Slug | Inter | 11px | 500 | 1.30 | 0.16em | Photo credits, issue numbers, slide counters. |
+| CTA Label | Inter | 12px | 600 | 1.30 | 0.14em | The bottom-right CTA micro-copy ("SHOP NOW TO ELEVATE YOUR LOOK"). |
+
+### Principles
+- **Anton is display-only, yellow-only**: Anton appears exactly once per frame, always in the drop panel, always in highlighter yellow, always in ALL CAPS, always at 72px or larger. It is never used for subtitles, body text, labels, or anything that isn't the single hero headline.
+- **Inter is metadata-only, white-only, uppercase-only**: Inter exists in this style purely to label the corners with tracked-uppercase product-label fine print. It is never set in sentence case. It is never set larger than 16px. It is never set in any color other than white.
+- **Two lines, never one**: The display headline is always structured as a two-line stack. "OUR NEW / CRUSH" is the reference shape. A one-line headline reads as a billboard; a three-line headline reads as a menu -- this style wants neither.
+- **Tight negative tracking as identity**: The display headline uses `letter-spacing: -0.02em to -0.04em` -- not for elegance but for weight. Anton letters brick together and form a single dense block, which is the point.
+- **Wide positive tracking on metadata**: The corner labels use `letter-spacing: 0.12em to 0.16em` -- the opposite extreme. The tension between the tight-tracked display and the wide-tracked metadata is a core signature of this style.
+- **Mixed case is forbidden**: Every character of visible type in this style is uppercase. Mixed case breaks the editorial-drop energy instantly.
+- **No font below 11px, no body font above 16px**: The corner metadata is the floor; 16px is the ceiling for any non-display text. The entire visual budget for size goes to the Anton headline.
+
+## 4. Component Patterns
+
+### Title Block (Full Frame: Photograph + Drop Panel)
+
+```html
+<div style="width: 1080px; height: 1350px; background: var(--color-panel); position: relative; overflow: hidden; font-family: var(--font-body);">
+  <!-- Photograph (top 60%) -->
+  <div style="position: absolute; top: 0; left: 0; right: 0; height: 60%; overflow: hidden;">
+    <img src="hero.jpg" alt="" style="width: 100%; height: 100%; object-fit: cover; filter: grayscale(100%) contrast(1.2) brightness(0.95); display: block;">
+    <!-- Optional soft vignette to blend into drop panel -->
+    <div style="position: absolute; left: 0; right: 0; bottom: 0; height: 60px; background: linear-gradient(to bottom, transparent, rgba(0,0,0,0.35));"></div>
+  </div>
+  <!-- Drop Panel (bottom 40%) -->
+  <div style="position: absolute; left: 0; right: 0; bottom: 0; height: 40%; background: var(--color-panel); padding: 64px 60px 72px;">
+    <!-- Massive Yellow Display Headline -->
+    <h1 style="font-family: var(--font-display); font-size: 120px; font-weight: 400; line-height: 0.92; letter-spacing: -0.03em; text-transform: uppercase; color: var(--color-yellow); margin: 0; text-align: center;">OUR NEW<br>CRUSH</h1>
+    <!-- Corner Metadata Labels -->
+    <div style="position: absolute; left: 60px; bottom: 40px; font-family: var(--font-body); font-size: 12px; font-weight: 600; line-height: 1.3; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-white);">100% UV<br>SCRATCH-RESISTANT</div>
+    <div style="position: absolute; right: 60px; bottom: 40px; text-align: right; font-family: var(--font-body); font-size: 12px; font-weight: 600; line-height: 1.3; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-white);">SHOP NOW TO<br>ELEVATE YOUR LOOK</div>
+  </div>
+</div>
+```
+
+### Full-Bleed BW Photo Container
+
+```html
+<div style="position: absolute; top: 0; left: 0; right: 0; height: 60%; overflow: hidden;">
+  <img src="hero.jpg" alt="" style="width: 100%; height: 100%; object-fit: cover; filter: grayscale(100%) contrast(1.2) brightness(0.95); display: block;">
+</div>
+```
+
+### Black Drop Panel with Yellow Display
+
+```html
+<div style="background: var(--color-panel); padding: 72px 60px; position: relative;">
+  <h1 style="font-family: var(--font-display); font-size: 108px; font-weight: 400; line-height: 0.92; letter-spacing: -0.03em; text-transform: uppercase; color: var(--color-yellow); margin: 0; text-align: center;">FALL<br>DROP 2026</h1>
+</div>
+```
+
+### Corner Metadata Labels (Bottom-Left + Bottom-Right Pair)
+
+```html
+<div style="position: absolute; left: 60px; bottom: 40px; font-family: var(--font-body); font-size: 12px; font-weight: 600; line-height: 1.3; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-white);">
+  SS26 EDITION<br>CHROME SERIES
+</div>
+<div style="position: absolute; right: 60px; bottom: 40px; text-align: right; font-family: var(--font-body); font-size: 12px; font-weight: 600; line-height: 1.3; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-white);">
+  AVAILABLE 04.15<br>WORLDWIDE
+</div>
+```
+
+### Massive Yellow Display Block (Standalone)
+
+```html
+<h1 style="font-family: var(--font-display); font-size: 120px; font-weight: 400; line-height: 0.92; letter-spacing: -0.03em; text-transform: uppercase; color: var(--color-yellow); margin: 0; text-align: center; background: var(--color-panel); padding: 80px 60px;">TWO<br>THOUSAND<br>TWENTY-SIX</h1>
+```
+
+### Full-Bleed Photo Slide (No Drop Panel)
+
+```html
+<div style="width: 1080px; height: 1350px; background: var(--color-panel); position: relative; overflow: hidden;">
+  <img src="editorial.jpg" alt="" style="position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; filter: grayscale(100%) contrast(1.2) brightness(0.95);">
+  <!-- Slug in top-left corner -->
+  <div style="position: absolute; top: 40px; left: 60px; font-family: var(--font-body); font-size: 11px; font-weight: 500; letter-spacing: 0.16em; text-transform: uppercase; color: var(--color-white);">EDITORIAL 01 / CHROME</div>
+  <!-- Slide counter in bottom-right -->
+  <div style="position: absolute; bottom: 40px; right: 60px; font-family: var(--font-body); font-size: 11px; font-weight: 500; letter-spacing: 0.16em; text-transform: uppercase; color: var(--color-white);">02 / 08</div>
+</div>
+```
+
+### Split Frame (Photo Left, Drop Panel Right)
+
+```html
+<div style="width: 1920px; height: 1080px; display: grid; grid-template-columns: 60% 40%; background: var(--color-panel);">
+  <div style="overflow: hidden;">
+    <img src="hero.jpg" alt="" style="width: 100%; height: 100%; object-fit: cover; filter: grayscale(100%) contrast(1.2) brightness(0.95);">
+  </div>
+  <div style="padding: 80px 60px; position: relative; display: flex; flex-direction: column; justify-content: center;">
+    <h1 style="font-family: var(--font-display); font-size: 108px; font-weight: 400; line-height: 0.92; letter-spacing: -0.03em; text-transform: uppercase; color: var(--color-yellow); margin: 0;">OUR NEW<br>CRUSH</h1>
+    <div style="position: absolute; left: 60px; bottom: 48px; font-family: var(--font-body); font-size: 12px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-white); line-height: 1.3;">100% UV<br>SCRATCH-RESISTANT</div>
+    <div style="position: absolute; right: 60px; bottom: 48px; text-align: right; font-family: var(--font-body); font-size: 12px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-white); line-height: 1.3;">SHOP NOW TO<br>ELEVATE YOUR LOOK</div>
+  </div>
+</div>
+```
+
+### CTA Frame (All Drop Panel, No Photo)
+
+```html
+<div style="width: 1080px; height: 1350px; background: var(--color-panel); position: relative; display: flex; align-items: center; justify-content: center; padding: 80px 60px;">
+  <h1 style="font-family: var(--font-display); font-size: 140px; font-weight: 400; line-height: 0.90; letter-spacing: -0.035em; text-transform: uppercase; color: var(--color-yellow); margin: 0; text-align: center;">SHOP<br>THE<br>DROP</h1>
+  <div style="position: absolute; left: 60px; bottom: 48px; font-family: var(--font-body); font-size: 12px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-white); line-height: 1.3;">LINK IN BIO<br>04.15.2026</div>
+  <div style="position: absolute; right: 60px; bottom: 48px; text-align: right; font-family: var(--font-body); font-size: 12px; font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--color-white); line-height: 1.3;">LIMITED<br>WORLDWIDE</div>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **0px**: The horizon line between the photograph and the drop panel. No gap, no rule, no blur. Pixel-sharp edge.
+- **4px**: Micro gap inside multi-line metadata labels.
+- **8px**: Tight gap between stacked metadata lines.
+- **16px**: Standard gap between the last headline line and any optional sub-label in the drop panel.
+- **24px**: Gap between major metadata clusters within a single corner.
+- **40px**: Distance from the frame edge to the bottom of corner metadata blocks.
+- **48px**: Standard bottom padding for the drop panel when the headline sits centered.
+- **60px**: Standard horizontal padding (left/right) for every format. The corner metadata sits flush to this margin.
+- **72px**: Top padding inside the drop panel above the headline.
+- **80px**: Maximum padding on the Slides (1920x1080) format.
+
+### Format Padding
+| Format | Outer Padding | Photo Height | Drop Panel Height | Content Max-Width |
+|--------|---------------|--------------|-------------------|-------------------|
+| Carousel (1080x1080) | 60px horizontal | 55% (594px) | 45% (486px) | 960px |
+| Infographic (1080xN) | 60px horizontal, 80px vertical | Variable | 400-500px per drop | 960px |
+| Slides (1920x1080) | 80px horizontal | 60% (648px) OR split-right 40% | 40% (432px) OR split-right full-height | 1760px |
+| Poster (1080x1350) | 60px horizontal, 72px vertical | 60% (810px) | 40% (540px) | 960px |
+| Story (1080x1920) | 60px horizontal, 120px top / 160px bottom safe zone | 58% (1113px) | 42% (807px) | 960px |
+
+### Alignment & Grid
+- **Headline alignment**: Centered in the drop panel by default. Left-aligned is the acceptable variant for asymmetric compositions. Right-aligned is forbidden -- the yellow block always anchors to the left or to dead-center.
+- **Corner metadata**: Always in a bottom-left + bottom-right pair. Never three corners, never a single corner. The pair creates the "product label" symmetry that is core to the identity. Bottom-left is always left-aligned, bottom-right is always right-aligned.
+- **Horizon ratio**: 60/40 is the canonical split (photograph / drop panel). 55/45 is acceptable for formats that need more typographic room (Carousel). 50/50 is forbidden -- it flattens the hierarchy.
+- **Grid**: This style uses no internal grid. Content is positioned absolutely from the frame edges using the 60px horizontal rhythm. Cards, columns, and containers are not used.
+- **Vertical rhythm**: The drop panel has exactly one primary element (the Anton headline) and exactly two secondary elements (the corner labels). No additional hierarchy fits inside the drop panel -- if more content is needed, move to a multi-slide sequence.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, `#0A0A0A` drop panel fill | The entire style. Default everywhere. |
+| Photograph (Level 1) | The BW photograph itself, bleeding to the frame edges | The only "elevated" element -- depth comes from the photograph's own tonal range |
+| Vignette (Level 2) | `linear-gradient(to bottom, transparent, rgba(0,0,0,0.35))` 60px tall | Optional blend between the photograph's bottom edge and the drop panel |
+| Horizon Edge (Level 3) | `0 -1px 0 rgba(0,0,0,1)` -- a 1px hard line at the horizon if the photograph has a bright bottom edge | Only used when the photograph's lower border is too bright to sit cleanly on the drop panel |
+| Display Shadow (Level 4) | Forbidden | This style never applies shadow, glow, or stroke to the Anton headline |
+
+### Border Treatments
+- **Default border**: `none`. Cards, panels, and containers in this style have no visible borders. Structure comes from the hard horizon line and the 60px margin rhythm.
+- **Horizon line**: The pixel-sharp edge where the photograph meets the drop panel. This is the only structural line in the composition and it must be razor-straight.
+- **Hairline divider (rare)**: `1px solid rgba(255, 255, 255, 0.12)` -- used only to separate stacked metadata groups inside the Story format's sub-panel.
+- **No rounded corners**: All edges are square. `border-radius: 0` is the default and the rule.
+
+### Surface Hierarchy
+On this style, depth is binary: there is the photograph, and there is the drop panel. Everything else is flat against the drop panel.
+1. **Photograph** -- full tonal range of the BW image, the only source of visual depth.
+2. **Drop Panel** (`#0A0A0A`) -- the flat surface that carries all typography.
+3. **Yellow Headline** (`#F4ED2B`) -- pure fill, no shadow, no glow; sits visually on top of the drop panel as the highest-contrast element.
+4. **White Metadata** (`#FFFFFF`) -- the second-highest contrast element, anchored to the corners.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use **true black-and-white photography** -- import the image and run it through `filter: grayscale(100%) contrast(1.2) brightness(0.95)`. The photograph must read as silver-print, not colorized.
+- Use highlighter yellow (`#F4ED2B`) **exclusively for the Anton display headline** -- nothing else in the frame is yellow, ever.
+- Use **Anton for the display** at 92-120px, always in ALL CAPS, always at weight 400 (which reads as 900), always with `-0.02em to -0.04em` negative tracking.
+- Structure the display headline as exactly **two lines** -- the two-line stack is the shape of this style.
+- Place corner metadata in **bottom-left and bottom-right as a pair** of tracked-uppercase Inter labels at 12px, `letter-spacing: 0.12em`, white on the drop panel.
+- Maintain a **60/40 horizon split** -- photograph on top, near-black drop panel on bottom, hard pixel-sharp edge between them.
+- Keep the drop panel near-black (`#0A0A0A`) -- slightly warmer than pure black, but unambiguously black on every screen.
+- Use exactly **two Inter weights** -- 500 for the smallest credit/slug copy, 600 for the primary metadata labels.
+- Use `letter-spacing: 0.12em to 0.16em` on all metadata -- the wide positive tracking is the deliberate foil to the tight negative tracking on the headline.
+- Treat the **horizon line** between photograph and drop panel as the most important compositional element in the frame -- always straight, always sharp, always uncompromised.
+
+### Don't
+- **Don't duotone the photograph.** This style is true B&W. Duotone, sepia, split-tone, or any color cast breaks the identity. If you want duotone, use `vintage-duotone-poster.md` instead.
+- **Don't use colored backgrounds.** The only allowed background is the near-black drop panel (`#0A0A0A`). No gray, no off-black, no colored panel, no gradient.
+- **Don't use body text above 16px.** This style reserves size exclusively for the Anton display headline. The corner metadata caps at 12-13px, the rare Body Cap in the Story sub-panel caps at 16px. Nothing else gets to be big.
+- Don't use yellow anywhere except the display headline -- never yellow body, never yellow metadata, never yellow borders.
+- Don't set the display headline in mixed case or sentence case -- ALL CAPS is the rule.
+- Don't set the display headline to one line or three lines -- two lines is the shape.
+- Don't apply drop shadow, stroke, glow, outline, or any effect to the yellow headline. Pure flat fill only.
+- Don't use serif, script, or any typeface besides Anton for the display and Inter for the metadata.
+- Don't right-align the headline. Center or left only.
+- Don't add rounded corners anywhere. `border-radius: 0` is a hard rule.
+- Don't add decorative elements -- no icons, no badges, no pills, no rules, no illustrations, no emoji.
+- Don't use pure white (`#FFFFFF`) anywhere except the metadata labels, and don't use pure black (`#000000`) anywhere except the crushed shadows inside the photograph.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale**: Anton display drops to **92px** (from 120px). Line-height 0.94, tracking -0.025em. Metadata stays at 12px.
+- **Padding**: 60px horizontal, 48px vertical.
+- **Horizon split**: 55/45 -- photograph top 594px, drop panel bottom 486px. The square format needs slightly more room for typography.
+- **Cover slide**: Full BW photo on top, drop panel with 2-line Anton headline centered, bottom-left + bottom-right metadata labels.
+- **Content slides**: Can alternate full-bleed BW photo slides (with a single slug in the top-left and a slide counter in the bottom-right) and drop-panel slides (all black, massive yellow headline, corner metadata).
+- **CTA slide**: All drop panel, no photograph. Anton at 108-120px, centered. "SHOP THE DROP" style CTA with LINK IN BIO metadata.
+- **Slide counter**: Bottom-right, Inter 500 11px, `letter-spacing: 0.16em`, white. "02 / 08" format.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Display Hero at 108px at the top. Each subsequent drop-panel section uses Display Medium at 92px.
+- **Padding**: 60px horizontal, 80px top/bottom.
+- **Vertical rhythm**: Alternate full-bleed BW photograph sections (800-900px tall) with 400-500px drop panels carrying yellow Anton headlines. Each drop panel repeats the bottom-left + bottom-right metadata pair.
+- **Section spacing**: 0px -- sections butt directly against each other. The horizon line between each photograph and its drop panel is the only visible separator.
+- **Footer**: The final drop panel functions as the CTA. No additional footer chrome.
+
+### Slides (1920x1080px)
+- **Typography scale**: Display Hero at **108px** (slightly smaller than poster because the horizontal format needs the room). Metadata at 13px.
+- **Padding**: 80px horizontal.
+- **Layout options**:
+  - **Horizontal 60/40**: Photograph on the left 60%, drop panel on the right 40%. Headline left-aligned in the drop panel. Corner metadata at bottom-left (60px from left edge) and bottom-right (60px from right edge) of the drop panel only.
+  - **Full BW photo**: Pure editorial shot with slug top-left and counter bottom-right.
+  - **All drop panel**: CTA slide, Anton at 140px, centered, corner metadata pair.
+- **Title slides**: Split frame with photograph left, Anton headline right.
+- **Content slides**: Full-bleed photograph with slug/counter corners.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at **120px** -- this is the canonical size for the style. Line-height 0.92, tracking -0.03em.
+- **Padding**: 60px horizontal, 72px top (inside the drop panel), 48px bottom.
+- **Composition**: 60/40 horizon split -- photograph on top (810px), drop panel on bottom (540px). Anton headline centered in the drop panel, bottom-left + bottom-right corner metadata 40px from the bottom edge.
+- **This is the native format** -- the reference screenshot is a 4:5 poster and every value in this file is calibrated to it first.
+- **CTA placement**: The drop panel itself is the CTA. No additional button, no additional chrome.
+
+### Story (1080x1920px)
+- **Typography scale**: Display Hero at **132px** for maximum vertical impact (the tall format swallows typography if you scale to carousel size). Line-height 0.92, tracking -0.035em. Metadata at 13px.
+- **Padding**: 60px horizontal, 120px top / 160px bottom safe zones (reserved for platform UI -- avatar, progress bar, reply input). All critical content sits inside y=120 to y=1760.
+- **Horizon split**: 58/42 -- photograph top 1113px, drop panel bottom 807px. The extra vertical room in the Story format goes to the drop panel so the massive Anton headline has space to breathe and a rare second line of Body Cap sub-copy can sit beneath it.
+- **Cover slide**: Full BW photograph on top. Drop panel on bottom with a 132px two-line Anton headline centered, an optional 14px Body Cap sub-label (ALL CAPS, 0.08em tracking, white, `rgba(255,255,255,0.85)` opacity) 24px below the headline, and the bottom-left + bottom-right corner metadata pair at 48px from the bottom safe zone edge.
+- **Content slides**: Can run full-bleed BW photo with slug top-left (inside the top safe zone) and slide counter bottom-right (inside the bottom safe zone), or use the split layout. The drop panel can carry a second horizontal hairline rule (`1px solid rgba(255,255,255,0.12)`) 16px above the corner metadata to separate the headline block from the spec block -- the only case this style uses a visible divider.
+- **CTA slide**: All drop panel, Anton at 148px centered, bottom-left "LINK IN STICKER" / bottom-right "LIMITED DROP" metadata pair.
+- **Progress indicator**: Handled by the Story platform -- do not draw a custom progress bar.
+- **Tap zones**: Keep the Anton headline centered on x=540 (horizontal center) so edge taps for prev/next don't obscure type.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Drop Black | `#0A0A0A` | Drop panel fill, primary canvas |
+| Highlighter Yellow | `#F4ED2B` | Display headline only -- nothing else |
+| Signal White | `#FFFFFF` | Corner metadata labels only |
+| Yellow Hover | `#F8F34A` | Hover/active state for yellow (rare) |
+| Yellow Shadow | `#D4CD1F` | Optional 1-2px text shadow on yellow over bright photo regions (rare) |
+| Sub Panel | `#0F0F0F` | Rare recessed strip in Story format |
+| Metadata Muted | `rgba(255,255,255,0.6)` | Secondary metadata (slide counters) |
+| Border Default | `rgba(255,255,255,0.12)` | 1px hairline for Story sub-panel divider |
+| Photo Vignette | `rgba(0,0,0,0.35)` | Optional gradient blend at photo bottom edge |
+
+### Font Declarations
+
+```css
+/* Display (yellow headline only) */
+font-family: 'Anton', 'Oswald', Impact, 'Arial Narrow', sans-serif;
+
+/* Body / Metadata (white corner labels only) */
+font-family: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Anton&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-panel: #0A0A0A;
+  --color-yellow: #F4ED2B;
+  --color-white: #FFFFFF;
+
+  /* Colors -- Accent */
+  --color-yellow-hover: #F8F34A;
+  --color-yellow-shadow: #D4CD1F;
+  --color-deep-black: #000000;
+
+  /* Colors -- Neutral Scale */
+  --color-sub-panel: #0F0F0F;
+  --color-photo-black: #000000;
+  --color-photo-mid: #6A6A6A;
+  --color-photo-highlight: #EEEEEE;
+  --color-metadata-white: #FFFFFF;
+  --color-metadata-muted: rgba(255, 255, 255, 0.6);
+
+  /* Colors -- Surfaces */
+  --color-surface-drop: #0A0A0A;
+  --color-surface-sub: #0F0F0F;
+
+  /* Colors -- Borders */
+  --color-border-default: rgba(255, 255, 255, 0.12);
+  --color-divider: rgba(255, 255, 255, 0.08);
+  --color-border-none: transparent;
+
+  /* Colors -- Shadows */
+  --shadow-none: transparent;
+  --shadow-photo-vignette: rgba(0, 0, 0, 0.35);
+  --shadow-display-glow: rgba(244, 237, 43, 0.0);
+
+  /* Typography -- Families */
+  --font-display: 'Anton', 'Oswald', Impact, 'Arial Narrow', sans-serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 120px;
+  --text-display-large: 108px;
+  --text-display-medium: 92px;
+  --text-display-small: 72px;
+  --text-metadata-label: 12px;
+  --text-metadata-small: 11px;
+  --text-body-cap: 14px;
+  --text-credit-slug: 11px;
+  --text-cta-label: 12px;
+
+  /* Typography -- Weights */
+  --weight-display: 400;
+  --weight-metadata: 600;
+  --weight-metadata-small: 500;
+  --weight-cta: 600;
+
+  /* Typography -- Line Heights */
+  --leading-display-hero: 0.92;
+  --leading-display-medium: 0.94;
+  --leading-metadata: 1.30;
+  --leading-body-cap: 1.45;
+
+  /* Typography -- Letter Spacing */
+  --tracking-display-hero: -0.03em;
+  --tracking-display-medium: -0.025em;
+  --tracking-metadata: 0.12em;
+  --tracking-metadata-small: 0.14em;
+  --tracking-credit-slug: 0.16em;
+  --tracking-body-cap: 0.08em;
+
+  /* Spacing */
+  --space-horizon: 0px;
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-base: 16px;
+  --space-medium: 24px;
+  --space-corner-offset: 40px;
+  --space-drop-bottom: 48px;
+  --space-frame: 60px;
+  --space-drop-top: 72px;
+  --space-max: 80px;
+
+  /* Borders */
+  --radius-none: 0;
+
+  /* Composition Ratios */
+  --ratio-photo: 60%;
+  --ratio-drop: 40%;
+  --ratio-photo-carousel: 55%;
+  --ratio-drop-carousel: 45%;
+  --ratio-photo-story: 58%;
+  --ratio-drop-story: 42%;
+
+  /* Filters */
+  --filter-bw: grayscale(100%) contrast(1.2) brightness(0.95);
+}
+```
+
+### System Font Fallbacks
+- **Display (if Anton fails to load):** `'Oswald', Impact, 'Arial Narrow Bold', 'Arial Narrow', sans-serif` -- Oswald 900 is the closest widely-available backup. Impact is the ultimate OS-level fallback.
+- **Body / Metadata (if Inter fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/_full/card-toss.md
+++ b/skills/composites/goose-graphics/styles/_full/card-toss.md
@@ -1,0 +1,461 @@
+# Design Style: Card Toss
+
+## 1. Visual Theme & Atmosphere
+
+Card Toss is the design language of playful confidence -- the visual equivalent of tossing your best reviews onto a table and letting them speak for themselves. The pure black canvas (`#000000`) acts as a void, a stage floor, an infinite dark surface on which brightly colored cards appear to have been casually scattered at jaunty angles. This is not the darkness of sophistication or mystery; it is the darkness of a photographer's backdrop, chosen so that every card pops with maximum saturation and presence. The overall effect is bold, app-native, and unapologetically marketing-forward -- the kind of graphic you see in a top-grossing app's press kit or App Store feature.
+
+The typography lives on the cards themselves, not floating in the void. Each card is a self-contained world with its own color, its own message, and its own typographic rules. Headings use a confident serif -- warm, slightly editorial, with visible stroke contrast -- that gives award announcements and testimonials a sense of authority and earned credibility. Body text and names use a clean geometric sans-serif that stays legible at small sizes and provides a modern counterpoint to the serif display text. The combination of serif authority and sans-serif clarity gives each card the feel of a premium product review or magazine pull-quote. Star ratings, avatar photos, and brand logos add social proof density without cluttering the composition.
+
+The color system is deliberately limited to three card surface colors -- a vivid sunshine yellow (`#FFD60A`), a clear cornflower blue (`#4A9FE5`), and a warm coral-orange (`#F47B5E`) -- against the pure black background. These are not pastel or muted; they are saturated, confident, and immediately recognizable. The off-white circle element floating between cards acts as a punctuation mark, a visual breath, a subtle nod to app iconography. Cards are rotated at slight angles (-5 to +8 degrees), overlapping casually, creating a sense of physical objects tossed onto a surface. The large rounded corners (20px radius) reinforce the app-native, friendly, touchable quality of the cards. This is design that says "people love us, and we are not afraid to show it."
+
+**Key Characteristics:**
+- Pure black background (`#000000`) as a void stage for maximum card contrast
+- Three saturated card surface colors: sunshine yellow (`#FFD60A`), cornflower blue (`#4A9FE5`), coral-orange (`#F47B5E`)
+- Dark text (`#1A1A1A`) on colored card surfaces -- black-on-color for readability
+- Cards rotated at casual angles (-5deg to +8deg) with overlapping composition
+- Large rounded corners (`20px`) on all cards -- app-native, friendly, touchable
+- Serif display font (DM Serif Display) for headlines, awards, and testimonial quotes -- editorial authority
+- Sans-serif body font (DM Sans) for names, labels, and supporting text -- clean and modern
+- Star ratings rendered as solid black stars on yellow cards -- social proof as visual element
+- Avatar photos (circular, 40-48px) paired with reviewer names for testimonial credibility
+- Off-white accent circle (`#F5F0E0`) as a floating decorative element between cards
+- No visible borders on cards -- color surfaces define the card edges against the black void
+- Physical "tossed" energy: slight rotations, overlaps, and casual placement create a tangible, real-world feel
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Void Black** (`#000000`): Primary background. Pure black as an infinite stage for the colored cards.
+- **Card Text** (`#1A1A1A`): Primary text color on card surfaces. Near-black for maximum readability on bright card colors.
+- **Sunshine Yellow** (`#FFD60A`): Primary card color. Used for the dominant testimonial card -- warm, energetic, attention-grabbing.
+
+### Accent
+- **Cornflower Blue** (`#4A9FE5`): Secondary card color for award badges, accolades, and secondary social proof.
+- **Coral Orange** (`#F47B5E`): Tertiary card color for brand cards, logos, and supplementary content.
+- **Dark Yellow** (`#D4B000`): Hover/pressed state for yellow card interactions.
+- **Dark Blue** (`#3A7FBF`): Hover/pressed state for blue card interactions.
+- **Dark Coral** (`#D4664D`): Hover/pressed state for coral card interactions.
+
+### Neutral Scale
+- **Off-White** (`#F5F0E0`): Decorative accent circles and soft highlight elements.
+- **Light Gray** (`#E8E8E8`): Secondary text on dark surfaces (if needed outside cards).
+- **Medium Gray** (`#999999`): Tertiary text, metadata, timestamps on dark backgrounds.
+- **Dark Gray** (`#555555`): Disabled text and placeholder content.
+- **Charcoal** (`#2A2A2A`): Subtle surface variation on dark backgrounds for non-card containers.
+- **Near Black** (`#111111`): Elevated surface slightly above the void for section differentiation.
+
+### Surface & Borders
+- **Surface Void** (`#000000`): Base canvas, the infinite black backdrop.
+- **Surface Elevated** (`#111111`): Slightly lifted dark surface for non-card content areas.
+- **Card Surface Yellow** (`#FFD60A`): Yellow card background.
+- **Card Surface Blue** (`#4A9FE5`): Blue card background.
+- **Card Surface Coral** (`#F47B5E`): Coral card background.
+- **Border Default** (`rgba(255,255,255,0.08)`): Subtle border for rare edge cases on dark surfaces.
+- **Border Card** (`none`): Cards have no borders -- color surfaces define edges against black.
+- **Divider Rule** (`rgba(255,255,255,0.12)`): Faint divider for content within dark sections.
+
+### Shadow Colors
+- **Shadow Deep** (`rgba(0,0,0,0.7)`): Primary card drop shadow creating the floating "tossed" effect.
+- **Shadow Medium** (`rgba(0,0,0,0.4)`): Standard elevation shadow for cards at rest.
+- **Shadow Warm** (`rgba(0,0,0,0.5)`): Shadow with slightly warm cast for overlapping card edges.
+- **Shadow Ambient** (`rgba(0,0,0,0.2)`): Subtle ambient shadow for gentle lift.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'DM Serif Display', Georgia, 'Times New Roman', serif`
+- **Body**: `'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | DM Serif Display | 64px | 400 | 1.05 | -0.5px | Card headlines, award announcements, maximum impact |
+| Section Heading | DM Serif Display | 44px | 400 | 1.10 | -0.3px | Major card headings, accolade text |
+| Sub-heading | DM Serif Display | 32px | 400 | 1.15 | 0px | Secondary card titles, smaller testimonial quotes |
+| Body Large | DM Sans | 20px | 400 | 1.55 | 0px | Lead testimonial text, primary quotes on cards |
+| Body | DM Sans | 16px | 400 | 1.60 | 0px | Standard card body text, testimonial copy |
+| Small / Caption | DM Sans | 13px | 500 | 1.45 | 0.3px | Metadata, source attributions, dates |
+| Big Numbers | DM Serif Display | 120px | 400 | 0.90 | -2px | Oversized ratings, scores, or metrics on cards |
+| Reviewer Name | DM Sans | 16px | 600 | 1.20 | 0px | Attribution names below testimonials |
+| CTA Text | DM Sans | 16px | 700 | 1.00 | 1px | Button and call-to-action text, uppercase |
+| Star Rating | System | 20px | 400 | 1.00 | 2px | Black star characters on yellow cards |
+
+### Principles
+- **Serif for authority, sans for clarity**: DM Serif Display on headings and awards conveys editorial weight and credibility -- the kind of typeface you see in magazine award announcements. DM Sans handles body text and names with clean, modern legibility.
+- **Text lives on cards, not in the void**: Almost all typography appears on colored card surfaces. The black background is empty space. This means text color is almost always dark (`#1A1A1A`) on bright surfaces, not light-on-dark.
+- **Generous but not loose**: Line heights on cards (1.55-1.60 for body) give testimonial text breathing room without feeling sparse. Serif display text runs tighter (1.05-1.15) for impact.
+- **Weight contrast within DM Sans**: Reviewer names at 600 weight stand out from body text at 400 weight, creating a clear attribution hierarchy without changing font family.
+- **No uppercase on serif headings**: DM Serif Display is used in title case or sentence case, never all-caps. Its stroke contrast and serifs provide enough visual weight without uppercase treatment.
+- **Star ratings as typography**: Star characters (Unicode black stars) are rendered inline as a typographic element, not as icon images. They follow the same color rules as text.
+
+## 4. Component Patterns
+
+### Testimonial Card (Primary)
+
+```html
+<div style="background-color: var(--color-sunshine-yellow); padding: 40px 36px; border-radius: 20px; transform: rotate(-3deg); max-width: 480px; box-shadow: var(--shadow-card);">
+  <div style="font-size: 20px; letter-spacing: 2px; color: var(--color-card-text); margin: 0 0 20px;">&#9733;&#9733;&#9733;&#9733;&#9733;</div>
+  <p style="font-family: var(--font-body); font-size: 18px; font-weight: 400; line-height: 1.55; color: var(--color-card-text); margin: 0 0 28px;">"I've tried a handful of health apps over the years, but this is the first one that actually helped me stay consistent. The daily check-ins are quick and the progress tracking makes it easy to see improvements over time."</p>
+  <div style="display: flex; align-items: center; gap: 12px;">
+    <div style="width: 44px; height: 44px; border-radius: 50%; background: var(--color-charcoal); overflow: hidden;"><img src="avatar.jpg" style="width: 100%; height: 100%; object-fit: cover;" /></div>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 600; line-height: 1.20; color: var(--color-card-text); margin: 0;">Maya Davidson</p>
+  </div>
+</div>
+```
+
+### Award Card
+
+```html
+<div style="background-color: var(--color-cornflower-blue); padding: 48px 40px; border-radius: 20px; transform: rotate(4deg); max-width: 420px; box-shadow: var(--shadow-card); text-align: center;">
+  <h2 style="font-family: var(--font-display); font-size: 44px; font-weight: 400; line-height: 1.10; letter-spacing: -0.3px; color: var(--color-card-text); margin: 0;">Awarded Gold in Customer Safety by App Guide 2026</h2>
+</div>
+```
+
+### Brand Logo Card
+
+```html
+<div style="background-color: var(--color-coral-orange); padding: 32px 40px; border-radius: 20px; transform: rotate(-5deg); max-width: 280px; box-shadow: var(--shadow-card); display: flex; align-items: center; gap: 12px;">
+  <div style="font-size: 28px; color: var(--color-card-text);">&#9658;&#9658;</div>
+  <span style="font-family: var(--font-display); font-size: 48px; font-weight: 400; color: var(--color-card-text); margin: 0;">Duo</span>
+</div>
+```
+
+### Stat Display Card
+
+```html
+<div style="background-color: var(--color-sunshine-yellow); padding: 48px 36px; border-radius: 20px; transform: rotate(2deg); max-width: 400px; box-shadow: var(--shadow-card); text-align: center;">
+  <p style="font-family: var(--font-display); font-size: 120px; font-weight: 400; line-height: 0.90; letter-spacing: -2px; color: var(--color-card-text); margin: 0 0 16px;">4.9</p>
+  <div style="font-size: 20px; letter-spacing: 2px; color: var(--color-card-text); margin: 0 0 12px;">&#9733;&#9733;&#9733;&#9733;&#9733;</div>
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 500; line-height: 1.45; color: var(--color-card-text); margin: 0;">Average rating across 12,000+ reviews</p>
+</div>
+```
+
+### Decorative Circle
+
+```html
+<div style="width: 80px; height: 80px; border-radius: 50%; background-color: var(--color-off-white); box-shadow: var(--shadow-ambient);"></div>
+```
+
+### Comparison Grid (Two Cards)
+
+```html
+<div style="position: relative; width: 100%; padding: 60px;">
+  <div style="background-color: var(--color-sunshine-yellow); padding: 36px 32px; border-radius: 20px; transform: rotate(-4deg); max-width: 440px; box-shadow: var(--shadow-card); position: relative; z-index: 2;">
+    <h3 style="font-family: var(--font-display); font-size: 32px; font-weight: 400; line-height: 1.15; color: var(--color-card-text); margin: 0 0 12px;">Before</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.60; color: var(--color-card-text); margin: 0;">Manual tracking, forgotten goals, and inconsistent habits across multiple disconnected apps.</p>
+  </div>
+  <div style="background-color: var(--color-cornflower-blue); padding: 36px 32px; border-radius: 20px; transform: rotate(3deg); max-width: 440px; box-shadow: var(--shadow-card); position: relative; z-index: 1; margin-top: -30px; margin-left: 60px;">
+    <h3 style="font-family: var(--font-display); font-size: 32px; font-weight: 400; line-height: 1.15; color: var(--color-card-text); margin: 0 0 12px;">After</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.60; color: var(--color-card-text); margin: 0;">One app, daily check-ins, visible progress, and a community that keeps you accountable.</p>
+  </div>
+</div>
+```
+
+### Quote Card
+
+```html
+<div style="background-color: var(--color-coral-orange); padding: 40px 36px; border-radius: 20px; transform: rotate(2deg); max-width: 480px; box-shadow: var(--shadow-card);">
+  <p style="font-family: var(--font-display); font-size: 32px; font-weight: 400; line-height: 1.15; color: var(--color-card-text); margin: 0 0 24px;">"The best investment I made in my health this year."</p>
+  <div style="display: flex; align-items: center; gap: 12px;">
+    <div style="width: 40px; height: 3px; background: var(--color-card-text);"></div>
+    <p style="font-family: var(--font-body); font-size: 14px; font-weight: 600; letter-spacing: 0.5px; color: var(--color-card-text); margin: 0;">Dr. Sarah Kim, Wellness Coach</p>
+  </div>
+</div>
+```
+
+### CTA Card
+
+```html
+<div style="background-color: var(--color-cornflower-blue); padding: 48px 40px; border-radius: 20px; transform: rotate(-2deg); max-width: 480px; box-shadow: var(--shadow-card); text-align: center;">
+  <h2 style="font-family: var(--font-display); font-size: 44px; font-weight: 400; line-height: 1.10; color: var(--color-card-text); margin: 0 0 20px;">Ready to start your journey?</h2>
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.60; color: var(--color-card-text); max-width: 360px; margin: 0 auto 28px;">Join millions of users who transformed their daily habits.</p>
+  <a style="display: inline-block; background: var(--color-card-text); color: var(--color-cornflower-blue); font-family: var(--font-body); font-size: 16px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; text-decoration: none; padding: 16px 40px; border-radius: 12px;">Download Free</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between star characters in a rating row.
+- **8px**: Tight gap -- between label and sub-label within a card.
+- **12px**: Small gap -- between avatar and reviewer name, between icon and brand text.
+- **16px**: Base gap -- between heading and body text on a card, between paragraphs.
+- **20px**: Card internal -- between star rating and testimonial text.
+- **28px**: Medium gap -- between testimonial body and attribution, between sections within a card.
+- **36px**: Card padding (horizontal) -- standard internal padding on card surfaces.
+- **40px**: Card padding (vertical top/bottom) -- generous breathing room inside cards.
+- **48px**: Large card padding -- hero cards and award cards with extra presence.
+- **60px**: Scene padding -- outer margin around the entire card composition.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 48px all sides | 984px |
+| Infographic (1080xN) | 48px left/right, 60px top/bottom | 984px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 48px left/right, 60px top/bottom | 984px |
+
+### Alignment & Grid
+- **Primary alignment**: Cards are positioned in a loose, organic scatter -- not on a rigid grid. The overall composition is roughly centered, but individual cards are offset and rotated.
+- **Rotation range**: Cards rotate between -8deg and +8deg. No card should be perfectly horizontal. Vary rotations so adjacent cards are not at the same angle.
+- **Overlap strategy**: Cards overlap by 20-60px at edges, creating a layered stack. Use `z-index` to control which card appears on top. The most important card (primary testimonial) should have the highest z-index.
+- **Scatter placement**: Use absolute or relative positioning with manual offsets to create the "tossed" arrangement. Avoid CSS grid or flexbox for the main card layout -- the irregularity is the point.
+- **Decorative elements**: Off-white circles (60-100px diameter) float between cards as visual punctuation. Place 1-2 per composition.
+- **Vertical flow**: In multi-slide formats, the card scatter should flow top-to-bottom with the primary card near the top and supporting cards below and to the sides.
+- **Content gravity**: The densest card (most text, star rating, avatar) should be positioned in the upper-center area. Smaller accent cards (brand logo, award badge) occupy the lower corners.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, background `#000000` | The void background, empty canvas |
+| Subtle (Level 1) | `rgba(0,0,0,0.2) 0px 4px 12px` | Decorative circles, small accent elements |
+| Card (Level 2) | `rgba(0,0,0,0.4) 0px 12px 32px` | Standard tossed cards -- the primary elevation level |
+| Featured (Level 3) | `rgba(0,0,0,0.5) 0px 20px 48px, rgba(0,0,0,0.3) 0px 8px 16px` | Primary testimonial card, highest-priority card in stack |
+| Overlay (Level 4) | `rgba(0,0,0,0.7) 0px 24px 60px` | Modals or popups if needed (rare in this style) |
+
+### Border Treatments
+- **Standard border**: `none` -- cards in this style have no visible borders. The saturated card surface against the black void provides all the edge definition needed.
+- **Internal divider**: `1px solid rgba(0,0,0,0.1)` -- a faint line within a card to separate sections, used sparingly.
+- **Avatar border**: `2px solid rgba(255,255,255,0.3)` -- thin white ring around circular avatars for subtle separation from the card surface.
+- **Decorative only**: If a border must be used, keep it at `1px solid rgba(0,0,0,0.08)` -- nearly invisible, just enough to hint at structure.
+
+### Surface Hierarchy
+On the pure black background, depth is communicated entirely through shadow intensity and card stacking:
+1. **Void** (`#000000`) -- the bottomless dark surface. Nothing lives here except space.
+2. **Background cards** -- cards at the bottom of the z-index stack, partially occluded, with standard shadows.
+3. **Foreground cards** -- the primary content card(s), highest z-index, with heavier shadows and slight scale advantage.
+4. **Decorative elements** -- off-white circles and small accent shapes that float between card layers.
+
+The "tossed" physical metaphor is the depth system. Cards that appear closer (higher z-index, larger shadow offset) feel like they are sitting on top of cards further back. The rotation angles reinforce this -- a card tilted differently from its neighbor reads as being on a different plane.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use pure black (`#000000`) as the background -- no near-blacks, no dark grays. The void must be absolute.
+- Rotate every card between -8deg and +8deg -- the casual scatter is the core visual identity.
+- Use large rounded corners (`border-radius: 20px`) on all cards -- this is non-negotiable for the app-native feel.
+- Use DM Serif Display for headings and award text on cards -- the serif authority is the typographic signature.
+- Keep text color at `#1A1A1A` (near-black) on all colored card surfaces -- dark-on-bright for readability.
+- Include star ratings (Unicode black stars) as a typographic social proof element on testimonial cards.
+- Pair testimonial text with a circular avatar (44px) and a name in DM Sans 600 weight.
+- Overlap cards by 20-60px to create the physical "tossed" layering effect.
+- Use only the three card colors: sunshine yellow (`#FFD60A`), cornflower blue (`#4A9FE5`), coral orange (`#F47B5E`).
+- Place 1-2 off-white decorative circles (`#F5F0E0`, 60-100px) between cards as visual punctuation.
+- Use `box-shadow` with `rgba(0,0,0,0.4)` offsets of 12-20px to create convincing floating card depth.
+
+### Don't
+- Don't use visible borders on cards -- the saturated surface against black provides all edge definition.
+- Don't align cards on a grid or make them perfectly horizontal -- the organic scatter is the entire point.
+- Don't use more than 3 card colors in a single composition -- yellow, blue, and coral only.
+- Don't use light text on card surfaces -- always use dark text (`#1A1A1A`) on bright card colors.
+- Don't place text directly on the black background as a primary content strategy -- text lives on cards.
+- Don't use small corner radii (4px, 8px) on cards -- always use 20px for the rounded, friendly feel.
+- Don't use uppercase on DM Serif Display headings -- title case or sentence case only.
+- Don't rotate cards beyond 10deg -- extreme rotations look chaotic rather than casually confident.
+- Don't stack more than 4-5 cards in a single composition -- each card needs room to breathe and be read.
+- Don't use gradients on card surfaces -- cards should be flat, solid color fills.
+- Don't use glow effects or neon treatments -- this style is warm and physical, not digital and electric.
+- Don't use thin font weights (300 or below) for body text on cards -- the colored surfaces demand at least 400 weight.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale**: Display Hero becomes 52px (from 64px). Section Heading becomes 36px. Body stays 16px.
+- **Padding**: 48px on all sides. Card internal padding reduces to 32px horizontal, 36px vertical.
+- **Card count**: Maximum 2-3 cards per slide. Cover slide: one large primary card with star rating and testimonial. Supporting slides: one card per slide with decorative circle.
+- **Rotation**: Reduce rotation range to -5deg to +5deg on carousel format for better readability.
+- **Swipe indicator**: Small off-white dots (`#F5F0E0`) at bottom center, 8px diameter, 12px gap.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Full-scale type hierarchy. Display Hero at 64px for the top card section.
+- **Padding**: 48px left/right. 60px top/bottom margins.
+- **Card flow**: Cards scatter down the vertical canvas. Alternate left-offset and right-offset cards with varying rotations. Space cards 40-60px apart vertically.
+- **Section breaks**: Use off-white decorative circles between card groups. No horizontal rules.
+- **Footer**: Small card at the bottom in coral with brand logo and CTA.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 72px. Section Heading becomes 52px. Body Large becomes 22px.
+- **Padding**: 80px on all sides. Cards have generous 48px internal padding.
+- **Layout**: Widescreen allows side-by-side card scatter. 2-3 cards spread across the horizontal plane with overlaps. Primary card occupies center-left, supporting cards offset to the right.
+- **Title slides**: Single large card centered with rotation, brand logo card in corner.
+- **Content slides**: Card cluster with supporting data. Off-white circles as spacers.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 56px. Section Heading at 40px. Body at 16px.
+- **Padding**: 48px left/right, 60px top/bottom.
+- **Composition**: Top third: primary testimonial card (largest, most prominent rotation). Middle third: award card and brand logo card overlapping. Bottom third: CTA card or additional testimonial.
+- **Vertical cascade**: Cards cascade downward with staggered rotations, creating a diagonal energy from top-left to bottom-right.
+- **Decorative circles**: Place 2 off-white circles -- one between top and middle cards, one near the bottom edge.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Hero becomes 68px (approximately 30% larger than Carousel 52px). Section Heading becomes 48px. Body Large becomes 22px. Big Numbers for rating stats become 140px.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical text must sit inside y=160 to y=1760.
+- **Layout**: Single centered column. Content max-width 960px. Vertical center of gravity -- cluster hero content in y=400 to y=1500 range. Cards are still scattered inside this column with rotations and overlaps.
+- **Cover slide**: One primary yellow testimonial card (`#FFD60A`) centered high in the safe zone at roughly -4deg rotation, carrying the full DM Serif Display headline, 5-star Unicode rating, testimonial body in DM Sans, circular avatar, and reviewer name. An off-white decorative circle floats to one side. Card max-width around 820px so it still feels tossed onto the tall black void.
+- **Content slides**: One card per slide, rotation -6deg to +6deg, with the tallest card taking the hero position (around y=500) and a smaller supporting card (brand logo, award) offset below it. Maintain the signature overlap -- let the secondary card tuck under the primary by 40-60px. Keep the cards solid yellow/blue/coral on the pure `#000000` void.
+- **CTA slide**: Single cornflower blue card (`#4A9FE5`) centered with a -2deg rotation. DM Serif Display headline at 60px, short body, and a dark pill button (`#1A1A1A`) with white DM Sans 700 uppercase CTA text. Decorative off-white circle floats near the bottom edge of the safe zone.
+- **Progress indicator**: Small off-white dots (`#F5F0E0`, 10px diameter, 14px gap) horizontally centered at the bottom edge of the bottom safe zone. Active dot fully opaque, inactive dots at 40% opacity. No swipe label -- the tossed cards already feel app-native.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Void Black | `#000000` | Primary background -- pure black void |
+| Card Text | `#1A1A1A` | Text on all colored card surfaces |
+| Sunshine Yellow | `#FFD60A` | Primary card color: testimonials, star ratings |
+| Cornflower Blue | `#4A9FE5` | Secondary card color: awards, accolades, CTAs |
+| Coral Orange | `#F47B5E` | Tertiary card color: brand logos, quotes |
+| Off-White | `#F5F0E0` | Decorative circles, soft accent elements |
+| Dark Yellow | `#D4B000` | Hover state for yellow cards |
+| Dark Blue | `#3A7FBF` | Hover state for blue cards |
+| Dark Coral | `#D4664D` | Hover state for coral cards |
+| Light Gray | `#E8E8E8` | Secondary text on dark surfaces (rare) |
+| Medium Gray | `#999999` | Tertiary text, metadata |
+| Charcoal | `#2A2A2A` | Subtle dark surface variation |
+| Near Black | `#111111` | Elevated dark surface |
+
+### Font Declarations
+
+```css
+font-family: 'DM Serif Display', Georgia, 'Times New Roman', serif;
+font-family: 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-void-black: #000000;
+  --color-card-text: #1A1A1A;
+  --color-sunshine-yellow: #FFD60A;
+
+  /* Colors -- Accent */
+  --color-cornflower-blue: #4A9FE5;
+  --color-coral-orange: #F47B5E;
+  --color-dark-yellow: #D4B000;
+  --color-dark-blue: #3A7FBF;
+  --color-dark-coral: #D4664D;
+
+  /* Colors -- Neutral Scale */
+  --color-off-white: #F5F0E0;
+  --color-light-gray: #E8E8E8;
+  --color-medium-gray: #999999;
+  --color-dark-gray: #555555;
+  --color-charcoal: #2A2A2A;
+  --color-near-black: #111111;
+
+  /* Colors -- Surfaces */
+  --color-surface-void: #000000;
+  --color-surface-elevated: #111111;
+  --color-surface-yellow: #FFD60A;
+  --color-surface-blue: #4A9FE5;
+  --color-surface-coral: #F47B5E;
+
+  /* Colors -- Borders */
+  --color-border-default: rgba(255, 255, 255, 0.08);
+  --color-border-internal: rgba(0, 0, 0, 0.1);
+  --color-border-avatar: rgba(255, 255, 255, 0.3);
+  --color-divider-rule: rgba(255, 255, 255, 0.12);
+
+  /* Colors -- Shadows */
+  --shadow-deep: rgba(0, 0, 0, 0.7);
+  --shadow-medium: rgba(0, 0, 0, 0.4);
+  --shadow-warm: rgba(0, 0, 0, 0.5);
+  --shadow-ambient: rgba(0, 0, 0, 0.2);
+
+  /* Typography -- Families */
+  --font-display: 'DM Serif Display', Georgia, 'Times New Roman', serif;
+  --font-body: 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 64px;
+  --text-section-heading: 44px;
+  --text-sub-heading: 32px;
+  --text-body-large: 20px;
+  --text-body: 16px;
+  --text-small: 13px;
+  --text-big-number: 120px;
+  --text-reviewer-name: 16px;
+  --text-cta: 16px;
+  --text-star-rating: 20px;
+
+  /* Typography -- Weights */
+  --weight-display: 400;
+  --weight-body: 400;
+  --weight-body-medium: 500;
+  --weight-name: 600;
+  --weight-cta: 700;
+
+  /* Typography -- Line Heights */
+  --leading-display: 1.05;
+  --leading-heading: 1.10;
+  --leading-sub-heading: 1.15;
+  --leading-body-large: 1.55;
+  --leading-body: 1.60;
+  --leading-small: 1.45;
+  --leading-number: 0.90;
+  --leading-name: 1.20;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-card-gap: 20px;
+  --space-medium: 28px;
+  --space-card-h: 36px;
+  --space-card-v: 40px;
+  --space-large: 48px;
+  --space-scene: 60px;
+
+  /* Borders */
+  --radius-card: 20px;
+  --radius-avatar: 50%;
+  --radius-button: 12px;
+
+  /* Shadows -- Composed */
+  --shadow-card: rgba(0,0,0,0.4) 0px 12px 32px;
+  --shadow-featured: rgba(0,0,0,0.5) 0px 20px 48px, rgba(0,0,0,0.3) 0px 8px 16px;
+  --shadow-subtle: rgba(0,0,0,0.2) 0px 4px 12px;
+  --shadow-overlay: rgba(0,0,0,0.7) 0px 24px 60px;
+
+  /* Card Rotations */
+  --rotate-slight-left: rotate(-3deg);
+  --rotate-slight-right: rotate(3deg);
+  --rotate-medium-left: rotate(-6deg);
+  --rotate-medium-right: rotate(6deg);
+}
+```
+
+### System Font Fallbacks
+- **Display (if DM Serif Display fails to load):** `Georgia, 'Times New Roman', serif`
+- **Body (if DM Sans fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/_full/cinematic-romance.md
+++ b/skills/composites/goose-graphics/styles/_full/cinematic-romance.md
@@ -1,0 +1,494 @@
+# Design Style: Cinematic Romance
+
+## 1. Visual Theme & Atmosphere
+
+Cinematic Romance is the design language of a streaming-platform teaser poster -- the visual equivalent of a Netflix limited-series key art or a Vogue title card caught in the opening seconds of a perfume commercial. Inspired by Borcelle-style cinematic brand films, this style treats the photograph as the entire design surface: a full-bleed, cool-graded portrait fills the canvas edge to edge, blurred just enough to feel atmospheric, and type floats directly on top of it. There is no card, no frame, no chrome, no container. The photo IS the design. A heavy-slant hot pink script headline swoops across the middle of the composition with long confident descenders, framed above by a tight uppercase sans-serif "PRESENTS" line and below by an uppercase sans-serif logline set in the same hot pink.
+
+The color grade is the signature move. Every photograph passes through a cool cyan-teal tint (`#3a5f6b` to `#5a8591`) that desaturates skin, flattens highlights, and unifies otherwise clashing inputs into a single cinematic palette. This teal background creates the perfect foil for the hot pink (`#E8449A`) display type -- the complementary tension between cool teal and hot pink is what makes this style feel like a romance-genre title card rather than generic editorial. The pink is never muted: it is hot, saturated, fully lit, with enough magenta to push through the blur and dominate the composition. The script typeface is the most recognisable element -- a heavy, steeply-slanted chancery display face (Allura, standing in for Monotype Corsiva / Allura Pro) with tight letter connections, pronounced ball terminals, and exaggerated descenders on letters like `g`, `y`, and `L`.
+
+The supporting type is tiny, uppercase, letter-spaced, and always hot pink. It serves as the "studio presents" line above the script and the logline below it -- both framing the script like cinematic credits. A minimal UI chrome element (a small square pause button in the bottom-left corner, and optionally a small triangle play indicator at bottom-center) sells the "this is a movie poster" fiction without becoming a real control. Real-world analogies: a Netflix originals key art card, a 1970s Harlequin romance paperback cover reimagined for streaming, the opening title of a Sofia Coppola film, the teaser poster for a Luca Guadagnino romance.
+
+**Key Characteristics:**
+- Full-bleed cool-graded portrait photograph as the entire canvas -- no borders, no frames, no cards
+- Cool cyan-teal color grade (`#3a5f6b` background tone) unifies all photography
+- Hot pink (`#E8449A`) as the only type color -- script headline, uppercase top line, and uppercase logline
+- Heavy-slant script display face (Allura) for the central headline, 180-240px on 1080 canvas
+- Uppercase tracked sans-serif (Inter) for the "STUDIO PRESENTS" line at ~14px, letter-spacing 3-4px
+- Uppercase centered sans-serif logline in the same hot pink, 16-20px, line-height 1.45
+- Type centered horizontally and vertically stacked: top line, huge script, logline
+- Blurred atmospheric photography (8-16px Gaussian blur) -- never sharp, always soft
+- Minimal cinematic UI chrome: 40x40px dark pause square bottom-left, optional triangle play bottom-center
+- No cards, no borders, no shadows on containers -- depth comes entirely from the photograph
+- Content-only slides (no photo available) fall back to a dark-teal-to-hot-pink radial/linear gradient
+- Zero use of white backgrounds -- the style breaks the moment a white surface appears
+- Text shadow on script headline: subtle `0 2px 20px rgba(0,0,0,0.35)` for legibility over photo
+- Body-copy slides use hot pink on deep teal, never white on white
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Teal Graded** (`#3a5f6b`): Primary canvas tone. The cool cyan-teal that every photo is graded toward and that content-only slides fall back to. Reads as cinematic, slightly desaturated, atmospheric.
+- **Hot Pink** (`#E8449A`): Primary and only type color. Used for every headline, every logline, every uppercase line. Vivid, saturated, lit. This is the signature hue of the style.
+- **Off-White Dim** (`#f2e6ec`): Softened near-white for rare cases where pink-on-teal contrast fails. Always tinted warm pink, never pure white.
+
+### Accent
+- **Pink Deep** (`#C1297A`): Hover/active state for pink interactive elements and the second stop in the dark-to-pink gradient fallback.
+- **Pink Hot** (`#FF5FAE`): Brighter pink used for the "now playing" indicator dot, hover glow, and any ultra-highlighted word inside the script headline.
+- **Teal Deep** (`#1f3942`): The darker end of the teal gradient, used for vignette corners and content slides that need a dark base.
+
+### Neutral Scale
+- **Ink** (`#0d1a1f`): Near-black with a teal undertone. Used for the pause-button chrome and any dark UI element. Never pure black.
+- **Graded Skin** (`#b88e87`): The color family that skin tones collapse to under the teal grade -- warm peach muted by cool wash. Useful when generating synthetic photo placeholders.
+- **Teal Mid** (`#4b7583`): The midtones of the canvas blur -- useful for photo-less content slide backgrounds.
+- **Teal Highlight** (`#78a2ad`): The blown highlights of the graded photo -- rim light, edge of cheek, hair backlight.
+- **Caption Pink Dim** (`rgba(232,68,154,0.72)`): Slightly muted hot pink for secondary captions and metadata.
+
+### Surface & Borders
+- **Surface Canvas** (`linear-gradient(180deg, #1f3942 0%, #3a5f6b 40%, #4b7583 100%)`): The content-only slide background when no photo is available.
+- **Surface Romantic** (`radial-gradient(ellipse at 50% 60%, #E8449A 0%, #C1297A 35%, #1f3942 100%)`): Alternate fallback for CTA slides -- dark teal corners bleeding into a hot pink center.
+- **Surface Inset** (`rgba(13,26,31,0.35)`): Subtle dark scrim laid over photos to boost type legibility, never more than 35% opacity.
+- **Border None**: This style has effectively no borders. Containers are invisible.
+- **Divider Rule** (`rgba(232,68,154,0.35)`): Thin hot-pink line used once per slide at most -- under a logline or between the script and a caption.
+
+### Shadow Colors
+- **Type Glow Pink** (`0 0 32px rgba(232,68,154,0.25)`): Soft pink glow around the script headline to make it feel lit.
+- **Type Shadow Dark** (`0 2px 20px rgba(13,26,31,0.45)`): Drop shadow under the script for legibility on lighter photo areas.
+- **Vignette** (`radial-gradient(ellipse at center, transparent 40%, rgba(13,26,31,0.6) 100%)`): Dark vignette applied on top of every photo to pull focus toward the center.
+- **Caption Halo** (`0 1px 10px rgba(13,26,31,0.55)`): Faint shadow behind uppercase caption text.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Allura&family=Inter:wght@400;500;600;700&family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+```
+
+- **Display Script**: `'Allura', 'Great Vibes', 'Monotype Corsiva', 'Apple Chancery', cursive`
+- **Body / UI**: `'Inter', 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Script | Allura | 220px | 400 | 0.90 | 0px | The huge pink script headline. Only weight Allura has. |
+| Presents Line | Inter | 14px | 600 | 1.00 | 3.5px | "BORCELLE STUDIO PRESENTS" above the script. Uppercase. |
+| Logline | Inter | 18px | 600 | 1.45 | 1.2px | Uppercase centered copy below the script. Max 3 lines. |
+| Episode Label | Inter | 12px | 700 | 1.00 | 4px | "EPISODE ONE" / "CHAPTER 01" metadata. Uppercase. |
+| Body Large | Inter | 22px | 500 | 1.55 | 0.3px | Long-form reading copy on content slides. Hot pink on teal. |
+| Body | Inter | 18px | 500 | 1.60 | 0.2px | Standard body on content slides. |
+| Caption | Inter | 13px | 500 | 1.40 | 1px | Photo credits, scene metadata, timestamps. Uppercase. |
+| Big Number | Allura | 180px | 400 | 0.90 | 0px | Script-set numerals for stat displays. Pink. |
+| Stat Label | Inter | 13px | 600 | 1.00 | 3px | Uppercase label below a big script number. |
+| UI Element | Inter | 11px | 600 | 1.00 | 2px | Pause button label, scene index, "NOW PLAYING". |
+
+### Principles
+- **Script as the sole voice of authority**: Only the headline is script. Everything else is uppercase sans. The contrast between heavy-slant cursive and geometric uppercase is the style's core typographic tension. Never set body copy in script -- it becomes illegible instantly.
+- **Hot pink is non-negotiable**: Every piece of type, regardless of hierarchy, is `#E8449A`. This is not a style where color communicates hierarchy -- size, case, and weight do. Color is identity.
+- **Uppercase everywhere except the script**: Supporting type is always uppercase with 1-4px letter-spacing. Mixed case appears only inside the script headline.
+- **Tracking scales inversely with size**: Tiny caption text (12px) gets 3-4px of spacing; 18px logline copy gets 1.2px; the script headline has 0px tracking because Allura's connected letterforms cannot be stretched.
+- **Line height is tight**: Script runs at 0.90 (letters almost touching descender to ascender). Loglines run at 1.45. This echoes poster typesetting -- dense, not airy.
+- **Type lives on the photo**: There is no type-against-solid-surface treatment in the cover slide. The type sits directly on the image with a subtle drop shadow for legibility.
+- **One script per slide**: Never more than one script-set phrase. Multiple script headlines compete and break the poster fiction.
+
+## 4. Component Patterns
+
+### Title Block (Cover / Hero Over Photo)
+
+```html
+<div style="position: relative; width: 100%; min-height: 608px; background: linear-gradient(180deg, #1f3942 0%, #3a5f6b 55%, #4b7583 100%); overflow: hidden; text-align: center;">
+  <!-- Photo layer (replace with actual image when available) -->
+  <div style="position: absolute; inset: 0; background-image: url('photo.jpg'); background-size: cover; background-position: center; filter: blur(12px) saturate(0.85) hue-rotate(-10deg) brightness(0.85);"></div>
+  <!-- Teal grade overlay -->
+  <div style="position: absolute; inset: 0; background: linear-gradient(180deg, rgba(31,57,66,0.55) 0%, rgba(58,95,107,0.35) 50%, rgba(31,57,66,0.65) 100%); mix-blend-mode: multiply;"></div>
+  <!-- Vignette -->
+  <div style="position: absolute; inset: 0; background: radial-gradient(ellipse at center, transparent 40%, rgba(13,26,31,0.55) 100%);"></div>
+  <!-- Content -->
+  <div style="position: relative; z-index: 2; padding: 72px 60px 120px; display: flex; flex-direction: column; justify-content: center; min-height: 608px;">
+    <p style="font-family: var(--font-body); font-size: 14px; font-weight: 600; letter-spacing: 3.5px; text-transform: uppercase; color: var(--color-pink); margin: 0 0 32px; text-shadow: 0 1px 10px rgba(13,26,31,0.55);">Borcelle Studio Presents</p>
+    <h1 style="font-family: var(--font-display); font-size: 220px; font-weight: 400; line-height: 0.90; color: var(--color-pink); margin: 0 0 40px; text-shadow: 0 2px 20px rgba(13,26,31,0.45), 0 0 32px rgba(232,68,154,0.25);">Love Language</h1>
+    <p style="font-family: var(--font-body); font-size: 18px; font-weight: 600; letter-spacing: 1.2px; line-height: 1.45; text-transform: uppercase; color: var(--color-pink); max-width: 720px; margin: 0 auto; text-shadow: 0 1px 10px rgba(13,26,31,0.55);">Love Language explores the unspoken connections that bind people, revealing how love transcends words through shared glances, gestures, and moments of understanding.</p>
+  </div>
+  <!-- Pause chrome -->
+  <div style="position: absolute; bottom: 28px; left: 28px; z-index: 3; width: 40px; height: 40px; background: rgba(13,26,31,0.85); display: flex; align-items: center; justify-content: center; border-radius: 2px;">
+    <div style="display: flex; gap: 4px;"><span style="width: 4px; height: 14px; background: #f2e6ec;"></span><span style="width: 4px; height: 14px; background: #f2e6ec;"></span></div>
+  </div>
+</div>
+```
+
+### Numbered Item (Chapter Card Over Gradient)
+
+```html
+<div style="position: relative; padding: 64px 60px; background: linear-gradient(135deg, #1f3942 0%, #3a5f6b 60%, #4b7583 100%); overflow: hidden; text-align: center;">
+  <div style="position: absolute; inset: 0; background: radial-gradient(ellipse at 50% 70%, rgba(232,68,154,0.18) 0%, transparent 60%);"></div>
+  <div style="position: relative; z-index: 1;">
+    <p style="font-family: var(--font-body); font-size: 12px; font-weight: 700; letter-spacing: 4px; text-transform: uppercase; color: var(--color-pink); margin: 0 0 24px;">Chapter One</p>
+    <h2 style="font-family: var(--font-display); font-size: 140px; font-weight: 400; line-height: 0.90; color: var(--color-pink); margin: 0 0 28px; text-shadow: 0 2px 20px rgba(13,26,31,0.45);">First Glance</h2>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 600; letter-spacing: 1.2px; line-height: 1.50; text-transform: uppercase; color: var(--color-pink); max-width: 560px; margin: 0 auto;">The moment across a crowded room when the world softens and everything else falls away.</p>
+  </div>
+</div>
+```
+
+### Stat Display (Script Numeral)
+
+```html
+<div style="position: relative; padding: 80px 40px; background: linear-gradient(180deg, #1f3942 0%, #3a5f6b 100%); text-align: center; overflow: hidden;">
+  <div style="position: absolute; inset: 0; background: radial-gradient(ellipse at center, rgba(232,68,154,0.15) 0%, transparent 55%);"></div>
+  <div style="position: relative; z-index: 1;">
+    <p style="font-family: var(--font-display); font-size: 180px; font-weight: 400; line-height: 0.90; color: var(--color-pink); margin: 0 0 12px; text-shadow: 0 2px 24px rgba(13,26,31,0.5);">92%</p>
+    <p style="font-family: var(--font-body); font-size: 13px; font-weight: 600; letter-spacing: 3px; text-transform: uppercase; color: var(--color-pink); margin: 0;">Of Viewers Finished The Series</p>
+  </div>
+</div>
+```
+
+### Comparison Grid (Two Photo Halves)
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0; min-height: 540px;">
+  <div style="position: relative; background: linear-gradient(180deg, #1f3942 0%, #3a5f6b 100%); overflow: hidden; display: flex; align-items: center; justify-content: center;">
+    <div style="position: absolute; inset: 0; background: radial-gradient(ellipse at center, rgba(232,68,154,0.12) 0%, transparent 60%);"></div>
+    <div style="position: relative; z-index: 1; text-align: center; padding: 40px;">
+      <p style="font-family: var(--font-body); font-size: 12px; font-weight: 700; letter-spacing: 4px; text-transform: uppercase; color: var(--color-pink); margin: 0 0 20px;">Act I</p>
+      <h3 style="font-family: var(--font-display); font-size: 96px; font-weight: 400; line-height: 0.90; color: var(--color-pink); margin: 0 0 20px;">The Meeting</h3>
+      <p style="font-family: var(--font-body); font-size: 14px; font-weight: 600; letter-spacing: 1px; text-transform: uppercase; color: var(--color-pink); max-width: 320px; margin: 0 auto;">A chance encounter at the last train of the night.</p>
+    </div>
+  </div>
+  <div style="position: relative; background: linear-gradient(180deg, #3a5f6b 0%, #1f3942 100%); overflow: hidden; display: flex; align-items: center; justify-content: center;">
+    <div style="position: absolute; inset: 0; background: radial-gradient(ellipse at center, rgba(232,68,154,0.12) 0%, transparent 60%);"></div>
+    <div style="position: relative; z-index: 1; text-align: center; padding: 40px;">
+      <p style="font-family: var(--font-body); font-size: 12px; font-weight: 700; letter-spacing: 4px; text-transform: uppercase; color: var(--color-pink); margin: 0 0 20px;">Act II</p>
+      <h3 style="font-family: var(--font-display); font-size: 96px; font-weight: 400; line-height: 0.90; color: var(--color-pink); margin: 0 0 20px;">The Letter</h3>
+      <p style="font-family: var(--font-body); font-size: 14px; font-weight: 600; letter-spacing: 1px; text-transform: uppercase; color: var(--color-pink); max-width: 320px; margin: 0 auto;">Words she could never say in person.</p>
+    </div>
+  </div>
+</div>
+```
+
+### List Item (Scene Index)
+
+```html
+<div style="display: flex; align-items: baseline; gap: 32px; padding: 24px 0; border-bottom: 1px solid rgba(232,68,154,0.25);">
+  <span style="font-family: var(--font-body); font-size: 13px; font-weight: 700; letter-spacing: 2px; text-transform: uppercase; color: var(--color-pink); min-width: 64px;">S01 &middot; E03</span>
+  <div style="flex: 1;">
+    <h4 style="font-family: var(--font-display); font-size: 56px; font-weight: 400; line-height: 0.95; color: var(--color-pink); margin: 0 0 8px;">In the Rain</h4>
+    <p style="font-family: var(--font-body); font-size: 13px; font-weight: 500; letter-spacing: 1.5px; text-transform: uppercase; color: rgba(232,68,154,0.72); margin: 0;">Directed by S. Coppola &middot; 42 Minutes</p>
+  </div>
+</div>
+```
+
+### Quote Block (Floating Script Pull-Quote)
+
+```html
+<div style="position: relative; padding: 100px 80px; background: linear-gradient(180deg, #1f3942 0%, #3a5f6b 50%, #1f3942 100%); text-align: center; overflow: hidden;">
+  <div style="position: absolute; inset: 0; background: radial-gradient(ellipse at center, rgba(232,68,154,0.18) 0%, transparent 65%);"></div>
+  <div style="position: relative; z-index: 1;">
+    <p style="font-family: var(--font-body); font-size: 12px; font-weight: 700; letter-spacing: 4px; text-transform: uppercase; color: var(--color-pink); margin: 0 0 36px;">A Critic Wrote</p>
+    <p style="font-family: var(--font-display); font-size: 96px; font-weight: 400; line-height: 0.95; color: var(--color-pink); margin: 0 0 36px; text-shadow: 0 2px 20px rgba(13,26,31,0.5);">"Breathtaking."</p>
+    <div style="display: inline-block; width: 48px; height: 2px; background: var(--color-pink); margin: 0 0 20px;"></div>
+    <p style="font-family: var(--font-body); font-size: 13px; font-weight: 600; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-pink); margin: 0;">The New Yorker</p>
+  </div>
+</div>
+```
+
+### CTA Block (Teaser Finale)
+
+```html
+<div style="position: relative; padding: 100px 60px; background: radial-gradient(ellipse at 50% 60%, #E8449A 0%, #C1297A 30%, #1f3942 100%); text-align: center; overflow: hidden;">
+  <div style="position: absolute; inset: 0; background: radial-gradient(ellipse at center, transparent 40%, rgba(13,26,31,0.45) 100%);"></div>
+  <div style="position: relative; z-index: 1;">
+    <p style="font-family: var(--font-body); font-size: 14px; font-weight: 600; letter-spacing: 3.5px; text-transform: uppercase; color: #f2e6ec; margin: 0 0 32px; text-shadow: 0 1px 10px rgba(13,26,31,0.55);">Streaming April 14</p>
+    <h2 style="font-family: var(--font-display); font-size: 180px; font-weight: 400; line-height: 0.90; color: #f2e6ec; margin: 0 0 40px; text-shadow: 0 2px 24px rgba(13,26,31,0.55);">Watch Now</h2>
+    <a style="display: inline-block; font-family: var(--font-body); font-size: 14px; font-weight: 700; letter-spacing: 3px; text-transform: uppercase; color: #1f3942; background: #f2e6ec; padding: 20px 56px; text-decoration: none; border-radius: 2px;">Play Trailer</a>
+  </div>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between the two vertical bars of the pause-button glyph.
+- **8px**: Tight gap -- between stat numeral and its label.
+- **12px**: Small gap -- between logline line breaks if a hard break is used.
+- **20px**: Base gap -- between episode label and chapter title.
+- **32px**: Medium gap -- between "STUDIO PRESENTS" line and the script headline.
+- **40px**: Primary gap -- between script headline and logline below it.
+- **60px**: Section padding -- left/right canvas margin on cover slides.
+- **80px**: Large padding -- top padding on CTA and cover slides.
+- **120px**: Extra-large padding -- top/bottom padding for Story format.
+- **160px**: Story safe zone -- keep all type at least 160px from top/bottom edges on 1080x1920 canvases.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px left/right, 80px top/bottom | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 100px top/bottom | 960px |
+| **Story (1080x1920)** | **60px left/right, 120px top/bottom** | **960px** (160px top/bottom safe zones) |
+
+### Alignment & Grid
+- **Primary alignment**: Centered for everything. This is a poster style -- content is axial, vertically stacked, and horizontally centered.
+- **Vertical stack**: Every slide follows the pattern `[uppercase label] -> [script headline] -> [uppercase logline]`. Optional fourth line: thin pink divider + secondary caption.
+- **Grid**: Single-column dominates. Two-column grids appear only for comparison/act-break slides, and both halves must share the same teal grade so they read as one image.
+- **Content gravity**: Title and cover slides center vertically within the canvas. Content slides may anchor the script headline at ~55% canvas height (golden ratio low) to leave room for a logline beneath.
+- **Photo treatment**: Full-bleed, blurred 8-16px, saturation 0.85, teal multiply overlay at 35-55%, dark vignette at corners. Every photo passes through this pipeline.
+- **Chrome**: 40x40px dark pause square sits at `bottom: 28px; left: 28px;` on cover slides. Optional small triangle play indicator at `bottom: 28px; left: 50%;` translateX(-50%). No other UI chrome exists.
+- **No cards**: Containers are invisible. If a content region needs separation, it gets its own gradient canvas -- not a card.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | Teal gradient canvas, no overlay | Base content slides with no photo |
+| Graded (Level 1) | Photo + teal multiply overlay at 40% + dark vignette | Standard cover slides with background photography |
+| Lit (Level 2) | Level 1 + radial pink glow `rgba(232,68,154,0.15)` at 50% 60% | Feature slides where the script headline is the focal point |
+| Cinematic (Level 3) | Level 2 + `text-shadow: 0 2px 20px rgba(13,26,31,0.45), 0 0 32px rgba(232,68,154,0.25)` on headline | Hero cover slides |
+| Chrome (Level 4) | Pause button `rgba(13,26,31,0.85)` 40x40 square at bottom-left | UI chrome layer that sits above everything |
+
+### Border Treatments
+- **No standard borders**: This style does not use borders on containers. Depth comes from photography, gradient, and vignette -- never from rectangles with outlines.
+- **Thin pink rule** (`1px solid rgba(232,68,154,0.35)` or `2px solid #E8449A`): Used exactly once per slide, either under a logline or as a 48x2px horizontal accent between quote body and attribution.
+- **Divider accent** (`width: 48px; height: 2px; background: #E8449A;`): Short centered horizontal rule. Appears in quote blocks and CTA blocks as a separator.
+- **Chrome corners** (`border-radius: 2px` on pause button): The only rounded corners in the style. Almost-square, just softened enough to feel like UI rather than a hard block.
+
+### Surface Hierarchy
+On a photo canvas, depth is communicated by optical weight, not shadows:
+1. **Photograph layer** (bottom) -- blurred, graded, vignetted. Provides atmosphere.
+2. **Teal multiply overlay** (`rgba(31,57,66,0.35-0.55)`) -- unifies the photo with the palette.
+3. **Vignette layer** (dark radial) -- pulls the eye toward center.
+4. **Pink radial glow** (subtle `rgba(232,68,154,0.15)`) -- optional, adds the lit-from-within romance feeling.
+5. **Type layer** -- the script headline, loglines, and labels in hot pink sit above everything.
+6. **Chrome layer** -- the pause square sits above type, darker than type, in the corner only.
+
+## 7. Do's and Don'ts
+
+### Do
+- Do use a full-bleed, blurred, teal-graded photograph as the cover canvas whenever a photo is available.
+- Do set every piece of type in hot pink (`#E8449A`) -- every label, every headline, every logline, no exceptions.
+- Do use Allura (or the closest available chancery script) for the central headline, sized 180-240px on a 1080 canvas with line-height 0.90.
+- Do wrap the script headline with an uppercase 12-14px "STUDIO PRESENTS" label above and an uppercase 16-20px logline below.
+- Do apply a subtle text shadow `0 2px 20px rgba(13,26,31,0.45)` on the script headline for legibility over photos.
+- Do apply the teal multiply overlay at 35-55% opacity to every background photo -- this is the grade that makes everything feel cinematic.
+- Do add the small 40x40px dark pause square `rgba(13,26,31,0.85)` at `bottom: 28px; left: 28px;` on cover slides to sell the poster fiction.
+- Do fall back to a `linear-gradient(180deg, #1f3942 0%, #3a5f6b 55%, #4b7583 100%)` canvas when no photo is available.
+- Do use 3-4px letter-spacing on uppercase labels -- the tight geometric tracking is part of the signature.
+- Do use `text-transform: uppercase` on every supporting type element.
+- Do keep cover slides axial and centered -- script headline dead-centre, label and logline stacked above and below.
+- Do use `filter: blur(12px) saturate(0.85)` on the photo layer to achieve the atmospheric look.
+
+### Don't
+- Don't use white backgrounds. A white surface breaks the cinematic fiction instantly. Fallback is always dark teal to pink gradient.
+- Don't use any color other than hot pink for type. No black text, no white text, no teal text. Pink only. (Exception: the CTA block button can invert to `#f2e6ec` on pink.)
+- Don't use sharp, unblurred photography. Photos must always be softened 8-16px. The style is atmospheric, not editorial-sharp.
+- Don't set body copy in the script typeface. Allura is headline-only. Body copy is always Inter uppercase.
+- Don't use mixed case on supporting type. Loglines, labels, captions, and metadata are always uppercase.
+- Don't use cards, borders, or frames around content. Type floats on the photo. If you need structural separation, use a new gradient canvas, not a container.
+- Don't use drop shadows on cards (there are no cards). The only shadow in the style is the subtle pink/dark shadow on the script headline.
+- Don't use more than one script-set phrase per slide. Multiple scripts compete and collapse the hierarchy.
+- Don't use green, blue, orange, or any non-pink accent. The palette is teal + hot pink. Anything else breaks the identity.
+- Don't use serif body fonts. Supporting type is geometric sans only (Inter).
+- Don't use tight letter-spacing on uppercase labels. Minimum 2px, ideal 3-4px.
+- Don't set the script headline below 140px on a 1080 canvas -- it needs to dominate. Sub-140px script reads as afterthought.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale**: Display Script becomes 180px (from 220px baseline). Presents Line stays 14px. Logline stays 18px. Episode Label 12px.
+- **Padding**: 60px left/right, 80px top/bottom. Content area is 960x920px.
+- **Cover slide**: Full-bleed teal-graded photo. "STUDIO PRESENTS" label centered at ~25% canvas height. Script headline centered at ~50%. Logline centered at ~72%. Pause chrome at bottom-left.
+- **Content slides**: If no photo, use dark-teal-to-pink gradient fallback. Single script headline per slide, max 2 lines. Logline underneath. Optional episode label above.
+- **Comparison slides**: Split into two vertical halves (540x1080 each), each a self-contained graded canvas with its own script headline and caption.
+- **Swipe indicator**: Small hot-pink dots at `bottom: 12px` center, 6px diameter, `rgba(232,68,154,0.4)` inactive and `#E8449A` active.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Full-scale hierarchy. Display Script at 220px for the title section. Scene-index list items use 56px Allura.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Section spacing**: 120px vertical gap between major sections (larger than other styles -- the cinematic pacing demands breathing room).
+- **Vertical rhythm**: Alternate between full-bleed photo sections and gradient-only sections. Never two full-bleed photo sections in a row -- introduce a gradient interlude between them.
+- **Footer**: Small "END OF FEATURE" label in uppercase hot pink + small pink divider rule. No logo lockup.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Script becomes 280px. Presents Line becomes 16px. Logline becomes 22px.
+- **Padding**: 80px all sides. Content area is 1760x920px.
+- **Layout**: Axial, centered. The script headline sits dead-center vertically with 120-160px clearance above and below for the label and logline.
+- **Title slides**: Full-bleed graded photo. Vertical stack center-aligned: label (top), script (middle), logline (bottom). Pause chrome at `bottom: 40px; left: 40px;`.
+- **Content slides**: Either full-bleed photo or gradient canvas. Script headline at center, logline beneath. Optional thin pink rule and attribution beneath logline.
+- **CTA slides**: Dark-teal-to-hot-pink radial gradient. "STREAMING APRIL 14" label at top. Script "Watch Now" at center. Light CTA button at bottom.
+
+### Poster (1080x1350px)
+- **Typography**: Display Script at 240px. Presents Line at 14px. Logline at 18px.
+- **Padding**: 60px left/right, 100px top/bottom.
+- **Composition**: Full-bleed blurred photo across the entire 1080x1350 canvas. Vertical content stack: "STUDIO PRESENTS" at 22% height, script headline at 48% height, logline at 72% height, episode/metadata label at 88% height.
+- **Vertical flow**: Poster is the purest expression of the style -- one photo, one script, one logline. No sectioning.
+- **CTA placement**: Small rectangular button (no border-radius or 2px) at bottom-center, 160px above the canvas edge, labeled "PLAY TRAILER" or "STREAM NOW" in uppercase.
+
+### Story (1080x1920px)
+- **Typography**: Display Script becomes 280-320px (30% larger than carousel to fill the vertical canvas). Presents Line becomes 16px. Logline becomes 20px.
+- **Padding**: 60px left/right, 120px top/bottom. Safe zones of 160px top and bottom to avoid Instagram/TikTok UI chrome overlay.
+- **Composition**: Full-bleed 9:16 blurred graded photo. The portrait orientation finally gives the photograph room to breathe -- face fills the canvas from top to ~70%, type stack occupies the lower-middle third. Label at ~45% height, script headline at ~58% height, logline at ~75% height.
+- **Max slides**: 10 per story (Instagram's cap). Each slide is a complete poster moment -- not a fragment of a carousel.
+- **Interaction cues**: Optional small "SWIPE UP" or "HOLD TO PAUSE" uppercase label at `bottom: 180px` center in `rgba(232,68,154,0.72)`. Pause chrome sits at `bottom: 180px; left: 60px;` to stay inside the safe zone.
+- **Content-only slides**: Dark-teal-to-hot-pink radial gradient fallback. Same vertical stack pattern as photo slides.
+- **Episode sequencing**: Use 12px "EPISODE 01" labels at the top safe zone (180px from top) to indicate position in a multi-slide story arc.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Teal Graded | `#3a5f6b` | Primary canvas tone, photo grade target |
+| Hot Pink | `#E8449A` | All type, every single element |
+| Pink Deep | `#C1297A` | Hover/active state, gradient stop |
+| Pink Hot | `#FF5FAE` | Highlighted accents, glow |
+| Teal Deep | `#1f3942` | Gradient corners, dark canvas base |
+| Teal Mid | `#4b7583` | Mid-tone content slide bg |
+| Teal Highlight | `#78a2ad` | Rim light, highlight family |
+| Off-White Dim | `#f2e6ec` | Warm-tinted light for CTA inversions |
+| Ink | `#0d1a1f` | Pause chrome, UI darks |
+| Graded Skin | `#b88e87` | Skin-tone family under grade |
+| Caption Pink Dim | `rgba(232,68,154,0.72)` | Secondary captions, metadata |
+
+### Font Declarations
+
+```css
+/* Display Script (headlines only) */
+font-family: 'Allura', 'Great Vibes', 'Monotype Corsiva', 'Apple Chancery', cursive;
+
+/* Body / UI (everything else) */
+font-family: 'Inter', 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Allura&family=Inter:wght@400;500;600;700&family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-teal: #3a5f6b;
+  --color-pink: #E8449A;
+  --color-off-white: #f2e6ec;
+
+  /* Colors -- Accent */
+  --color-pink-deep: #C1297A;
+  --color-pink-hot: #FF5FAE;
+  --color-teal-deep: #1f3942;
+
+  /* Colors -- Neutral Scale */
+  --color-ink: #0d1a1f;
+  --color-skin-graded: #b88e87;
+  --color-teal-mid: #4b7583;
+  --color-teal-highlight: #78a2ad;
+  --color-caption-pink: rgba(232, 68, 154, 0.72);
+
+  /* Colors -- Surfaces */
+  --surface-canvas: linear-gradient(180deg, #1f3942 0%, #3a5f6b 55%, #4b7583 100%);
+  --surface-romantic: radial-gradient(ellipse at 50% 60%, #E8449A 0%, #C1297A 30%, #1f3942 100%);
+  --surface-inset: rgba(13, 26, 31, 0.35);
+  --surface-photo-multiply: rgba(31, 57, 66, 0.45);
+
+  /* Colors -- Borders */
+  --border-none: none;
+  --border-pink-thin: 1px solid rgba(232, 68, 154, 0.35);
+  --border-pink-accent: 2px solid #E8449A;
+
+  /* Colors -- Shadows */
+  --shadow-type-dark: 0 2px 20px rgba(13, 26, 31, 0.45);
+  --shadow-type-glow: 0 0 32px rgba(232, 68, 154, 0.25);
+  --shadow-type-cinematic: 0 2px 20px rgba(13, 26, 31, 0.45), 0 0 32px rgba(232, 68, 154, 0.25);
+  --shadow-caption-halo: 0 1px 10px rgba(13, 26, 31, 0.55);
+  --vignette: radial-gradient(ellipse at center, transparent 40%, rgba(13, 26, 31, 0.6) 100%);
+
+  /* Photo treatment */
+  --photo-filter: blur(12px) saturate(0.85) brightness(0.85);
+  --photo-overlay: linear-gradient(180deg, rgba(31,57,66,0.55) 0%, rgba(58,95,107,0.35) 50%, rgba(31,57,66,0.65) 100%);
+
+  /* Typography -- Families */
+  --font-display: 'Allura', 'Great Vibes', 'Monotype Corsiva', 'Apple Chancery', cursive;
+  --font-body: 'Inter', 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-script: 220px;
+  --text-display-script-slides: 280px;
+  --text-display-script-story: 300px;
+  --text-display-script-carousel: 180px;
+  --text-presents: 14px;
+  --text-logline: 18px;
+  --text-episode-label: 12px;
+  --text-body-large: 22px;
+  --text-body: 18px;
+  --text-caption: 13px;
+  --text-big-number: 180px;
+  --text-stat-label: 13px;
+  --text-ui: 11px;
+
+  /* Typography -- Weights */
+  --weight-display: 400;
+  --weight-label: 600;
+  --weight-label-bold: 700;
+  --weight-body: 500;
+  --weight-body-bold: 600;
+  --weight-ui: 700;
+
+  /* Typography -- Line Heights */
+  --leading-display: 0.90;
+  --leading-label: 1.00;
+  --leading-logline: 1.45;
+  --leading-body: 1.60;
+  --leading-caption: 1.40;
+
+  /* Typography -- Letter Spacing */
+  --tracking-presents: 3.5px;
+  --tracking-episode: 4px;
+  --tracking-logline: 1.2px;
+  --tracking-body: 0.3px;
+  --tracking-caption: 1px;
+  --tracking-ui: 2px;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 20px;
+  --space-medium: 32px;
+  --space-gap: 40px;
+  --space-section: 60px;
+  --space-large: 80px;
+  --space-xl: 120px;
+  --space-safe-zone: 160px;
+
+  /* Borders & Radius */
+  --radius-chrome: 2px;
+  --radius-none: 0px;
+
+  /* Chrome */
+  --chrome-pause-size: 40px;
+  --chrome-pause-bg: rgba(13, 26, 31, 0.85);
+  --chrome-pause-glyph: #f2e6ec;
+}
+```
+
+### System Font Fallbacks
+- **Display Script (if Allura fails to load):** `'Great Vibes', 'Monotype Corsiva', 'Apple Chancery', 'Brush Script MT', cursive`
+- **Body / UI (if Inter fails to load):** `'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Emergency fallback for Allura:** Allura is the only Google Fonts option that captures the heavy-slant chancery + long descender feel of Monotype Corsiva. If Allura fails, `Great Vibes` is the second-best match (slightly lighter weight but same calligraphic family). Never fall back to `Dancing Script` -- it's too casual and breaks the cinematic tone.

--- a/skills/composites/goose-graphics/styles/_full/clean-slate.md
+++ b/skills/composites/goose-graphics/styles/_full/clean-slate.md
@@ -1,0 +1,433 @@
+# Design Style: Clean Slate
+
+## 1. Visual Theme & Atmosphere
+
+Clean Slate is the design language of radical reduction -- the visual equivalent of a perfectly empty desk with one carefully chosen object on it. The pure white canvas (`#ffffff`) is not blank; it is a deliberate assertion that every element must justify its existence. This is the aesthetic of Vercel's dashboard, of Linear's marketing pages, of a Dieter Rams product photographed against infinity white. There is nowhere to hide in this much light. Every pixel of padding, every shade of gray, every typographic decision is exposed and accountable.
+
+The single typeface approach -- Space Grotesk for both display and body -- creates a unified visual voice that reinforces the reductive philosophy. Space Grotesk is a geometric sans-serif with distinctive character: its proportional spacing, open apertures, and subtly squared curves give it personality without ornamentation. At display sizes (48px+), it runs with aggressive negative tracking (-1.5px to -2px), creating dense, architecturally precise headline blocks that feel engineered rather than designed. At body sizes, lighter weights (300-400) open up into clean, highly readable text. The single-family approach means hierarchy is established entirely through size, weight, and spacing -- no serif/sans-serif tension, just pure typographic scale.
+
+Blue (`#0066ff`) is the sole accent colour -- a precise, saturated hue that reads as confident and technical without being cold. It is not a brand blue or a link blue; it is a signal colour, used the way an architect uses a single red line on a blueprint. Against the white field, it vibrates with controlled intensity. The restraint of a single accent means that when blue appears -- as a button fill, an underline, a stat number -- the eye goes there immediately. Light gray (`#f5f5f5`) provides the subtlest possible surface differentiation, creating depth through barely-there value shifts rather than shadows or borders. The signature "shadow-as-border" technique (`box-shadow: 0 0 0 1px rgba(0,0,0,0.08)`) defines containers with a line so fine it feels structural rather than decorative -- like the edge of a sheet of paper, not a drawn border.
+
+**Key Characteristics:**
+- Pure white background (`#ffffff`) as the dominant surface -- whiteness as an active design choice, not a default
+- Near-black (`#171717`) for all primary text -- warm enough to avoid harshness, dark enough for maximum legibility
+- Space Grotesk for all typography -- single family, hierarchy through size and weight only
+- Tight tracking at display sizes (-1.5px to -2px) for dense, engineered headline blocks
+- Blue (`#0066ff`) as the singular accent colour for CTAs, focal numbers, and interactive elements
+- Light gray (`#f5f5f5`) for subtle surface differentiation -- depth through value, not shadow
+- Shadow-as-border technique (`box-shadow: 0 0 0 1px rgba(0,0,0,0.08)`) for container definition
+- Extreme whitespace -- sections breathe with 64-80px gaps, content floats in generous margins
+- No gradients, no rounded corners above 8px, no decorative elements -- every mark is functional
+
+## 2. Color Palette & Roles
+
+### Primary
+- **White** (`#ffffff`): Primary background. Pure, uncompromised white -- the canvas against which everything else is measured.
+- **Near-Black** (`#171717`): Primary text colour. A warm black that avoids the harshness of `#000000` while maintaining commanding contrast.
+- **Blue** (`#0066ff`): Primary accent. Used for CTAs, focal statistics, active states, and any element that demands immediate attention.
+
+### Accent
+- **Light Blue** (`#e6f0ff`): Blue tint for hover backgrounds, tag fills, and subtle emphasis areas.
+- **Dark Blue** (`#0052cc`): Hover/active state for blue interactive elements. Deeper, more saturated.
+- **Warm Gray Text** (`#6b7280`): Secondary text colour for descriptions, captions, and supporting copy.
+
+### Neutral Scale
+- **Snow** (`#f5f5f5`): Elevated surface -- cards, containers, and content panels sitting above the white background.
+- **Light Border** (`#ebebeb`): Visible border for inputs, dividers, and structural lines when shadow-as-border is insufficient.
+- **Mid Gray** (`#d4d4d4`): Disabled states, placeholder text, and inactive elements.
+- **Cool Gray** (`#9ca3af`): Tertiary text for timestamps, metadata, and low-priority labels.
+- **Slate** (`#4b5563`): Secondary headings and medium-emphasis text.
+- **Charcoal** (`#374151`): High-emphasis body text, slightly lighter than primary for visual breathing room.
+
+### Surface & Borders
+- **Surface Primary** (`#f5f5f5`): Card and container background.
+- **Surface Inset** (`#fafafa`): Recessed areas, code blocks, and inset panels.
+- **Border Default** (`rgba(0,0,0,0.08)`): Shadow-as-border for standard containers.
+- **Border Accent** (`rgba(0,102,255,0.3)`): Blue-tinted border for active or featured elements.
+- **Border Strong** (`rgba(0,0,0,0.15)`): Higher-contrast border for prominent containers and inputs.
+- **Divider Rule** (`#0066ff`): Solid blue for accent rules (typically 2px height).
+
+### Shadow Colors
+- **Shadow Subtle** (`rgba(0,0,0,0.04)`): Primary ambient shadow for minimal lift.
+- **Shadow Medium** (`rgba(0,0,0,0.08)`): Standard card elevation.
+- **Shadow Deep** (`rgba(0,0,0,0.12)`): High-elevation elements like dropdowns and modals.
+- **Shadow Border** (`rgba(0,0,0,0.08)`): The signature 0-spread ring shadow used as a border replacement.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Space Grotesk', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Body**: `'Space Grotesk', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Space Grotesk | 72px | 700 | 1.05 | -2px | Hero headlines, single powerful statement |
+| Section Heading | Space Grotesk | 48px | 700 | 1.10 | -1.5px | Major section titles |
+| Sub-heading | Space Grotesk | 32px | 600 | 1.15 | -0.75px | Subsection titles, card headings |
+| Body Large | Space Grotesk | 20px | 300 | 1.65 | 0px | Lead paragraphs, introductions |
+| Body | Space Grotesk | 16px | 400 | 1.65 | 0px | Standard reading text |
+| Small / Caption | Space Grotesk | 13px | 400 | 1.50 | 0.2px | Metadata, attributions, timestamps |
+| Big Numbers | Space Grotesk | 64px | 700 | 1.00 | -1.5px | Statistics, key metrics, hero data |
+| Numbered Label | Space Grotesk | 14px | 500 | 1.00 | 1.5px | Uppercase step labels ("01 -- STRATEGY") |
+| CTA Text | Space Grotesk | 15px | 600 | 1.00 | 0.5px | Button and call-to-action text |
+
+### Principles
+- **One family, total discipline**: Space Grotesk handles everything. Hierarchy is achieved through size, weight, and tracking alone. This constraint is the style's identity.
+- **Aggressive tracking at display sizes**: -2px at 72px, -1.5px at 48px, -0.75px at 32px. Headlines should feel tight, precise, and engineered -- like type on a technical drawing.
+- **Light body weight**: Body text at weight 300-400 creates an airy, open reading experience. The geometric letterforms of Space Grotesk maintain clarity even at light weights.
+- **Tracking opens at small sizes**: Captions and labels use positive tracking (0.2px-1.5px) for legibility. Uppercase labels always use wide tracking.
+- **Generous line height**: 1.65 for body text ensures comfortable reading on bright white backgrounds where dense text becomes tiring.
+- **Uppercase sparingly**: Reserve uppercase + wide tracking for numbered labels and small UI elements. Headlines and body are always mixed case.
+
+## 4. Component Patterns
+
+### Title Block (Cover / Header Section)
+
+```html
+<div style="background-color: var(--color-white); padding: 80px 60px; text-align: center;">
+  <p style="font-family: var(--font-display); font-size: 14px; font-weight: 500; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-blue); margin: 0 0 24px;">THE FUTURE OF WORK</p>
+  <h1 style="font-family: var(--font-display); font-size: 72px; font-weight: 700; line-height: 1.05; letter-spacing: -2px; color: var(--color-near-black); margin: 0 0 24px;">Autonomous Teams,<br>Real Results</h1>
+  <p style="font-family: var(--font-body); font-size: 20px; font-weight: 300; line-height: 1.65; color: var(--color-warm-gray); max-width: 560px; margin: 0 auto;">How AI coworkers are reshaping the way teams operate, collaborate, and deliver results.</p>
+</div>
+```
+
+### Numbered Item
+
+```html
+<div style="display: flex; gap: 24px; align-items: flex-start; padding: 32px 0; border-bottom: 1px solid rgba(0,0,0,0.08);">
+  <span style="font-family: var(--font-display); font-size: 48px; font-weight: 700; line-height: 1.00; letter-spacing: -1.5px; color: var(--color-blue); min-width: 72px;">01</span>
+  <div>
+    <p style="font-family: var(--font-body); font-size: 14px; font-weight: 500; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-cool-gray); margin: 0 0 8px;">SIGNAL-BASED OUTBOUND</p>
+    <h3 style="font-family: var(--font-display); font-size: 32px; font-weight: 600; line-height: 1.15; letter-spacing: -0.75px; color: var(--color-near-black); margin: 0 0 12px;">Find buyers before they find you</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-warm-gray); margin: 0;">Monitor hiring signals, funding events, and tech stack changes to identify high-intent prospects the moment they enter the market.</p>
+  </div>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="text-align: center; padding: 40px 24px; background: var(--color-snow); box-shadow: 0 0 0 1px rgba(0,0,0,0.08); border-radius: 8px;">
+  <p style="font-family: var(--font-display); font-size: 64px; font-weight: 700; line-height: 1.00; letter-spacing: -1.5px; color: var(--color-blue); margin: 0 0 8px;">47%</p>
+  <p style="font-family: var(--font-body); font-size: 14px; font-weight: 500; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-near-black); margin: 0 0 12px;">FASTER RESPONSE</p>
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-warm-gray); max-width: 280px; margin: 0 auto;">Teams using AI coworkers respond to inbound leads nearly twice as fast as manual workflows.</p>
+</div>
+```
+
+### Comparison Grid
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: rgba(0,0,0,0.08); border-radius: 8px; overflow: hidden;">
+  <div style="background: var(--color-white); padding: 40px 32px;">
+    <p style="font-family: var(--font-body); font-size: 13px; font-weight: 400; letter-spacing: 0.2px; color: var(--color-cool-gray); margin: 0 0 16px;">Without Goose</p>
+    <h3 style="font-family: var(--font-display); font-size: 32px; font-weight: 600; line-height: 1.15; letter-spacing: -0.75px; color: var(--color-near-black); margin: 0 0 16px;">Manual & Fragmented</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-warm-gray); margin: 0;">Teams juggle Slack threads, spreadsheets, and context-switching between a dozen tabs to coordinate basic workflows.</p>
+  </div>
+  <div style="background: var(--color-white); padding: 40px 32px; border-left: 2px solid var(--color-blue);">
+    <p style="font-family: var(--font-body); font-size: 13px; font-weight: 400; letter-spacing: 0.2px; color: var(--color-blue); margin: 0 0 16px;">With Goose</p>
+    <h3 style="font-family: var(--font-display); font-size: 32px; font-weight: 600; line-height: 1.15; letter-spacing: -0.75px; color: var(--color-near-black); margin: 0 0 16px;">Orchestrated & Autonomous</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-warm-gray); margin: 0;">AI coworkers handle research, drafting, and follow-up autonomously. Your team focuses on decisions, not busywork.</p>
+  </div>
+</div>
+```
+
+### List Item
+
+```html
+<div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0; border-bottom: 1px solid rgba(0,0,0,0.08);">
+  <div style="width: 40px; height: 40px; min-width: 40px; display: flex; align-items: center; justify-content: center; box-shadow: 0 0 0 1px rgba(0,0,0,0.08); border-radius: 8px; color: var(--color-blue); font-size: 16px;">&#9632;</div>
+  <div>
+    <h4 style="font-family: var(--font-display); font-size: 22px; font-weight: 600; line-height: 1.20; color: var(--color-near-black); margin: 0 0 8px;">Persistent Memory</h4>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-warm-gray); margin: 0;">Every agent maintains its own filesystem, notes, and learned preferences across sessions. Context is never lost.</p>
+  </div>
+</div>
+```
+
+### Quote Block
+
+```html
+<div style="padding: 48px 40px; border-left: 2px solid var(--color-blue); background: var(--color-surface-inset);">
+  <p style="font-family: var(--font-display); font-size: 32px; font-weight: 400; line-height: 1.35; letter-spacing: -0.75px; color: var(--color-near-black); margin: 0 0 24px;">"It felt less like configuring software and more like onboarding a new team member."</p>
+  <div style="display: flex; align-items: center; gap: 12px;">
+    <div style="width: 32px; height: 2px; background: var(--color-blue);"></div>
+    <p style="font-family: var(--font-body); font-size: 14px; font-weight: 500; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-cool-gray); margin: 0;">SARAH CHEN, VP OPERATIONS</p>
+  </div>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="text-align: center; padding: 60px 40px; background: var(--color-snow); box-shadow: 0 0 0 1px rgba(0,0,0,0.08); border-radius: 8px;">
+  <h2 style="font-family: var(--font-display); font-size: 40px; font-weight: 700; line-height: 1.10; letter-spacing: -1px; color: var(--color-near-black); margin: 0 0 16px;">Ready to meet your team?</h2>
+  <p style="font-family: var(--font-body); font-size: 18px; font-weight: 300; line-height: 1.65; color: var(--color-warm-gray); max-width: 480px; margin: 0 auto 32px;">Deploy your first AI coworker in under five minutes. No setup fees, no long-term commitments.</p>
+  <a style="display: inline-block; background: var(--color-blue); color: var(--color-white); font-family: var(--font-body); font-size: 15px; font-weight: 600; letter-spacing: 0.5px; text-decoration: none; padding: 14px 36px; border-radius: 6px;">Get Started</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between icon and inline label.
+- **8px**: Tight gap -- between sub-label and heading, between stat number and label.
+- **12px**: Small gap -- between heading and body text within a component.
+- **16px**: Base gap -- between body paragraphs, between list items in compact mode.
+- **24px**: Medium gap -- between components within a section, standard list item padding.
+- **32px**: Section internal -- padding inside cards and containers, gap between grouped items.
+- **48px**: Section divider -- vertical space between major content blocks.
+- **64px**: Large section padding -- top/bottom padding for hero and CTA blocks.
+- **80px**: Maximum section padding -- cover slides and high-impact hero areas.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 960px |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned text for body content. Center-aligned for hero titles, stats, and CTA blocks.
+- **Grid**: Use a simple 2-column grid for comparison layouts. Single-column for narrative and list content. 3-column for stat grids on widescreen slides.
+- **Accent rules**: 2px tall, blue (`#0066ff`), used sparingly as underlines beneath hero text or as section openers -- never centered decorative rules. This style prefers structural whitespace over decorative dividers.
+- **Vertical rhythm**: Maintain consistent 48px gaps between top-level sections. Use 24px gaps between items within a section.
+- **Content gravity**: On widescreen slides (1920x1080), anchor content to the left two-thirds of the frame. Leave the right third as breathing room or for supporting imagery.
+- **Gallery-like whitespace**: Treat the white background as active design space. Generous margins (60-80px) ensure content floats freely rather than filling the frame.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, background `#ffffff` | Page canvas, base layer |
+| Ring (Level 1) | `0 0 0 1px rgba(0,0,0,0.08)` | Standard container definition -- the signature shadow-as-border |
+| Subtle (Level 2) | `0 1px 3px rgba(0,0,0,0.04), 0 0 0 1px rgba(0,0,0,0.08)` | Cards and content panels with barely-there lift |
+| Elevated (Level 3) | `0 4px 16px rgba(0,0,0,0.08), 0 0 0 1px rgba(0,0,0,0.08)` | Featured cards, dropdowns, hover states |
+| Overlay (Level 4) | `0 12px 40px rgba(0,0,0,0.12)` | Modals, overlays, high-priority popups |
+
+### Border Treatments
+- **Shadow-as-border**: `box-shadow: 0 0 0 1px rgba(0,0,0,0.08)` -- the primary method for defining containers. Produces a hairline border effect that is softer and more refined than a CSS border.
+- **Structural border**: `1px solid rgba(0,0,0,0.08)` -- fallback for contexts where box-shadow is unavailable (table cells, grid gaps).
+- **Accent border**: `2px solid #0066ff` -- blue accent for active states, featured panels, and the left border on quote blocks.
+- **Divider line**: `1px solid rgba(0,0,0,0.06)` -- nearly invisible separator for dense list content.
+
+### Surface Hierarchy
+On white backgrounds, elevation is communicated through minimal shadow rather than colour shifts:
+1. **Background** (`#ffffff`) -- the purest layer, the canvas.
+2. **Surface** (`#f5f5f5`) -- cards and containers step up with the subtlest possible gray.
+3. **Inset** (`#fafafa`) -- recessed areas sit between background and surface.
+4. **Elevated** (`#ffffff` with Level 2-3 shadow) -- the highest non-overlay surface uses white with shadow to separate from the white canvas.
+
+The shadow-as-border ring (`rgba(0,0,0,0.08)`) is the primary depth mechanism. Real drop shadows are reserved for interactive states (hover) and high-elevation overlays. Most of the time, a single-pixel ring shadow is all a container needs.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use the shadow-as-border technique (`box-shadow: 0 0 0 1px rgba(0,0,0,0.08)`) as the primary container definition method -- it is the signature of this style.
+- Use blue (`#0066ff`) exclusively as the accent colour -- it is the only chromatic element in the entire system.
+- Keep Space Grotesk at tight tracking (-1.5px to -2px) for display sizes -- loose headlines break the engineered precision.
+- Maintain extreme whitespace between sections (48-80px) -- this style breathes through emptiness.
+- Use weight contrast within the single typeface: 700 for display, 300-400 for body, 500-600 for labels and CTAs.
+- Keep border-radius at 6-8px maximum -- subtle rounding, never bubbly.
+- Let the white background do the work -- empty space is the primary design element.
+- Use uppercase + tracking only for small labels and category tags.
+- Limit each slide/section to one focal stat or headline -- clean design lets single ideas command the space.
+
+### Don't
+- Don't introduce additional accent colours -- no greens, oranges, or purples. Blue and the gray scale only.
+- Don't use heavy drop shadows -- this style relies on ring shadows and barely-there lifts, not dramatic depth.
+- Don't use a background colour darker than `#f5f5f5` for any surface -- this is a light, airy style.
+- Don't apply weight 700 to body text -- it creates visual heaviness that contradicts the clean aesthetic.
+- Don't use rounded corners above 8px -- anything rounder than that shifts from "precise" to "playful."
+- Don't use decorative elements, icons, or emoji -- if a visual marker is needed, use a small geometric square (&#9632;) in blue.
+- Don't center-align body paragraphs -- only headlines, stats, and CTAs should be centered.
+- Don't use gradients or colour fills beyond `#f5f5f5` -- this is a monochromatic palette. Depth comes from shadow and spacing, not colour.
+- Don't place more than 3 stat numbers in a single row -- each number needs space to breathe.
+- Don't use borders and box-shadows simultaneously on the same element -- choose one method of definition.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale down**: Display Hero becomes 56px (from 72px). Section Heading becomes 40px. Sub-heading stays 32px. Body stays 16px.
+- **Padding**: 60px on all sides. Content area is 960x960px.
+- **Cover slide**: Title centered vertically and horizontally. Blue uppercase label above the headline. Subtitle in warm gray below.
+- **Content slides**: Left-aligned text. One concept per slide. Number in blue (48px) at top-left; content below.
+- **Stat slides**: Single stat centered. Big number at 64px in blue. Label and description below.
+- **Swipe indicator**: Small mid-gray dots at bottom center, 8px diameter, 12px gap. Active dot in blue.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Uses full-scale type hierarchy. Display Hero at 72px for the title section.
+- **Padding**: 60px left/right. 80px top/bottom margins.
+- **Section spacing**: 64px vertical gap between major sections. Thin 1px gray rules between sections -- no decorative accent rules, just structural dividers.
+- **Vertical rhythm**: Alternate between full-width sections and 2-column grids. Use numbered items for sequential content, stat displays for key metrics, and quote blocks for testimonials.
+- **Footer**: Cool gray text, 13px Space Grotesk, with a final thin rule above.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 80px with -2.5px tracking. Section Heading becomes 56px. Body Large becomes 22px.
+- **Padding**: 80px on all sides. Content area is 1760x920px.
+- **Layout**: Left-heavy composition. Title and body text occupy the left 60% of the frame. Right 40% is breathing room or supporting content (stats, minimal visuals).
+- **Title slides**: Headline centered on frame. Blue label above. Subtitle below.
+- **Content slides**: 2-column max for comparisons. Single column for narrative.
+- **Stat slides**: Up to 3 stats in a row, evenly spaced, each in a ring-shadow container.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 64px. Section Heading at 40px. Body at 16px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top third for headline and blue label. Middle third for key content (stats, list, or comparison). Bottom third for CTA or closing statement.
+- **Vertical flow**: Content reads top-to-bottom with clear sections. Generous whitespace separates the three zones -- no decorative dividers needed.
+- **CTA placement**: Always in the bottom zone, centered, with generous padding above. Blue button against white.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Hero becomes 72px with -2px tracking (approximately 30% larger than Carousel 56px). Section Heading becomes 52px with -1.5px tracking. Body Large becomes 22px at weight 300 for the signature airy reading feel. Big Numbers at 80px in blue.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical text must sit inside y=160 to y=1760.
+- **Layout**: Single centered column. Content max-width 960px. Vertical center of gravity -- cluster hero content in y=400 to y=1500 range. Aggressive whitespace above and below the focal element -- this style breathes through emptiness, and the tall frame should feel mostly empty.
+- **Cover slide**: Tiny blue uppercase label at 14px with 1.5px tracking sitting around y=520, followed by the hero headline in Space Grotesk 700 at 72px centered, then a 20px weight-300 subtitle in warm gray below. The whole block occupies only the central third of the frame; pure white does the rest. Optional 2px x 64px blue accent rule centered between label and headline.
+- **Content slides**: One concept per slide, engineered precision throughout. Oversized blue stat or blue numeral (72-80px) anchors the upper third; Space Grotesk 600 sub-heading and 16px warm-gray body sit below. Use a single shadow-as-border container (`box-shadow: 0 0 0 1px rgba(0,0,0,0.08)`) around stat blocks -- never a real border.
+- **CTA slide**: Space Grotesk 700 headline at 56px centered in the middle zone. Weight-300 subtitle below. Blue (`#0066ff`) pill button at 6-8px radius centered just above the bottom safe zone, with `Get Started` in Space Grotesk 600 at 15px.
+- **Progress indicator**: Thin segmented bars (one per slide) at the very top inside the safe zone, 4px tall, 1px gap between segments. Inactive segments in `rgba(0,0,0,0.08)`; active segment solid `#0066ff`. Keeps the signal-color discipline.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| White | `#ffffff` | Primary background |
+| Near-Black | `#171717` | Primary text |
+| Blue | `#0066ff` | Accent: CTAs, numbers, active states, focal points |
+| Light Blue | `#e6f0ff` | Hover backgrounds, tag fills, subtle emphasis |
+| Dark Blue | `#0052cc` | Hover/active state for blue elements |
+| Snow | `#f5f5f5` | Card/container surface |
+| Surface Inset | `#fafafa` | Recessed panels, code blocks |
+| Light Border | `#ebebeb` | Structural borders, input fields |
+| Mid Gray | `#d4d4d4` | Disabled states, placeholders |
+| Cool Gray | `#9ca3af` | Tertiary text, timestamps |
+| Warm Gray | `#6b7280` | Secondary text, descriptions |
+| Slate | `#4b5563` | Secondary headings |
+| Charcoal | `#374151` | High-emphasis body text |
+
+### Font Declarations
+
+```css
+font-family: 'Space Grotesk', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-white: #ffffff;
+  --color-near-black: #171717;
+  --color-blue: #0066ff;
+
+  /* Colors -- Accent */
+  --color-light-blue: #e6f0ff;
+  --color-dark-blue: #0052cc;
+  --color-warm-gray: #6b7280;
+
+  /* Colors -- Neutral Scale */
+  --color-snow: #f5f5f5;
+  --color-light-border: #ebebeb;
+  --color-mid-gray: #d4d4d4;
+  --color-cool-gray: #9ca3af;
+  --color-slate: #4b5563;
+  --color-charcoal: #374151;
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: #f5f5f5;
+  --color-surface-inset: #fafafa;
+
+  /* Colors -- Borders */
+  --color-border-default: rgba(0, 0, 0, 0.08);
+  --color-border-accent: rgba(0, 102, 255, 0.3);
+  --color-border-strong: rgba(0, 0, 0, 0.15);
+  --color-divider-rule: #0066ff;
+
+  /* Colors -- Shadows */
+  --shadow-ring: rgba(0, 0, 0, 0.08);
+  --shadow-subtle: rgba(0, 0, 0, 0.04);
+  --shadow-medium: rgba(0, 0, 0, 0.08);
+  --shadow-deep: rgba(0, 0, 0, 0.12);
+
+  /* Typography -- Families */
+  --font-display: 'Space Grotesk', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-body: 'Space Grotesk', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 72px;
+  --text-section-heading: 48px;
+  --text-sub-heading: 32px;
+  --text-body-large: 20px;
+  --text-body: 16px;
+  --text-small: 13px;
+  --text-big-number: 64px;
+  --text-label: 14px;
+  --text-cta: 15px;
+
+  /* Typography -- Weights */
+  --weight-display: 700;
+  --weight-sub-heading: 600;
+  --weight-body-light: 300;
+  --weight-body: 400;
+  --weight-label: 500;
+  --weight-cta: 600;
+
+  /* Typography -- Line Heights */
+  --leading-display: 1.05;
+  --leading-heading: 1.10;
+  --leading-sub-heading: 1.15;
+  --leading-body-large: 1.65;
+  --leading-body: 1.65;
+  --leading-small: 1.50;
+  --leading-number: 1.00;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-medium: 24px;
+  --space-large: 32px;
+  --space-section: 48px;
+  --space-hero: 64px;
+  --space-max: 80px;
+
+  /* Borders */
+  --radius-standard: 8px;
+  --radius-small: 6px;
+
+  /* Shadows -- Composed */
+  --shadow-card: 0 1px 3px rgba(0,0,0,0.04), 0 0 0 1px rgba(0,0,0,0.08);
+  --shadow-featured: 0 4px 16px rgba(0,0,0,0.08), 0 0 0 1px rgba(0,0,0,0.08);
+  --shadow-border: 0 0 0 1px rgba(0,0,0,0.08);
+}
+```
+
+### System Font Fallbacks
+- **Sans-serif (if Space Grotesk fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/_full/deep-ocean.md
+++ b/skills/composites/goose-graphics/styles/_full/deep-ocean.md
@@ -1,0 +1,443 @@
+# Design Style: Deep Ocean
+
+## 1. Visual Theme & Atmosphere
+
+Deep Ocean draws its language from the luminescent world beneath the surface -- where bioluminescent organisms pulse with cyan light against an infinite dark, where sonar pings trace through navy-black water, and where every point of light earns its presence through sheer contrast with the surrounding void. The deep blue-black background (`#0a1628`) is not simply dark; it carries the chromatic depth of ocean water at 200 metres, where the last traces of sunlight dissolve into indigo. Light blue-gray text (`#c8d6e5`) reads against this surface like the ghostly luminescence of deep-sea creatures -- visible, legible, but never harsh. The overall effect is one of calm immersion: the viewer is underwater, surrounded by information that glows with quiet authority.
+
+The typographic system uses Satoshi from Fontshare -- a clean, modern sans-serif that feels technical without being cold, geometric without being rigid. At display sizes (48px+), Satoshi at weight 700 delivers headlines with clarity and confidence, its letterforms open and legible even against dark backgrounds. For body text, Satoshi at weight 400 provides an excellent reading experience with clean, even strokes. The single-family approach maintains the immersive atmosphere -- switching fonts would break the environmental consistency, like switching camera angles in a documentary. Everything stays within the same visual current.
+
+Cyan-teal (`#00d4aa`) is the accent colour -- the bioluminescent glow that gives this style its signature character. It is not the cold cyan of a loading spinner but a warm teal that sits between cyan and green, carrying the organic quality of sea-glass or phosphorescent plankton. On dark surfaces, it creates a genuine glow effect through box-shadows (`box-shadow: 0 0 20px rgba(0,212,170,0.3)`) that simulate light emission rather than mere colour application. Muted blue (`#3d6b99`) serves as the secondary accent -- the ambient colour of deep water itself, used for secondary borders, background tints, and quiet structural elements that maintain the oceanic environment without competing with the cyan focal points.
+
+**Key Characteristics:**
+- Deep blue-black background (`#0a1628`) -- oceanic depth with chromatic richness, not flat black
+- Light blue-gray text (`#c8d6e5`) -- soft, luminescent readability against dark surfaces
+- Cyan-teal accent (`#00d4aa`) -- bioluminescent glow for focal points, numbers, CTAs, and interactive elements
+- Muted blue secondary (`#3d6b99`) -- ambient ocean colour for borders, secondary elements, and structural tints
+- Satoshi font throughout: weight 700 for display, weight 400-500 for body. Clean, modern, technical
+- Glow effects on accent elements: `box-shadow: 0 0 20px rgba(0,212,170,0.3)` for simulated light emission
+- Dark gradient backgrounds using subtle shifts between navy tones for environmental depth
+- Calm authority -- professional without being corporate, immersive without being distracting
+- Thin borders using muted blue (`1px solid rgba(61,107,153,0.3)`) for structural definition
+- Environmental consistency -- every element feels like it belongs underwater
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Deep Ocean** (`#0a1628`): Primary background. A blue-black with chromatic depth, like ocean water beyond the photic zone.
+- **Luminous Gray** (`#c8d6e5`): Primary text colour. Light blue-gray with a cool undertone that reads as natural light through water.
+- **Cyan Glow** (`#00d4aa`): Primary accent. The bioluminescent focal colour for numbers, rules, CTAs, and interactive highlights.
+
+### Accent
+- **Muted Blue** (`#3d6b99`): Secondary accent for borders, secondary labels, and ambient structural elements.
+- **Bright Cyan** (`#33e8c0`): Tertiary accent for hover states and high-emphasis text. A brighter, more energetic cyan.
+- **Deep Teal** (`#009b7d`): Darker cyan for active states on interactive elements.
+
+### Neutral Scale
+- **Navy Surface** (`#0e1f3a`): Elevated surface -- cards, containers, content panels sitting above the ocean background.
+- **Navy Mid** (`#132847`): Secondary surface for nested containers, input fields, and inset areas.
+- **Dark Slate** (`#2a4060`): Disabled text, placeholder content, and subtle dividers.
+- **Ocean Gray** (`#5a7a9e`): Tertiary text for timestamps, metadata, and low-priority labels.
+- **Silver Sea** (`#8aa0b8`): Used sparingly for de-emphasized captions on dark surfaces.
+
+### Surface & Borders
+- **Surface Primary** (`#0e1f3a`): Card and container background.
+- **Surface Inset** (`#091320`): Recessed areas, code blocks, and inset panels.
+- **Border Default** (`rgba(61,107,153,0.25)`): Standard muted-blue border for cards and dividers.
+- **Border Accent** (`rgba(0,212,170,0.3)`): Cyan-tinted border for active or featured elements.
+- **Border Strong** (`rgba(200,214,229,0.12)`): Higher-contrast cool border for prominent containers.
+- **Border Muted** (`rgba(61,107,153,0.15)`): Subtle blue border for dense list content.
+- **Divider Rule** (`#00d4aa`): Solid cyan for horizontal accent rules (typically 2px height).
+
+### Shadow Colors
+- **Shadow Glow** (`rgba(0,212,170,0.15)`): Primary glow shadow -- cyan-tinted light emission for accent elements.
+- **Shadow Ambient** (`rgba(0,212,170,0.08)`): Subtle cyan ambient glow for on-palette elevation.
+- **Shadow Deep** (`rgba(0,0,0,0.5)`): Deep shadow for high-elevation elements like modals.
+- **Shadow Soft** (`rgba(0,0,0,0.3)`): Standard shadow layer for cards and containers.
+- **Shadow Faint** (`rgba(0,212,170,0.04)`): Barely perceptible glow for subtle lift.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Fontshare CDN:**
+```html
+<link href="https://api.fontshare.com/v2/css?f[]=satoshi@400,500,700&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Satoshi', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Body**: `'Satoshi', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Satoshi | 72px | 700 | 1.05 | -1px | Bold, clear, authoritative |
+| Section Heading | Satoshi | 48px | 700 | 1.10 | -0.5px | Major section titles |
+| Sub-heading | Satoshi | 32px | 700 | 1.15 | -0.3px | Subsection titles, card headings |
+| Body Large | Satoshi | 20px | 400 | 1.65 | 0px | Lead paragraphs, introductions |
+| Body | Satoshi | 16px | 400 | 1.70 | 0.1px | Standard reading text |
+| Small / Caption | Satoshi | 13px | 400 | 1.50 | 0.3px | Metadata, attributions, timestamps |
+| Big Numbers | Satoshi | 64px | 700 | 1.00 | -1px | Statistics, key metrics, hero data |
+| Label | Satoshi | 14px | 500 | 1.00 | 2px | Uppercase category labels ("01 -- RESEARCH") |
+| CTA Text | Satoshi | 15px | 700 | 1.00 | 1px | Button and call-to-action text, uppercase |
+
+### Principles
+- **Single-family immersion**: Satoshi handles all typographic roles. Switching fonts would break the environmental consistency. Hierarchy comes from weight and size.
+- **Bold display, regular body**: Satoshi at weight 700 for display type creates confident, clear headlines. Weight 400 for body keeps reading comfortable and unforced.
+- **Tight tracking at display, open at small sizes**: Negative letter-spacing (-1px to -0.3px) at display sizes creates dense, impactful headlines. Small labels open up (2px) for legibility.
+- **Generous line height for body**: 1.65-1.70 for body text ensures comfortable reading against dark backgrounds where dense text becomes fatiguing.
+- **Medium weight for labels**: Weight 500 for labels provides a subtle emphasis above body weight (400) without the heaviness of 700.
+- **Uppercase sparingly**: Reserved for labels and CTA buttons only. All headlines use mixed case for a professional, calm tone.
+
+## 4. Component Patterns
+
+### Title Block (Cover / Header Section)
+
+```html
+<div style="background: linear-gradient(180deg, #0a1628 0%, #0e1f3a 100%); padding: 80px 60px; text-align: center;">
+  <div style="width: 60px; height: 2px; background: #00d4aa; margin: 0 auto 32px; box-shadow: 0 0 12px rgba(0,212,170,0.3);"></div>
+  <h1 style="font-family: 'Satoshi', sans-serif; font-size: 72px; font-weight: 700; line-height: 1.05; letter-spacing: -1px; color: #c8d6e5; margin: 0 0 24px;">The Future of<br>Autonomous Work</h1>
+  <p style="font-family: 'Satoshi', sans-serif; font-size: 20px; font-weight: 400; line-height: 1.65; color: #5a7a9e; max-width: 600px; margin: 0 auto;">How AI coworkers are reshaping the way teams operate, collaborate, and deliver results.</p>
+  <div style="width: 60px; height: 2px; background: #00d4aa; margin: 40px auto 0; box-shadow: 0 0 12px rgba(0,212,170,0.3);"></div>
+</div>
+```
+
+### Numbered Item
+
+```html
+<div style="display: flex; gap: 24px; align-items: flex-start; padding: 32px 0; border-bottom: 1px solid rgba(61,107,153,0.25);">
+  <span style="font-family: 'Satoshi', sans-serif; font-size: 48px; font-weight: 700; line-height: 1.00; color: #00d4aa; min-width: 72px; text-shadow: 0 0 20px rgba(0,212,170,0.3);">01</span>
+  <div>
+    <p style="font-family: 'Satoshi', sans-serif; font-size: 14px; font-weight: 500; letter-spacing: 2px; text-transform: uppercase; color: #3d6b99; margin: 0 0 8px;">SIGNAL-BASED OUTBOUND</p>
+    <h3 style="font-family: 'Satoshi', sans-serif; font-size: 32px; font-weight: 700; line-height: 1.15; letter-spacing: -0.3px; color: #c8d6e5; margin: 0 0 12px;">Find buyers before they find you</h3>
+    <p style="font-family: 'Satoshi', sans-serif; font-size: 16px; font-weight: 400; line-height: 1.70; color: #5a7a9e; margin: 0;">Monitor hiring signals, funding events, and tech stack changes to identify high-intent prospects the moment they enter the market.</p>
+  </div>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="text-align: center; padding: 40px 24px; background: #0e1f3a; border: 1px solid rgba(61,107,153,0.25); border-radius: 8px;">
+  <p style="font-family: 'Satoshi', sans-serif; font-size: 64px; font-weight: 700; line-height: 1.00; letter-spacing: -1px; color: #00d4aa; margin: 0 0 8px; text-shadow: 0 0 24px rgba(0,212,170,0.3);">47%</p>
+  <p style="font-family: 'Satoshi', sans-serif; font-size: 14px; font-weight: 500; letter-spacing: 2px; text-transform: uppercase; color: #c8d6e5; margin: 0 0 12px;">FASTER RESPONSE</p>
+  <p style="font-family: 'Satoshi', sans-serif; font-size: 16px; font-weight: 400; line-height: 1.70; color: #5a7a9e; max-width: 280px; margin: 0 auto;">Teams using AI coworkers respond to inbound leads nearly twice as fast as manual workflows.</p>
+</div>
+```
+
+### Comparison Grid
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: rgba(61,107,153,0.25); border-radius: 8px; overflow: hidden;">
+  <div style="background: #0e1f3a; padding: 40px 32px;">
+    <p style="font-family: 'Satoshi', sans-serif; font-size: 13px; font-weight: 400; letter-spacing: 0.3px; color: #3d6b99; margin: 0 0 16px;">Without Goose</p>
+    <h3 style="font-family: 'Satoshi', sans-serif; font-size: 32px; font-weight: 700; line-height: 1.15; letter-spacing: -0.3px; color: #c8d6e5; margin: 0 0 16px;">Manual & Fragmented</h3>
+    <p style="font-family: 'Satoshi', sans-serif; font-size: 16px; font-weight: 400; line-height: 1.70; color: #5a7a9e; margin: 0;">Teams juggle Slack threads, spreadsheets, and context-switching between a dozen tabs to coordinate basic workflows.</p>
+  </div>
+  <div style="background: #0e1f3a; padding: 40px 32px; border-left: 2px solid #00d4aa;">
+    <p style="font-family: 'Satoshi', sans-serif; font-size: 13px; font-weight: 400; letter-spacing: 0.3px; color: #00d4aa; margin: 0 0 16px;">With Goose</p>
+    <h3 style="font-family: 'Satoshi', sans-serif; font-size: 32px; font-weight: 700; line-height: 1.15; letter-spacing: -0.3px; color: #c8d6e5; margin: 0 0 16px;">Orchestrated & Autonomous</h3>
+    <p style="font-family: 'Satoshi', sans-serif; font-size: 16px; font-weight: 400; line-height: 1.70; color: #5a7a9e; margin: 0;">AI coworkers handle research, drafting, and follow-up autonomously. Your team focuses on decisions, not busywork.</p>
+  </div>
+</div>
+```
+
+### List Item
+
+```html
+<div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0; border-bottom: 1px solid rgba(61,107,153,0.25);">
+  <div style="width: 40px; height: 40px; min-width: 40px; display: flex; align-items: center; justify-content: center; border: 1px solid rgba(0,212,170,0.3); border-radius: 8px; color: #00d4aa; font-size: 18px; box-shadow: 0 0 12px rgba(0,212,170,0.15);">&#9670;</div>
+  <div>
+    <h4 style="font-family: 'Satoshi', sans-serif; font-size: 22px; font-weight: 700; line-height: 1.20; color: #c8d6e5; margin: 0 0 8px;">Persistent Memory</h4>
+    <p style="font-family: 'Satoshi', sans-serif; font-size: 16px; font-weight: 400; line-height: 1.70; color: #5a7a9e; margin: 0;">Every agent maintains its own filesystem, notes, and learned preferences across sessions. Context is never lost.</p>
+  </div>
+</div>
+```
+
+### Quote Block
+
+```html
+<div style="padding: 48px 40px; border-left: 2px solid #00d4aa; background: linear-gradient(90deg, rgba(0,212,170,0.04) 0%, transparent 40%); border-radius: 0 8px 8px 0;">
+  <p style="font-family: 'Satoshi', sans-serif; font-size: 32px; font-weight: 400; font-style: italic; line-height: 1.35; letter-spacing: -0.3px; color: #c8d6e5; margin: 0 0 24px;">"It felt less like configuring software and more like onboarding a new team member."</p>
+  <div style="display: flex; align-items: center; gap: 12px;">
+    <div style="width: 32px; height: 2px; background: #00d4aa; box-shadow: 0 0 8px rgba(0,212,170,0.3);"></div>
+    <p style="font-family: 'Satoshi', sans-serif; font-size: 14px; font-weight: 500; letter-spacing: 2px; text-transform: uppercase; color: #3d6b99; margin: 0;">SARAH CHEN, VP OPERATIONS</p>
+  </div>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="text-align: center; padding: 60px 40px; background: linear-gradient(180deg, #0e1f3a, #132847); border: 1px solid rgba(0,212,170,0.2); border-radius: 8px;">
+  <h2 style="font-family: 'Satoshi', sans-serif; font-size: 40px; font-weight: 700; line-height: 1.10; letter-spacing: -0.5px; color: #c8d6e5; margin: 0 0 16px;">Ready to meet your team?</h2>
+  <p style="font-family: 'Satoshi', sans-serif; font-size: 18px; font-weight: 400; line-height: 1.65; color: #5a7a9e; max-width: 480px; margin: 0 auto 32px;">Deploy your first AI coworker in under five minutes. No setup fees, no long-term commitments.</p>
+  <a style="display: inline-block; background: #00d4aa; color: #0a1628; font-family: 'Satoshi', sans-serif; font-size: 15px; font-weight: 700; letter-spacing: 1px; text-transform: uppercase; text-decoration: none; padding: 16px 40px; border-radius: 8px; box-shadow: 0 0 24px rgba(0,212,170,0.3);">Get Started</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between icon and inline label.
+- **8px**: Tight gap -- between sub-label and heading, between stat number and label.
+- **12px**: Small gap -- between heading and body text within a component.
+- **16px**: Base gap -- between body paragraphs, between list items in compact mode.
+- **24px**: Medium gap -- between components within a section, standard list item padding.
+- **32px**: Section internal -- padding inside cards and containers, gap between grouped items.
+- **48px**: Section divider -- vertical space between major content blocks.
+- **60px**: Large section padding -- top/bottom padding for hero and CTA blocks.
+- **80px**: Maximum section padding -- cover slides and high-impact hero areas.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 960px |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned text for body content. Center-aligned for hero titles, stats, and CTA blocks.
+- **Grid**: Use a simple 2-column grid for comparison layouts. Single-column for narrative and list content. 3-column for stat grids on widescreen slides.
+- **Horizontal rules**: 2px tall, cyan (`#00d4aa`) with glow shadow, 60px wide, centered -- used as section dividers.
+- **Vertical rhythm**: Maintain consistent 48px gaps between top-level sections. Use 24px gaps between items within a section.
+- **Content gravity**: On widescreen slides (1920x1080), anchor content to the left two-thirds of the frame. Leave the right third as breathing room.
+- **Gradient backgrounds**: Subtle `linear-gradient(180deg, #0a1628, #0e1f3a)` shifts between sections to create environmental depth -- like descending deeper underwater.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, background `#0a1628` | Page canvas, base layer |
+| Subtle (Level 1) | `rgba(0,0,0,0.3) 0px 2px 8px` | Slight lift for list items on hover |
+| Card (Level 2) | `rgba(0,0,0,0.3) 0px 8px 24px, rgba(0,212,170,0.04) 0px 0px 12px` | Standard card and container elevation |
+| Featured (Level 3) | `rgba(0,0,0,0.4) 0px 16px 40px, rgba(0,212,170,0.08) 0px 0px 20px` | Featured cards, quote blocks, hero elements |
+| Glow (Level 3+) | `0px 0px 20px rgba(0,212,170,0.3), 0px 0px 40px rgba(0,212,170,0.1)` | Accent elements that emit light: numbers, CTAs, glowing rules |
+| Overlay (Level 4) | `rgba(0,0,0,0.6) 0px 24px 60px` | Modals, overlays, high-priority popups |
+
+### Border Treatments
+- **Standard border**: `1px solid rgba(61,107,153,0.25)` -- muted blue line that defines edges with oceanic calm.
+- **Active border**: `1px solid rgba(0,212,170,0.3)` -- cyan-tinted border for featured or active containers.
+- **Accent rule**: `2px solid #00d4aa` -- solid cyan line used as a left-border accent on quote blocks and featured items, or as horizontal dividers.
+- **Muted border**: `1px solid rgba(61,107,153,0.15)` -- barely visible separator for dense list content.
+- **Glow border**: `1px solid rgba(0,212,170,0.3)` combined with `box-shadow: 0 0 12px rgba(0,212,170,0.15)` -- border that emits light.
+
+### Surface Hierarchy
+On deep ocean backgrounds, elevation communicates through lightness and blue-shift:
+1. **Background** (`#0a1628`) -- the deepest layer, the abyss.
+2. **Inset** (`#091320`) -- recessed areas sit darker than the background, like trenches.
+3. **Surface** (`#0e1f3a`) -- cards and containers step up by becoming lighter, rising through the water column.
+4. **Elevated** (`#132847`) -- the highest non-overlay surface, closest to the light.
+
+Cyan-tinted ambient shadows (`rgba(0,212,170,0.04-0.08)`) simulate bioluminescent light emission. On accent elements, the glow effect (`0 0 20px rgba(0,212,170,0.3)`) makes elements appear to generate their own light rather than merely reflecting it.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use cyan-teal (`#00d4aa`) as the bioluminescent accent -- it should feel like it emits light on the dark surface.
+- Apply glow effects (`box-shadow: 0 0 20px rgba(0,212,170,0.3)`) on cyan accent elements -- numbers, rules, buttons, and active borders.
+- Use subtle gradient backgrounds (`linear-gradient(180deg, #0a1628, #0e1f3a)`) to create depth between sections.
+- Use Satoshi at weight 700 for display headings and weight 400 for body -- the weight range creates clear hierarchy.
+- Use muted blue (`#3d6b99`) for secondary labels, metadata, and structural borders -- it is the ambient water colour.
+- Maintain generous line height (1.65-1.70) for body text -- dark backgrounds demand breathing room.
+- Use 8px border-radius on cards and containers -- slightly more rounded than editorial styles, matching the organic underwater feel.
+- Use `text-shadow: 0 0 20px rgba(0,212,170,0.3)` on large cyan numbers for the glowing data effect.
+- Limit glow effects to 1-2 elements per section -- bioluminescence is rare, which is what makes it striking.
+- Use horizontal cyan rules (2px, 60px wide) with glow shadows as section dividers.
+
+### Don't
+- Don't use more than 2 accent colours per section -- cyan and muted blue only. No golds, reds, or greens.
+- Don't use pure white (`#ffffff`) for text -- always use light blue-gray (`#c8d6e5`) to maintain the underwater tone.
+- Don't use pure black (`#000000`) for backgrounds -- always use deep blue-black (`#0a1628`) for chromatic depth.
+- Don't overdo glow effects -- more than 2 glowing elements per section breaks the calm, immersive mood.
+- Don't use border-radius above 8px -- this style is modern and technical, not bubbly or playful.
+- Don't center-align body paragraphs -- only headlines, stats, and CTAs should be centered.
+- Don't use hard-edged box shadows without the cyan tint -- all elevation should carry a faint oceanic glow.
+- Don't use warm colours (oranges, yellows, reds) -- they break the cool, deep-water palette entirely.
+- Don't use Satoshi below weight 400 for body text -- unlike some styles, Deep Ocean doesn't use ultra-light weights.
+- Don't place more than 3 stat numbers in a single row -- each glowing number needs space to breathe and emit.
+- Don't use decorative icons or emoji -- if a visual marker is needed, use a diamond (&#9670;) or small circle in cyan.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale down**: Display Hero becomes 56px (from 72px). Section Heading becomes 40px. Sub-heading stays 32px. Body stays 16px.
+- **Padding**: 60px on all sides. Content area is 960x960px.
+- **Cover slide**: Title centered vertically and horizontally. Cyan glowing rule above and below. Subtitle in muted blue.
+- **Content slides**: Left-aligned text. One concept per slide. Glowing cyan number (48px Satoshi) at top-left; content below.
+- **Stat slides**: Single stat centered. Big number at 56px with cyan glow. Label and description below.
+- **Swipe indicator**: Small dots at bottom center, 8px diameter, 12px gap, using `rgba(0,212,170,0.3)` for inactive and `#00d4aa` with glow for active.
+- **Background**: Use `linear-gradient(180deg, #0a1628, #0e1f3a)` on all slides for depth.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Uses full-scale type hierarchy. Display Hero at 72px for the title section.
+- **Padding**: 60px left/right. 80px top/bottom margins.
+- **Section spacing**: 64px vertical gap between major sections. Cyan glowing rules (60px wide, centered) between sections.
+- **Vertical rhythm**: Alternate between full-width sections and 2-column grids. Use numbered items for sequential content, stat displays for key metrics, and quote blocks for testimonials.
+- **Background gradient**: Gradual shift from `#0a1628` at the top to `#0e1f3a` at the bottom -- simulating increasing depth.
+- **Footer**: Muted blue text, 13px Satoshi, with a final cyan glowing rule above.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 80px. Section Heading becomes 56px. Body Large becomes 22px.
+- **Padding**: 80px on all sides. Content area is 1760x920px.
+- **Layout**: Left-heavy composition. Title and body text occupy the left 60% of the frame. Right 40% is breathing room or supporting content.
+- **Title slides**: Headline centered on frame. Cyan glowing rule centered. Subtitle below in ocean gray.
+- **Content slides**: 2-column max for comparisons. Single column for narrative. Muted blue borders between columns.
+- **Stat slides**: Up to 3 stats in a row, each with glowing cyan numbers, evenly spaced with muted blue borders.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 64px. Section Heading at 40px. Body at 16px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top third for headline. Middle third for key content (stats, list, or comparison). Bottom third for CTA or closing statement.
+- **Vertical flow**: Content reads top-to-bottom with clear sections. Cyan glowing rules separate the three zones.
+- **CTA placement**: Always in the bottom zone, centered, with generous padding above. Cyan button with glow shadow.
+- **Background**: Subtle gradient from lighter navy at top to deeper navy at bottom.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Hero becomes 72px (approximately 30% larger than Carousel 56px). Section Heading becomes 52px. Body Large becomes 22px. Big Numbers for hero stats become 84px with full cyan glow text-shadow.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical text must sit inside y=160 to y=1760.
+- **Layout**: Single centered column. Content max-width 960px. Vertical center of gravity -- cluster hero content in y=400 to y=1500 range. The background gradient runs a longer arc (`linear-gradient(180deg, #0a1628 0%, #0e1f3a 100%)`), so the top of the canvas feels like the surface and the bottom like the abyss -- the viewer descends as they read.
+- **Cover slide**: Headline in Satoshi 700 at 72px in luminous gray centered inside the safe zone. A 2px cyan rule 80px wide sits above and below the headline, each with `box-shadow: 0 0 16px rgba(0,212,170,0.35)` so the rules literally glow in the void. Subtitle in ocean gray below. Keep the composition symmetrical -- the stillness is part of the underwater mood.
+- **Content slides**: One concept per slide -- a glowing cyan numeral (`01`, `02`) at 84px with `text-shadow: 0 0 24px rgba(0,212,170,0.3)` anchored upper-left inside the safe zone, then a muted-blue uppercase label, then the Satoshi 700 sub-heading, then body in ocean gray. Limit glow to one element per slide so bioluminescence stays rare and striking.
+- **CTA slide**: Navy-mid surface card (`#132847`) centered in the middle zone with a 1px cyan-tinted border. Satoshi 700 headline at 56px in luminous gray, short supporting copy, and a cyan (`#00d4aa`) pill button with `box-shadow: 0 0 28px rgba(0,212,170,0.35)` for true light emission.
+- **Progress indicator**: Thin segmented rules at the top of the safe zone, 2px tall, styled as dim muted-blue (`rgba(61,107,153,0.25)`) for inactive and glowing cyan (`#00d4aa` with `0 0 12px rgba(0,212,170,0.3)`) for the active segment -- each segment feels like a sonar ping.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Deep Ocean | `#0a1628` | Primary background |
+| Luminous Gray | `#c8d6e5` | Primary text |
+| Cyan Glow | `#00d4aa` | Accent: numbers, rules, CTAs, glowing focal points |
+| Muted Blue | `#3d6b99` | Secondary accent: borders, labels, structural elements |
+| Bright Cyan | `#33e8c0` | Hover state text, high-emphasis elements |
+| Deep Teal | `#009b7d` | Hover/active state for cyan elements |
+| Navy Surface | `#0e1f3a` | Card/container surface |
+| Surface Inset | `#091320` | Recessed panels, code blocks |
+| Navy Mid | `#132847` | Nested containers, elevated surfaces |
+| Dark Slate | `#2a4060` | Disabled text, subtle dividers |
+| Ocean Gray | `#5a7a9e` | Tertiary text, descriptions |
+| Silver Sea | `#8aa0b8` | De-emphasized captions |
+
+### Font Declarations
+
+```css
+font-family: 'Satoshi', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Fontshare Link
+
+```html
+<link href="https://api.fontshare.com/v2/css?f[]=satoshi@400,500,700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-deep-ocean: #0a1628;
+  --color-luminous-gray: #c8d6e5;
+  --color-cyan-glow: #00d4aa;
+
+  /* Colors -- Accent */
+  --color-muted-blue: #3d6b99;
+  --color-bright-cyan: #33e8c0;
+  --color-deep-teal: #009b7d;
+
+  /* Colors -- Neutral Scale */
+  --color-navy-surface: #0e1f3a;
+  --color-navy-mid: #132847;
+  --color-dark-slate: #2a4060;
+  --color-ocean-gray: #5a7a9e;
+  --color-silver-sea: #8aa0b8;
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: #0e1f3a;
+  --color-surface-inset: #091320;
+
+  /* Colors -- Borders */
+  --color-border-default: rgba(61, 107, 153, 0.25);
+  --color-border-accent: rgba(0, 212, 170, 0.3);
+  --color-border-strong: rgba(200, 214, 229, 0.12);
+  --color-border-muted: rgba(61, 107, 153, 0.15);
+  --color-divider-rule: #00d4aa;
+
+  /* Colors -- Shadows */
+  --shadow-glow: rgba(0, 212, 170, 0.15);
+  --shadow-ambient: rgba(0, 212, 170, 0.08);
+  --shadow-deep: rgba(0, 0, 0, 0.5);
+  --shadow-soft: rgba(0, 0, 0, 0.3);
+  --shadow-faint: rgba(0, 212, 170, 0.04);
+
+  /* Typography -- Families */
+  --font-display: 'Satoshi', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-body: 'Satoshi', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 72px;
+  --text-section-heading: 48px;
+  --text-sub-heading: 32px;
+  --text-body-large: 20px;
+  --text-body: 16px;
+  --text-small: 13px;
+  --text-big-number: 64px;
+  --text-label: 14px;
+  --text-cta: 15px;
+
+  /* Typography -- Weights */
+  --weight-display: 700;
+  --weight-body: 400;
+  --weight-label: 500;
+
+  /* Typography -- Line Heights */
+  --leading-display: 1.05;
+  --leading-heading: 1.10;
+  --leading-sub-heading: 1.15;
+  --leading-body-large: 1.65;
+  --leading-body: 1.70;
+  --leading-small: 1.50;
+  --leading-number: 1.00;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-medium: 24px;
+  --space-large: 32px;
+  --space-section: 48px;
+  --space-hero: 60px;
+  --space-max: 80px;
+
+  /* Borders */
+  --radius-standard: 8px;
+
+  /* Shadows -- Composed */
+  --shadow-card: rgba(0,0,0,0.3) 0px 8px 24px, rgba(0,212,170,0.04) 0px 0px 12px;
+  --shadow-featured: rgba(0,0,0,0.4) 0px 16px 40px, rgba(0,212,170,0.08) 0px 0px 20px;
+  --shadow-glow-accent: 0px 0px 20px rgba(0,212,170,0.3), 0px 0px 40px rgba(0,212,170,0.1);
+
+  /* Gradients */
+  --gradient-depth: linear-gradient(180deg, #0a1628, #0e1f3a);
+  --gradient-glow: linear-gradient(90deg, rgba(0,212,170,0.04), transparent);
+}
+```
+
+### System Font Fallbacks
+- **Sans-serif (if Satoshi fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/_full/electric-burst.md
+++ b/skills/composites/goose-graphics/styles/_full/electric-burst.md
@@ -1,0 +1,458 @@
+# Design Style: Electric Burst
+
+## 1. Visual Theme & Atmosphere
+
+Electric Burst is the design language of maximum impact -- the visual equivalent of a stadium floodlight cutting through darkness, of a neon sign on a rain-slicked street, of a festival lineup poster that stops you mid-scroll. The near-black canvas (`#0a0a0a`) is not understated; it is a stage designed to make everything on it scream. Where other dark styles use darkness for sophistication, Electric Burst uses it as a launchpad for visual volume. This is not calm. This is not quiet. This is the design language of bold claims, oversized numbers, and unapologetic confidence.
+
+The typographic pairing of Archivo Black and Inter creates a deliberate collision of energies. Archivo Black -- a heavy, slightly condensed display face with nearly uniform stroke width -- delivers headlines that hit like a wall of sound. Its dense, block-like letterforms at display sizes (64px+) are designed to be read from a distance, to be felt before they are parsed. This is type as physical presence. Against this brutalist display face, Inter provides clean, neutral body text that never competes with the headlines. The contrast is extreme by design: Archivo Black is all personality, all weight, all impact; Inter is all clarity, all function, all readability. The display type makes the claim; the body type delivers the evidence.
+
+Neon yellow (`#e6ff00`) is the accent that electrifies this system. It is not a friendly yellow or a warm gold -- it is a fluorescent, almost phosphorescent hue that reads as energy, urgency, and technological edge. On the black background, it glows with the intensity of a highlighter under UV light. Hot pink (`#ff2d6f`) serves as the secondary accent, adding a second voltage to the palette -- the colour of laser beams, of concert wristbands, of urgent notifications. Together, neon yellow and hot pink create a palette that is deliberately confrontational: these are not colours that politely request attention; they seize it. The glow effect -- achieved through layered `text-shadow` and `box-shadow` using the accent colours -- is the signature technique of this style, giving key elements an actual luminous quality that no flat colour alone can deliver.
+
+**Key Characteristics:**
+- Near-black background (`#0a0a0a`) as the dominant surface -- darkness as amplifier, not atmosphere
+- Pure white (`#ffffff`) for all primary text -- maximum contrast, no compromise
+- Archivo Black for all display type -- heavy, condensed, oversized, felt before read
+- Inter for all body text -- clean, neutral counterpoint to the heavy display face
+- Neon yellow (`#e6ff00`) as the primary accent for numbers, CTAs, highlights, and glow effects
+- Hot pink (`#ff2d6f`) as the secondary accent for supporting emphasis, tags, and secondary focal points
+- Glow effects via `text-shadow` and `box-shadow` using accent colours at low opacity -- elements that literally luminescence
+- Oversized numbers (200px+ for hero stats) -- data as visual spectacle
+- Maximum contrast everywhere -- this style has no quiet mode
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Void** (`#0a0a0a`): Primary background. Near-black with a neutral undertone -- the darkest viable canvas.
+- **White** (`#ffffff`): Primary text colour. Pure white for maximum contrast against the void.
+- **Neon Yellow** (`#e6ff00`): Primary accent. Used for hero numbers, CTA buttons, glow effects, and primary focal points. The signature colour.
+
+### Accent
+- **Hot Pink** (`#ff2d6f`): Secondary accent for tags, secondary highlights, alternate CTAs, and supporting focal points.
+- **Dark Yellow** (`#b8cc00`): Muted neon for hover/active states on yellow elements and secondary labels.
+- **Dark Pink** (`#cc2459`): Darker pink for hover/active states on pink interactive elements.
+- **Yellow Glow** (`rgba(230,255,0,0.15)`): Low-opacity neon for glow halos and ambient light effects.
+- **Pink Glow** (`rgba(255,45,111,0.15)`): Low-opacity pink for secondary glow effects.
+
+### Neutral Scale
+- **Dark Surface** (`#141414`): Elevated surface -- cards, containers, and content panels sitting above the void.
+- **Charcoal** (`#1e1e1e`): Secondary surface for nested containers, input fields, and inset areas.
+- **Graphite** (`#2a2a2a`): Tertiary surface for deeply nested content.
+- **Steel** (`#555555`): Disabled text, placeholder content, and subtle dividers.
+- **Ash** (`#888888`): Tertiary text for timestamps, metadata, and low-priority labels.
+- **Silver** (`#aaaaaa`): Secondary body text and descriptions.
+
+### Surface & Borders
+- **Surface Primary** (`#141414`): Card and container background.
+- **Surface Inset** (`#111111`): Recessed areas, code blocks, and inset panels.
+- **Border Default** (`rgba(255,255,255,0.1)`): Standard whisper-thin border for cards and dividers.
+- **Border Accent Yellow** (`rgba(230,255,0,0.3)`): Neon yellow border for active or featured elements.
+- **Border Accent Pink** (`rgba(255,45,111,0.3)`): Hot pink border for secondary featured elements.
+- **Border Strong** (`rgba(255,255,255,0.2)`): Higher-contrast border for prominent containers.
+- **Divider Rule** (`#e6ff00`): Solid neon yellow for horizontal accent rules (typically 3px height).
+
+### Shadow Colors
+- **Shadow Neon** (`rgba(230,255,0,0.12)`): Primary glow shadow -- neon-tinted ambient for on-palette luminescence.
+- **Shadow Pink** (`rgba(255,45,111,0.12)`): Secondary glow shadow for pink-accented elements.
+- **Shadow Deep** (`rgba(0,0,0,0.6)`): Deep shadow for high-elevation elements.
+- **Shadow Soft** (`rgba(0,0,0,0.3)`): Standard shadow layer for cards and containers.
+- **Shadow Ambient** (`rgba(230,255,0,0.06)`): Subtle neon ambient for barely-there glow.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Archivo Black', Impact, 'Arial Black', sans-serif`
+- **Body**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Archivo Black | 80px | 400 | 1.00 | -1px | Cover headlines, maximum visual impact (Archivo Black has one weight) |
+| Section Heading | Archivo Black | 56px | 400 | 1.05 | -0.5px | Major section titles |
+| Sub-heading | Archivo Black | 36px | 400 | 1.10 | 0px | Subsection titles, card headings |
+| Body Large | Inter | 20px | 400 | 1.60 | 0px | Lead paragraphs, introductions |
+| Body | Inter | 16px | 400 | 1.65 | 0px | Standard reading text |
+| Small / Caption | Inter | 13px | 500 | 1.50 | 0.5px | Metadata, attributions, timestamps |
+| Big Numbers | Archivo Black | 200px | 400 | 0.85 | -4px | Oversized statistics, hero data -- the spectacle numbers |
+| Numbered Label | Inter | 14px | 700 | 1.00 | 3px | Uppercase step labels ("01 -- ATTACK") |
+| CTA Text | Inter | 16px | 700 | 1.00 | 1.5px | Button and call-to-action text, uppercase |
+
+### Principles
+- **Extreme weight contrast**: Archivo Black (the heaviest available weight, rendered at its native 400 which is already ultra-bold) owns the headlines. Inter at 400 provides a stark contrast. The collision between the two is the energy source of this style.
+- **Oversized is the default**: Hero numbers at 200px. Display headlines at 80px. This style operates at sizes that other styles would consider absurd. Scale is the message.
+- **Tight line height for display**: 1.00 or less for display type and big numbers. Headlines should feel stacked and compressed, like lines on a concert poster.
+- **Wide tracking on labels**: Numbered labels and CTA text use 1.5px-3px tracking with uppercase -- this creates the contrast between the dense display type and the spaced-out functional type.
+- **Body text is functional**: Inter at 400 weight, standard tracking, comfortable line height (1.65). Body text's job is to be read quickly, not to be noticed. All personality lives in the display type.
+- **Archivo Black has one weight**: Unlike variable-weight fonts, Archivo Black comes in a single weight. Size and colour are the only tools for display hierarchy.
+
+## 4. Component Patterns
+
+### Title Block (Cover / Header Section)
+
+```html
+<div style="background-color: var(--color-void); padding: 80px 60px; text-align: center;">
+  <p style="font-family: var(--font-body); font-size: 14px; font-weight: 700; letter-spacing: 3px; text-transform: uppercase; color: var(--color-neon-yellow); margin: 0 0 24px;">THE FUTURE OF WORK</p>
+  <h1 style="font-family: var(--font-display); font-size: 80px; font-weight: 400; line-height: 1.00; letter-spacing: -1px; color: var(--color-white); text-transform: uppercase; margin: 0 0 24px; text-shadow: 0 0 40px rgba(230,255,0,0.15);">AUTONOMOUS<br>TEAMS</h1>
+  <p style="font-family: var(--font-body); font-size: 20px; font-weight: 400; line-height: 1.60; color: var(--color-silver); max-width: 600px; margin: 0 auto;">How AI coworkers are reshaping the way teams operate, collaborate, and deliver results.</p>
+  <div style="width: 80px; height: 3px; background: var(--color-neon-yellow); margin: 40px auto 0; box-shadow: 0 0 12px rgba(230,255,0,0.4);"></div>
+</div>
+```
+
+### Numbered Item
+
+```html
+<div style="display: flex; gap: 24px; align-items: flex-start; padding: 32px 0; border-bottom: 1px solid rgba(255,255,255,0.1);">
+  <span style="font-family: var(--font-display); font-size: 56px; font-weight: 400; line-height: 1.00; color: var(--color-neon-yellow); min-width: 80px; text-shadow: 0 0 20px rgba(230,255,0,0.3);">01</span>
+  <div>
+    <p style="font-family: var(--font-body); font-size: 14px; font-weight: 700; letter-spacing: 3px; text-transform: uppercase; color: var(--color-hot-pink); margin: 0 0 8px;">SIGNAL-BASED OUTBOUND</p>
+    <h3 style="font-family: var(--font-display); font-size: 36px; font-weight: 400; line-height: 1.10; color: var(--color-white); margin: 0 0 12px;">Find buyers before they find you</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-silver); margin: 0;">Monitor hiring signals, funding events, and tech stack changes to identify high-intent prospects the moment they enter the market.</p>
+  </div>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="text-align: center; padding: 48px 24px; background: var(--color-dark-surface); border: 1px solid rgba(230,255,0,0.3); border-radius: 4px; box-shadow: 0 0 30px rgba(230,255,0,0.08);">
+  <p style="font-family: var(--font-display); font-size: 200px; font-weight: 400; line-height: 0.85; letter-spacing: -4px; color: var(--color-neon-yellow); margin: 0 0 16px; text-shadow: 0 0 60px rgba(230,255,0,0.3), 0 0 120px rgba(230,255,0,0.1);">47</p>
+  <p style="font-family: var(--font-body); font-size: 14px; font-weight: 700; letter-spacing: 3px; text-transform: uppercase; color: var(--color-white); margin: 0 0 12px;">PERCENT FASTER</p>
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-silver); max-width: 320px; margin: 0 auto;">Teams using AI coworkers respond to inbound leads nearly twice as fast as manual workflows.</p>
+</div>
+```
+
+### Comparison Grid
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2px; background: rgba(255,255,255,0.1); border-radius: 4px; overflow: hidden;">
+  <div style="background: var(--color-dark-surface); padding: 40px 32px;">
+    <p style="font-family: var(--font-body); font-size: 13px; font-weight: 500; letter-spacing: 0.5px; color: var(--color-ash); margin: 0 0 16px;">Without Goose</p>
+    <h3 style="font-family: var(--font-display); font-size: 36px; font-weight: 400; line-height: 1.10; color: var(--color-white); margin: 0 0 16px;">Manual & Fragmented</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-silver); margin: 0;">Teams juggle Slack threads, spreadsheets, and context-switching between a dozen tabs to coordinate basic workflows.</p>
+  </div>
+  <div style="background: var(--color-dark-surface); padding: 40px 32px; border-left: 3px solid var(--color-neon-yellow); box-shadow: inset 20px 0 40px rgba(230,255,0,0.05);">
+    <p style="font-family: var(--font-body); font-size: 13px; font-weight: 500; letter-spacing: 0.5px; color: var(--color-neon-yellow); margin: 0 0 16px;">With Goose</p>
+    <h3 style="font-family: var(--font-display); font-size: 36px; font-weight: 400; line-height: 1.10; color: var(--color-white); margin: 0 0 16px;">Orchestrated & Autonomous</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-silver); margin: 0;">AI coworkers handle research, drafting, and follow-up autonomously. Your team focuses on decisions, not busywork.</p>
+  </div>
+</div>
+```
+
+### List Item
+
+```html
+<div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0; border-bottom: 1px solid rgba(255,255,255,0.1);">
+  <div style="width: 40px; height: 40px; min-width: 40px; display: flex; align-items: center; justify-content: center; border: 1px solid rgba(255,45,111,0.3); border-radius: 4px; color: var(--color-hot-pink); font-size: 18px; box-shadow: 0 0 12px rgba(255,45,111,0.1);">&#9650;</div>
+  <div>
+    <h4 style="font-family: var(--font-display); font-size: 24px; font-weight: 400; line-height: 1.15; color: var(--color-white); margin: 0 0 8px;">Persistent Memory</h4>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-silver); margin: 0;">Every agent maintains its own filesystem, notes, and learned preferences across sessions. Context is never lost.</p>
+  </div>
+</div>
+```
+
+### Quote Block
+
+```html
+<div style="padding: 48px 40px; border-left: 3px solid var(--color-hot-pink); background: var(--color-surface-inset); box-shadow: inset 20px 0 40px rgba(255,45,111,0.05);">
+  <p style="font-family: var(--font-display); font-size: 36px; font-weight: 400; line-height: 1.15; color: var(--color-white); margin: 0 0 24px;">"IT FELT LESS LIKE CONFIGURING SOFTWARE AND MORE LIKE ONBOARDING A NEW TEAM MEMBER."</p>
+  <div style="display: flex; align-items: center; gap: 12px;">
+    <div style="width: 32px; height: 3px; background: var(--color-hot-pink); box-shadow: 0 0 8px rgba(255,45,111,0.4);"></div>
+    <p style="font-family: var(--font-body); font-size: 14px; font-weight: 700; letter-spacing: 3px; text-transform: uppercase; color: var(--color-ash); margin: 0;">SARAH CHEN, VP OPERATIONS</p>
+  </div>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="text-align: center; padding: 60px 40px; background: var(--color-dark-surface); border: 1px solid rgba(230,255,0,0.3); border-radius: 4px; box-shadow: 0 0 40px rgba(230,255,0,0.08);">
+  <h2 style="font-family: var(--font-display); font-size: 48px; font-weight: 400; line-height: 1.05; color: var(--color-white); text-transform: uppercase; margin: 0 0 16px;">Ready to meet<br>your team?</h2>
+  <p style="font-family: var(--font-body); font-size: 18px; font-weight: 400; line-height: 1.60; color: var(--color-silver); max-width: 480px; margin: 0 auto 32px;">Deploy your first AI coworker in under five minutes. No setup fees, no long-term commitments.</p>
+  <a style="display: inline-block; background: var(--color-neon-yellow); color: var(--color-void); font-family: var(--font-body); font-size: 16px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; text-decoration: none; padding: 18px 48px; border-radius: 4px; box-shadow: 0 0 20px rgba(230,255,0,0.3), 0 0 60px rgba(230,255,0,0.1);">Get Started</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between icon and inline label.
+- **8px**: Tight gap -- between sub-label and heading, between stat number and label.
+- **16px**: Small-base gap -- between heading and body text, between body paragraphs.
+- **24px**: Medium gap -- between components within a section, standard list item padding.
+- **32px**: Section internal -- padding inside cards and containers, gap between grouped items.
+- **48px**: Section divider -- vertical space between major content blocks.
+- **60px**: Large section padding -- top/bottom padding for hero and CTA blocks.
+- **80px**: Maximum section padding -- cover slides and high-impact hero areas.
+- **120px**: Oversized spacing -- used above and below hero stat numbers to give them stage presence.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 960px |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned text for body content. Center-aligned for hero titles, stats, and CTA blocks.
+- **Grid**: Use a simple 2-column grid for comparison layouts. Single-column for narrative and list content. 3-column for stat grids on widescreen slides.
+- **Accent rules**: 3px tall, neon yellow (`#e6ff00`), 80px wide, with a glow shadow (`box-shadow: 0 0 12px rgba(230,255,0,0.4)`) -- used as section dividers and energy accents.
+- **Vertical rhythm**: Maintain consistent 48px gaps between top-level sections. Use 24px gaps between items within a section.
+- **Content gravity**: On widescreen slides (1920x1080), oversized numbers or headlines can bleed into the full width. Body text anchors to the left 60%.
+- **Visual impact zones**: Each slide or section should have one dominant element (a massive number, a glowing headline, a neon CTA) that occupies disproportionate visual weight. Everything else supports it.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, background `#0a0a0a` | Page canvas, base layer |
+| Subtle (Level 1) | `rgba(0,0,0,0.3) 0px 2px 8px` | Slight lift for list items on hover |
+| Card (Level 2) | `rgba(0,0,0,0.4) 0px 8px 24px, rgba(230,255,0,0.04) 0px 0px 16px` | Standard card and container elevation |
+| Glow (Level 3) | `rgba(0,0,0,0.5) 0px 16px 40px, rgba(230,255,0,0.08) 0px 0px 30px` | Featured cards, stat displays, hero elements |
+| Overlay (Level 4) | `rgba(0,0,0,0.7) 0px 24px 60px, rgba(230,255,0,0.12) 0px 0px 40px` | Modals, overlays, high-priority popups |
+
+### Border Treatments
+- **Standard border**: `1px solid rgba(255,255,255,0.1)` -- barely visible white line that defines edges in the darkness.
+- **Neon border**: `1px solid rgba(230,255,0,0.3)` -- yellow-tinted border for featured or active containers, paired with a glow shadow.
+- **Pink border**: `1px solid rgba(255,45,111,0.3)` -- pink-tinted border for secondary featured elements.
+- **Accent rule**: `3px solid #e6ff00` with `box-shadow: 0 0 12px rgba(230,255,0,0.4)` -- glowing neon line used as horizontal dividers and left-border accents.
+- **Divider line**: `1px solid rgba(255,255,255,0.06)` -- nearly invisible separator for dense list content.
+
+### Surface Hierarchy
+On near-black backgrounds, elevation is communicated through lightness and glow:
+1. **Void** (`#0a0a0a`) -- the darkest layer, the stage.
+2. **Surface** (`#141414`) -- cards and containers step up by becoming slightly lighter.
+3. **Inset** (`#111111`) -- recessed areas sit between void and surface.
+4. **Elevated** (`#1e1e1e`) -- the highest non-overlay surface for nested content.
+
+Neon glow shadows (`rgba(230,255,0,0.04-0.12)`) add luminescent energy to elevation. Featured elements should feel like they are emitting light, not just reflecting it. The glow effect is the primary depth differentiator -- a card with a neon glow reads as more important than a card with only a dark shadow.
+
+### Glow Technique Reference
+- **Text glow**: `text-shadow: 0 0 20px rgba(230,255,0,0.3), 0 0 60px rgba(230,255,0,0.1)` -- for neon-coloured text.
+- **Box glow**: `box-shadow: 0 0 20px rgba(230,255,0,0.3), 0 0 60px rgba(230,255,0,0.1)` -- for CTA buttons and featured containers.
+- **Inset glow**: `box-shadow: inset 20px 0 40px rgba(230,255,0,0.05)` -- for the "preferred" side of comparison panels.
+- **Rule glow**: `box-shadow: 0 0 12px rgba(230,255,0,0.4)` -- for accent rules and dividers.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use neon yellow (`#e6ff00`) as the primary accent and hot pink (`#ff2d6f`) as the secondary -- they are the dual-voltage energy source of this style.
+- Use Archivo Black only for display text (36px and above) and oversized numbers -- it has one weight and exists for impact.
+- Keep body text in Inter at weight 400-500 -- clean and functional, letting the display type carry the personality.
+- Use glow effects (`text-shadow` and `box-shadow` with accent colours) on focal elements -- glowing neon is the visual signature.
+- Make stat numbers absurdly large (200px for hero stats, 120px for supporting stats) -- this style treats data as visual spectacle.
+- Use uppercase for Archivo Black headlines and labels -- the condensed letterforms are designed for all-caps impact.
+- Add `text-shadow` to neon-coloured text to create the luminescence effect -- flat neon text loses the electric feel.
+- Use 3px accent rules with glow shadows as section dividers.
+- Keep border-radius at 4px or 0px -- this is a sharp, angular style.
+
+### Don't
+- Don't use Archivo Black for body text or small sizes -- it is illegible below 24px and was never designed for reading.
+- Don't use more than 2 accent colours per slide -- neon yellow and hot pink only. No blues, greens, or oranges.
+- Don't skip the glow effect on accent-coloured elements -- without the glow, neon colours look flat and lose their electric character.
+- Don't use pure white (`#ffffff`) for backgrounds -- always use `#0a0a0a` or darker surfaces.
+- Don't use light or pastel colours anywhere -- every colour in this system is either near-black, pure white, or high-saturation neon.
+- Don't use rounded corners above 4px -- this style is sharp and aggressive, not soft or friendly.
+- Don't center-align body paragraphs -- only headlines, stats, and CTAs should be centered.
+- Don't use subtle or muted accents -- if something gets an accent colour, it should be at full intensity with a glow.
+- Don't place more than 2 oversized stat numbers on a single slide -- each number needs space to radiate.
+- Don't use thin font weights (300 or below) for Inter body text -- the dark background demands at least 400 weight for readability.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale down**: Display Hero becomes 64px (from 80px). Section Heading becomes 48px. Sub-heading stays 36px. Body stays 16px.
+- **Big Numbers**: Scale down from 200px to 120px for carousel format -- still oversized, but contained.
+- **Padding**: 60px on all sides. Content area is 960x960px.
+- **Cover slide**: Title centered in uppercase Archivo Black. Neon yellow label above. Glowing accent rule below. Subtitle in silver.
+- **Content slides**: Left-aligned text. One concept per slide. Number in neon yellow (56px) at top-left with glow; content below.
+- **Stat slides**: Single stat centered. Oversized number at 120px in neon yellow with glow. Label and description below.
+- **Swipe indicator**: Small neon yellow dots at bottom center, 8px diameter, 12px gap. Active dot with glow effect.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Uses full-scale type hierarchy. Display Hero at 80px for the title section. Big Numbers at 200px for hero stats.
+- **Padding**: 60px left/right. 80px top/bottom margins.
+- **Section spacing**: 64px vertical gap between major sections. Glowing neon rules (80px wide, centered) between sections.
+- **Vertical rhythm**: Alternate between full-width sections and 2-column grids. Use numbered items for sequential content, oversized stat displays for key metrics, and quote blocks for testimonials.
+- **Footer**: Ash gray text, 13px Inter, with a final glowing neon rule above.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 96px. Section Heading becomes 64px. Body Large becomes 22px.
+- **Big Numbers**: Full 200px+ on widescreen slides. Numbers can span the full width as a background element.
+- **Padding**: 80px on all sides. Content area is 1760x920px.
+- **Layout**: Oversized numbers and headlines can command the full frame. Body text anchors to the lower-left or right third.
+- **Title slides**: Headline in uppercase, centered, with neon glow. Label above in hot pink.
+- **Content slides**: 2-column max for comparisons. Single column for narrative.
+- **Stat slides**: Single oversized number centered with full glow treatment. Supporting text below.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 72px. Section Heading at 48px. Body at 16px. Big Numbers at 160px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top third for headline in uppercase with glow. Middle third for key content (oversized stat, list, or comparison). Bottom third for CTA with glowing button.
+- **Vertical flow**: Content reads top-to-bottom with high contrast between zones. Glowing neon rules separate the three sections.
+- **CTA placement**: Always in the bottom zone, centered, with generous padding above. Neon yellow button with full glow effect.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Hero becomes 84px in Archivo Black (approximately 30% larger than Carousel 64px). Section Heading becomes 60px. Body Large becomes 22px in Inter. Big Numbers for hero stats blow up to 240px -- data as visual spectacle, maximised for the tall frame.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical text must sit inside y=160 to y=1760.
+- **Layout**: Single centered column. Content max-width 960px. Vertical center of gravity -- cluster hero content in y=400 to y=1500 range. The near-black (`#0a0a0a`) void runs edge-to-edge so neon accents feel even more radioactive in the tall format.
+- **Cover slide**: Archivo Black uppercase headline at 84px in white, tight letter-spacing, stacked in 2-3 lines filling the middle of the safe zone. One key word highlighted in neon yellow (`#e6ff00`) with heavy `text-shadow: 0 0 32px rgba(230,255,0,0.5), 0 0 64px rgba(230,255,0,0.25)` so it genuinely glows against the void. Optional hot pink (`#ff2d6f`) tag above the headline.
+- **Content slides**: One oversized stat per slide -- the number pushed to 240px in neon yellow with full glow, filling half the vertical safe zone. Short Inter label in uppercase tracked pink or white below. Body copy in Inter 400 at 22px. Glow effects limited to the single hero number per slide so the impact doesn't dilute.
+- **CTA slide**: Full-frame black void with an Archivo Black headline at 64px centered in the middle zone. Neon yellow button with pill radius, black Inter text, and `box-shadow: 0 0 40px rgba(230,255,0,0.45)` so the button reads as a light source. Optional hot pink secondary text below.
+- **Progress indicator**: Thin segmented bars at the top inside the safe zone, 3px tall, neon yellow for the active segment with glow shadow, `rgba(255,255,255,0.2)` for inactive. The active segment should look electrified -- this style doesn't do subtle.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Void | `#0a0a0a` | Primary background |
+| White | `#ffffff` | Primary text |
+| Neon Yellow | `#e6ff00` | Primary accent: numbers, CTAs, glows, focal points |
+| Hot Pink | `#ff2d6f` | Secondary accent: tags, labels, secondary highlights |
+| Dark Yellow | `#b8cc00` | Hover/active for neon elements, secondary labels |
+| Dark Pink | `#cc2459` | Hover/active for pink elements |
+| Dark Surface | `#141414` | Card/container surface |
+| Surface Inset | `#111111` | Recessed panels, code blocks |
+| Charcoal | `#1e1e1e` | Nested containers, elevated surfaces |
+| Graphite | `#2a2a2a` | Tertiary surfaces |
+| Steel | `#555555` | Disabled text, subtle dividers |
+| Ash | `#888888` | Tertiary text, timestamps |
+| Silver | `#aaaaaa` | Secondary text, descriptions |
+
+### Font Declarations
+
+```css
+font-family: 'Archivo Black', Impact, 'Arial Black', sans-serif;
+font-family: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-void: #0a0a0a;
+  --color-white: #ffffff;
+  --color-neon-yellow: #e6ff00;
+
+  /* Colors -- Accent */
+  --color-hot-pink: #ff2d6f;
+  --color-dark-yellow: #b8cc00;
+  --color-dark-pink: #cc2459;
+  --color-yellow-glow: rgba(230, 255, 0, 0.15);
+  --color-pink-glow: rgba(255, 45, 111, 0.15);
+
+  /* Colors -- Neutral Scale */
+  --color-dark-surface: #141414;
+  --color-charcoal: #1e1e1e;
+  --color-graphite: #2a2a2a;
+  --color-steel: #555555;
+  --color-ash: #888888;
+  --color-silver: #aaaaaa;
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: #141414;
+  --color-surface-inset: #111111;
+
+  /* Colors -- Borders */
+  --color-border-default: rgba(255, 255, 255, 0.1);
+  --color-border-neon: rgba(230, 255, 0, 0.3);
+  --color-border-pink: rgba(255, 45, 111, 0.3);
+  --color-border-strong: rgba(255, 255, 255, 0.2);
+  --color-divider-rule: #e6ff00;
+
+  /* Colors -- Shadows */
+  --shadow-neon: rgba(230, 255, 0, 0.12);
+  --shadow-pink: rgba(255, 45, 111, 0.12);
+  --shadow-deep: rgba(0, 0, 0, 0.6);
+  --shadow-soft: rgba(0, 0, 0, 0.3);
+  --shadow-ambient: rgba(230, 255, 0, 0.06);
+
+  /* Typography -- Families */
+  --font-display: 'Archivo Black', Impact, 'Arial Black', sans-serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 80px;
+  --text-section-heading: 56px;
+  --text-sub-heading: 36px;
+  --text-body-large: 20px;
+  --text-body: 16px;
+  --text-small: 13px;
+  --text-big-number: 200px;
+  --text-label: 14px;
+  --text-cta: 16px;
+
+  /* Typography -- Weights */
+  --weight-display: 400;
+  --weight-body: 400;
+  --weight-body-medium: 500;
+  --weight-label: 700;
+  --weight-cta: 700;
+
+  /* Typography -- Line Heights */
+  --leading-display: 1.00;
+  --leading-heading: 1.05;
+  --leading-sub-heading: 1.10;
+  --leading-body-large: 1.60;
+  --leading-body: 1.65;
+  --leading-small: 1.50;
+  --leading-number: 0.85;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-base: 16px;
+  --space-medium: 24px;
+  --space-large: 32px;
+  --space-section: 48px;
+  --space-hero: 60px;
+  --space-max: 80px;
+  --space-spectacle: 120px;
+
+  /* Borders */
+  --radius-standard: 4px;
+
+  /* Shadows -- Composed */
+  --shadow-card: rgba(0,0,0,0.4) 0px 8px 24px, rgba(230,255,0,0.04) 0px 0px 16px;
+  --shadow-glow: rgba(0,0,0,0.5) 0px 16px 40px, rgba(230,255,0,0.08) 0px 0px 30px;
+  --shadow-neon-glow: 0 0 20px rgba(230,255,0,0.3), 0 0 60px rgba(230,255,0,0.1);
+  --shadow-pink-glow: 0 0 20px rgba(255,45,111,0.3), 0 0 60px rgba(255,45,111,0.1);
+  --shadow-rule-glow: 0 0 12px rgba(230,255,0,0.4);
+
+  /* Glow -- Text Shadows */
+  --glow-text-neon: 0 0 20px rgba(230,255,0,0.3), 0 0 60px rgba(230,255,0,0.1);
+  --glow-text-pink: 0 0 20px rgba(255,45,111,0.3), 0 0 60px rgba(255,45,111,0.1);
+  --glow-text-hero: 0 0 40px rgba(230,255,0,0.15);
+}
+```
+
+### System Font Fallbacks
+- **Display (if Archivo Black fails to load):** `Impact, 'Arial Black', sans-serif`
+- **Body (if Inter fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/_full/frosted-lens.md
+++ b/skills/composites/goose-graphics/styles/_full/frosted-lens.md
@@ -1,0 +1,508 @@
+# Design Style: Frosted Lens
+
+## 1. Visual Theme & Atmosphere
+
+Frosted Lens is the design language of controlled contrast -- a vibrant, kinetic energy field glimpsed through a pristine white window. The defining tension is between chaos and clarity: a background of blurred, streaked color (hot pinks, electric teals, deep blues, and warm ambers in motion-blur trails) and a large, softly rounded white card (`#ffffff` with 20-24px radius) that floats above it like a frosted glass panel. Inside the card, everything is calm, data-forward, and deliberately minimal. Outside, everything is alive and chromatic. This is the aesthetic of a tech startup's Series B announcement, of a Stripe product page meets a Figma conference slide -- polished data visualization dressed in startup energy.
+
+The typography is clean, contemporary sans-serif -- the kind of type you see on Y Combinator demo day decks and modern SaaS dashboards. Headings in DM Sans at semibold weight feel confident without being aggressive. Body text at regular weight is open and readable. A spaced-uppercase brand label ("INFRENCECORE") anchors the top of the card with quiet authority. The color story inside the card is deliberately restrained: a fresh sage-mint green (`#7CB68E`) for primary data bars, a muted dusty rose (`#D4A0A0`) for secondary data, and near-black text. The green bars are the heroes -- growing left to right like a growth chart, each topped with a clean data label in dark text. Below the chart, a bold statement headline in near-black seals the narrative.
+
+The magic of this style is the layering. The blurred chromatic background creates depth and energy without competing with the content. The white card acts as a lens or viewport -- a controlled space where information is presented with Swiss-level precision. The rounded corners (20-24px) soften the card enough to feel modern and approachable without becoming bubbly. Shadows are medium-depth and slightly warm-tinted, reinforcing the sense that the card floats above a luminous surface. This is the visual language of a company that wants to say: "We move fast, but our data is clean."
+
+**Key Characteristics:**
+- Vibrant blurred/abstract background with motion-blur color streaks (pinks `#E8457A`, teals `#3CBCB4`, blues `#2E5C9A`, ambers `#D4943C`)
+- Large white card overlay (`#ffffff`) with generous border-radius (20-24px) as the primary content surface
+- Sage-mint green (`#7CB68E`) as the primary accent for data visualization and positive metrics
+- Dusty rose (`#D4A0A0`) as a soft secondary accent for supporting data elements
+- Near-black (`#1A1A1A`) for all primary text -- warm enough to avoid harshness
+- Clean sans-serif typography (DM Sans) with spaced uppercase for brand labels and category tags
+- Medium card shadow (`0 8px 32px rgba(0,0,0,0.12)`) for floating-card depth
+- Generous internal card padding (40-48px) with content centered or left-aligned within the card
+- Data-forward layout: bar charts, big numbers, and growth metrics are the focal content
+- Strong contrast between energetic exterior and calm, minimal interior -- the "frosted lens" effect
+- Border-radius of 20-24px on the main card surface, 8-12px on internal elements like chart bars
+- Statement headlines below data visualizations that editorialize the numbers
+
+## 2. Color Palette & Roles
+
+### Primary
+- **White** (`#ffffff`): Primary card surface. The frosted lens through which all content is viewed. Pure white for maximum contrast against the chromatic background.
+- **Near-Black** (`#1A1A1A`): Primary text colour. Warm black for headlines, data labels, and body copy inside the card.
+- **Sage Mint** (`#7CB68E`): Primary accent. Used for main data bars, positive metrics, growth indicators, and key callouts. Fresh, optimistic, and distinctly startup.
+
+### Accent
+- **Dusty Rose** (`#D4A0A0`): Secondary data accent. Used for secondary bars, comparison data, and softer supporting elements. Muted and non-competing.
+- **Dark Sage** (`#5A9A6E`): Hover and active state for sage mint elements. Deeper, more saturated.
+- **Warm Gray** (`#6B7280`): Secondary text colour for descriptions, axis labels, captions, and supporting copy.
+
+### Neutral Scale
+- **Snow** (`#F5F5F5`): Elevated surface inside cards -- nested containers, chart backgrounds, and inset panels.
+- **Light Border** (`#E8E8E8`): Subtle borders for internal card elements, axis lines, and structural dividers.
+- **Mid Gray** (`#D1D5DB`): Disabled states, placeholder text, and inactive chart elements.
+- **Cool Gray** (`#9CA3AF`): Tertiary text for timestamps, footnotes, and low-priority metadata.
+- **Slate** (`#4B5563`): Secondary headings and medium-emphasis labels within the card.
+- **Charcoal** (`#374151`): High-emphasis body text, slightly lighter than primary for visual layering.
+
+### Surface & Borders
+- **Surface Primary** (`#ffffff`): The main card surface.
+- **Surface Inset** (`#F8F8F8`): Recessed areas within cards -- chart plot areas, code blocks, nested panels.
+- **Border Default** (`rgba(0,0,0,0.06)`): Subtle internal card borders for structural separation.
+- **Border Accent** (`rgba(124,182,142,0.35)`): Sage-tinted border for active or featured data elements.
+- **Border Strong** (`rgba(0,0,0,0.12)`): Higher-contrast border for prominent internal containers.
+- **Divider Rule** (`#7CB68E`): Solid sage for accent rules and active indicators.
+
+### Shadow Colors
+- **Shadow Subtle** (`rgba(0,0,0,0.06)`): Light ambient shadow for internal card elements.
+- **Shadow Medium** (`rgba(0,0,0,0.12)`): Standard card elevation shadow -- the primary floating-card shadow.
+- **Shadow Deep** (`rgba(0,0,0,0.18)`): High-elevation elements like overlays and featured panels.
+- **Shadow Warm** (`rgba(30,20,15,0.08)`): Warm-tinted ambient shadow that complements the chromatic background.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Body**: `'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | DM Sans | 64px | 700 | 1.08 | -1.5px | Hero headlines, bold growth statements |
+| Section Heading | DM Sans | 42px | 700 | 1.12 | -1px | Major section titles inside cards |
+| Sub-heading | DM Sans | 28px | 600 | 1.20 | -0.5px | Subsection titles, card sub-headers |
+| Body Large | DM Sans | 20px | 400 | 1.60 | 0px | Lead paragraphs, statement text below charts |
+| Body | DM Sans | 16px | 400 | 1.60 | 0px | Standard reading text |
+| Small / Caption | DM Sans | 13px | 400 | 1.45 | 0.15px | Axis labels, footnotes, metadata |
+| Big Numbers | DM Sans | 56px | 700 | 1.00 | -1px | Data labels on charts, hero statistics |
+| Brand Label | DM Sans | 12px | 500 | 1.00 | 2.5px | Uppercase spaced brand name, category tags |
+| Data Label | DM Sans | 18px | 600 | 1.00 | -0.25px | Chart data values (200k, 400k, 1.1m) |
+| CTA Text | DM Sans | 15px | 600 | 1.00 | 0.3px | Button and call-to-action text |
+
+### Principles
+- **Single family, flexible hierarchy**: DM Sans handles everything from brand labels to hero numbers. Its geometric-yet-friendly character matches the startup-meets-precision mood. Hierarchy is built through size, weight, and tracking.
+- **Tight tracking at display sizes**: -1.5px at 64px, -1px at 42px, -0.5px at 28px. Headlines should feel modern and confident, not loose or casual.
+- **Wide tracking for brand labels**: Uppercase text at 12-13px uses 2-3px letter-spacing. This creates the spaced, authoritative look seen in the "INFRENCECORE" label.
+- **Regular weight for body text**: Weight 400 for body copy keeps the interior of the card feeling light and clean. The contrast with bold 700 headlines creates clear hierarchy.
+- **Generous line height**: 1.60 for body text ensures readability inside the white card where dense text would feel cramped against the open, airy aesthetic.
+- **Data labels are semibold**: Chart annotations and data values use weight 600 at 18px -- prominent enough to read at a glance, but not competing with the headline.
+
+## 4. Component Patterns
+
+### Title Block (Cover / Header Section)
+
+```html
+<div style="position: relative; width: 100%; min-height: 600px; background: linear-gradient(135deg, #E8457A 0%, #3CBCB4 35%, #2E5C9A 65%, #D4943C 100%); filter: blur(0px); display: flex; align-items: center; justify-content: center; padding: 60px;">
+  <div style="background: var(--color-white); border-radius: 24px; padding: 56px 48px; box-shadow: var(--shadow-card); max-width: 640px; width: 100%;">
+    <p style="font-family: var(--font-display); font-size: 12px; font-weight: 500; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-warm-gray); margin: 0 0 32px;">COMPANY NAME</p>
+    <h1 style="font-family: var(--font-display); font-size: 64px; font-weight: 700; line-height: 1.08; letter-spacing: -1.5px; color: var(--color-near-black); margin: 0 0 20px;">Growth That<br>Speaks for Itself</h1>
+    <p style="font-family: var(--font-body); font-size: 20px; font-weight: 400; line-height: 1.60; color: var(--color-warm-gray); margin: 0;">The fastest growing AI infrastructure company in the industry.</p>
+  </div>
+</div>
+```
+
+### Numbered Item
+
+```html
+<div style="display: flex; gap: 20px; align-items: flex-start; padding: 28px 0; border-bottom: 1px solid rgba(0,0,0,0.06);">
+  <span style="font-family: var(--font-display); font-size: 42px; font-weight: 700; line-height: 1.00; letter-spacing: -1px; color: var(--color-sage-mint); min-width: 64px;">01</span>
+  <div>
+    <p style="font-family: var(--font-body); font-size: 12px; font-weight: 500; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-cool-gray); margin: 0 0 8px;">INFRASTRUCTURE</p>
+    <h3 style="font-family: var(--font-display); font-size: 28px; font-weight: 600; line-height: 1.20; letter-spacing: -0.5px; color: var(--color-near-black); margin: 0 0 10px;">Scalable from day one</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.60; color: var(--color-warm-gray); margin: 0;">Built to handle millions of inference requests from the start, with auto-scaling that keeps latency under 50ms at any volume.</p>
+  </div>
+</div>
+```
+
+### Stat Display (Bar Chart Growth)
+
+```html
+<div style="background: var(--color-white); border-radius: 24px; padding: 48px 40px; box-shadow: var(--shadow-card);">
+  <p style="font-family: var(--font-display); font-size: 12px; font-weight: 500; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-warm-gray); margin: 0 0 32px;">ANNUAL REVENUE</p>
+  <div style="display: flex; align-items: flex-end; gap: 16px; height: 240px; margin-bottom: 32px;">
+    <div style="display: flex; flex-direction: column; align-items: center; flex: 1;">
+      <span style="font-family: var(--font-display); font-size: 18px; font-weight: 600; color: var(--color-near-black); margin-bottom: 8px;">200k</span>
+      <div style="width: 100%; height: 80px; background: var(--color-dusty-rose); border-radius: 8px 8px 0 0;"></div>
+      <span style="font-family: var(--font-body); font-size: 13px; font-weight: 400; color: var(--color-cool-gray); margin-top: 8px;">2024</span>
+    </div>
+    <div style="display: flex; flex-direction: column; align-items: center; flex: 1;">
+      <span style="font-family: var(--font-display); font-size: 18px; font-weight: 600; color: var(--color-near-black); margin-bottom: 8px;">400k</span>
+      <div style="width: 100%; height: 140px; background: linear-gradient(180deg, var(--color-sage-mint), var(--color-dusty-rose)); border-radius: 8px 8px 0 0;"></div>
+      <span style="font-family: var(--font-body); font-size: 13px; font-weight: 400; color: var(--color-cool-gray); margin-top: 8px;">2025</span>
+    </div>
+    <div style="display: flex; flex-direction: column; align-items: center; flex: 1;">
+      <span style="font-family: var(--font-display); font-size: 18px; font-weight: 600; color: var(--color-near-black); margin-bottom: 8px;">1.1m</span>
+      <div style="width: 100%; height: 220px; background: var(--color-sage-mint); border-radius: 8px 8px 0 0;"></div>
+      <span style="font-family: var(--font-body); font-size: 13px; font-weight: 400; color: var(--color-cool-gray); margin-top: 8px;">2026</span>
+    </div>
+  </div>
+  <h2 style="font-family: var(--font-display); font-size: 28px; font-weight: 700; line-height: 1.20; letter-spacing: -0.5px; color: var(--color-near-black); margin: 0;">The fastest growing AI Infrastructure company in the industry.</h2>
+</div>
+```
+
+### Comparison Grid
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+  <div style="background: var(--color-white); border-radius: 20px; padding: 36px 32px; box-shadow: var(--shadow-subtle);">
+    <p style="font-family: var(--font-body); font-size: 12px; font-weight: 500; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-dusty-rose); margin: 0 0 16px;">BEFORE</p>
+    <h3 style="font-family: var(--font-display); font-size: 28px; font-weight: 600; line-height: 1.20; letter-spacing: -0.5px; color: var(--color-near-black); margin: 0 0 12px;">Slow & Fragmented</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.60; color: var(--color-warm-gray); margin: 0;">Teams manually routing requests, waiting minutes for cold starts, and piecing together multiple providers.</p>
+  </div>
+  <div style="background: var(--color-white); border-radius: 20px; padding: 36px 32px; box-shadow: var(--shadow-subtle); border-left: 3px solid var(--color-sage-mint);">
+    <p style="font-family: var(--font-body); font-size: 12px; font-weight: 500; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-sage-mint); margin: 0 0 16px;">AFTER</p>
+    <h3 style="font-family: var(--font-display); font-size: 28px; font-weight: 600; line-height: 1.20; letter-spacing: -0.5px; color: var(--color-near-black); margin: 0 0 12px;">Fast & Unified</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.60; color: var(--color-warm-gray); margin: 0;">One API, sub-50ms latency, auto-scaling inference that handles spikes without breaking a sweat.</p>
+  </div>
+</div>
+```
+
+### List Item
+
+```html
+<div style="display: flex; gap: 16px; align-items: flex-start; padding: 20px 0; border-bottom: 1px solid rgba(0,0,0,0.06);">
+  <div style="width: 36px; height: 36px; min-width: 36px; display: flex; align-items: center; justify-content: center; background: rgba(124,182,142,0.12); border-radius: 10px; color: var(--color-sage-mint); font-size: 14px;">&#9650;</div>
+  <div>
+    <h4 style="font-family: var(--font-display); font-size: 20px; font-weight: 600; line-height: 1.25; color: var(--color-near-black); margin: 0 0 6px;">Auto-Scaling Inference</h4>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.60; color: var(--color-warm-gray); margin: 0;">Handles traffic spikes automatically. Zero cold starts, zero manual intervention, zero downtime.</p>
+  </div>
+</div>
+```
+
+### Quote Block
+
+```html
+<div style="background: var(--color-white); border-radius: 20px; padding: 40px 36px; box-shadow: var(--shadow-subtle); border-left: 3px solid var(--color-sage-mint);">
+  <p style="font-family: var(--font-display); font-size: 28px; font-weight: 400; line-height: 1.35; letter-spacing: -0.5px; color: var(--color-near-black); margin: 0 0 24px;">"We migrated our entire inference stack in a weekend. Latency dropped 60% and we haven't touched it since."</p>
+  <div style="display: flex; align-items: center; gap: 12px;">
+    <div style="width: 28px; height: 3px; background: var(--color-sage-mint); border-radius: 2px;"></div>
+    <p style="font-family: var(--font-body); font-size: 12px; font-weight: 500; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-cool-gray); margin: 0;">ALEX CHEN, CTO AT SCALEAI</p>
+  </div>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="background: var(--color-white); border-radius: 24px; padding: 52px 40px; box-shadow: var(--shadow-card); text-align: center;">
+  <h2 style="font-family: var(--font-display); font-size: 36px; font-weight: 700; line-height: 1.12; letter-spacing: -1px; color: var(--color-near-black); margin: 0 0 14px;">Ready to scale?</h2>
+  <p style="font-family: var(--font-body); font-size: 18px; font-weight: 400; line-height: 1.60; color: var(--color-warm-gray); max-width: 440px; margin: 0 auto 28px;">Deploy your first model in under five minutes. No infrastructure headaches, no long-term contracts.</p>
+  <a style="display: inline-block; background: var(--color-sage-mint); color: var(--color-white); font-family: var(--font-body); font-size: 15px; font-weight: 600; letter-spacing: 0.3px; text-decoration: none; padding: 14px 36px; border-radius: 12px;">Get Started</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between icon and inline label, between data label and bar top.
+- **8px**: Tight gap -- between chart bar and axis label, between sub-label and heading.
+- **12px**: Small gap -- between heading and body text within a component.
+- **16px**: Base gap -- between chart bars, between body paragraphs.
+- **20px**: Medium-small gap -- between grid items, between list items in compact mode.
+- **24px**: Medium gap -- between components within a card, standard list item padding.
+- **32px**: Section internal -- between brand label and chart, between chart and headline.
+- **40px**: Card internal padding -- left/right padding inside the primary card surface.
+- **48px**: Large card padding -- top/bottom padding inside the primary card surface.
+- **60px**: Background padding -- space between the card edge and the chromatic background edge.
+- **80px**: Maximum section padding -- cover layouts and high-impact hero areas.
+
+### Format Padding
+| Format | Background Padding | Card Padding | Card Border Radius | Content Max-Width |
+|--------|--------------------|--------------|-------------------|-------------------|
+| Carousel (1080x1080) | 48px all sides | 40px all sides | 24px | 984px |
+| Infographic (1080xN) | 48px left/right, 60px top/bottom | 40px left/right, 48px top/bottom | 24px | 984px |
+| Slides (1920x1080) | 60px all sides | 48px all sides | 24px | 1800px |
+| Poster (1080x1350) | 48px left/right, 60px top/bottom | 40px left/right, 48px top/bottom | 24px | 984px |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned text for body content inside cards. Center-aligned for hero titles, single stats, and CTA blocks.
+- **Card-centric layout**: The white card is always the dominant structural element. Content lives inside cards, never directly on the chromatic background.
+- **Grid**: Single-column for narrative and chart content inside cards. 2-column grid for comparison layouts, with each column in its own rounded card. 3-column for stat grids on widescreen slides.
+- **Accent rules**: 3px wide, sage mint (`#7CB68E`), used as left borders on featured cards and quote blocks -- never as horizontal dividers. Structural separation comes from spacing and card boundaries.
+- **Vertical rhythm**: Maintain consistent 32px gaps between elements within a card. Use 20px gaps between grid items. Card padding provides the outer breathing room.
+- **Chart alignment**: Bar charts align to the bottom of the chart area. Data labels sit directly above their respective bars. Axis labels sit directly below.
+- **Background composition**: The chromatic blur background should extend to all edges. The card floats centered or slightly above center for visual balance.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Background (Level 0) | Chromatic blur gradient, no shadow | The energetic base layer -- blurred color streaks |
+| Flat Card (Level 1) | `background: #ffffff; border-radius: 24px;` | Simple white card with no shadow, for nested internal panels |
+| Standard Card (Level 2) | `0 4px 20px rgba(0,0,0,0.08), 0 8px 32px rgba(0,0,0,0.06)` | The primary floating card -- the frosted lens surface |
+| Featured Card (Level 3) | `0 8px 32px rgba(0,0,0,0.12), 0 16px 48px rgba(0,0,0,0.08)` | Hero cards, featured data displays, key stat panels |
+| Overlay (Level 4) | `0 16px 56px rgba(0,0,0,0.18)` | Modals, overlays, high-priority popups above the card layer |
+
+### Border Treatments
+- **Card border**: None by default. The shadow and white surface against the chromatic background provide sufficient definition. Do not add borders to the main card.
+- **Internal border**: `1px solid rgba(0,0,0,0.06)` -- subtle separator for list items and internal card sections.
+- **Accent border**: `3px solid #7CB68E` -- sage mint left-border for featured panels and quote blocks. Always on the left edge, never top or bottom.
+- **Divider line**: `1px solid rgba(0,0,0,0.04)` -- nearly invisible separator for dense content within cards.
+
+### Surface Hierarchy
+The defining depth relationship in this style is between the chromatic background and the white card:
+1. **Background** (chromatic blur) -- the deepest layer, full of energy and color. This is a CSS gradient with blur, or a blurred image.
+2. **Primary Card** (`#ffffff` with Level 2-3 shadow, 24px radius) -- the frosted lens. This is where all content lives. The shadow and radius create the floating effect.
+3. **Inset Surface** (`#F8F8F8` inside cards) -- recessed areas within the card for chart backgrounds or nested panels.
+4. **Data Elements** (colored bars, stat numbers) -- the highest visual layer within the card, using color to pop forward.
+
+The white card's shadow against the colorful background is the signature depth mechanism. Inside the card, depth is communicated through subtle color differences (white vs. `#F8F8F8`) rather than additional shadows. Avoid nesting shadowed cards inside shadowed cards.
+
+## 7. Do's and Don'ts
+
+### Do
+- Always place content inside a white card (`#ffffff`) with `border-radius: 24px` -- the card-on-chromatic-background is the signature of this style.
+- Use sage mint (`#7CB68E`) as the primary accent for positive data, growth metrics, and CTAs -- it is the optimistic signal color.
+- Use dusty rose (`#D4A0A0`) only as a secondary data color for comparison bars and supporting metrics -- never for CTAs or headlines.
+- Keep the chromatic background abstract and blurred -- motion-blur streaks, not recognizable imagery or sharp gradients.
+- Use spaced uppercase (letter-spacing: 2-3px) for brand labels and category tags at 12-13px size.
+- Maintain generous card padding (40-48px) -- content should breathe inside the white surface.
+- Use `border-radius: 8-12px` for internal elements (chart bars, buttons, icon containers) to echo the card's rounded aesthetic.
+- Let data visualizations (bar charts, line graphs, big numbers) be the hero content -- this style is data-forward.
+- Use a single bold statement headline below or beside the data to editorialize the numbers.
+- Include a brand label in spaced uppercase at the top of the card to anchor the composition.
+
+### Don't
+- Don't place text or content directly on the chromatic background -- everything lives inside the white card.
+- Don't use sharp corners (0px radius) on the main card -- the minimum is 20px. Sharp corners break the frosted-lens softness.
+- Don't use more than 2 chromatic accent colors inside the card (sage mint + dusty rose). The card interior is calm and restrained.
+- Don't use CSS gradients for the background -- use a real photograph or artwork with `filter: blur(24px)`. CSS gradients look flat and artificial; this style requires organic chromatic texture from a real image.
+- Don't use heavy black drop shadows -- shadows should be medium-depth (`rgba(0,0,0,0.08-0.12)`) and diffused. Harsh shadows feel dated against this aesthetic.
+- Don't use weight 700 for body text inside the card -- keep body at 400 to maintain the clean, open feel.
+- Don't apply borders to the main white card -- the shadow against the chromatic background provides all the definition needed.
+- Don't center-align body paragraphs -- only headlines, single stats, and CTAs should be centered.
+- Don't use gradients inside the card for backgrounds or text -- the card interior is flat white. Gradients belong to the background layer only.
+- Don't exceed 3 data bars or metrics in a single chart row -- each element needs space to read clearly.
+- Don't use serif fonts or monospace fonts -- the clean sans-serif is essential to the modern startup feel.
+- Don't place the card flush against the background edge -- maintain at least 48px of visible chromatic background on all sides.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale down**: Display Hero becomes 48px (from 64px). Section Heading becomes 36px. Sub-heading stays 28px. Body stays 16px. Data Labels stay 18px.
+- **Background padding**: 48px on all sides. The chromatic blur is visible as a vibrant border around the card.
+- **Card**: Single white card fills most of the frame (984x984px content area). Border-radius 24px. Padding 40px inside.
+- **Cover slide**: Brand label at top, hero headline centered, subtitle in warm gray below. Card floats on chromatic background.
+- **Data slides**: Bar chart or single big stat centered in the card. Statement headline below the data.
+- **Swipe indicator**: Small white dots with 50% opacity at bottom of the chromatic background area, 8px diameter, 12px gap. Active dot fully opaque.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Uses full-scale type hierarchy. Display Hero at 64px for the title section.
+- **Background**: Chromatic blur runs the full height. Multiple white cards stacked vertically with 24px gaps between them.
+- **Card stacking**: Each major section gets its own card. Cards share the same 24px radius and 40px internal padding.
+- **Section spacing**: 24px vertical gap between cards. No additional dividers needed -- the chromatic background peeks through the gaps.
+- **Vertical rhythm**: Alternate between data-focused cards (charts, stats) and narrative cards (quote blocks, feature lists).
+- **Footer**: Final card contains CTA. Brand label repeats in a small card at the very bottom.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 72px with -2px tracking. Section Heading becomes 48px. Body Large becomes 22px. Data Labels become 22px.
+- **Background padding**: 60px on all sides.
+- **Card sizing**: Card can be full-width (1800x960px) or split into 2 side-by-side cards for comparison layouts.
+- **Title slides**: Single large card centered. Brand label, headline, and subtitle vertically stacked inside.
+- **Data slides**: Card with chart on the left 60%, statement headline on the right 40% -- or chart centered with headline below.
+- **Two-card layouts**: Two rounded cards side-by-side with 24px gap between them. Chromatic background visible in the gap.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 56px. Section Heading at 36px. Body at 16px.
+- **Background padding**: 48px left/right, 60px top/bottom.
+- **Composition**: Single tall white card occupying most of the frame. Top zone for brand label and headline. Middle zone for data visualization. Bottom zone for statement headline and CTA.
+- **Vertical flow**: Content reads top-to-bottom inside the card. Generous 32px spacing between zones.
+- **CTA placement**: Always in the bottom zone of the card, centered, with a sage mint button.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Hero becomes 64px (approximately 30% larger than Carousel 48px). Section Heading becomes 48px in DM Sans 600. Body Large becomes 22px. Data labels become 22px. Brand label (spaced uppercase) stays 14px at the top of the card.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical text must sit inside y=160 to y=1760.
+- **Layout**: A single tall white card (`#ffffff`, 24px radius) occupies roughly 860px wide by 1520px tall, centered at y=200 to y=1720 inside the safe zone. The blurred chromatic background (pinks, teals, blues, ambers in motion) fills the frame behind it so the card still reads as a frosted lens floating over movement.
+- **Cover slide**: Brand label (`INFERENCECORE`) spaced uppercase at the top of the card, then the headline in DM Sans 600 at 64px in near-black centered inside the card, then supporting body in near-black/warm gray below. Keep the interior calm -- all the visual energy lives in the blurred exterior.
+- **Content slides**: Tall vertical bar chart as the hero element filling the middle two-thirds of the card, with sage-mint (`#7CB68E`) primary bars and dusty rose (`#D4A0A0`) secondary bars, each topped with a dark data label. Below the chart, a bold near-black statement headline editorializes the numbers. One chart or one metric block per slide -- the data is the story.
+- **CTA slide**: Inside the same white card, centered headline at 56px in DM Sans 600 near-black, short supporting line, and a sage-mint pill button with near-black DM Sans 700 CTA text. Medium warm card shadow (`0 16px 48px rgba(0,0,0,0.14)`) stays under the card throughout the story.
+- **Progress indicator**: Thin progress segments (2px, 4px gap) at the top of the safe zone in sage-mint at 40% opacity for inactive and full sage-mint for active -- placed above the card so the card's interior stays pristine.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| White | `#ffffff` | Primary card surface |
+| Near-Black | `#1A1A1A` | Primary text |
+| Sage Mint | `#7CB68E` | Accent: primary data, CTAs, growth indicators |
+| Dark Sage | `#5A9A6E` | Hover/active state for sage elements |
+| Dusty Rose | `#D4A0A0` | Secondary data bars, comparison metrics |
+| Snow | `#F5F5F5` | Nested card surfaces, inset panels |
+| Surface Inset | `#F8F8F8` | Chart backgrounds, recessed areas |
+| Light Border | `#E8E8E8` | Internal structural borders |
+| Mid Gray | `#D1D5DB` | Disabled states, placeholders |
+| Cool Gray | `#9CA3AF` | Tertiary text, axis labels |
+| Warm Gray | `#6B7280` | Secondary text, descriptions |
+| Slate | `#4B5563` | Secondary headings |
+| Charcoal | `#374151` | High-emphasis body text |
+| BG Pink | `#E8457A` | Chromatic background streak |
+| BG Teal | `#3CBCB4` | Chromatic background streak |
+| BG Blue | `#2E5C9A` | Chromatic background streak |
+| BG Amber | `#D4943C` | Chromatic background streak |
+
+### Font Declarations
+
+```css
+font-family: 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-white: #ffffff;
+  --color-near-black: #1A1A1A;
+  --color-sage-mint: #7CB68E;
+
+  /* Colors -- Accent */
+  --color-dark-sage: #5A9A6E;
+  --color-dusty-rose: #D4A0A0;
+  --color-warm-gray: #6B7280;
+
+  /* Colors -- Neutral Scale */
+  --color-snow: #F5F5F5;
+  --color-light-border: #E8E8E8;
+  --color-mid-gray: #D1D5DB;
+  --color-cool-gray: #9CA3AF;
+  --color-slate: #4B5563;
+  --color-charcoal: #374151;
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: #ffffff;
+  --color-surface-inset: #F8F8F8;
+
+  /* Colors -- Chromatic Background */
+  --color-bg-pink: #E8457A;
+  --color-bg-teal: #3CBCB4;
+  --color-bg-blue: #2E5C9A;
+  --color-bg-amber: #D4943C;
+
+  /* Colors -- Borders */
+  --color-border-default: rgba(0, 0, 0, 0.06);
+  --color-border-accent: rgba(124, 182, 142, 0.35);
+  --color-border-strong: rgba(0, 0, 0, 0.12);
+  --color-divider-rule: #7CB68E;
+
+  /* Colors -- Shadows */
+  --shadow-subtle-color: rgba(0, 0, 0, 0.06);
+  --shadow-medium-color: rgba(0, 0, 0, 0.12);
+  --shadow-deep-color: rgba(0, 0, 0, 0.18);
+  --shadow-warm-color: rgba(30, 20, 15, 0.08);
+
+  /* Typography -- Families */
+  --font-display: 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-body: 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 64px;
+  --text-section-heading: 42px;
+  --text-sub-heading: 28px;
+  --text-body-large: 20px;
+  --text-body: 16px;
+  --text-small: 13px;
+  --text-big-number: 56px;
+  --text-brand-label: 12px;
+  --text-data-label: 18px;
+  --text-cta: 15px;
+
+  /* Typography -- Weights */
+  --weight-display: 700;
+  --weight-sub-heading: 600;
+  --weight-body: 400;
+  --weight-body-light: 300;
+  --weight-label: 500;
+  --weight-cta: 600;
+
+  /* Typography -- Line Heights */
+  --leading-display: 1.08;
+  --leading-heading: 1.12;
+  --leading-sub-heading: 1.20;
+  --leading-body-large: 1.60;
+  --leading-body: 1.60;
+  --leading-small: 1.45;
+  --leading-number: 1.00;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-medium-small: 20px;
+  --space-medium: 24px;
+  --space-large: 32px;
+  --space-card-padding: 40px;
+  --space-card-padding-lg: 48px;
+  --space-background: 60px;
+  --space-max: 80px;
+
+  /* Borders */
+  --radius-card: 24px;
+  --radius-internal: 12px;
+  --radius-small: 8px;
+  --radius-button: 12px;
+
+  /* Shadows -- Composed */
+  --shadow-subtle: 0 2px 12px rgba(0,0,0,0.06);
+  --shadow-card: 0 4px 20px rgba(0,0,0,0.08), 0 8px 32px rgba(0,0,0,0.06);
+  --shadow-featured: 0 8px 32px rgba(0,0,0,0.12), 0 16px 48px rgba(0,0,0,0.08);
+  --shadow-overlay: 0 16px 56px rgba(0,0,0,0.18);
+
+  /* Background Gradient */
+  --bg-chromatic: linear-gradient(135deg, #E8457A 0%, #3CBCB4 30%, #2E5C9A 60%, #D4943C 100%);
+}
+```
+
+### System Font Fallbacks
+- **Sans-serif (if DM Sans fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Background Generation
+
+**IMPORTANT: Use a real image for the background, NOT CSS gradients.** CSS gradients cannot replicate the organic, chromatic quality this style requires. The background must be a real photograph or artwork — abstract, colorful, and high-energy.
+
+**Recommended approach:** Use an Unsplash image or similar source with vibrant, abstract colors. Apply CSS `filter: blur(24px)` and `transform: scale(1.15)` to create the frosted effect.
+
+```css
+.frosted-lens-bg {
+  position: absolute;
+  inset: 0;
+  background-image: url('YOUR_IMAGE_URL_HERE');
+  background-size: cover;
+  background-position: center;
+  filter: blur(24px);
+  transform: scale(1.15); /* prevents blur edge artifacts */
+  z-index: 0;
+}
+```
+
+**Good image search terms for Unsplash:** "abstract colorful", "gradient art", "colorful bokeh", "abstract painting vibrant", "iridescent texture"
+
+**Fallback only (if no image is available):** Use the CSS variable `--bg-chromatic` as a last resort, but always prefer a real image.
+
+```css
+  --bg-chromatic: linear-gradient(135deg, #E8457A 0%, #3CBCB4 30%, #2E5C9A 60%, #D4943C 100%);
+```

--- a/skills/composites/goose-graphics/styles/_full/garden-blur.md
+++ b/skills/composites/goose-graphics/styles/_full/garden-blur.md
@@ -1,0 +1,492 @@
+# Design Style: Garden Blur
+
+## 1. Visual Theme & Atmosphere
+
+Garden Blur is the visual language of authenticity -- the kind of design you see from lifestyle brands, personal creators, and wellness-adjacent products that want to feel real, grounded, and human. The defining feature is a heavily blurred photographic backdrop of natural greenery -- warm olive tones, sage greens, earthy browns, and soft bokeh light spots that evoke a sun-dappled garden viewed through a window. This is not a flat color or a CSS gradient; it is a living, breathing photograph rendered as atmosphere through aggressive Gaussian blur (30-50px). The blur transforms a specific photograph into a universal mood: warmth, growth, presence.
+
+Against this rich organic backdrop, crisp white cards (`#ffffff`) emerge with generous rounded corners (24px) and clean edges. The contrast is the entire story -- raw nature made abstract versus precise digital typography. The cards carry no visible border and minimal shadow; the depth of field blur provides all the elevation they need. Inside the cards, the typographic system is restrained and modern: a single sans-serif family (Inter from Google Fonts, matching the system-UI feel of the reference) handles every role from bold display names to quiet metadata handles. The weight range is narrow -- 400 for body, 500 for secondary, 700 for names and emphasis -- creating hierarchy through weight alone, never through decorative treatment.
+
+The color story is deliberately quiet inside the cards. Near-black charcoal (`#1c1c1e`) for primary text, warm medium gray (`#8e8e93`) for secondary text and icons, and a single muted accent -- a dusty rose (`#a3867a`) -- for interactive highlights like the heart icon. This restraint is intentional: all the visual energy lives in the blurred backdrop, and the card content stays clean and readable. The overall effect feels like scrolling through a thoughtful person's feed while sitting in a greenhouse -- digital content that doesn't forget the physical world exists. Think of the aesthetic sensibility of Kinfolk magazine crossed with the clean card patterns of iOS notification design.
+
+**Key Characteristics:**
+- Blurred photographic backdrop of natural greenery with warm olive (`#6b7a52`), sage (`#8a9668`), and earthy brown (`#7a6b52`) tones
+- Heavy Gaussian blur (30-50px) on the background image, creating a painterly bokeh atmosphere
+- White (`#ffffff`) card surfaces with large rounded corners (24px) floating on the blurred backdrop
+- Near-black charcoal (`#1c1c1e`) for primary text -- dark enough for strong contrast, warm enough to avoid coldness
+- Inter at weights 400-700 throughout -- one font family, clean and system-native in feel
+- Warm medium gray (`#8e8e93`) for all secondary text, handles, metadata, and icons
+- Dusty rose (`#a3867a`) as the sole accent color -- used sparingly for interactive highlights
+- No visible card borders -- depth comes from the contrast between sharp white cards and the soft blurred background
+- Generous internal card padding (32-40px) with relaxed line heights for a breathable reading experience
+- Social-card component pattern: circular avatar, name/handle pair, body text, interaction icon row
+- Minimal UI chrome -- three-dot menus, outline icons, no filled buttons inside content cards
+
+## 2. Color Palette & Roles
+
+### Primary
+- **White** (`#ffffff`): Card and container surface. The primary content background that creates contrast against the blurred backdrop.
+- **Near-Black Charcoal** (`#1c1c1e`): Primary text color. Warm-leaning dark for high readability without the harshness of pure black.
+- **Dusty Rose** (`#a3867a`): Primary accent. Used for interactive highlights (heart icon, active states), the only chromatic color inside the cards.
+
+### Accent
+- **Warm Taupe** (`#b89e8e`): Lighter accent for hover states, secondary interactive elements, and soft highlights.
+- **Deep Rose** (`#8a6e62`): Darker accent for pressed/active states on interactive elements.
+- **Sage Tint** (`#d4dcc8`): Background tint derived from the garden backdrop, used for subtle tag backgrounds or highlighted sections.
+
+### Neutral Scale
+- **Near-Black Charcoal** (`#1c1c1e`): Primary text, display names, headings, and high-emphasis content.
+- **Dark Gray** (`#3a3a3c`): Secondary text for descriptions and supporting body copy.
+- **Medium Gray** (`#636366`): Tertiary text for timestamps, bylines, and less prominent metadata.
+- **Warm Gray** (`#8e8e93`): Handles, icons, placeholder text, and de-emphasized UI elements.
+- **Light Gray** (`#c7c7cc`): Borders, dividers, and subtle structural lines within cards.
+- **Pale Gray** (`#f2f2f7`): Hover surface tint on white cards, subtle background for inset sections.
+
+### Surface & Borders
+- **Surface Primary** (`#ffffff`): Card and container background.
+- **Surface Tinted** (`#faf8f6`): Warm-tinted surface for featured or highlighted cards.
+- **Surface Backdrop**: Blurred photographic image with dominant tones of olive (`#6b7a52`), sage (`#8a9668`), and earthy brown (`#7a6b52`).
+- **Border Default** (`rgba(28,28,30,0.08)`): Subtle border for card edges when needed (usually omitted).
+- **Border Accent** (`rgba(163,134,122,0.4)`): Rose-tinted border for active or featured elements.
+- **Border Light** (`rgba(28,28,30,0.05)`): Barely visible divider for list items and sections within cards.
+
+### Shadow Colors
+- **Shadow Warm** (`rgba(107,122,82,0.12)`): Primary shadow -- green-tinted ambient glow that ties cards to the garden backdrop.
+- **Shadow Medium** (`rgba(107,122,82,0.18)`): Medium elevation for featured cards and hover states.
+- **Shadow Soft** (`rgba(28,28,30,0.06)`): Neutral soft shadow for minimal depth.
+- **Shadow Deep** (`rgba(28,28,30,0.20)`): Deep shadow for modals and overlays.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Body**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Inter | 56px | 700 | 1.12 | -0.8px | Hero headlines, cover statements |
+| Section Heading | Inter | 36px | 700 | 1.18 | -0.4px | Major section titles |
+| Sub-heading | Inter | 24px | 600 | 1.25 | -0.2px | Card headings, subsection titles |
+| Body Large | Inter | 20px | 400 | 1.55 | -0.1px | Lead paragraphs, tweet-style body text |
+| Body | Inter | 16px | 400 | 1.60 | 0px | Standard reading text |
+| Display Name | Inter | 17px | 700 | 1.25 | 0px | User names, bold inline labels |
+| Small / Caption | Inter | 14px | 400 | 1.45 | 0px | Handles, metadata, timestamps |
+| Big Numbers | Inter | 52px | 700 | 1.00 | -0.5px | Statistics, key metrics |
+| Label | Inter | 12px | 500 | 1.00 | 0.3px | Uppercase tag labels, category markers |
+| CTA Text | Inter | 15px | 600 | 1.00 | 0.2px | Button text |
+
+### Principles
+- **One family, weight-driven hierarchy**: Inter handles every role. Hierarchy comes from size and weight shifts, not font-family mixing. This mirrors the system-UI feel of the reference.
+- **Regular weight for body**: Weight 400 for body text keeps the reading experience clean and neutral. Weight 500 is reserved for secondary emphasis like handles and captions that need slight differentiation.
+- **Bold for names and display**: Weight 700 is used for display names, hero text, and big numbers. It creates clear focal points without needing color differentiation.
+- **Tight tracking at large sizes**: Negative letter-spacing (-0.4px to -0.8px) at 36px+ keeps large text feeling compact and modern. At body sizes, tracking is neutral (0px).
+- **Relaxed line heights for body**: 1.55-1.60 for body text creates the open, breathable reading rhythm that matches the spacious card layout.
+- **No uppercase in body content**: Uppercase is reserved for tiny labels (12px) only. All headings, names, and body text use natural casing.
+
+## 4. Component Patterns
+
+### Title Block (Cover / Header Section)
+
+```html
+<div style="position: relative; width: 100%; height: 100%; background: url('garden-backdrop.jpg') center/cover no-repeat; filter: blur(0px);">
+  <div style="position: absolute; inset: 0; backdrop-filter: blur(40px); -webkit-backdrop-filter: blur(40px); background: rgba(107,122,82,0.15);"></div>
+  <div style="position: relative; z-index: 1; display: flex; align-items: center; justify-content: center; height: 100%; padding: 60px;">
+    <div style="background: var(--color-white); border-radius: 24px; padding: 48px 40px; max-width: 600px; width: 100%; text-align: center;">
+      <h1 style="font-family: var(--font-display); font-size: 56px; font-weight: 700; line-height: 1.12; letter-spacing: -0.8px; color: var(--color-charcoal); margin: 0 0 16px;">Thoughts from the garden</h1>
+      <p style="font-family: var(--font-body); font-size: 20px; font-weight: 400; line-height: 1.55; color: var(--color-warm-gray); margin: 0;">A collection of ideas worth sharing.</p>
+    </div>
+  </div>
+</div>
+```
+
+### Social Card (Signature Component)
+
+```html
+<div style="background: var(--color-white); border-radius: 24px; padding: 32px; max-width: 540px;">
+  <div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 20px;">
+    <div style="display: flex; align-items: center; gap: 12px;">
+      <div style="width: 48px; height: 48px; border-radius: 50%; background: var(--color-pale-gray); overflow: hidden;"><img src="avatar.jpg" style="width: 100%; height: 100%; object-fit: cover;"></div>
+      <div>
+        <p style="font-family: var(--font-display); font-size: 17px; font-weight: 700; line-height: 1.25; color: var(--color-charcoal); margin: 0;">Noah Carter</p>
+        <p style="font-family: var(--font-body); font-size: 14px; font-weight: 400; line-height: 1.45; color: var(--color-warm-gray); margin: 0;">@noahcarter</p>
+      </div>
+    </div>
+    <span style="color: var(--color-warm-gray); font-size: 20px; letter-spacing: 2px;">&#8943;</span>
+  </div>
+  <p style="font-family: var(--font-body); font-size: 20px; font-weight: 400; line-height: 1.55; letter-spacing: -0.1px; color: var(--color-charcoal); margin: 0 0 24px;">Doing great work is simple: open the doc, stare at it, question your life choices, rewrite everything, drink coffee, and suddenly it's 4PM. Repeat.</p>
+  <div style="display: flex; gap: 20px;">
+    <span style="color: var(--color-accent); font-size: 18px;">&#9829;</span>
+    <span style="color: var(--color-warm-gray); font-size: 18px;">&#9633;</span>
+    <span style="color: var(--color-warm-gray); font-size: 18px;">&#8679;</span>
+  </div>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="background: var(--color-white); border-radius: 24px; padding: 40px 32px; text-align: center;">
+  <p style="font-family: var(--font-display); font-size: 52px; font-weight: 700; line-height: 1.00; letter-spacing: -0.5px; color: var(--color-accent); margin: 0 0 8px;">4PM</p>
+  <p style="font-family: var(--font-body); font-size: 12px; font-weight: 500; letter-spacing: 0.3px; text-transform: uppercase; color: var(--color-charcoal); margin: 0 0 12px;">Average Realization Time</p>
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.60; color: var(--color-warm-gray); max-width: 280px; margin: 0 auto;">The moment when the day's ambition meets reality and coffee stops working.</p>
+</div>
+```
+
+### Comparison Grid
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+  <div style="background: var(--color-white); border-radius: 24px; padding: 36px 28px;">
+    <div style="display: inline-block; background: var(--color-pale-gray); border-radius: 20px; padding: 4px 14px; margin-bottom: 16px;">
+      <span style="font-family: var(--font-body); font-size: 12px; font-weight: 500; color: var(--color-warm-gray);">Before</span>
+    </div>
+    <h3 style="font-family: var(--font-display); font-size: 24px; font-weight: 600; line-height: 1.25; letter-spacing: -0.2px; color: var(--color-charcoal); margin: 0 0 10px;">Scattered & Manual</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.60; color: var(--color-medium-gray); margin: 0;">Context scattered across tabs, threads, and half-finished docs nobody remembers starting.</p>
+  </div>
+  <div style="background: var(--color-white); border-radius: 24px; padding: 36px 28px; border: 2px solid rgba(163,134,122,0.4);">
+    <div style="display: inline-block; background: rgba(163,134,122,0.1); border-radius: 20px; padding: 4px 14px; margin-bottom: 16px;">
+      <span style="font-family: var(--font-body); font-size: 12px; font-weight: 600; color: var(--color-accent);">After</span>
+    </div>
+    <h3 style="font-family: var(--font-display); font-size: 24px; font-weight: 600; line-height: 1.25; letter-spacing: -0.2px; color: var(--color-charcoal); margin: 0 0 10px;">Focused & Flowing</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.60; color: var(--color-medium-gray); margin: 0;">One place, one rhythm, one conversation that remembers where you left off.</p>
+  </div>
+</div>
+```
+
+### List Item
+
+```html
+<div style="display: flex; gap: 16px; align-items: flex-start; padding: 20px 0; border-bottom: 1px solid rgba(28,28,30,0.05);">
+  <div style="width: 36px; height: 36px; min-width: 36px; display: flex; align-items: center; justify-content: center; background: rgba(163,134,122,0.1); border-radius: 50%; color: var(--color-accent); font-size: 16px;">&#10003;</div>
+  <div>
+    <h4 style="font-family: var(--font-display); font-size: 17px; font-weight: 700; line-height: 1.25; color: var(--color-charcoal); margin: 0 0 4px;">Persistent Context</h4>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.60; color: var(--color-warm-gray); margin: 0;">Your agent remembers every conversation, every file, every preference -- no repetition needed.</p>
+  </div>
+</div>
+```
+
+### Quote Block
+
+```html
+<div style="background: var(--color-white); border-radius: 24px; padding: 36px 32px; border-left: 3px solid var(--color-accent);">
+  <p style="font-family: var(--font-body); font-size: 20px; font-weight: 400; font-style: italic; line-height: 1.55; color: var(--color-charcoal); margin: 0 0 20px;">"The best tools disappear into your workflow. You stop thinking about the tool and start thinking about the work."</p>
+  <div style="display: flex; align-items: center; gap: 12px;">
+    <div style="width: 36px; height: 36px; border-radius: 50%; background: linear-gradient(135deg, var(--color-accent), #8a9668);"></div>
+    <div>
+      <p style="font-family: var(--font-body); font-size: 15px; font-weight: 600; color: var(--color-charcoal); margin: 0;">Elena Vasquez</p>
+      <p style="font-family: var(--font-body); font-size: 13px; font-weight: 400; color: var(--color-warm-gray); margin: 0;">Head of Product, Meridian</p>
+    </div>
+  </div>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="text-align: center; padding: 48px 36px; background: var(--color-white); border-radius: 24px;">
+  <h2 style="font-family: var(--font-display); font-size: 36px; font-weight: 700; line-height: 1.18; letter-spacing: -0.4px; color: var(--color-charcoal); margin: 0 0 12px;">Start something real</h2>
+  <p style="font-family: var(--font-body); font-size: 18px; font-weight: 400; line-height: 1.55; color: var(--color-warm-gray); max-width: 420px; margin: 0 auto 28px;">No setup. No configuration maze. Just open it and go.</p>
+  <a style="display: inline-block; background: var(--color-charcoal); color: #ffffff; font-family: var(--font-body); font-size: 15px; font-weight: 600; letter-spacing: 0.2px; text-decoration: none; padding: 14px 32px; border-radius: 12px;">Get Started</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between name and handle vertically, between icon and inline count.
+- **8px**: Tight gap -- between stat number and label, between small grouped elements.
+- **12px**: Small gap -- between heading and subtitle within a card, between avatar and name block.
+- **16px**: Base gap -- between body paragraphs, between compact list items.
+- **20px**: Card gap -- between cards in a grid, between interaction icons in a row, between avatar row and body text.
+- **24px**: Medium gap -- between body text and interaction row, standard list item vertical padding.
+- **32px**: Card padding -- internal padding for standard cards.
+- **40px**: Large card padding -- internal padding for hero and featured cards.
+- **48px**: Section divider -- vertical space between major content blocks on the backdrop.
+- **60px**: Hero padding -- top/bottom padding for cover sections.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 48px all sides | 984px |
+| Infographic (1080xN) | 40px left/right, 48px top/bottom | 1000px |
+| Slides (1920x1080) | 60px all sides | 1800px |
+| Poster (1080x1350) | 40px left/right, 48px top/bottom | 1000px |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned text inside cards. Center-aligned for hero titles, stat displays, and CTA blocks.
+- **Grid**: Single white card centered on backdrop for social-card layouts. 2-column grid with 20px gaps for comparison and feature cards. Single-column for narrative and quote content.
+- **Card placement**: Cards should be centered on the blurred backdrop with visible backdrop margin on all sides -- the backdrop is a framing device, not wallpaper.
+- **Rounded corners**: 24px for all cards and major containers. 12px for buttons. 50% (circular) for avatars and small icon containers. 20px for pill badges.
+- **Content gravity**: On widescreen formats (1920x1080), center the card(s) with generous margins. The blurred backdrop should be prominently visible as atmospheric framing. On square formats, the card can fill more of the frame but should never touch the edges.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Backdrop (Level 0) | Blurred photographic image, no shadow | Page canvas, atmospheric base layer |
+| Resting (Level 1) | `rgba(107,122,82,0.08) 0px 2px 12px` | Subtle lift for secondary elements on the backdrop |
+| Card (Level 2) | `rgba(107,122,82,0.12) 0px 4px 24px, rgba(28,28,30,0.04) 0px 1px 4px` | Standard card elevation on blurred backdrop |
+| Featured (Level 3) | `rgba(107,122,82,0.18) 0px 8px 36px, rgba(28,28,30,0.06) 0px 2px 8px` | Featured cards, hover states |
+| Overlay (Level 4) | `rgba(28,28,30,0.20) 0px 16px 48px` | Modals, overlays, floating panels |
+
+### Border Treatments
+- **Standard border**: None. Cards in this style rely on the contrast between the white surface and the blurred backdrop for definition. Borders are generally omitted.
+- **Active border**: `2px solid rgba(163,134,122,0.4)` -- rose-tinted border for featured or selected containers.
+- **Divider line**: `1px solid rgba(28,28,30,0.05)` -- barely visible separator for list items within cards.
+- **Accent rule**: `3px solid var(--color-accent)` -- left-side accent bar for quote blocks and highlighted sections.
+
+### Surface Hierarchy
+On the blurred photographic backdrop, elevation is communicated primarily through contrast and blur differential:
+1. **Backdrop** (blurred photograph, olive/sage/brown tones) -- the atmospheric base. Always blurred at 30-50px.
+2. **Surface** (`#ffffff`) -- white cards with sharp edges float above the soft backdrop. The blur-to-sharp transition is the primary depth cue.
+3. **Tinted Surface** (`#faf8f6`) -- warm-tinted cards for featured content, slightly distinguishable from pure white.
+4. **Inset** (`#f2f2f7`) -- recessed areas within white cards for input fields or secondary panels.
+
+Green-tinted shadows (`rgba(107,122,82,0.08-0.18)`) maintain the connection between the card and the natural backdrop, preventing the cards from feeling pasted on.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use a blurred photographic backdrop with natural greenery, warm olive, and sage tones as the atmospheric base for every design.
+- Apply heavy Gaussian blur (30-50px) to the backdrop image so it reads as texture and color, not as a specific photograph.
+- Float white cards (`#ffffff`) with 24px border-radius on the blurred backdrop -- the sharp-vs-soft contrast is the signature of this style.
+- Use Inter at weight 400 for body text and 700 for display names and headings -- hierarchy through weight, not decoration.
+- Keep the interior of cards quiet and restrained: near-black text (`#1c1c1e`), warm gray (`#8e8e93`) for secondary elements, minimal accent color.
+- Use dusty rose (`#a3867a`) as the only accent color inside cards, and use it sparingly -- one or two elements per card maximum.
+- Maintain generous card padding (32-40px) and relaxed line heights (1.55-1.60) for body text.
+- Use circular avatars (border-radius: 50%) for profile images, sized at 44-48px.
+- Leave visible backdrop margin around cards -- the blurred garden is a framing device and should always be seen.
+- Use outline-style icons (not filled) for interaction elements like heart, comment, and share.
+- Choose backdrop photos with warm, golden-hour lighting for the most cohesive feel.
+
+### Don't
+- Don't use pure black (`#000000`) for text -- always use near-black charcoal (`#1c1c1e`) to maintain warmth.
+- Don't use sharp corners (border-radius: 0-8px) on cards -- the minimum card radius is 24px in this style.
+- Don't add visible borders to cards unless marking them as featured or active. The blur-to-sharp contrast provides all the definition needed.
+- Don't use multiple bright accent colors -- this style uses a single muted accent (dusty rose `#a3867a`) and neutral grays. No blues, greens, or saturated reds inside cards.
+- Don't use heavy drop shadows on cards -- shadows should be subtle and green-tinted (`rgba(107,122,82,0.12)`), not dark or dramatic.
+- Don't use a solid color or CSS gradient as the backdrop -- the style requires a blurred photograph with organic texture and variation.
+- Don't use weight 700 for body text or small labels -- bold is reserved for display names (17px+) and headings (24px+).
+- Don't crowd the backdrop -- cards should occupy 60-75% of the frame at most, leaving the blurred garden visible.
+- Don't use filled/solid icons -- this style uses outline icons with warm gray (`#8e8e93`) stroke.
+- Don't use uppercase text for anything except small labels (12px) -- headings and names are always mixed case.
+- Don't use cold-toned backdrops (blue sky, ice, concrete) -- the backdrop must feel warm, organic, and garden-like.
+- Don't use dark mode cards or dark surfaces -- the entire aesthetic depends on white cards against a warm, blurred natural backdrop.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale down**: Display Hero becomes 44px (from 56px). Section Heading becomes 30px. Sub-heading stays 24px. Body Large stays 20px.
+- **Padding**: 48px on all sides. Card(s) centered within the frame.
+- **Cover slide**: Single white card centered on the blurred backdrop. Title and subtitle inside the card. Backdrop visible on all sides.
+- **Content slides**: One social card per slide, centered. Or one concept card per slide with heading + body text.
+- **Stat slides**: Single stat centered within a white card. Big number in accent color, label below.
+- **Swipe indicator**: Small dots at bottom center, 7px diameter, 10px gap. Active dot in charcoal, inactive dots at 25% opacity.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Full-scale hierarchy. Display Hero at 56px for the title section.
+- **Padding**: 40px left/right, 48px top/bottom margins.
+- **Section spacing**: 32px vertical gap between cards. Each major section is its own white card floating on the continuous blurred backdrop.
+- **Vertical rhythm**: Alternate between social cards, stat displays, and text cards. The blurred backdrop runs continuously behind all cards, creating a vertical garden strip.
+- **Footer**: Secondary text, 13px Inter, centered within a final card or directly on the backdrop in white.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 64px. Section Heading becomes 44px. Body Large becomes 22px.
+- **Padding**: 60px on all sides. Content area is 1800x960px.
+- **Layout**: Cards centered with generous backdrop visibility. The wide format means more backdrop is visible -- use this to create atmosphere.
+- **Title slides**: Single large white card (max 720px wide) centered on frame with headline and subtitle.
+- **Content slides**: 2-3 cards in a row for comparisons with 20px gaps. Single large card for narrative content.
+- **Stat slides**: Up to 3 stat cards in a row, evenly spaced, with visible backdrop between them.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 48px. Section Heading at 32px. Body at 16px.
+- **Padding**: 40px left/right, 48px top/bottom.
+- **Composition**: Top section for hero card with headline. Middle section for feature cards (single column or 2-column grid). Bottom section for CTA card.
+- **Vertical flow**: Cards stack vertically with 24px gaps. The blurred backdrop fills the tall frame, providing continuous warmth between card sections.
+- **CTA placement**: In its own white card at the bottom, with a dark charcoal button centered.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Hero becomes 56px (approximately 30% larger than Carousel 44px). Section Heading becomes 40px in Inter 700. Body Large becomes 22px in Inter 400. Names stay at Inter 700, handles in Inter 500 medium gray.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical text must sit inside y=160 to y=1760.
+- **Layout**: Single centered column. Content max-width 880px. Vertical center of gravity -- cluster hero content in y=400 to y=1500 range. The heavily blurred photographic backdrop of greenery (olive, sage, earthy browns, bokeh highlights) fills the entire frame so every card floats on that sun-dappled atmosphere.
+- **Cover slide**: Single tall white card (24px radius, 32-40px internal padding, no visible border) centered in the safe zone. Headline in Inter 700 at 56px near-black charcoal with relaxed 1.2 line-height, short subtitle in warm medium gray below. The blurred garden shows above, below, and to the sides of the card -- whitespace is atmosphere.
+- **Content slides**: One social-style card per slide. Circular avatar 56px at top, name in Inter 700 and handle in Inter 500 medium gray beside it, body content in Inter 400 at 22px, and an icon row along the bottom (outline icons in medium gray with one dusty-rose heart as the accent). Only one card per slide so the content breathes inside the garden light.
+- **CTA slide**: A single white card with the headline in Inter 700 at 48px, a short line of supporting body, and a rounded pill button in near-black charcoal with white Inter 600 CTA text. Dusty rose (`#a3867a`) underline or micro-icon adds the one accent.
+- **Progress indicator**: Ultra-thin segmented bars (2px, 6px gap) at the top inside the safe zone in `rgba(255,255,255,0.5)` for inactive and solid white for active. The subtlety matches the restrained UI chrome of the rest of the system.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| White | `#ffffff` | Card and container surface |
+| Near-Black Charcoal | `#1c1c1e` | Primary text, headings, display names |
+| Dusty Rose | `#a3867a` | Accent: interactive highlights, heart icons, active states |
+| Warm Taupe | `#b89e8e` | Hover/light accent states |
+| Deep Rose | `#8a6e62` | Pressed/active accent states |
+| Sage Tint | `#d4dcc8` | Tag backgrounds, subtle highlights |
+| Dark Gray | `#3a3a3c` | Secondary text, descriptions |
+| Medium Gray | `#636366` | Tertiary text, timestamps |
+| Warm Gray | `#8e8e93` | Handles, icons, metadata, placeholders |
+| Light Gray | `#c7c7cc` | Borders, dividers |
+| Pale Gray | `#f2f2f7` | Hover surface, inset backgrounds |
+| Tinted Surface | `#faf8f6` | Featured card background |
+| Backdrop Olive | `#6b7a52` | Dominant backdrop tone (for solid fallback) |
+| Backdrop Sage | `#8a9668` | Secondary backdrop tone |
+| Backdrop Brown | `#7a6b52` | Tertiary backdrop tone |
+
+### Font Declarations
+
+```css
+font-family: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-white: #ffffff;
+  --color-charcoal: #1c1c1e;
+  --color-accent: #a3867a;
+
+  /* Colors -- Accent */
+  --color-warm-taupe: #b89e8e;
+  --color-deep-rose: #8a6e62;
+  --color-sage-tint: #d4dcc8;
+
+  /* Colors -- Neutral Scale */
+  --color-dark-gray: #3a3a3c;
+  --color-medium-gray: #636366;
+  --color-warm-gray: #8e8e93;
+  --color-light-gray: #c7c7cc;
+  --color-pale-gray: #f2f2f7;
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: #ffffff;
+  --color-surface-tinted: #faf8f6;
+  --color-backdrop-olive: #6b7a52;
+  --color-backdrop-sage: #8a9668;
+  --color-backdrop-brown: #7a6b52;
+
+  /* Colors -- Borders */
+  --color-border-default: rgba(28, 28, 30, 0.08);
+  --color-border-accent: rgba(163, 134, 122, 0.4);
+  --color-border-light: rgba(28, 28, 30, 0.05);
+
+  /* Colors -- Shadows */
+  --shadow-warm: rgba(107, 122, 82, 0.12);
+  --shadow-warm-medium: rgba(107, 122, 82, 0.18);
+  --shadow-soft: rgba(28, 28, 30, 0.06);
+  --shadow-deep: rgba(28, 28, 30, 0.20);
+
+  /* Typography -- Families */
+  --font-display: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 56px;
+  --text-section-heading: 36px;
+  --text-sub-heading: 24px;
+  --text-body-large: 20px;
+  --text-body: 16px;
+  --text-display-name: 17px;
+  --text-small: 14px;
+  --text-big-number: 52px;
+  --text-label: 12px;
+  --text-cta: 15px;
+
+  /* Typography -- Weights */
+  --weight-display: 700;
+  --weight-heading: 600;
+  --weight-body-medium: 500;
+  --weight-body: 400;
+  --weight-label: 500;
+
+  /* Typography -- Line Heights */
+  --leading-display: 1.12;
+  --leading-heading: 1.18;
+  --leading-sub-heading: 1.25;
+  --leading-body-large: 1.55;
+  --leading-body: 1.60;
+  --leading-small: 1.45;
+  --leading-number: 1.00;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-card-gap: 20px;
+  --space-medium: 24px;
+  --space-card-padding: 32px;
+  --space-large: 40px;
+  --space-section: 48px;
+  --space-hero: 60px;
+
+  /* Borders */
+  --radius-card: 24px;
+  --radius-button: 12px;
+  --radius-pill: 20px;
+  --radius-avatar: 50%;
+
+  /* Shadows -- Composed */
+  --shadow-card: rgba(107,122,82,0.12) 0px 4px 24px, rgba(28,28,30,0.04) 0px 1px 4px;
+  --shadow-featured: rgba(107,122,82,0.18) 0px 8px 36px, rgba(28,28,30,0.06) 0px 2px 8px;
+
+  /* Backdrop Blur */
+  --backdrop-blur: 40px;
+}
+```
+
+### System Font Fallbacks
+- **Sans-serif (if Inter fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Background Generation
+
+**IMPORTANT: Use a real photograph for the backdrop, NOT CSS gradients or radial-gradient stacks.** CSS gradients cannot replicate the organic bokeh and natural light variation this style requires. The backdrop must be a real nature photograph.
+
+**Recommended approach:** Use an Unsplash image of natural greenery, gardens, or foliage. Apply CSS `filter: blur(16px)` and `transform: scale(1.15)` to create the garden-blur effect.
+
+```css
+.garden-blur-backdrop {
+  position: absolute;
+  inset: 0;
+  background-image: url('YOUR_IMAGE_URL_HERE');
+  background-size: cover;
+  background-position: center;
+  filter: blur(16px);
+  transform: scale(1.15); /* prevents blur edge artifacts */
+  z-index: 0;
+}
+```
+
+**Good image search terms for Unsplash:** "garden bokeh", "green leaves sunlight", "nature golden hour", "foliage warm light", "botanical garden blur"
+
+**Never fall back to CSS gradients.** If no image URL is available, ask the user for one or search Unsplash. The entire aesthetic depends on organic photographic texture — gradients will look flat and artificial.

--- a/skills/composites/goose-graphics/styles/_full/golden-dusk.md
+++ b/skills/composites/goose-graphics/styles/_full/golden-dusk.md
@@ -1,0 +1,440 @@
+# Design Style: Golden Dusk
+
+## 1. Visual Theme & Atmosphere
+
+Golden Dusk is the design language of quiet luxury -- the kind found not in logos or conspicuous branding, but in the weight of the paper, the precision of the typesetting, the way a single gold foil detail on a navy cover signals "this is for people who notice." The dark navy background (`#0f1629`) is not the flat black of a dark mode toggle; it is the deep, inky blue of a midnight sky just after the last light fades, carrying warmth in its depth. Warm white text (`#f5f2ed`) reads against this surface like cream stock embossed onto a leather portfolio -- soft, warm, and deliberately chosen over stark white.
+
+The typographic system uses DM Sans throughout -- a geometric sans-serif from Google Fonts that walks the line between modern and classic. At display sizes (48px+), DM Sans runs at weight 500-600 with generous letter-spacing (+0.5px to +1px), creating headlines that feel spaced and considered, like the masthead of a premium publication. For body text, DM Sans drops to weight 300-400, achieving the light, confident reading style pioneered by Stripe and Apple -- text that whispers rather than shouts, trusting the reader to lean in. The single-family approach keeps the design cohesive and sophisticated; the hierarchy comes from weight, size, and spacing rather than from font contrast.
+
+Gold (`#d4a853`) is the signature accent -- not the bright gold of a trophy, but the aged, muted gold of antique hardware, of a well-worn signet ring, of old-money understatement. It appears in thin linear-gradients on accent bars, in hairline borders (`1px solid rgba(212,168,83,0.3)`), and in small typographic details. Copper (`#b87333`) serves as the secondary accent, providing warmth below gold in the hierarchy -- for secondary borders, metadata labels, and hover states. Together, gold and copper establish a warm metallic vocabulary that feels premium without veering into gaudy territory. The rule is restraint: gold is the spice, not the dish.
+
+**Key Characteristics:**
+- Dark navy background (`#0f1629`) -- warm, deep, inky blue with subtle blue undertone
+- Warm white (`#f5f2ed`) for all primary text -- softer than pure white, carrying the warmth of cream stock
+- Gold (`#d4a853`) as the primary accent -- muted, aged, restrained. Used for accent bars, numbers, and focal points
+- Copper (`#b87333`) as secondary accent -- warmer and darker than gold, for borders, labels, and secondary emphasis
+- DM Sans throughout: weight 500-600 for display, weight 300-400 for body. Single-family elegance
+- Generous letter-spacing at display sizes (+0.5px to +1px) for an open, premium feel
+- Hairline borders (`1px solid rgba(212,168,83,0.3)`) -- gold-tinted, barely visible, structurally precise
+- Subtle gold linear-gradients on accent elements (bars, rules, button backgrounds)
+- Weight 300 for body text -- light, confident, trusting the content to carry itself
+- Premium restraint in every choice -- if in doubt, remove rather than add
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Deep Navy** (`#0f1629`): Primary background. A warm, inky blue-black that feels richer than pure dark grey.
+- **Warm White** (`#f5f2ed`): Primary text colour. Cream-toned white that softens contrast and adds warmth.
+- **Gold** (`#d4a853`): Primary accent. Used for accent bars, numbering, CTAs, and focal-point elements. The signature colour.
+
+### Accent
+- **Copper** (`#b87333`): Secondary accent for borders, captions, secondary labels, and hover states on gold elements.
+- **Light Gold** (`#e8c877`): Tertiary accent for hover states and high-emphasis text. Brighter than gold.
+- **Deep Gold** (`#b8923d`): Darker gold for active states on interactive elements.
+
+### Neutral Scale
+- **Navy Surface** (`#162040`): Elevated surface -- cards, containers, content panels sitting above the navy background.
+- **Navy Light** (`#1c2a50`): Secondary surface for nested containers, input fields, and inset areas.
+- **Slate** (`#3d4a6b`): Disabled text, placeholder content, and subtle dividers.
+- **Muted Blue** (`#6b7a9e`): Tertiary text for timestamps, metadata, and low-priority labels.
+- **Silver Blue** (`#8a96b5`): Used sparingly for de-emphasized captions on dark surfaces.
+
+### Surface & Borders
+- **Surface Primary** (`#162040`): Card and container background.
+- **Surface Inset** (`#111b33`): Recessed areas, code blocks, and inset panels.
+- **Border Default** (`rgba(212,168,83,0.15)`): Whisper-thin gold border for cards and dividers.
+- **Border Accent** (`rgba(212,168,83,0.3)`): Gold-tinted border for active or featured elements.
+- **Border Strong** (`rgba(245,242,237,0.12)`): Higher-contrast warm white border for prominent containers.
+- **Border Copper** (`rgba(184,115,51,0.3)`): Copper-tinted border for secondary emphasis.
+- **Divider Rule** (`#d4a853`): Solid gold for horizontal accent rules (typically 1px height).
+
+### Shadow Colors
+- **Shadow Gold** (`rgba(212,168,83,0.06)`): Primary shadow -- gold-tinted ambient glow for on-palette elevation.
+- **Shadow Deep** (`rgba(0,0,0,0.5)`): Deep shadow for high-elevation elements like modals.
+- **Shadow Soft** (`rgba(0,0,0,0.3)`): Standard shadow layer for cards and containers.
+- **Shadow Ambient** (`rgba(212,168,83,0.03)`): Subtle gold ambient for barely-there lift.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,300;1,9..40,400&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Body**: `'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | DM Sans | 72px | 600 | 1.05 | +0.5px | Open, premium feel. Generous tracking |
+| Section Heading | DM Sans | 48px | 600 | 1.10 | +0.5px | Major section titles |
+| Sub-heading | DM Sans | 32px | 500 | 1.20 | 0px | Subsection titles, card headings |
+| Body Large | DM Sans | 20px | 300 | 1.65 | 0px | Lead paragraphs, introductions |
+| Body | DM Sans | 16px | 400 | 1.70 | 0.1px | Standard reading text |
+| Small / Caption | DM Sans | 13px | 400 | 1.50 | 0.5px | Metadata, attributions, timestamps |
+| Big Numbers | DM Sans | 64px | 700 | 1.00 | -0.5px | Statistics, key metrics, hero data |
+| Label | DM Sans | 13px | 500 | 1.00 | 2.5px | Uppercase category labels ("01 -- STRATEGY") |
+| CTA Text | DM Sans | 15px | 600 | 1.00 | 1.5px | Button and call-to-action text, uppercase |
+
+### Principles
+- **Single-family elegance**: DM Sans handles everything from display to body to labels. Hierarchy is established through weight, size, and letter-spacing alone. No serif/sans-serif tension -- the sophistication comes from restraint.
+- **Light body, medium display**: Body text at weight 300-400 creates an airy, confident reading experience. Display at 500-600 (not 700-900) keeps headlines refined rather than aggressive.
+- **Open tracking at display sizes**: Positive letter-spacing (+0.5px to +1px) for headlines creates the premium, spaced-out feel of luxury brand typesetting. Body text uses minimal tracking.
+- **Wide letter-spacing on labels**: Uppercase labels at 2.5px letter-spacing create elegant, widely-set category markers that feel curated and intentional.
+- **Generous line height for body**: 1.65-1.70 for body text creates a luxuriously spaced reading rhythm. Dark backgrounds demand generous breathing room.
+- **Weight 300 as a statement**: The lightest body weight signals confidence -- the content is strong enough to stand without typographic emphasis.
+
+## 4. Component Patterns
+
+### Title Block (Cover / Header Section)
+
+```html
+<div style="background-color: #0f1629; padding: 80px 60px; text-align: center;">
+  <div style="width: 80px; height: 1px; background: linear-gradient(90deg, transparent, #d4a853, transparent); margin: 0 auto 40px;"></div>
+  <h1 style="font-family: 'DM Sans', sans-serif; font-size: 72px; font-weight: 600; line-height: 1.05; letter-spacing: 0.5px; color: #f5f2ed; margin: 0 0 24px;">The Future of<br>Autonomous Work</h1>
+  <p style="font-family: 'DM Sans', sans-serif; font-size: 20px; font-weight: 300; line-height: 1.65; color: #b87333; max-width: 560px; margin: 0 auto;">How AI coworkers are reshaping the way teams operate, collaborate, and deliver results.</p>
+  <div style="width: 80px; height: 1px; background: linear-gradient(90deg, transparent, #d4a853, transparent); margin: 40px auto 0;"></div>
+</div>
+```
+
+### Numbered Item
+
+```html
+<div style="display: flex; gap: 24px; align-items: flex-start; padding: 32px 0; border-bottom: 1px solid rgba(212,168,83,0.15);">
+  <span style="font-family: 'DM Sans', sans-serif; font-size: 48px; font-weight: 700; line-height: 1.00; color: #d4a853; min-width: 72px;">01</span>
+  <div>
+    <p style="font-family: 'DM Sans', sans-serif; font-size: 13px; font-weight: 500; letter-spacing: 2.5px; text-transform: uppercase; color: #b87333; margin: 0 0 8px;">SIGNAL-BASED OUTBOUND</p>
+    <h3 style="font-family: 'DM Sans', sans-serif; font-size: 32px; font-weight: 500; line-height: 1.20; color: #f5f2ed; margin: 0 0 12px;">Find buyers before they find you</h3>
+    <p style="font-family: 'DM Sans', sans-serif; font-size: 16px; font-weight: 400; line-height: 1.70; color: #6b7a9e; margin: 0;">Monitor hiring signals, funding events, and tech stack changes to identify high-intent prospects the moment they enter the market.</p>
+  </div>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="text-align: center; padding: 40px 24px; background: #162040; border: 1px solid rgba(212,168,83,0.15); border-radius: 4px;">
+  <p style="font-family: 'DM Sans', sans-serif; font-size: 64px; font-weight: 700; line-height: 1.00; letter-spacing: -0.5px; color: #d4a853; margin: 0 0 8px;">47%</p>
+  <p style="font-family: 'DM Sans', sans-serif; font-size: 13px; font-weight: 500; letter-spacing: 2.5px; text-transform: uppercase; color: #f5f2ed; margin: 0 0 12px;">FASTER RESPONSE</p>
+  <p style="font-family: 'DM Sans', sans-serif; font-size: 16px; font-weight: 400; line-height: 1.70; color: #6b7a9e; max-width: 280px; margin: 0 auto;">Teams using AI coworkers respond to inbound leads nearly twice as fast as manual workflows.</p>
+</div>
+```
+
+### Comparison Grid
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1px; background: rgba(212,168,83,0.15); border-radius: 4px; overflow: hidden;">
+  <div style="background: #162040; padding: 40px 32px;">
+    <p style="font-family: 'DM Sans', sans-serif; font-size: 13px; font-weight: 400; letter-spacing: 0.5px; color: #b87333; margin: 0 0 16px;">Without Goose</p>
+    <h3 style="font-family: 'DM Sans', sans-serif; font-size: 32px; font-weight: 500; line-height: 1.20; color: #f5f2ed; margin: 0 0 16px;">Manual & Fragmented</h3>
+    <p style="font-family: 'DM Sans', sans-serif; font-size: 16px; font-weight: 400; line-height: 1.70; color: #6b7a9e; margin: 0;">Teams juggle Slack threads, spreadsheets, and context-switching between a dozen tabs to coordinate basic workflows.</p>
+  </div>
+  <div style="background: #162040; padding: 40px 32px; border-left: 1px solid rgba(212,168,83,0.3);">
+    <p style="font-family: 'DM Sans', sans-serif; font-size: 13px; font-weight: 400; letter-spacing: 0.5px; color: #d4a853; margin: 0 0 16px;">With Goose</p>
+    <h3 style="font-family: 'DM Sans', sans-serif; font-size: 32px; font-weight: 500; line-height: 1.20; color: #f5f2ed; margin: 0 0 16px;">Orchestrated & Autonomous</h3>
+    <p style="font-family: 'DM Sans', sans-serif; font-size: 16px; font-weight: 400; line-height: 1.70; color: #6b7a9e; margin: 0;">AI coworkers handle research, drafting, and follow-up autonomously. Your team focuses on decisions, not busywork.</p>
+  </div>
+</div>
+```
+
+### List Item
+
+```html
+<div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0; border-bottom: 1px solid rgba(212,168,83,0.15);">
+  <div style="width: 40px; height: 40px; min-width: 40px; display: flex; align-items: center; justify-content: center; border: 1px solid rgba(212,168,83,0.3); border-radius: 4px; color: #d4a853; font-size: 18px;">&#9670;</div>
+  <div>
+    <h4 style="font-family: 'DM Sans', sans-serif; font-size: 22px; font-weight: 500; line-height: 1.25; color: #f5f2ed; margin: 0 0 8px;">Persistent Memory</h4>
+    <p style="font-family: 'DM Sans', sans-serif; font-size: 16px; font-weight: 400; line-height: 1.70; color: #6b7a9e; margin: 0;">Every agent maintains its own filesystem, notes, and learned preferences across sessions. Context is never lost.</p>
+  </div>
+</div>
+```
+
+### Quote Block
+
+```html
+<div style="padding: 48px 40px; border-left: 1px solid rgba(212,168,83,0.3); background: #111b33;">
+  <p style="font-family: 'DM Sans', sans-serif; font-size: 32px; font-weight: 300; font-style: italic; line-height: 1.35; color: #f5f2ed; margin: 0 0 24px;">"It felt less like configuring software and more like onboarding a new team member."</p>
+  <div style="display: flex; align-items: center; gap: 12px;">
+    <div style="width: 32px; height: 1px; background: #d4a853;"></div>
+    <p style="font-family: 'DM Sans', sans-serif; font-size: 13px; font-weight: 500; letter-spacing: 2.5px; text-transform: uppercase; color: #b87333; margin: 0;">SARAH CHEN, VP OPERATIONS</p>
+  </div>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="text-align: center; padding: 60px 40px; background: #162040; border: 1px solid rgba(212,168,83,0.3); border-radius: 4px;">
+  <h2 style="font-family: 'DM Sans', sans-serif; font-size: 40px; font-weight: 600; line-height: 1.10; letter-spacing: 0.5px; color: #f5f2ed; margin: 0 0 16px;">Ready to meet your team?</h2>
+  <p style="font-family: 'DM Sans', sans-serif; font-size: 18px; font-weight: 300; line-height: 1.65; color: #6b7a9e; max-width: 480px; margin: 0 auto 32px;">Deploy your first AI coworker in under five minutes. No setup fees, no long-term commitments.</p>
+  <a style="display: inline-block; background: linear-gradient(135deg, #d4a853, #b87333); color: #0f1629; font-family: 'DM Sans', sans-serif; font-size: 15px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase; text-decoration: none; padding: 16px 40px; border-radius: 4px;">Get Started</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between icon and inline label.
+- **8px**: Tight gap -- between sub-label and heading, between stat number and label.
+- **12px**: Small gap -- between heading and body text within a component.
+- **16px**: Base gap -- between body paragraphs, between list items in compact mode.
+- **24px**: Medium gap -- between components within a section, standard list item padding.
+- **32px**: Section internal -- padding inside cards and containers, gap between grouped items.
+- **48px**: Section divider -- vertical space between major content blocks.
+- **60px**: Large section padding -- top/bottom padding for hero and CTA blocks.
+- **80px**: Maximum section padding -- cover slides and high-impact hero areas.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 960px |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned text for body content. Center-aligned for hero titles, stats, and CTA blocks.
+- **Grid**: Use a simple 2-column grid for comparison layouts. Single-column for narrative and list content. 3-column for stat grids on widescreen slides. Grids separated by 1px gold-tinted borders, not gaps.
+- **Horizontal rules**: 1px tall, gold linear-gradient (`linear-gradient(90deg, transparent, #d4a853, transparent)`), 80px wide, centered -- used as section dividers with a fading-light quality.
+- **Vertical rhythm**: Maintain consistent 48px gaps between top-level sections. Use 24px gaps between items within a section.
+- **Content gravity**: On widescreen slides (1920x1080), anchor content to the left two-thirds of the frame. Leave the right third as breathing room or for supporting metrics.
+- **Restraint principle**: Every layout decision should feel like a subtraction. If a section can work with fewer elements, remove the extras.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, background `#0f1629` | Page canvas, base layer |
+| Subtle (Level 1) | `rgba(0,0,0,0.3) 0px 2px 8px` | Slight lift for list items on hover |
+| Card (Level 2) | `rgba(0,0,0,0.4) 0px 8px 24px, rgba(212,168,83,0.03) 0px 0px 12px` | Standard card and container elevation |
+| Featured (Level 3) | `rgba(0,0,0,0.5) 0px 16px 40px, rgba(212,168,83,0.06) 0px 0px 20px` | Featured cards, quote blocks, hero elements |
+| Overlay (Level 4) | `rgba(0,0,0,0.7) 0px 24px 60px` | Modals, overlays, high-priority popups |
+
+### Border Treatments
+- **Standard border**: `1px solid rgba(212,168,83,0.15)` -- barely visible gold-tinted line that defines edges with whisper-thin precision.
+- **Active border**: `1px solid rgba(212,168,83,0.3)` -- gold-tinted border for featured or active containers.
+- **Copper border**: `1px solid rgba(184,115,51,0.3)` -- copper-tinted border for secondary elements and hover states.
+- **Accent rule**: `1px solid #d4a853` -- solid gold line used as horizontal dividers and accent bars.
+- **Divider line**: `1px solid rgba(245,242,237,0.06)` -- nearly invisible separator for dense list content.
+- **Gradient rule**: `linear-gradient(90deg, transparent, #d4a853, transparent)` -- fading gold rule for section dividers. 1px height.
+
+### Surface Hierarchy
+On dark navy backgrounds, elevation is communicated through lightness and warmth:
+1. **Background** (`#0f1629`) -- the deepest layer, the canvas.
+2. **Inset** (`#111b33`) -- recessed areas sit between background and surface.
+3. **Surface** (`#162040`) -- cards and containers step up by becoming slightly lighter.
+4. **Elevated** (`#1c2a50`) -- the highest non-overlay surface, used for nested content inside cards.
+
+Gold-tinted ambient shadows (`rgba(212,168,83,0.03-0.06)`) add warmth to elevation and prevent the dark-on-dark layering from feeling cold. The gold influence should be barely perceptible -- like catching the glint of a gold pen on a dark desk.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use gold (`#d4a853`) as the spice, not the dish -- accent bars, numbers, CTAs, and single focal points only.
+- Use DM Sans at weight 300 for body text -- the lightness signals confidence and luxury.
+- Use generous letter-spacing (+0.5px to +1px) on display headings for an open, premium feel.
+- Use hairline borders (`1px solid rgba(212,168,83,0.15)`) to define structure without adding visual weight.
+- Use subtle gold linear-gradients on accent rules for the signature fading-light effect.
+- Maintain generous line height (1.65-1.70) for body text -- luxury design gives words room to breathe.
+- Use copper (`#b87333`) for secondary labels, metadata, and secondary borders -- it is gold's quieter companion.
+- Limit each slide/section to one focal stat or headline -- restraint is the hallmark of premium design.
+- Use the gradient rule (`linear-gradient(90deg, transparent, #d4a853, transparent)`) as the signature section divider.
+- Keep CTA buttons understated -- a subtle gradient and moderate padding, never oversized or aggressive.
+
+### Don't
+- Don't use gold on large surfaces (backgrounds, full-width bars) -- gold is an accent, not a surface colour.
+- Don't use weight 700+ for display headings -- 500-600 is the ceiling. Heavy type breaks the refined feel.
+- Don't use pure white (`#ffffff`) for text -- always use warm white (`#f5f2ed`) to preserve the warm tone.
+- Don't use pure black (`#000000`) for backgrounds -- always use deep navy (`#0f1629`) for the colour depth.
+- Don't use bright or saturated colours alongside gold -- no blues, greens, or oranges. Only gold and copper.
+- Don't apply more than one gold gradient per section -- multiple gradients feel garish, not premium.
+- Don't use rounded corners above 4px -- this style is precise and architectural, not soft or playful.
+- Don't center-align body paragraphs -- only headlines, stats, and CTAs should be centered.
+- Don't use thick borders (2px+) -- hairline (1px) borders are the rule. Thickness breaks the delicate feel.
+- Don't use decorative icons or emoji -- if a visual marker is needed, use a diamond (&#9670;) or thin line in gold.
+- Don't overuse uppercase -- reserve it for labels (13px) and CTA buttons only. Headlines are always mixed case.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale down**: Display Hero becomes 56px (from 72px). Section Heading becomes 40px. Sub-heading stays 32px. Body stays 16px.
+- **Padding**: 60px on all sides. Content area is 960x960px.
+- **Cover slide**: Title centered vertically and horizontally. Gold gradient rule above and below (80px wide). Subtitle in copper.
+- **Content slides**: Left-aligned text. One concept per slide. Gold number (48px DM Sans, weight 700) at top-left; content below.
+- **Stat slides**: Single stat centered. Big number at 56px in gold. Label and description below.
+- **Swipe indicator**: Small gold dots at bottom center, 6px diameter, 12px gap, using `rgba(212,168,83,0.5)` for inactive and `#d4a853` for active.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Uses full-scale type hierarchy. Display Hero at 72px for the title section.
+- **Padding**: 60px left/right. 80px top/bottom margins.
+- **Section spacing**: 64px vertical gap between major sections. Gold gradient rules (80px wide, centered) between sections.
+- **Vertical rhythm**: Alternate between full-width sections and 2-column grids. Use numbered items for sequential content, stat displays for key metrics, and quote blocks for testimonials.
+- **Footer**: Copper text, 13px DM Sans weight 400, with a final gold gradient rule above.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 80px. Section Heading becomes 56px. Body Large becomes 22px.
+- **Padding**: 80px on all sides. Content area is 1760x920px.
+- **Layout**: Left-heavy composition. Title and body text occupy the left 60% of the frame. Right 40% is breathing room or supporting content.
+- **Title slides**: Headline centered on frame. Gold gradient rule centered. Subtitle in copper below.
+- **Content slides**: 2-column max for comparisons. Single column for narrative.
+- **Stat slides**: Up to 3 stats in a row, each in its own gold-bordered panel with generous internal padding.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 64px. Section Heading at 40px. Body at 16px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top third for headline. Middle third for key content (stats, list, or comparison). Bottom third for CTA or closing statement.
+- **Vertical flow**: Content reads top-to-bottom with clear sections. Gold gradient rules separate the three zones.
+- **CTA placement**: Always in the bottom zone, centered, with generous padding above. Gold-to-copper gradient button.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Hero becomes 72px in DM Sans 600 with +0.75px letter-spacing (approximately 30% larger than Carousel 56px). Section Heading becomes 52px. Body Large becomes 22px at weight 300 for the signature whisper-style reading voice. Numbering labels stay at 14px with wide tracking in gold.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical text must sit inside y=160 to y=1760.
+- **Layout**: Single centered column. Content max-width 920px. Vertical center of gravity -- cluster hero content in y=400 to y=1500 range. Deep navy background (`#0f1629`) runs edge-to-edge with optional subtle gradient to `#132036` for extra warmth.
+- **Cover slide**: Thin gold (`#d4a853`) linear-gradient accent bar 2px tall, 80px wide centered above the headline. DM Sans 600 headline at 72px in warm white with generous +0.75px letter-spacing, carefully kerned. Subtitle below in warm white at 22px weight 300. A second gold bar below the subtitle closes the composition. Everything quiet, considered, expensive -- like the masthead of a private members' publication.
+- **Content slides**: One idea per slide. Copper (`#b87333`) uppercase label at 14px with 2px tracking anchors the top of the content block, followed by a DM Sans 600 sub-heading at 52px in warm white, then weight-300 body copy in cream. A hairline gold-tinted divider (`1px solid rgba(212,168,83,0.3)`) separates heading from body. Restraint is the feature -- never fill the frame.
+- **CTA slide**: Warm white headline at 56px centered in the middle zone. Short body in weight 300. Gold-to-copper linear-gradient button (pill radius, 8px) with navy text in DM Sans 600. Final hairline gold divider below the CTA as a visual sign-off.
+- **Progress indicator**: Whisper-thin gold segments 1.5px tall at the top of the safe zone -- inactive segments at `rgba(212,168,83,0.25)`, active at full gold. No glow, no animation -- just precise hardware-like marks, in keeping with the aged-metal vocabulary.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Deep Navy | `#0f1629` | Primary background |
+| Warm White | `#f5f2ed` | Primary text |
+| Gold | `#d4a853` | Accent: numbers, rules, CTAs, focal points |
+| Copper | `#b87333` | Secondary accent: borders, captions, labels |
+| Light Gold | `#e8c877` | Hover state text, high-emphasis elements |
+| Deep Gold | `#b8923d` | Hover/active state for gold elements |
+| Navy Surface | `#162040` | Card/container surface |
+| Surface Inset | `#111b33` | Recessed panels, code blocks |
+| Navy Light | `#1c2a50` | Nested containers, elevated surfaces |
+| Slate | `#3d4a6b` | Disabled text, subtle dividers |
+| Muted Blue | `#6b7a9e` | Tertiary text, descriptions |
+| Silver Blue | `#8a96b5` | De-emphasized captions |
+
+### Font Declarations
+
+```css
+font-family: 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,300;1,9..40,400&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-deep-navy: #0f1629;
+  --color-warm-white: #f5f2ed;
+  --color-gold: #d4a853;
+
+  /* Colors -- Accent */
+  --color-copper: #b87333;
+  --color-light-gold: #e8c877;
+  --color-deep-gold: #b8923d;
+
+  /* Colors -- Neutral Scale */
+  --color-navy-surface: #162040;
+  --color-navy-light: #1c2a50;
+  --color-slate: #3d4a6b;
+  --color-muted-blue: #6b7a9e;
+  --color-silver-blue: #8a96b5;
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: #162040;
+  --color-surface-inset: #111b33;
+
+  /* Colors -- Borders */
+  --color-border-default: rgba(212, 168, 83, 0.15);
+  --color-border-accent: rgba(212, 168, 83, 0.3);
+  --color-border-strong: rgba(245, 242, 237, 0.12);
+  --color-border-copper: rgba(184, 115, 51, 0.3);
+  --color-divider-rule: #d4a853;
+
+  /* Colors -- Shadows */
+  --shadow-gold: rgba(212, 168, 83, 0.06);
+  --shadow-deep: rgba(0, 0, 0, 0.5);
+  --shadow-soft: rgba(0, 0, 0, 0.3);
+  --shadow-ambient: rgba(212, 168, 83, 0.03);
+
+  /* Typography -- Families */
+  --font-display: 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-body: 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 72px;
+  --text-section-heading: 48px;
+  --text-sub-heading: 32px;
+  --text-body-large: 20px;
+  --text-body: 16px;
+  --text-small: 13px;
+  --text-big-number: 64px;
+  --text-label: 13px;
+  --text-cta: 15px;
+
+  /* Typography -- Weights */
+  --weight-display: 600;
+  --weight-display-medium: 500;
+  --weight-display-heavy: 700;
+  --weight-body-light: 300;
+  --weight-body: 400;
+  --weight-label: 500;
+
+  /* Typography -- Line Heights */
+  --leading-display: 1.05;
+  --leading-heading: 1.10;
+  --leading-sub-heading: 1.20;
+  --leading-body-large: 1.65;
+  --leading-body: 1.70;
+  --leading-small: 1.50;
+  --leading-number: 1.00;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-medium: 24px;
+  --space-large: 32px;
+  --space-section: 48px;
+  --space-hero: 60px;
+  --space-max: 80px;
+
+  /* Borders */
+  --radius-standard: 4px;
+
+  /* Shadows -- Composed */
+  --shadow-card: rgba(0,0,0,0.4) 0px 8px 24px, rgba(212,168,83,0.03) 0px 0px 12px;
+  --shadow-featured: rgba(0,0,0,0.5) 0px 16px 40px, rgba(212,168,83,0.06) 0px 0px 20px;
+
+  /* Gradients */
+  --gradient-gold: linear-gradient(135deg, #d4a853, #b87333);
+  --gradient-rule: linear-gradient(90deg, transparent, #d4a853, transparent);
+}
+```
+
+### System Font Fallbacks
+- **Sans-serif (if DM Sans fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/_full/grid-quote-editorial.md
+++ b/skills/composites/goose-graphics/styles/_full/grid-quote-editorial.md
@@ -1,0 +1,525 @@
+# Design Style: Grid Quote Editorial
+
+## 1. Visual Theme & Atmosphere
+
+Grid Quote Editorial is the design language of the pull-quote spread -- the kind of widescreen panel you find on the interstitial pages of a literary magazine, the title card of a design-studio keynote, or the oversized wall-type installed at a writer's conference. It takes a single sentence and treats it like a monument. The canvas is a deep, saturated royal purple (`#2D1A5E`) -- not navy, not plum, but the specific rich indigo-violet of a velvet theater curtain or a Penguin Classics spine. Across this purple, a thin pale-pink grid (`#F2C9C4`) divides the surface into editorial cells, giving the composition the structural rhythm of a newspaper front page or a modernist poster. Into the largest cell drops the hero: a three-line pull quote set in mint-green (`#C9E8B5`) heavy rounded sans display type, occupying nearly half the width of the canvas and speaking with the confidence of a chapter opener.
+
+The contrast is the entire identity. Three colors only: deep purple as the stage, pale pink as the scaffolding, mint green as the voice. Pink and mint against purple is a specifically editorial move -- it reads as thoughtful and literary rather than loud, because the pink is desaturated into a peach-cream and the mint is pushed toward celadon rather than neon. The grid lines are hairline-thin (1px) and never interrupt the type; they simply slice the canvas into zones that suggest "this is structured writing, not decoration." In the top-left grid cell sits a small pink opening-quotation-mark glyph (`"`) -- the signature detail that telegraphs "this is a quote card" before your eye reaches the words. At the bottom-left, the attribution sits in small pink tracked uppercase caps, whispering the source. Nothing else. No photographs, no gradients, no shadows, no illustrations. The entire style is composed from color, grid, and one enormous piece of type.
+
+This is the design language of a literary quarterly's contributor-quote page, the typographic discipline of a Pentagram quote poster, and the editorial confidence of a Criterion Collection title card. It works because it refuses to decorate the sentence -- it simply gives it a room, draws the walls with a pink grid, and lets it speak. The mood is contemplative, literate, and quietly theatrical. It is flat by design: every element sits on the same visual plane, and depth comes from color contrast alone. This makes it a natural widescreen format -- slides and conference-room panels are its native habitat, though it carries into square and vertical formats by reducing the hero quote to two lines and tightening the grid accordingly.
+
+**Key Characteristics:**
+- Deep royal purple background (`#2D1A5E`) -- saturated, indigo-leaning, never navy
+- Pale peach-pink grid overlay (`#F2C9C4`) at 1px line weight dividing the canvas into 2-3 columns x 3-4 rows
+- Mint-green pull quote (`#C9E8B5`) in Figtree 800 -- the entire hero element of every slide
+- Small pink opening-quote glyph (`"`) in the top-left grid cell at 96-120px
+- Bottom-left attribution in tracked uppercase caps at 14-16px pink, letter-spacing 2px
+- Hero quote at 88-120px line-height 1.10, left-aligned, 3-line stack preferred
+- Figtree 800 (heavy rounded geometric sans) for all display type -- never regular weight
+- Strictly flat: no shadows, no gradients, no rounded containers, no photographic elements
+- Restricted 3-color palette: purple canvas + pink grid/glyph/attribution + mint quote
+- Widescreen-native: 16:9 slides are the canonical format; other formats adapt the grid ratio
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Royal Purple** (`#2D1A5E`): Primary background. Deep, saturated indigo-violet that reads as literary and theatrical. The entire canvas sits in this color.
+- **Mint Green** (`#C9E8B5`): Primary display color. Used exclusively for the hero pull quote -- never for body text, never for accents elsewhere. This is the voice of the style.
+- **Peach Pink** (`#F2C9C4`): Primary structural accent. Used for grid lines, opening-quote glyph, and attribution text. The scaffolding color.
+
+### Accent
+- **Deep Purple** (`#1F0F47`): Darker variant of the background for depth-stacked panels or subtle background modulation when slides must visually separate.
+- **Soft Mint** (`#D4ECB8`): Slightly lighter mint for secondary display type on multi-line layouts or subtitle accents (use sparingly).
+- **Dusty Pink** (`#E5B8B3`): A shade darker than the pink, reserved for hover states or for secondary tag accents on non-quote slides.
+
+### Neutral Scale
+- **Purple Canvas** (`#2D1A5E`): Base canvas -- the only true surface color in the style.
+- **Purple Inset** (`#251353`): Barely-perceptible inset for containers that need to "press into" the canvas.
+- **Pink Dim** (`rgba(242, 201, 196, 0.55)`): Secondary pink for less critical structural elements like progress indicators.
+- **Pink Faint** (`rgba(242, 201, 196, 0.25)`): Divider lines and tertiary structural elements.
+- **Mint Dim** (`rgba(201, 232, 181, 0.80)`): Secondary mint for subordinate display text on multi-quote layouts.
+
+### Surface & Borders
+- **Surface Primary** (`#2D1A5E`): The canvas is the surface. No cards, no containers.
+- **Surface Inset** (`#251353`): Used only when a slide absolutely requires a secondary zone -- never as a rounded card.
+- **Grid Line** (`#F2C9C4`): The 1px pink grid line color. Applied via absolutely-positioned 1px divs.
+- **Grid Line Dim** (`rgba(242, 201, 196, 0.50)`): Lighter grid variant for secondary grid lines on denser layouts.
+- **Border Default** (`#F2C9C4`): There are no borders in this style beyond the grid itself. If a border is required, use the grid color at 1px.
+- **Divider Rule** (`rgba(242, 201, 196, 0.30)`): A thin divider rule for separating grid cells on list layouts.
+
+### Shadow Colors
+This style is strictly flat. No shadows are used. The following are reserved for edge cases only and should be treated as "never in normal use."
+- **Shadow Forbidden** -- do not use drop shadows on any element in this style.
+- **Elevation via Color** -- if an element needs to "lift," use a slightly lighter purple inset rather than a shadow.
+
+### Texture
+This style has no texture. The canvas is flat color. The only "texture" is the pink grid overlay itself.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Figtree:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Figtree', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Body**: `'Figtree', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+Figtree is a single-family style. The entire design is set in Figtree -- display at weight 800, caption at weight 500-600. Figtree has the heavy-rounded geometric character of the reference screenshot: closed apertures, friendly rounded terminals, and a confident 800-weight that reads as an editorial display face. Alternatives if Figtree is unavailable: Plus Jakarta Sans 800 (slightly more condensed) or Manrope 800 (slightly more humanist).
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Pull Quote Hero (Slides) | Figtree | 120px | 800 | 1.10 | -1px | The hero. Mint green. 3-line stack preferred. |
+| Pull Quote Hero (Carousel) | Figtree | 88px | 800 | 1.10 | -0.5px | Scaled-down hero for square format. |
+| Pull Quote Hero (Story) | Figtree | 116px | 800 | 1.08 | -0.5px | ~30% larger than Carousel for vertical format. |
+| Pull Quote Hero (Poster) | Figtree | 96px | 800 | 1.10 | -0.5px | Poster-scaled hero. |
+| Section Heading | Figtree | 56px | 800 | 1.15 | -0.5px | Used only on non-quote slides (cover, CTA). Mint. |
+| Sub-heading | Figtree | 36px | 700 | 1.20 | 0px | Supporting headlines on multi-element slides. |
+| Body Large | Figtree | 22px | 500 | 1.55 | 0px | Subtitles and lead paragraphs on intro slides. |
+| Body | Figtree | 18px | 500 | 1.55 | 0px | Standard body text (rarely used in this style). |
+| Small / Caption | Figtree | 14px | 600 | 1.50 | 0.3px | Metadata and secondary labels. |
+| Attribution Caps | Figtree | 16px | 600 | 1.00 | 2px | Bottom-left attribution. Uppercase. Pink. |
+| Opening Quote Glyph | Figtree | 120px | 900 | 1.00 | 0px | The pink `"` in the top-left grid cell. |
+| Slide Number | Figtree | 14px | 500 | 1.00 | 1.5px | Small pink number, top-right or bottom-right. |
+
+### Principles
+- **One face, two weights**: Figtree 800 for display, Figtree 500-600 for caption. That is the entire typographic system. The weight contrast (500 vs. 800) is the visual rhythm.
+- **Left-aligned always**: Every hero quote is left-aligned. Center-aligning a pull quote in this style breaks the editorial grid logic. Attribution is also left-aligned beneath the quote.
+- **Three-line hero preferred**: The canonical pull quote is a 2- or 3-line stack. Longer quotes should be broken at natural clause boundaries (after commas, after "I", before verbs). Never allow a hero quote to exceed 4 lines -- shorten the quote or scale down.
+- **Tracked caps for attribution only**: Uppercase with 2px letter-spacing is reserved for attribution and framework labels. The hero quote is always mixed case.
+- **Tight line-height on display**: Line-height 1.08-1.10 on the hero quote is essential -- it creates the monumental stacked-block feel of the reference. Never use 1.2+ on display.
+- **No italics**: This style does not use italic type. Emphasis within a quote is handled by isolating the sentence itself, not by styling individual words.
+- **Opening-quote glyph is part of the type system**: The `"` glyph in the top-left is not decoration -- it is set in Figtree 900 at ~120px and treated as a typographic element, not an icon.
+
+## 4. Component Patterns
+
+### Grid Overlay Container (THE signature component)
+
+The grid is rendered as absolutely-positioned 1px divs. It divides the slide into 2-3 columns and 3-4 rows. Always placed as the first child inside the slide container with `pointer-events: none` so it never interferes with content interaction.
+
+```html
+<div style="position: absolute; inset: 0; pointer-events: none;">
+  <!-- Horizontal grid lines (3 lines = 4 rows) -->
+  <div style="position: absolute; left: 0; right: 0; top: 25%; height: 1px; background: var(--color-grid);"></div>
+  <div style="position: absolute; left: 0; right: 0; top: 50%; height: 1px; background: var(--color-grid);"></div>
+  <div style="position: absolute; left: 0; right: 0; top: 75%; height: 1px; background: var(--color-grid);"></div>
+  <!-- Vertical grid lines (2 lines = 3 columns) -->
+  <div style="position: absolute; top: 0; bottom: 0; left: 12%; width: 1px; background: var(--color-grid);"></div>
+  <div style="position: absolute; top: 0; bottom: 0; left: 88%; width: 1px; background: var(--color-grid);"></div>
+</div>
+```
+
+For a tighter 2x3 grid (2 columns, 3 rows):
+
+```html
+<div style="position: absolute; inset: 0; pointer-events: none;">
+  <!-- Horizontal grid lines -->
+  <div style="position: absolute; left: 0; right: 0; top: 33.33%; height: 1px; background: var(--color-grid);"></div>
+  <div style="position: absolute; left: 0; right: 0; top: 66.66%; height: 1px; background: var(--color-grid);"></div>
+  <!-- Vertical grid line -->
+  <div style="position: absolute; top: 0; bottom: 0; left: 50%; width: 1px; background: var(--color-grid);"></div>
+</div>
+```
+
+### Opening-Quote Glyph Cell
+
+A small pink `"` glyph placed in the top-left grid cell. Always sits roughly centered within its own cell, with ~40-60px of padding from the grid line edges.
+
+```html
+<div style="position: absolute; top: 48px; left: 72px; font-family: var(--font-display); font-size: 96px; font-weight: 900; line-height: 0.80; color: var(--color-pink); margin: 0;">&ldquo;</div>
+```
+
+For widescreen Slides format, scale up the glyph to 120px and offset further into the top-left cell:
+
+```html
+<div style="position: absolute; top: 80px; left: 120px; font-family: var(--font-display); font-size: 120px; font-weight: 900; line-height: 0.80; color: var(--color-pink); margin: 0;">&ldquo;</div>
+```
+
+### Pull Quote Hero
+
+The hero quote is the single most important component of the style. It is a huge mint-green Figtree 800 block, left-aligned, with line-height 1.10. Positioned to occupy roughly the middle-left of the canvas, starting below the second horizontal grid line.
+
+```html
+<h1 style="font-family: var(--font-display); font-size: 120px; font-weight: 800; line-height: 1.10; letter-spacing: -1px; color: var(--color-mint); margin: 0; max-width: 1400px; text-align: left;">
+  I don't know<br>
+  what I think<br>
+  until I write it<br>
+  down.
+</h1>
+```
+
+For Carousel (1080x1080):
+
+```html
+<h1 style="font-family: var(--font-display); font-size: 88px; font-weight: 800; line-height: 1.10; letter-spacing: -0.5px; color: var(--color-mint); margin: 0; max-width: 900px; text-align: left;">
+  I don't know<br>
+  what I think<br>
+  until I write<br>
+  it down.
+</h1>
+```
+
+### Caps Attribution
+
+The bottom-left attribution block. Small, tracked, pink, uppercase. Sits inside the bottom-left grid cell.
+
+```html
+<p style="font-family: var(--font-display); font-size: 16px; font-weight: 600; line-height: 1.00; letter-spacing: 2px; text-transform: uppercase; color: var(--color-pink); margin: 0;">Joan Didion</p>
+```
+
+With optional secondary metadata:
+
+```html
+<div style="position: absolute; bottom: 80px; left: 120px;">
+  <p style="font-family: var(--font-display); font-size: 16px; font-weight: 600; line-height: 1.00; letter-spacing: 2px; text-transform: uppercase; color: var(--color-pink); margin: 0 0 8px;">Joan Didion</p>
+  <p style="font-family: var(--font-display); font-size: 13px; font-weight: 500; line-height: 1.00; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-pink-dim); margin: 0;">The White Album, 1979</p>
+</div>
+```
+
+### Full Quote Slide (complete slide composition)
+
+```html
+<div style="position: relative; width: 1920px; height: 1080px; background: var(--color-purple); overflow: hidden;">
+  <!-- Grid overlay -->
+  <div style="position: absolute; inset: 0; pointer-events: none;">
+    <div style="position: absolute; left: 0; right: 0; top: 25%; height: 1px; background: var(--color-grid);"></div>
+    <div style="position: absolute; left: 0; right: 0; top: 75%; height: 1px; background: var(--color-grid);"></div>
+    <div style="position: absolute; top: 0; bottom: 0; left: 12%; width: 1px; background: var(--color-grid);"></div>
+    <div style="position: absolute; top: 0; bottom: 0; left: 88%; width: 1px; background: var(--color-grid);"></div>
+  </div>
+  <!-- Opening quote glyph -->
+  <div style="position: absolute; top: 80px; left: 120px; font-family: var(--font-display); font-size: 120px; font-weight: 900; line-height: 0.80; color: var(--color-pink);">&ldquo;</div>
+  <!-- Hero quote -->
+  <h1 style="position: absolute; top: 340px; left: 300px; font-family: var(--font-display); font-size: 120px; font-weight: 800; line-height: 1.10; letter-spacing: -1px; color: var(--color-mint); margin: 0; max-width: 1400px;">
+    I don't know what I<br>think until I write it<br>down.
+  </h1>
+  <!-- Attribution -->
+  <p style="position: absolute; bottom: 120px; left: 300px; font-family: var(--font-display); font-size: 16px; font-weight: 600; line-height: 1.00; letter-spacing: 2px; text-transform: uppercase; color: var(--color-pink); margin: 0;">Joan Didion</p>
+</div>
+```
+
+### Cover Slide (no grid -- reserved for quote slides)
+
+Cover slides drop the grid and use a simpler centered composition. The grid is reserved exclusively for the pull-quote interior slides.
+
+```html
+<div style="position: relative; width: 1920px; height: 1080px; background: var(--color-purple); display: flex; flex-direction: column; justify-content: center; align-items: flex-start; padding: 120px 160px;">
+  <p style="font-family: var(--font-display); font-size: 16px; font-weight: 600; line-height: 1.00; letter-spacing: 2px; text-transform: uppercase; color: var(--color-pink); margin: 0 0 48px;">Essays on Writing</p>
+  <h1 style="font-family: var(--font-display); font-size: 140px; font-weight: 800; line-height: 1.05; letter-spacing: -1.5px; color: var(--color-mint); margin: 0 0 32px; max-width: 1400px;">Quotes for<br>writers who<br>write to think.</h1>
+  <p style="font-family: var(--font-display); font-size: 22px; font-weight: 500; line-height: 1.55; color: var(--color-pink); margin: 0; max-width: 700px;">A collection of one-line arguments for the notebook and the blank page.</p>
+</div>
+```
+
+### CTA Slide (no grid)
+
+Like the cover, the CTA slide reserves the grid for quote interior slides and uses a simpler left-aligned composition with a mint-colored link-underline accent for the action.
+
+```html
+<div style="position: relative; width: 1920px; height: 1080px; background: var(--color-purple); display: flex; flex-direction: column; justify-content: center; align-items: flex-start; padding: 120px 160px;">
+  <p style="font-family: var(--font-display); font-size: 16px; font-weight: 600; line-height: 1.00; letter-spacing: 2px; text-transform: uppercase; color: var(--color-pink); margin: 0 0 48px;">Keep Reading</p>
+  <h2 style="font-family: var(--font-display); font-size: 96px; font-weight: 800; line-height: 1.10; letter-spacing: -0.5px; color: var(--color-mint); margin: 0 0 56px; max-width: 1200px;">More essays on<br>writing to think.</h2>
+  <a style="display: inline-block; font-family: var(--font-display); font-size: 22px; font-weight: 700; color: var(--color-pink); text-decoration: underline; text-underline-offset: 8px; text-decoration-thickness: 2px; letter-spacing: 0.2px;">gooseworks.ai/essays &rarr;</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Hairline gap -- between attribution lines.
+- **8px**: Tight gap -- between metadata rows.
+- **16px**: Base gap -- between attribution and secondary metadata.
+- **24px**: Small gap -- between grid cell padding and content.
+- **32px**: Medium gap -- between header label and hero headline.
+- **48px**: Standard vertical rhythm -- between major vertical content blocks.
+- **72px**: Grid cell inset -- standard padding inside a grid cell.
+- **120px**: Outer padding for Slides format -- breathing room at the canvas edges.
+- **160px**: Story-format outer padding on left/right for large vertical breathing.
+- **300px**: Hero quote left-offset on Slides format -- places the hero in the 2nd vertical column.
+
+### Format Padding
+
+| Format | Outer Padding | Content Max-Width | Grid Config |
+|--------|---------------|-------------------|-------------|
+| Carousel (1080x1080) | 72px all sides | 936px | 2 cols x 3 rows |
+| Infographic (1080xN) | 72px left/right, 96px top/bottom | 936px | 2 cols x 4+ rows |
+| Slides (1920x1080) **HERO** | 120px all sides | 1680px | 3 cols x 4 rows |
+| Poster (1080x1350) | 72px left/right, 96px top/bottom | 936px | 2 cols x 4 rows |
+| Story (1080x1920) | 60px left/right, 120px top/bottom | 960px | 2 cols x 5 rows |
+
+**Slides is the hero format.** This style is widescreen-native -- the reference is a 16:9 quote card, and the grid + hero quote composition reads best at that aspect ratio. When designing for other formats, treat Slides as the canonical version and adapt downward.
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned for all quote slides. Cover and CTA slides may be left-aligned or vertically centered but never horizontally centered (centering breaks the editorial grid logic).
+- **Grid**: The pink grid overlay is the structural organizing system. Quote slides use a 3-column 4-row grid (widescreen) or 2-column 3-row grid (square/vertical). Grid lines are 1px `#F2C9C4` with no opacity.
+- **Hero quote placement**: The hero sits in the middle-left zone, starting roughly at the second horizontal grid line and extending to the third. It aligns its left edge with the first vertical grid line +180px indent.
+- **Opening-quote glyph placement**: Always in the top-left grid cell, offset inward by 24-48px from the cell corners.
+- **Attribution placement**: Always in the bottom-left grid cell, offset inward by 24-48px from the cell edges, left-edge aligned with the hero quote.
+- **Vertical rhythm**: 48-72px gaps between top-level content blocks. The grid cells themselves provide the structural rhythm -- resist the urge to add extra spacing inside a cell.
+- **Content gravity**: On widescreen, content gravitates to the left half of the canvas. The right column is intentionally empty -- it is "air" for the quote to breathe into.
+
+## 6. Depth & Elevation
+
+This style is **strictly flat**. There is no elevation, no shadows, no layered cards. Depth comes from color contrast alone -- mint on purple, pink on purple -- and from the grid structure defining zones.
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | Background `#2D1A5E`, no shadow | Canvas, the only surface |
+| Grid (Level 1) | 1px `#F2C9C4` line overlay | Structural divider (not elevation) |
+| Type (Level 2) | Mint/pink text on purple | Content elevation via color contrast |
+| Disallowed | Shadows, gradients, bevels, rounded containers | Never used |
+
+### Border Treatments
+- **Grid line**: `1px solid #F2C9C4` -- the only border in the entire style. Applied only as grid dividers.
+- **Grid line dim**: `1px solid rgba(242, 201, 196, 0.50)` -- for secondary grid lines on denser multi-element layouts.
+- **No card borders**: Cards do not exist in this style. If you find yourself reaching for a bordered card, use a grid cell instead.
+- **No rounded corners**: All structural elements are rectilinear. `border-radius: 0` is the default.
+
+### Surface Hierarchy
+On the deep purple canvas, elevation is communicated entirely by color contrast:
+1. **Canvas** (`#2D1A5E`) -- the only surface. Everything sits directly on this.
+2. **Grid overlay** (`#F2C9C4`) -- the structural layer, 1px thin.
+3. **Attribution + glyph** (`#F2C9C4`) -- small pink elements sit at the middle of the visual stack.
+4. **Hero quote** (`#C9E8B5`) -- mint green commands the highest contrast and is always the primary focal point.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use mint-green (`#C9E8B5`) for the hero pull quote exclusively. The mint is the voice of the style -- every slide has exactly one mint element.
+- Use pink (`#F2C9C4`) for the grid overlay, opening-quote glyph, and attribution -- and for nothing else. Pink is the scaffolding color, not a general accent.
+- Keep the purple background deep and saturated (`#2D1A5E`). Do not lighten, do not tint, do not gradient.
+- Use Figtree 800 for all display type. Heavy weight is essential to the editorial-monumental feel.
+- Use the grid overlay (absolutely-positioned 1px pink lines) on every pull-quote interior slide. It is the signature structural element.
+- Place the opening-quote glyph in the top-left grid cell at 96-120px, Figtree 900, in pink.
+- Left-align the hero pull quote with line-height 1.10 and break it into 2-4 lines at natural clause boundaries.
+- Place the attribution at the bottom-left in small tracked uppercase pink, letter-spacing 2px.
+- Keep the right-half of the canvas intentionally empty -- it is "breathing room" for the hero quote.
+- Use widescreen Slides (1920x1080) as the canonical format for this style.
+- Break long quotes at natural clause boundaries (after commas, after "I", before verbs) to preserve editorial rhythm.
+- Limit each slide to exactly one pull quote. Multi-quote layouts destroy the style.
+
+### Don't
+- Don't use the grid overlay on cover slides or CTA slides. The grid is reserved exclusively for pull-quote interior slides -- covers and CTAs use a simpler ungridded composition.
+- Don't use shadows. This style is flat. Drop shadows, inner shadows, glows, and bevels are all forbidden.
+- Don't use rounded corners. All structural elements are rectilinear. No `border-radius` anywhere except optional minor radius on CTA buttons (and even then, prefer sharp).
+- Don't use more than 2 colors beyond the purple canvas. Mint for the quote, pink for the structure. That is the entire palette. Adding a third accent breaks the style.
+- Don't use Figtree at regular weight (400) for display type. Display is always 800. Light or regular weight mint-on-purple looks washed-out and non-editorial.
+- Don't center-align the hero quote. Left-alignment is part of the style's editorial grid logic.
+- Don't use the grid with more than 3 columns or more than 4 rows. Denser grids read as technical/engineering, not editorial.
+- Don't use italics for emphasis within a quote. The quote itself is the emphasis.
+- Don't add icons, illustrations, or photography. This style is pure type + grid.
+- Don't use gradients. The background is flat purple, the type is flat mint/pink.
+- Don't let the hero quote exceed 4 lines. If the quote is longer, shorten it or scale down the font size. 3 lines is the canonical target.
+- Don't mix this style with other accent colors from the broader palette. Purple-pink-mint is a closed system.
+- Don't let the grid lines interact with content -- always use `pointer-events: none` on the grid overlay.
+- Don't use Figtree 800 for body/caption text. Weight 500-600 is the correct subordinate weight.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+**Slides (1920x1080) is the hero format for this style.** The reference is a widescreen editorial quote card, and the grid + hero + attribution composition reads best at that aspect ratio. Design for Slides first, then adapt.
+
+### Slides (1920x1080px) -- HERO FORMAT
+- **Typography scale**: Pull Quote Hero at 120px Figtree 800, line-height 1.10, letter-spacing -1px. Cover headline at 140px. CTA headline at 96px. Attribution at 16px letter-spacing 2px.
+- **Padding**: 120px all sides. Content area is 1680x840px.
+- **Grid**: 3 columns x 4 rows. Vertical lines at 12% and 88% (leaving wide center column). Horizontal lines at 25% and 75% (creating a central middle band for the hero quote).
+- **Hero placement**: Quote starts at roughly x=300 (inside the second column), y=340 (just below the upper horizontal line), and wraps at max-width 1400px.
+- **Opening-quote glyph**: Top-left grid cell at top=80, left=120, 120px Figtree 900 in pink.
+- **Attribution**: Bottom-left grid cell at bottom=120, left=300 (aligned with hero quote left edge).
+- **Cover slide**: No grid. Left-aligned, vertically centered, with a small pink framework-label at the top.
+- **CTA slide**: No grid. Left-aligned mint headline with pink underlined CTA link.
+- **Swipe indicator**: Thin pink segments at the top-right corner, each 40px wide, 2px tall, 8px apart. Active segment in full pink, inactive in `rgba(242, 201, 196, 0.35)`.
+
+### Carousel (1080x1080px)
+- **Typography scale down**: Pull Quote Hero becomes 88px (from 120px). Cover headline becomes 96px. Attribution stays 14-16px.
+- **Padding**: 72px on all sides. Content area is 936x936px.
+- **Grid**: 2 columns x 3 rows. Single vertical line at 50%, two horizontal lines at 33% and 67%. A simpler grid suited to the square format.
+- **Hero placement**: Quote starts at roughly x=144 (inside the left column), y=380, max-width 840px, typically 3-4 lines.
+- **Opening-quote glyph**: Top-left at top=72, left=72, 80px Figtree 900.
+- **Attribution**: Bottom-left at bottom=72, left=144 (aligned with hero quote left edge).
+- **Cover slide**: No grid. Framework label at top, centered vertical stack with left-aligned text.
+- **Content slides**: Each slide carries one quote. Quote-card series works as a carousel of 5-8 quotes.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Full scale. Pull Quote Hero at 88px (Carousel scale). Section dividers at 48px.
+- **Padding**: 72px left/right, 96px top/bottom.
+- **Grid**: 2 columns x N rows. Vertical line at 50%. Horizontal lines every 400px creating stacked quote "rooms."
+- **Layout**: Stack multiple quote slides vertically, each one its own grid cell with its own opening-quote glyph and attribution. Treat each quote-zone as a mini-slide within the infographic.
+- **Vertical rhythm**: Each quote zone is 500-700px tall depending on quote length. No decorative dividers between zones -- the pink grid lines do the structural work.
+- **Footer**: Pink tracked-caps label at the bottom, centered or left-aligned.
+
+### Poster (1080x1350px)
+- **Typography**: Pull Quote Hero at 96px. Section heading at 56px. Attribution at 16px.
+- **Padding**: 72px left/right, 96px top/bottom.
+- **Grid**: 2 columns x 4 rows. Vertical line at 50%, three horizontal lines at 25%, 50%, 75%.
+- **Composition**: Top third for framework label and opening-quote glyph. Middle two thirds for the hero pull quote. Bottom third for attribution and optional secondary metadata.
+- **Hero placement**: Quote starts at roughly x=144, y=420, max-width 900px, 3-4 lines.
+- **Use case**: Single monumental quote-as-poster, suitable for wall-print, social share image, or event poster.
+
+### Story (1080x1920px)
+- **Typography scale up**: Pull Quote Hero becomes 116px Figtree 800 (approximately 30% larger than Carousel's 88px). Cover headline at 124px. CTA headline at 88px. Attribution at 18px letter-spacing 2px.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical text must sit inside y=160 to y=1760.
+- **Grid**: 2 columns x 5 rows. Vertical line at 50%. Horizontal lines at 20%, 40%, 60%, 80%. The taller vertical aspect takes more horizontal divisions to maintain the editorial rhythm.
+- **Hero placement**: Quote starts at roughly x=120 (inside the left column), y=700, max-width 880px, wrapping 4-5 lines naturally. Content clusters in y=400 to y=1500.
+- **Opening-quote glyph**: Top-left cell at top=200, left=120, 96px Figtree 900 (smaller than Slides due to narrower canvas). Must sit inside the top safe zone.
+- **Attribution**: Bottom-left at bottom=240, left=120 (respecting bottom safe zone).
+- **Cover slide**: No grid. Framework label at top of safe zone. Cover headline centered vertically with the hero scaled to 124px. Supporting line in pink below.
+- **CTA slide**: No grid. Mint CTA headline, pink underlined link, both inside safe zones.
+- **Max 10 slides**: Story carousels should not exceed 10 slides. Each slide holds exactly one quote.
+- **Progress indicator**: Thin pink segments at the top of the safe zone (y=120) -- inactive in `rgba(242, 201, 196, 0.35)`, active in full pink `#F2C9C4`.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Royal Purple | `#2D1A5E` | Primary background -- the entire canvas |
+| Mint Green | `#C9E8B5` | Pull quote display color -- hero only |
+| Peach Pink | `#F2C9C4` | Grid lines, opening-quote glyph, attribution |
+| Deep Purple | `#1F0F47` | Inset/depth variant of background |
+| Soft Mint | `#D4ECB8` | Secondary mint for multi-line subtitle accents |
+| Dusty Pink | `#E5B8B3` | Hover/secondary pink |
+| Pink Dim | `rgba(242,201,196,0.55)` | Secondary pink for inactive elements |
+| Pink Faint | `rgba(242,201,196,0.25)` | Dividers, tertiary structure |
+| Grid Line | `#F2C9C4` | 1px grid overlay line color |
+| Purple Inset | `#251353` | Subtle depth stepping within canvas |
+
+### Font Declarations
+
+```css
+/* Display and body (single-family system) */
+font-family: 'Figtree', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Figtree:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-purple: #2D1A5E;
+  --color-mint: #C9E8B5;
+  --color-pink: #F2C9C4;
+
+  /* Colors -- Accent */
+  --color-purple-deep: #1F0F47;
+  --color-purple-inset: #251353;
+  --color-mint-soft: #D4ECB8;
+  --color-pink-dusty: #E5B8B3;
+
+  /* Colors -- Dim Variants */
+  --color-pink-dim: rgba(242, 201, 196, 0.55);
+  --color-pink-faint: rgba(242, 201, 196, 0.25);
+  --color-mint-dim: rgba(201, 232, 181, 0.80);
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: #2D1A5E;
+  --color-surface-inset: #251353;
+
+  /* Colors -- Borders / Grid */
+  --color-grid: #F2C9C4;
+  --color-grid-dim: rgba(242, 201, 196, 0.50);
+  --color-divider: rgba(242, 201, 196, 0.30);
+
+  /* Colors -- Shadows (forbidden in this style) */
+  --shadow-none: none;
+
+  /* Typography -- Families */
+  --font-display: 'Figtree', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-body: 'Figtree', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes (Slides-format canonical) */
+  --text-hero-slides: 120px;
+  --text-hero-carousel: 88px;
+  --text-hero-story: 116px;
+  --text-hero-poster: 96px;
+  --text-section-heading: 56px;
+  --text-sub-heading: 36px;
+  --text-body-large: 22px;
+  --text-body: 18px;
+  --text-small: 14px;
+  --text-attribution: 16px;
+  --text-glyph: 120px;
+
+  /* Typography -- Weights */
+  --weight-display: 800;
+  --weight-display-extra: 900;
+  --weight-heading: 700;
+  --weight-attribution: 600;
+  --weight-body: 500;
+
+  /* Typography -- Line Heights */
+  --leading-hero: 1.10;
+  --leading-hero-tight: 1.08;
+  --leading-heading: 1.15;
+  --leading-body: 1.55;
+  --leading-caption: 1.50;
+  --leading-number: 1.00;
+
+  /* Typography -- Letter Spacing */
+  --tracking-hero: -1px;
+  --tracking-heading: -0.5px;
+  --tracking-body: 0px;
+  --tracking-caption: 0.3px;
+  --tracking-caps: 2px;
+
+  /* Spacing */
+  --space-hairline: 4px;
+  --space-tight: 8px;
+  --space-base: 16px;
+  --space-small: 24px;
+  --space-medium: 32px;
+  --space-standard: 48px;
+  --space-cell-inset: 72px;
+  --space-slides-padding: 120px;
+  --space-story-padding: 160px;
+  --space-hero-offset: 300px;
+
+  /* Borders */
+  --radius-none: 0px;
+  --grid-line-width: 1px;
+
+  /* Grid -- Slides (3x4) */
+  --grid-slides-col-1: 12%;
+  --grid-slides-col-2: 88%;
+  --grid-slides-row-1: 25%;
+  --grid-slides-row-2: 50%;
+  --grid-slides-row-3: 75%;
+
+  /* Grid -- Carousel (2x3) */
+  --grid-carousel-col-1: 50%;
+  --grid-carousel-row-1: 33.33%;
+  --grid-carousel-row-2: 66.66%;
+
+  /* Grid -- Story (2x5) */
+  --grid-story-col-1: 50%;
+  --grid-story-row-1: 20%;
+  --grid-story-row-2: 40%;
+  --grid-story-row-3: 60%;
+  --grid-story-row-4: 80%;
+}
+```
+
+### System Font Fallbacks
+- **Sans-serif (if Figtree fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Alternative heavy rounded sans:** `'Plus Jakarta Sans', 'Manrope', -apple-system, sans-serif` (set both at weight 800)

--- a/skills/composites/goose-graphics/styles/_full/heatwave-orange.md
+++ b/skills/composites/goose-graphics/styles/_full/heatwave-orange.md
@@ -1,0 +1,551 @@
+# Design Style: Heatwave Orange
+
+## 1. Visual Theme & Atmosphere
+
+Heatwave Orange is the design language of a high-confidence copywriting brand that wants every slide to feel like a magazine cover. It draws from the aesthetic of modern Instagram carousel creators (think Copywriting Tips, High Signal, indie newsletter brands) crossed with the broadcast graphics of a sports channel -- heavy sans-serif headlines, saturated heat-orange surfaces, and corner-radiating "speed line" decorations that give every slide a sense of forward motion. The mood is assertive, direct, and slightly loud. There is no whispering in this style. Every slide shouts its point, then hands the reader a round lavender arrow and says "keep going."
+
+The signature move is a **three-background variant system**: every carousel deliberately rotates between near-white (`#F0EFEA`), saturated heat-orange (`#E06A2C`), and near-black (`#0D0D0D`). This is not decorative -- it is structural. Cover slides are white. Content slides are orange. Quote or pause slides are black. CTA slides return to orange. The rotation creates rhythm across a 5-slide carousel the way cuts create rhythm in a music video: white grabs attention, orange delivers the lesson, black gives the reader a breath, orange brings them home. On the white variant, a **peach highlight block** sits behind one word of the headline (e.g., "Headline?" in the cover) -- it mimics a highlighter stroke and is the one moment of warmth in an otherwise cool slide. On orange and black variants, text is always pure white. The headline type is heavy Inter 900 at 72-90px, stacked 3-4 lines, tight leading, tight tracking.
+
+The second signature element is the **line-wave corner decoration**: a set of thin horizontal curving lines radiating from the bottom-right corner, drawn as SVG paths with stroke and no fill. On white slides the lines are peach. On orange slides the lines are a slightly lighter orange-white tint. On black slides they are gold/tan. They look like topographic contour lines, radio waves, or the speed lines behind a cartoon runner. A small round lavender arrow button (`#D0C8E8`) sits at the bottom-right of every slide as a "swipe next" indicator -- it is the one soft element in an otherwise hard composition, and the color contrast with the heat-orange is the brand's visual fingerprint. A metadata strip at the top of every slide labels the content: category ("Copywriting Tips"), author ("Sebastian Bennett"), and handle ("@reallygreatsite").
+
+**Key Characteristics:**
+- Three-background variant system: near-white (`#F0EFEA`), heat-orange (`#E06A2C`), near-black (`#0D0D0D`) -- rotated deliberately across a carousel
+- Heavy sans-serif headlines in Inter 900 at 72-90px, stacked 3-4 lines, tight leading (1.05)
+- Peach highlight block (`#F2A36A`) behind one word on white slides only
+- Line-wave corner decoration (SVG curved paths) at bottom-right on at least half of slides
+- Round lavender arrow button (`#D0C8E8`) with black arrow at bottom-right as swipe indicator
+- Metadata strip at top: small Inter 500 labels for category, author, handle
+- White text on orange and black variants; near-black text on white variant
+- Left-aligned headlines on content slides; generous left padding (60-80px)
+- Minimum type weight is 600 -- no thin fonts, ever
+- No rounded corners on text blocks; 6px radius on example tags; fully round only on the arrow button
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Heat Orange** (`#E06A2C`): Primary accent and dominant slide surface color for content and CTA slides. The heart of the brand -- warm, saturated, almost sunburnt.
+- **Heat Orange Light** (`#E37230`): A slightly lighter tint used for hover states, highlight flourishes, and secondary orange surfaces.
+- **Near-White** (`#F0EFEA`): Cover slide background. Not pure white -- a warm cream-adjacent neutral that keeps the style from feeling sterile.
+- **Near-Black** (`#0D0D0D`): Quote/pause slide background and all primary text on white slides. Deep, inky, but not pure black.
+- **Pure White** (`#FFFFFF`): Primary text on orange and black variants.
+
+### Accent
+- **Peach Highlight** (`#F2A36A`): The signature highlighter block behind one word on white slides. A warm peach that sits between cream and orange.
+- **Peach Deep** (`#E0896B`): Alternate peach for the line-wave decoration on white slides.
+- **Lavender Button** (`#D0C8E8`): The soft round arrow button fill. The single cool color in the palette -- its job is to contrast the heat.
+- **Lavender Deep** (`#C8BFE0`): Hover/active state for the lavender button.
+- **Gold Tan** (`#C9A46B`): Tint for line-wave decoration on black variant slides only.
+
+### Neutral Scale
+- **Off-White** (`#F0EFEA`): Primary cream background.
+- **Off-White 2** (`#E8E6DF`): A slightly darker cream for subtle inset surfaces on white slides.
+- **Charcoal** (`#2B2B2B`): Secondary text on white slides (metadata, handle).
+- **Tertiary Gray** (`#6A6A6A`): Muted labels and low-priority text on white slides.
+- **Orange Dim** (`rgba(255,255,255,0.7)`): Secondary text on orange slides (handle, metadata sublabels).
+- **Black Dim** (`rgba(255,255,255,0.65)`): Secondary text on black slides.
+
+### Surface & Borders
+- **Surface White** (`#F0EFEA`): White slide background.
+- **Surface Orange** (`#E06A2C`): Orange slide background.
+- **Surface Black** (`#0D0D0D`): Black slide background.
+- **Surface Tag Dark** (`#0D0D0D`): Black "Example" tag fill on orange slides.
+- **Surface Tag Peach** (`#F2A36A`): Peach highlight block behind headline words on white slides.
+- **Border Subtle** (`rgba(0,0,0,0.08)`): Rare divider line on white slides.
+- **Border White-on-Orange** (`rgba(255,255,255,0.25)`): Thin dividers on orange variants.
+- **Divider Rule** (`rgba(255,255,255,0.15)`): Metadata strip dividers on dark variants.
+
+### Shadow Colors
+- **Shadow Warm** (`rgba(224,106,44,0.25)`): Subtle orange-tinted ambient shadow for raised elements on white slides.
+- **Shadow Medium** (`rgba(0,0,0,0.18)`): Standard shadow for the lavender arrow button.
+- **Shadow Deep** (`rgba(0,0,0,0.30)`): High-elevation shadow -- rarely used, this style is mostly flat.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+```
+
+- **Display & Body**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+A single-family system. Inter does everything from the 72px hero headline to the 14px metadata label. The variation comes from weight (400 through 900) and size, not from mixing typefaces. This keeps the style feeling like one voice shouting at different volumes.
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Inter | 88px | 900 | 1.05 | -2px | Headline stack, 3-4 lines. Used on cover and content slides. |
+| Display Stack | Inter | 76px | 900 | 1.05 | -1.5px | Slightly smaller headline variant for longer text. |
+| Section Heading | Inter | 56px | 900 | 1.08 | -1px | Mid-size headline for dense content slides. |
+| Sub-heading | Inter | 32px | 800 | 1.15 | -0.5px | Supporting statement below a headline. |
+| Body Large | Inter | 22px | 600 | 1.45 | 0px | Example text, supporting lines on content slides. |
+| Body | Inter | 18px | 600 | 1.50 | 0px | Standard body text. |
+| Small / Caption | Inter | 14px | 500 | 1.45 | 0.2px | Metadata strip: category, author, handle. |
+| Big Numbers | Inter | 120px | 900 | 1.00 | -3px | Statistics on content or poster slides. |
+| Tag Label | Inter | 16px | 800 | 1.00 | 0.3px | Black "Example" tag text on orange slides. |
+| CTA Text | Inter | 18px | 800 | 1.00 | 0.3px | Button text, close-out lines. |
+
+### Principles
+- **Single family, multiple voices**: Every weight from 400 to 900 is on the table. Inter 900 is the headline voice, Inter 600 is the body voice, Inter 500 is the caption voice. No other families.
+- **Minimum weight is 600**: This style has no use for 300 or 400 light weight body text. If you need a softer voice, use 600; if you need a harder voice, use 900. Weight is the main axis of expression.
+- **Tight leading on headlines**: Headlines stack 3-4 lines with line-height 1.05. The stack is the composition -- it is meant to read like a magazine cover wordmark, not a paragraph.
+- **Left-aligned by default**: Every headline on every content slide is left-aligned. Center-alignment is reserved for the cover slide in some variants. The metadata strip and the arrow button sit at opposite corners to create visual tension.
+- **Tight tracking on large sizes**: Hero and display sizes get -1px to -2px letter-spacing. Body text sits at 0. Metadata gets +0.2px. Never use wide tracking -- this style is compact and assertive.
+- **Mixed case always**: Headlines and body are mixed case. Uppercase is reserved only for the tiny "EXAMPLE" tag when tag-labeled, and even then only at 16px.
+
+## 4. Component Patterns
+
+### Title Block -- WHITE Variant (Cover Slide)
+
+```html
+<div style="background-color: #F0EFEA; padding: 60px; position: relative; min-height: 100%; display: flex; flex-direction: column; justify-content: space-between;">
+  <!-- Metadata strip -->
+  <div style="font-family: var(--font-body); font-size: 14px; font-weight: 500; color: #2B2B2B; letter-spacing: 0.2px;">Copywriting Tips</div>
+
+  <!-- Line-wave corner decoration (see component below) -->
+
+  <!-- Headline stack -->
+  <div style="position: relative; z-index: 2;">
+    <h1 style="font-family: var(--font-body); font-size: 88px; font-weight: 900; line-height: 1.05; letter-spacing: -2px; color: #0D0D0D; margin: 0;">
+      How to write<br>
+      a better<br>
+      <span style="background: #F2A36A; padding: 4px 18px; display: inline-block; color: #0D0D0D;">Headline?</span>
+    </h1>
+  </div>
+
+  <!-- Footer: author + arrow -->
+  <div style="display: flex; align-items: flex-end; justify-content: space-between; position: relative; z-index: 2;">
+    <div>
+      <p style="font-family: var(--font-body); font-size: 18px; font-weight: 700; color: #0D0D0D; margin: 0 0 2px;">Sebastian Bennett</p>
+      <p style="font-family: var(--font-body); font-size: 14px; font-weight: 500; color: #6A6A6A; margin: 0;">@reallygreatsite</p>
+    </div>
+    <!-- Arrow button here -->
+  </div>
+</div>
+```
+
+### Title Block -- ORANGE Variant (Content Slide)
+
+```html
+<div style="background-color: #E06A2C; padding: 60px; position: relative; min-height: 100%; display: flex; flex-direction: column; justify-content: space-between;">
+  <div style="font-family: var(--font-body); font-size: 14px; font-weight: 500; color: #FFFFFF; letter-spacing: 0.2px;">Copywriting Tips</div>
+
+  <div style="position: relative; z-index: 2;">
+    <h1 style="font-family: var(--font-body); font-size: 80px; font-weight: 900; line-height: 1.05; letter-spacing: -1.5px; color: #FFFFFF; margin: 0 0 40px;">
+      Use "you" to<br>
+      address the<br>
+      readers
+    </h1>
+
+    <!-- Black example tag -->
+    <span style="display: inline-block; background: #0D0D0D; color: #FFFFFF; font-family: var(--font-body); font-size: 16px; font-weight: 800; padding: 10px 22px; letter-spacing: 0.3px; margin: 0 0 18px;">Example</span>
+    <p style="font-family: var(--font-body); font-size: 22px; font-weight: 600; line-height: 1.45; color: #FFFFFF; margin: 0;">This is how you can earn<br>more money</p>
+  </div>
+
+  <div style="display: flex; align-items: flex-end; justify-content: space-between; position: relative; z-index: 2;">
+    <p style="font-family: var(--font-body); font-size: 18px; font-weight: 700; color: #FFFFFF; margin: 0;">Sebastian Bennett</p>
+    <!-- Arrow button here -->
+  </div>
+</div>
+```
+
+### Title Block -- BLACK Variant (Quote / CTA Slide)
+
+```html
+<div style="background-color: #0D0D0D; padding: 60px; position: relative; min-height: 100%; display: flex; flex-direction: column; justify-content: space-between;">
+  <div style="font-family: var(--font-body); font-size: 14px; font-weight: 500; color: #FFFFFF; letter-spacing: 0.2px;">Copywriting Tips</div>
+
+  <div style="position: relative; z-index: 2;">
+    <h1 style="font-family: var(--font-body); font-size: 84px; font-weight: 900; line-height: 1.05; letter-spacing: -1.5px; color: #FFFFFF; margin: 0;">
+      Follow us to<br>
+      get more<br>
+      <span style="background: #F2A36A; padding: 4px 18px; display: inline-block; color: #0D0D0D;">Information</span><br>
+      and tips like<br>
+      this.
+    </h1>
+  </div>
+
+  <div style="display: flex; align-items: flex-end; justify-content: space-between; position: relative; z-index: 2;">
+    <div>
+      <p style="font-family: var(--font-body); font-size: 18px; font-weight: 700; color: #FFFFFF; margin: 0 0 2px;">Sebastian Bennett</p>
+      <p style="font-family: var(--font-body); font-size: 14px; font-weight: 500; color: rgba(255,255,255,0.65); margin: 0;">@reallygreatsite</p>
+    </div>
+    <!-- Arrow button here -->
+  </div>
+</div>
+```
+
+### Line-Wave Corner Decoration (SVG, bottom-right)
+
+The signature decoration -- a set of thin curving horizontal lines radiating from the bottom-right corner of the slide. Adjust `stroke` color per variant:
+- White slide: `stroke="#E0896B"` (peach)
+- Orange slide: `stroke="rgba(255,255,255,0.55)"` (white tint)
+- Black slide: `stroke="#C9A46B"` (gold tan)
+
+```html
+<svg width="560" height="640" viewBox="0 0 560 640"
+     style="position: absolute; right: 0; bottom: 0; pointer-events: none; z-index: 1;"
+     fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M560 40 Q 380 52, 180 100"   stroke="#E0896B" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M560 80 Q 380 94, 160 146"   stroke="#E0896B" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M560 120 Q 380 136, 140 192" stroke="#E0896B" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M560 160 Q 380 178, 130 238" stroke="#E0896B" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M560 200 Q 380 220, 130 282" stroke="#E0896B" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M560 240 Q 380 262, 140 324" stroke="#E0896B" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M560 280 Q 380 304, 160 362" stroke="#E0896B" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M560 320 Q 380 344, 190 398" stroke="#E0896B" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M560 360 Q 380 382, 220 432" stroke="#E0896B" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M560 400 Q 380 418, 260 462" stroke="#E0896B" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M560 440 Q 420 452, 300 490" stroke="#E0896B" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M560 480 Q 450 488, 340 514" stroke="#E0896B" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M560 520 Q 480 524, 380 540" stroke="#E0896B" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M560 560 Q 500 562, 420 570" stroke="#E0896B" stroke-width="2.5" stroke-linecap="round"/>
+</svg>
+```
+
+### Peach Highlight Word (White variant only)
+
+Inline span that wraps one highlighted word in a cover headline. Used exclusively on white-variant slides.
+
+```html
+<span style="background: #F2A36A; padding: 4px 18px; display: inline-block; color: #0D0D0D; line-height: 1.05;">Headline?</span>
+```
+
+### Arrow Button Circle (bottom-right swipe indicator)
+
+A round lavender button with a black arrow. Present on every slide as the "swipe next" affordance.
+
+```html
+<div style="width: 68px; height: 68px; border-radius: 50%; background: #D0C8E8; display: flex; align-items: center; justify-content: center; box-shadow: 0 4px 12px rgba(0,0,0,0.18);">
+  <svg width="26" height="14" viewBox="0 0 26 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M1 7 L23 7 M17 1 L23 7 L17 13" stroke="#0D0D0D" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>
+</div>
+```
+
+### Black "Example" Tag (Orange variant)
+
+A sharp-edged black pill for labeling example text on orange slides. Note: not rounded, just slightly inset padding.
+
+```html
+<span style="display: inline-block; background: #0D0D0D; color: #FFFFFF; font-family: var(--font-body); font-size: 16px; font-weight: 800; padding: 10px 22px; letter-spacing: 0.3px; border-radius: 2px;">Example</span>
+```
+
+### Big Number Stat (Orange variant)
+
+```html
+<div style="padding: 40px 0;">
+  <p style="font-family: var(--font-body); font-size: 120px; font-weight: 900; line-height: 1.00; letter-spacing: -3px; color: #FFFFFF; margin: 0 0 12px;">87%</p>
+  <p style="font-family: var(--font-body); font-size: 22px; font-weight: 600; line-height: 1.45; color: #FFFFFF; max-width: 420px; margin: 0;">of readers decide to keep reading based on the headline alone.</p>
+</div>
+```
+
+### Metadata Strip (top of every slide)
+
+```html
+<div style="display: flex; align-items: center; gap: 16px; font-family: var(--font-body); font-size: 14px; font-weight: 500; letter-spacing: 0.2px;">
+  <span style="color: #0D0D0D;">Copywriting Tips</span>
+  <!-- On orange/black, swap color to #FFFFFF -->
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- inside the peach highlight padding.
+- **8px**: Tight gap -- between small metadata items.
+- **12px**: Small gap -- between stat number and its caption.
+- **16px**: Base gap -- between author name and handle.
+- **24px**: Medium gap -- between headline and supporting statement.
+- **32px**: Section internal -- gap between metadata strip and headline block.
+- **40px**: Content gap -- between headline block and example tag block.
+- **48px**: Section divider -- vertical space between major content blocks.
+- **60px**: Standard slide padding -- carousel outer margin.
+- **80px**: Maximum section padding -- infographic and slides outer margin.
+- **120px**: Story format top/bottom padding.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 960px |
+| Story (1080x1920) | 120px top/bottom, 60px left/right | 960px |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned on all content slides. The cover slide is also left-aligned but starts the headline block roughly 35% down the slide (not at the top).
+- **Headline stack**: Headlines always stack 3-4 lines. Do not let them run as a single long line. Manually break lines to control the composition.
+- **Metadata strip**: Always at the top-left. Never centered, never right-aligned.
+- **Arrow button**: Always at the bottom-right. Never inside a headline, never at the top.
+- **Author signature**: Always at the bottom-left, opposite the arrow button. The vertical axis between metadata (top-left), headline (center-left), and author (bottom-left) creates a strong left spine.
+- **Line-wave decoration**: Always at bottom-right, flowing toward upper-left. Never top-left. Never top-right. The wave must "run into" the headline from outside the frame.
+- **Vertical rhythm**: 40-48px gaps between top-level content blocks. Headlines breathe. Example tags and supporting text hug close (12-18px).
+- **Single-column**: This style does not use multi-column layouts. One headline, one supporting block, one arrow. Always.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, solid variant background | Slide canvas, headline text, the vast majority of elements |
+| Subtle (Level 1) | `0 2px 6px rgba(0,0,0,0.12)` | Hover states on the lavender arrow button |
+| Card (Level 2) | `0 4px 12px rgba(0,0,0,0.18)` | The lavender arrow button itself |
+| Warm (Level 3) | `0 8px 24px rgba(224,106,44,0.25)` | Rare: featured cards on white slides only |
+| Overlay (Level 4) | `0 16px 40px rgba(0,0,0,0.30)` | Modals and overlays (rarely used) |
+
+### Border Treatments
+- **No card borders**: This style does not use bordered cards. Content is defined by the slide background color and typographic weight, not by containers.
+- **Divider rule (dark variants)**: `1px solid rgba(255,255,255,0.15)` -- used only to separate metadata items on dark slides.
+- **Divider rule (light variants)**: `1px solid rgba(0,0,0,0.08)` -- used rarely to separate metadata items on white slides.
+- **Arrow button edge**: No visible border. Definition comes from the shadow.
+
+### Surface Hierarchy
+This style uses **background color swaps** as the primary depth mechanism, not shadows. The three variants (white, orange, black) are the three levels of surface:
+1. **Flat background** -- the dominant variant color fills the entire slide.
+2. **Peach highlight block** -- sits directly on the white background with no shadow, purely a color overlay.
+3. **Black example tag** -- sits directly on the orange background with no shadow.
+4. **Lavender arrow button** -- the one element with a real shadow, giving it the highest elevation on every slide.
+
+Elevation is rare in this style. Keep it reserved for the arrow button and the occasional hover state.
+
+## 7. Do's and Don'ts
+
+### Do
+- **Use the three-variant system deliberately**. A 5-slide carousel rotates: Cover WHITE -> Content ORANGE -> Content ORANGE -> Quote BLACK -> CTA ORANGE. This rotation is the backbone of the style.
+- **Use the line-wave decoration on at least half of slides**. It is the visual signature. Place it at bottom-right, flowing into the slide.
+- **Use peach highlight (`#F2A36A`) only on white slides**. Wrap one key word in the headline with a peach block -- never more than one word.
+- **Use Inter 900 for every headline**. The heavy weight is non-negotiable. Drop to 800 only if 900 is unavailable.
+- **Place the metadata strip at the top-left of every slide**. Category first, author handle second line below.
+- **Place the lavender arrow button at the bottom-right of every slide**. It is the only rounded element in the composition.
+- **Stack headlines 3-4 lines with manual line breaks**. The block shape matters as much as the words.
+- **Use tight letter-spacing (-1px to -2px) on all display sizes**. Loose tracking reads wrong in this style.
+- **Keep the color palette restricted**. Orange, white, black, peach, and lavender. No blues, no greens, no additional accents.
+- **Use Inter 600 minimum for body text**. The style speaks at a confident volume.
+- **Name the slide variants when briefing**. Label them WHITE, ORANGE, or BLACK in comments so the rotation stays intentional.
+
+### Don't
+- **Don't make all-orange carousels**. Without the rotation, the style is boring and loses its cover-story energy. Always mix at least two variants per carousel.
+- **Don't use peach highlight on orange slides**. Peach and heat-orange have almost no contrast -- the highlight will disappear.
+- **Don't use thin fonts**. Nothing lighter than Inter 600. Never use weights 300 or 400 for body or headline text.
+- **Don't use rounded corners on text blocks, tags, or cards**. The only round element allowed is the lavender arrow button. Peach highlight and example tag have 0-2px radius.
+- **Don't center-align content slides**. Headlines are always left-aligned.
+- **Don't let a headline run as a single line**. Force 3-4 line stacks with `<br>` tags.
+- **Don't mix typefaces**. Inter only. No serifs, no monospace, no display fonts.
+- **Don't place the line-wave decoration at the top of the slide**. It always anchors from the bottom-right corner.
+- **Don't use more than one peach-highlighted word per headline**. The highlight is a hook, not an ornament.
+- **Don't forget the lavender arrow button**. Every slide needs a swipe affordance, even the last one.
+- **Don't use shadows on text**. Shadows are reserved for the arrow button and (rarely) featured cards.
+- **Don't introduce new colors**. Stick to the 8-color palette. Extra colors dilute the brand.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale**: Display Hero is 88px for cover slides, 80px for content slides. Big Numbers at 120px.
+- **Padding**: 60px on all sides. Content area 960x960px.
+- **Variant rotation**: A 5-slide carousel should follow the pattern Cover WHITE -> Content ORANGE -> Content ORANGE -> Quote BLACK -> CTA ORANGE. For 3-slide carousels use WHITE -> ORANGE -> BLACK. For 7-slide carousels, insert an additional ORANGE and a second BLACK for rhythm.
+- **Cover slide (WHITE)**: Metadata strip top-left. Headline block positioned center-vertical with peach highlight on last word. Author block bottom-left. Arrow bottom-right. Line-wave decoration bottom-right, peach.
+- **Content slides (ORANGE)**: Left-aligned headline stack. Optional black "Example" tag + supporting line below. Line-wave decoration optional, white tint.
+- **Quote slide (BLACK)**: Left-aligned headline stack, optionally with peach-highlighted word. Gold-tan line-wave decoration required.
+- **CTA slide (ORANGE)**: "Follow for more" headline, arrow button prominent.
+- **Swipe indicator**: The lavender arrow button at bottom-right on every slide is itself the swipe indicator. No dots needed.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Display Hero at 88px for the title section. Section Heading at 56px for internal divisions.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Variant rotation**: Use full-bleed variant bands. A single infographic can stack a WHITE title band, an ORANGE body band, a BLACK quote band, and an ORANGE CTA band -- each full-width.
+- **Section spacing**: 80px vertical gap between variant bands. No borders between them -- the color change is the divider.
+- **Line-wave decoration**: Place one instance in the bottom-right corner of the overall composition and one at the transition between the first two bands for rhythm.
+- **Footer**: Author signature and handle in a bottom strip, color matching the final band.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 120px. Section Heading becomes 72px. Body Large becomes 28px.
+- **Padding**: 80px on all sides. Content area 1760x920px.
+- **Layout**: Headlines stack 2-3 lines (shorter stacks for wider canvas). Content block occupies left 65% of the slide; line-wave decoration occupies right 35%.
+- **Cover slide**: Headline left-aligned, peach-highlighted word optional. Metadata top-left, author bottom-left, arrow bottom-right.
+- **Content slide (ORANGE)**: Left headline, supporting black example tag and text on the left. Line-wave decoration extends from right edge across the right third of the slide.
+- **Quote slide (BLACK)**: Full-slide headline, centered in the left 65%. Gold-tan line-wave on the right.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 96px. Big Numbers at 140px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top zone (15%) for metadata strip. Middle zone (60%) for the headline stack, peach-highlighted where applicable. Bottom zone (25%) for author signature, supporting text, and arrow button.
+- **Variant choice**: Posters are typically single-variant -- pick ONE of WHITE, ORANGE, or BLACK for the entire poster. The variant choice defines the poster's tone.
+- **Line-wave decoration**: Always present on posters, flowing from bottom-right up and to the left, extending further than on carousel format (up to 60% of poster width).
+
+### Story (1080x1920px)
+- **Typography**: Display Hero becomes 104px (the largest practical size for the narrow format). Supporting text 26px. Big Numbers at 144px.
+- **Padding**: **120px top/bottom**, 60px left/right. The generous top/bottom padding reserves space for Instagram/IG Story UI chrome (profile bubble at top, reply bar at bottom).
+- **Hero sizing**: The hero headline stack takes ~30% more vertical space than in carousel format -- this format is built for thumb-stopping impact. Use 104px headline at line-height 1.03 for maximum density.
+- **Layout**: Single-column, everything stacks vertically. Metadata strip at top (below Story chrome). Headline block centered vertically, left-aligned, occupying ~50% of the vertical space. Author signature and arrow button anchored near the bottom chrome safe zone.
+- **Variant choice**: Story carousels rotate WHITE -> ORANGE -> BLACK across 3 stories, or single-variant for a standalone story.
+- **Line-wave decoration**: Required on every Story. Because the format is tall, use a vertically-extended wave that runs from bottom-right up to 80% of the slide height. Scale the SVG viewBox to 560x1280 for stories.
+- **Arrow button**: Position slightly higher than in square formats (at ~85% vertical position) so it clears the Instagram reply bar.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Heat Orange | `#E06A2C` | Orange variant background, primary accent |
+| Heat Orange Light | `#E37230` | Hover / secondary orange surface |
+| Near-White | `#F0EFEA` | White variant background (cream) |
+| Near-Black | `#0D0D0D` | Black variant background, primary text on white |
+| Pure White | `#FFFFFF` | Primary text on orange and black variants |
+| Peach Highlight | `#F2A36A` | Signature highlight block on white slides |
+| Peach Deep | `#E0896B` | Line-wave decoration on white slides |
+| Lavender Button | `#D0C8E8` | Round arrow button fill |
+| Lavender Deep | `#C8BFE0` | Arrow button hover state |
+| Gold Tan | `#C9A46B` | Line-wave decoration on black slides |
+| Charcoal | `#2B2B2B` | Secondary text on white slides |
+| Tertiary Gray | `#6A6A6A` | Muted metadata on white slides |
+
+### Font Declarations
+
+```css
+/* Display and body (single family system) */
+font-family: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-orange: #E06A2C;
+  --color-orange-light: #E37230;
+  --color-white-bg: #F0EFEA;
+  --color-black-bg: #0D0D0D;
+  --color-white: #FFFFFF;
+
+  /* Colors -- Accent */
+  --color-peach-highlight: #F2A36A;
+  --color-peach-deep: #E0896B;
+  --color-lavender: #D0C8E8;
+  --color-lavender-deep: #C8BFE0;
+  --color-gold-tan: #C9A46B;
+
+  /* Colors -- Neutral Scale */
+  --color-off-white: #F0EFEA;
+  --color-off-white-2: #E8E6DF;
+  --color-charcoal: #2B2B2B;
+  --color-tertiary: #6A6A6A;
+  --color-orange-dim: rgba(255, 255, 255, 0.7);
+  --color-black-dim: rgba(255, 255, 255, 0.65);
+
+  /* Colors -- Surfaces */
+  --color-surface-white: #F0EFEA;
+  --color-surface-orange: #E06A2C;
+  --color-surface-black: #0D0D0D;
+  --color-surface-tag-dark: #0D0D0D;
+  --color-surface-tag-peach: #F2A36A;
+
+  /* Colors -- Borders */
+  --color-border-subtle: rgba(0, 0, 0, 0.08);
+  --color-border-white-on-orange: rgba(255, 255, 255, 0.25);
+  --color-divider-dark: rgba(255, 255, 255, 0.15);
+
+  /* Colors -- Shadows */
+  --shadow-warm: rgba(224, 106, 44, 0.25);
+  --shadow-medium: rgba(0, 0, 0, 0.18);
+  --shadow-deep: rgba(0, 0, 0, 0.30);
+
+  /* Typography -- Families */
+  --font-display: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 88px;
+  --text-display-stack: 76px;
+  --text-section-heading: 56px;
+  --text-sub-heading: 32px;
+  --text-body-large: 22px;
+  --text-body: 18px;
+  --text-small: 14px;
+  --text-big-number: 120px;
+  --text-tag: 16px;
+  --text-cta: 18px;
+
+  /* Typography -- Weights */
+  --weight-headline: 900;
+  --weight-sub-heading: 800;
+  --weight-body-bold: 700;
+  --weight-body: 600;
+  --weight-caption: 500;
+
+  /* Typography -- Line Heights */
+  --leading-display: 1.05;
+  --leading-heading: 1.08;
+  --leading-sub-heading: 1.15;
+  --leading-body-large: 1.45;
+  --leading-body: 1.50;
+  --leading-small: 1.45;
+  --leading-number: 1.00;
+
+  /* Typography -- Letter Spacing */
+  --tracking-hero: -2px;
+  --tracking-display: -1.5px;
+  --tracking-heading: -1px;
+  --tracking-sub: -0.5px;
+  --tracking-body: 0px;
+  --tracking-caption: 0.2px;
+  --tracking-tag: 0.3px;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-medium: 24px;
+  --space-large: 32px;
+  --space-gap: 40px;
+  --space-section: 48px;
+  --space-outer: 60px;
+  --space-max: 80px;
+  --space-story: 120px;
+
+  /* Borders */
+  --radius-tag: 2px;
+  --radius-button: 50%;
+  --radius-none: 0px;
+
+  /* Composed Shadows */
+  --shadow-button: 0 4px 12px rgba(0, 0, 0, 0.18);
+  --shadow-button-hover: 0 2px 6px rgba(0, 0, 0, 0.12);
+  --shadow-warm-card: 0 8px 24px rgba(224, 106, 44, 0.25);
+  --shadow-overlay: 0 16px 40px rgba(0, 0, 0, 0.30);
+}
+```
+
+### Slide Variant System (quick reference)
+
+```
+VARIANT     BACKGROUND    TEXT       HIGHLIGHT   LINE-WAVE COLOR       USE
+-------     ----------    ----       ---------   ---------------       ---
+WHITE       #F0EFEA       #0D0D0D    #F2A36A     #E0896B (peach)       Cover, title slides
+ORANGE      #E06A2C       #FFFFFF    none        rgba(255,255,255,.55) Content slides, CTA
+BLACK       #0D0D0D       #FFFFFF    #F2A36A     #C9A46B (gold-tan)    Quote, pause, final CTA
+```
+
+### System Font Fallbacks
+- **Inter (if Google Fonts fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/_full/highlighter-yellow.md
+++ b/skills/composites/goose-graphics/styles/_full/highlighter-yellow.md
@@ -1,0 +1,478 @@
+# Design Style: Highlighter Yellow
+
+## 1. Visual Theme & Atmosphere
+
+Highlighter Yellow is the design language of the viral self-help Instagram carousel -- the visual shorthand for a question that stops the thumb mid-scroll. It draws from the aesthetic of personal-development creators, productivity coaches, and the "journal page meets highlighter pen" school of social graphics. The entire canvas is flooded with a saturated, mid-lemon yellow (`#F4DC2E`) -- not pastel, not electric, not mustard. This is the exact tone of a brand-new Stabilo Boss highlighter swiped across a fresh notebook page, and it is the single most important color decision in the style. Paired with near-black text (`#1A1A1A`), the contrast is maximum and the legibility is brutal; you cannot scroll past this.
+
+The signature move -- the thing that makes this style instantly recognizable -- is the **white-rectangle italic emphasis span**. One key word in every headline is lifted out of the sentence and dropped into a crisp white block (`#FFFFFF`) with sharp corners, inline padding, and the word itself rendered in italic at the same heavy weight as the headline. It reads like someone took a highlighter to the page, then came back with a white-out correction tape and re-wrote the key word in their own handwriting. It is the punch, the emphasis, the "this is the idea" marker. Used once per slide, it is electric. Used twice, it loses its voltage. This is non-negotiable: one white-rect word per slide.
+
+The typography is single-family, single-weight: **Inter at weight 900** (Black), tightly tracked at -1px, left-aligned, stacked in 3-line headlines that hit like a question you can't unask. A subtle dot-grid texture sits on the yellow background -- small near-black dots on a 16px grid at ~12% opacity -- giving the canvas the feel of journal dot-grid paper without competing with the typography. Below the headline, a thin horizontal black rule divides the hook from the follow-up, and at the bottom of every slide sits a white URL pill styled like a browser search bar, complete with a magnifying glass icon, plus a small black bookmark icon in the corner. The feel: high-energy, unapologetic, bold, and 100% built for the feed.
+
+**Key Characteristics:**
+- Saturated highlighter yellow background (`#F4DC2E`) -- mid-lemon, dead-center saturation, never pastel, never mustard
+- Dot-grid texture overlay -- near-black dots on a 16px grid at 12% opacity, using CSS radial-gradient
+- Near-black primary text (`#1A1A1A`) -- maximum contrast, no pure black harshness
+- Inter Black (weight 900) for all headlines -- 56-72px in Carousel, -1px letter-spacing
+- White-rectangle italic emphasis span -- one key word per slide in a white block with italic type
+- Left-aligned 3-line question headlines -- never centered, always stacked
+- Thin horizontal rule divider (`1px solid #1A1A1A`) between hook and follow-up
+- White URL pill at the bottom with magnifying glass icon -- browser search bar styling
+- Small black bookmark icon in the bottom corner
+- Sharp or near-sharp edges (0-4px border-radius) on the white rects; URL pill is fully rounded
+- Single typeface throughout (Inter) -- no serif, no secondary font
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Highlighter Yellow** (`#F4DC2E`): Primary background color. Saturated mid-lemon yellow. This is the entire canvas and it is non-negotiable -- no gradients, no tints, no alternatives.
+- **Near-Black** (`#1A1A1A`): Primary text color, divider rule, dot-grid dots, bookmark icon. Used everywhere text or structure needs to exist.
+- **Pure White** (`#FFFFFF`): The white-rectangle emphasis block, the URL pill, the icon surfaces. Reserved for the signature emphasis treatment -- white is load-bearing here, not decorative.
+
+### Accent
+- **Highlighter Yellow Deep** (`#F4D41E`): Hover/active or slightly darker yellow variant for layered backgrounds if ever needed. Rarely used.
+- **Highlighter Yellow Bright** (`#F6E038`): Alternate yellow one step brighter for variation between slides in a carousel, if the designer wants tonal rhythm. Still within the saturated-lemon family.
+
+### Neutral Scale
+- **Secondary Text** (`#3A3A3A`): Subtitles, supporting copy, minor labels. Only used when a second text level is needed -- this style prefers single-level typographic hierarchy.
+- **Tertiary Text** (`rgba(26,26,26,0.6)`): Metadata, URL domain text inside the pill, bookmark count.
+- **Muted Dot Grid** (`rgba(26,26,26,0.12)`): The dot-grid texture color. Visible but not distracting.
+- **Subtle Text** (`rgba(26,26,26,0.4)`): Watermarks and slide numbers on the yellow canvas.
+
+### Surface & Borders
+- **Surface White** (`#FFFFFF`): White-rectangle emphasis block, URL pill, icon surface.
+- **Surface Inset** (`#F9E668`): Rare lighter-yellow inset panel if needed for secondary callouts.
+- **Border Default** (`#1A1A1A`): 1px or 2px solid near-black border used for the divider rule and sometimes around icons.
+- **Border Rule** (`1px solid #1A1A1A`): The thin horizontal divider between headline and follow-up text.
+- **Divider Subtle** (`rgba(26,26,26,0.2)`): Secondary divider when a lighter touch is needed.
+
+### Shadow Colors
+- **Shadow None** (none): This style is FLAT. Shadows are antithetical to the highlighter feel.
+- **Shadow Micro** (`0 1px 0 rgba(26,26,26,0.08)`): Only used on the URL pill to give it the faintest sense of lift. Never on anything else.
+- **Shadow Card** (`0 2px 0 #1A1A1A`): Optional 2px offset "sticker shadow" on white rectangles -- use sparingly.
+
+### Texture
+- **Dot Grid**: `radial-gradient(circle, rgba(26,26,26,0.12) 1.5px, transparent 1.5px)` at `16px 16px` spacing. Applied as a full-bleed overlay on every slide.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,400;0,500;0,700;0,900;1,400;1,700;1,900&display=swap" rel="stylesheet">
+```
+
+- **Display & Body**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Italic emphasis**: `'Inter', ...` with `font-style: italic` (same family, italic variant)
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Inter | 72px | 900 | 1.08 | -1.5px | Headline question on Story/Slides |
+| Headline Large | Inter | 64px | 900 | 1.08 | -1px | Headline question on Carousel/Poster |
+| Headline | Inter | 56px | 900 | 1.08 | -1px | Compact Carousel headline |
+| Emphasis Italic | Inter | matches headline | 900 | matches | -1px | White-rect word, `font-style: italic` |
+| Sub-heading | Inter | 32px | 900 | 1.15 | -0.5px | Follow-up sentence under divider |
+| Body Large | Inter | 22px | 500 | 1.55 | 0px | Secondary copy when needed |
+| Body | Inter | 18px | 500 | 1.55 | 0px | Standard body text, rarely used |
+| Small / Caption | Inter | 14px | 500 | 1.50 | 0.2px | URL pill text, metadata |
+| URL Pill Text | Inter | 16px | 500 | 1.00 | 0px | Inside the white search-bar pill |
+| Icon Label | Inter | 12px | 700 | 1.00 | 1px | Uppercase micro-labels, rare |
+
+### Principles
+- **Single family, heavy weight**: Inter Black (900) for every headline. This is not a style that mixes weights in the headline -- the weight IS the tone of voice.
+- **Tight tracking**: `-1px` letter-spacing on headlines 56px+ is essential. Looser tracking softens the punch.
+- **Left-align always for long headlines**: 3-line question stacks are always left-aligned. Centering a 3-line headline kills its rhythm.
+- **Italic emphasis, same weight**: When a word goes into the white-rect emphasis block, it stays at weight 900 and flips to `font-style: italic`. Never drop the weight.
+- **Mixed case, question mark**: Headlines are sentence case with a terminal question mark. This style is literally built around questions.
+- **No serif anywhere**: Resist the urge to add a display serif. The single-sans discipline is the style's identity.
+- **Compact line-height**: `1.08` for headlines, `1.15` for sub-headings. Anything looser and the stacked effect breaks.
+
+## 4. Component Patterns
+
+### Highlighter Emphasis Span (THE SIGNATURE MOVE)
+
+```html
+<span style="display: inline-block; background: #FFFFFF; color: #1A1A1A; font-family: 'Inter', sans-serif; font-weight: 900; font-style: italic; padding: 2px 14px 4px; margin: 0 2px; border-radius: 4px; line-height: inherit;">stuck</span>
+```
+
+**Rules:** Use exactly ONCE per slide. The span sits inline inside the headline, picks up the headline's font-size and line-height, and changes ONLY to italic + white background. Padding is asymmetric (2px top, 4px bottom) so the block extends slightly below the word's baseline -- the hand-highlighter-pen feel. Border-radius `4px` keeps the edge crisp. Never use for two words in the same slide.
+
+### Question Headline (with Highlighter Emphasis)
+
+```html
+<h1 style="font-family: 'Inter', sans-serif; font-size: 64px; font-weight: 900; line-height: 1.08; letter-spacing: -1px; color: #1A1A1A; text-align: left; margin: 0 0 32px; max-width: 900px;">
+  Why do I feel
+  <span style="display: inline-block; background: #FFFFFF; color: #1A1A1A; font-weight: 900; font-style: italic; padding: 2px 14px 4px; margin: 0 2px; border-radius: 4px;">stuck</span>
+  <br>in life?
+</h1>
+```
+
+### Divider Rule
+
+```html
+<div style="width: 80px; height: 2px; background: #1A1A1A; margin: 24px 0 24px;"></div>
+```
+
+**Variant (full-width):**
+```html
+<div style="width: 100%; height: 1px; background: #1A1A1A; margin: 28px 0;"></div>
+```
+
+Used to separate the headline from the follow-up sentence. Short `80px` version for left-aligned layouts, full-width for more editorial rhythm.
+
+### Follow-Up Block (Sub-headline with Inline Emphasis)
+
+```html
+<p style="font-family: 'Inter', sans-serif; font-size: 32px; font-weight: 900; line-height: 1.15; letter-spacing: -0.5px; color: #1A1A1A; text-align: left; margin: 0 0 48px; max-width: 820px;">
+  It's not always an
+  <span style="display: inline-block; background: #FFFFFF; color: #1A1A1A; font-weight: 900; font-style: italic; padding: 2px 10px 3px; margin: 0 2px; border-radius: 4px;">easy</span>
+  question to answer.
+</p>
+```
+
+Same treatment as the headline but at 32px. Note: if the main headline already uses a white-rect emphasis, the follow-up should NOT -- pick one or the other per slide.
+
+### URL Pill (Search-Bar Styled)
+
+```html
+<div style="display: inline-flex; align-items: center; gap: 10px; background: #FFFFFF; padding: 14px 24px; border-radius: 999px; box-shadow: 0 1px 0 rgba(26,26,26,0.08);">
+  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#1A1A1A" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="11" cy="11" r="7"></circle>
+    <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+  </svg>
+  <span style="font-family: 'Inter', sans-serif; font-size: 16px; font-weight: 500; color: #1A1A1A; letter-spacing: 0.2px;">www.gooseworks.ai</span>
+</div>
+```
+
+### Bookmark Icon (Bottom Corner Mark)
+
+```html
+<svg width="22" height="28" viewBox="0 0 22 28" fill="#1A1A1A" xmlns="http://www.w3.org/2000/svg">
+  <path d="M2 2h18v24l-9-6-9 6V2z"></path>
+</svg>
+```
+
+Placed in the bottom-right or top-right corner as a small ownership/save marker.
+
+### Slide Canvas (Full Wrapper with Dot-Grid)
+
+```html
+<div style="background: #F4DC2E; padding: 80px 60px; position: relative; overflow: hidden;">
+  <!-- Dot grid overlay -->
+  <div style="position: absolute; inset: 0; background-image: radial-gradient(circle, rgba(26,26,26,0.12) 1.5px, transparent 1.5px); background-size: 16px 16px; pointer-events: none;"></div>
+  <div style="position: relative; z-index: 1;">
+    <!-- slide content -->
+  </div>
+</div>
+```
+
+### Numbered Item (Sequential List Variant)
+
+```html
+<div style="padding: 20px 0; text-align: left;">
+  <h2 style="font-family: 'Inter', sans-serif; font-size: 48px; font-weight: 900; line-height: 1.10; letter-spacing: -0.8px; color: #1A1A1A; margin: 0;">
+    1. You've
+    <span style="display: inline-block; background: #FFFFFF; color: #1A1A1A; font-weight: 900; font-style: italic; padding: 2px 12px 4px; border-radius: 4px;">outgrown</span>
+    <br>your current situation.
+  </h2>
+</div>
+```
+
+### Closing Statement Block
+
+```html
+<p style="font-family: 'Inter', sans-serif; font-size: 40px; font-weight: 900; line-height: 1.10; letter-spacing: -0.5px; color: #1A1A1A; text-align: left; margin: 0;">
+  The answer is closer<br>than you think.
+</p>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **2px**: Micro gap -- white-rect emphasis span inner padding top.
+- **4px**: Border radius on white-rect emphasis spans and small surfaces.
+- **8px**: Tight gap -- between icon and adjacent text.
+- **12px**: Small gap -- between label elements.
+- **16px**: Base gap -- dot-grid spacing, between inline items.
+- **24px**: Medium gap -- between divider rule and adjacent text.
+- **32px**: Section internal -- gap between headline and divider, or headline components.
+- **48px**: Content gap -- between major content blocks within a slide.
+- **60px**: Side padding on Carousel/Poster formats.
+- **80px**: Top/bottom padding on Carousel/Poster, all-sides on Slides.
+- **120px**: Vertical padding on Story format.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 80px top/bottom, 60px left/right | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 80px top/bottom, 60px left/right | 960px |
+| Story (1080x1920) | 120px top/bottom, 60px left/right | 960px |
+
+### Alignment & Grid
+- **Primary alignment**: LEFT-aligned for all long-form content, headlines, and follow-up blocks. Never center a 3-line headline.
+- **Centered allowed**: Only for the URL pill and bookmark icon at the bottom of slides.
+- **No columns**: This style is single-column top-to-bottom. No side-by-side card grids -- the headline owns the slide.
+- **Vertical rhythm**: Top zone for headline (60% of vertical space), middle zone for divider + follow-up (25%), bottom zone for URL pill + bookmark (15%).
+- **Content gravity**: Headlines sit in the upper two-thirds; the URL pill anchors the bottom. Never center a headline vertically -- the weight is always top-heavy.
+- **Dot-grid texture**: Applied globally on every slide as a background overlay. Never remove it.
+- **White-rect placement**: The emphasized word should fall in the center or toward the end of a line for visual balance. Avoid putting it at the very start of a line.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, `#F4DC2E` bg | Page canvas, all structural surfaces |
+| Dot Grid (Level 0.5) | Radial-gradient texture overlay | Background texture on every slide |
+| Sticker (Level 1) | `0 2px 0 #1A1A1A` (optional) | White-rect emphasis spans if desired |
+| Pill Lift (Level 1) | `0 1px 0 rgba(26,26,26,0.08)` | URL pill only |
+| Flat Border (Level 0) | `1px solid #1A1A1A` | Divider rule, icon outlines |
+
+### Border Treatments
+- **Standard divider rule**: `1px solid #1A1A1A`, no radius -- the thin horizontal separator between headline and follow-up.
+- **Short accent rule**: `2px solid #1A1A1A` at 80px wide -- used as a punctuation mark between content blocks.
+- **White-rect edge**: `border-radius: 4px` on emphasis spans -- crisp but not pixel-sharp.
+- **URL pill edge**: `border-radius: 999px` -- fully rounded, the only place in the style where full radius is used.
+- **No card borders**: Do not box content in bordered cards. The yellow canvas is the only container.
+
+### Surface Hierarchy
+This is a FLAT style. Depth is communicated through color contrast and typography weight, not shadows.
+1. **Background** (`#F4DC2E`) -- the yellow canvas, the one and only surface.
+2. **Dot-grid overlay** (`rgba(26,26,26,0.12)`) -- texture layer, not an elevation step.
+3. **White rect** (`#FFFFFF`) -- the highest-contrast element, reserved for emphasis.
+4. **URL pill** (`#FFFFFF` + micro shadow) -- anchors the bottom of the slide.
+5. **Near-black text** (`#1A1A1A`) -- sits on top of everything as primary content.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use saturated highlighter yellow (`#F4DC2E`) as the background on EVERY slide. Never pastel, never mustard, never desaturated.
+- Use Inter Black (weight 900) for every headline at 56-72px with -1px letter-spacing.
+- Use the white-rectangle italic emphasis treatment exactly ONCE per slide. One word, one block, one punch.
+- Left-align all long-form headlines. Stack headlines on 2-3 lines for rhythm.
+- Apply the dot-grid overlay to every slide using the 16px radial-gradient recipe.
+- Place a thin horizontal rule between the headline and the follow-up sentence.
+- End every slide with a white URL pill containing a magnifying glass icon -- it grounds the bottom.
+- Add a small black bookmark icon in the corner as the signature mark.
+- Keep the white-rect padding asymmetric (2px top, 4px bottom) so it extends below the baseline.
+- Use sentence case with a terminal question mark for headlines -- this style lives on questions.
+- Keep everything flat -- no shadows, no gradients, no bevels.
+- Use `4px` border-radius on the white-rect emphasis spans and nothing on divider rules.
+
+### Don't
+- Don't use the white-rect emphasis on more than one word per slide -- it loses its pop the moment it appears twice.
+- Don't use yellow below 80% saturation -- pastel yellow kills the signature instantly. No `#FEF9C3`, no mustard `#C9A227`.
+- Don't center-align a long headline -- 3-line question stacks must be left-aligned.
+- Don't introduce a serif typeface anywhere. Single-family Inter 900 discipline.
+- Don't use shadows on headlines or body text -- this is a flat style.
+- Don't add decorative icons beyond the magnifying glass (in the URL pill) and the bookmark mark.
+- Don't use pure black (`#000000`) -- always `#1A1A1A` for text and structure.
+- Don't introduce a secondary accent color. The yellow + black + white triad is the identity.
+- Don't drop the weight in the white-rect emphasis span -- stay at 900, just flip to italic.
+- Don't use card containers or bordered boxes -- the yellow canvas holds everything.
+- Don't use the dot grid at high opacity -- keep it at `rgba(26,26,26,0.12)` so it feels like paper texture.
+- Don't put the white-rect emphasis word at the very start of a line -- mid-line or end-of-line placement reads better.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale**: Headline at 64px (weight 900, -1px tracking). Sub-heading at 32px. URL pill at 16px.
+- **Padding**: 80px top/bottom, 60px left/right. Content area 960x920.
+- **Cover slide**: 3-line question headline with one white-rect italic emphasis word. Divider rule below. Optional follow-up sentence. URL pill bottom-center. Bookmark icon top-right or bottom-right.
+- **Content slides**: Left-aligned headline (shorter, 1-2 lines). Supporting text below divider. Consistent URL pill footer.
+- **Dot-grid texture**: Full-bleed overlay on every slide.
+- **Swipe indicator**: 3 small near-black dots (`#1A1A1A`, 8px diameter) at the bottom center above the URL pill. Active dot is solid, inactive dots are `rgba(26,26,26,0.3)`.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Display Hero at 72px for the title section. Headlines at 48-56px for each numbered section. Follow-up text at 24px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Section spacing**: 64px vertical gap between numbered sections. Thin horizontal divider between each.
+- **Layout**: Numbered question format -- each section starts with a bold number (1., 2., 3.) followed by a question, each with its own white-rect emphasis word (but only ONE per section, never multiple in the same headline).
+- **Footer**: URL pill centered at the very bottom with bookmark icon in the corner.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero at 96px (weight 900, -1.5px tracking). Section Heading at 64px. Body Large at 24px.
+- **Padding**: 80px all sides. Content area 1760x920.
+- **Layout**: Left-aligned content with ~60% width for the headline block. The right ~40% breathes empty (dot-grid visible). White-rect emphasis word in the headline.
+- **Title slides**: 3-line question headline. Divider rule. Follow-up sentence. URL pill at bottom-left. Bookmark icon at top-right.
+- **Content slides**: Single headline + supporting text. No multi-column layouts.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 80px. Section Heading at 48px. Body at 20px.
+- **Padding**: 80px top/bottom, 60px left/right.
+- **Composition**: Top half for the big question headline (with white-rect emphasis). Middle for divider + follow-up sentence. Bottom third for optional supporting copy. URL pill centered at the very bottom.
+- **Vertical flow**: Reads top-to-bottom. The headline owns the top two-thirds of the canvas.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Hero at 88px (weight 900, -1.5px tracking). Hero element sized ~30% bigger than Carousel equivalent. Follow-up at 36px.
+- **Padding**: 120px top/bottom, 60px left/right. Content area 960x1680.
+- **Composition**: Top 15% is safe-zone margin (avoid UI overlays from Instagram/TikTok Stories). Headline occupies vertical zone 15-60%. Divider rule at 65%. Follow-up sentence 65-80%. URL pill at 85%. Bookmark icon in the corner.
+- **Hero emphasis**: The white-rect italic word is visually the largest ever -- the Story format is the most dramatic canvas for the signature move. Boost the emphasis word's padding to `4px 18px 6px` for extra presence.
+- **Safe zones**: Keep all content within 120px top/bottom padding so mobile UI doesn't crop the message.
+- **Dot-grid texture**: Full-bleed, same 16px recipe -- critical for the tactile "journal page" feel at the larger canvas.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Highlighter Yellow | `#F4DC2E` | Primary background, every slide |
+| Highlighter Yellow Bright | `#F6E038` | Alternate variation |
+| Highlighter Yellow Deep | `#F4D41E` | Darker variant, rare |
+| Near-Black | `#1A1A1A` | All primary text, dividers, dots, icons |
+| Pure White | `#FFFFFF` | White-rect emphasis, URL pill |
+| Secondary Text | `#3A3A3A` | Rare secondary copy |
+| Tertiary Text | `rgba(26,26,26,0.6)` | URL domain text |
+| Dot Grid | `rgba(26,26,26,0.12)` | Background texture dots |
+| Muted | `rgba(26,26,26,0.4)` | Slide numbers, watermarks |
+
+### Font Declarations
+
+```css
+/* All typography -- single family */
+font-family: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+/* Headline */
+font-weight: 900;
+letter-spacing: -1px;
+
+/* White-rect emphasis */
+font-style: italic;
+font-weight: 900;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,400;0,500;0,700;0,900;1,400;1,700;1,900&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-bg: #F4DC2E;
+  --color-bg-bright: #F6E038;
+  --color-bg-deep: #F4D41E;
+  --color-near-black: #1A1A1A;
+  --color-white: #FFFFFF;
+
+  /* Colors -- Text */
+  --color-secondary: #3A3A3A;
+  --color-tertiary: rgba(26, 26, 26, 0.6);
+  --color-muted: rgba(26, 26, 26, 0.4);
+  --color-subtle: rgba(26, 26, 26, 0.25);
+
+  /* Colors -- Surfaces */
+  --color-surface-white: #FFFFFF;
+  --color-surface-inset: #F9E668;
+
+  /* Colors -- Borders */
+  --color-border-default: #1A1A1A;
+  --color-border-subtle: rgba(26, 26, 26, 0.2);
+  --color-divider: #1A1A1A;
+
+  /* Colors -- Shadows (mostly flat) */
+  --shadow-none: none;
+  --shadow-pill: 0 1px 0 rgba(26, 26, 26, 0.08);
+  --shadow-sticker: 0 2px 0 #1A1A1A;
+
+  /* Texture -- Dot Grid */
+  --dot-grid: radial-gradient(circle, rgba(26, 26, 26, 0.12) 1.5px, transparent 1.5px);
+  --dot-grid-size: 16px 16px;
+
+  /* Typography -- Families */
+  --font-display: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 72px;
+  --text-headline-large: 64px;
+  --text-headline: 56px;
+  --text-sub-heading: 32px;
+  --text-body-large: 22px;
+  --text-body: 18px;
+  --text-small: 14px;
+  --text-url-pill: 16px;
+  --text-icon-label: 12px;
+
+  /* Typography -- Weights */
+  --weight-headline: 900;
+  --weight-sub-heading: 900;
+  --weight-body: 500;
+  --weight-emphasis: 900;
+
+  /* Typography -- Line Heights */
+  --leading-headline: 1.08;
+  --leading-sub: 1.15;
+  --leading-body: 1.55;
+  --leading-tight: 1.00;
+
+  /* Typography -- Letter Spacing */
+  --tracking-headline: -1px;
+  --tracking-display: -1.5px;
+  --tracking-sub: -0.5px;
+  --tracking-body: 0px;
+
+  /* Spacing */
+  --space-micro: 2px;
+  --space-radius: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-medium: 24px;
+  --space-large: 32px;
+  --space-gap: 48px;
+  --space-side: 60px;
+  --space-top: 80px;
+  --space-story: 120px;
+
+  /* Borders */
+  --radius-emphasis: 4px;
+  --radius-pill: 999px;
+  --radius-none: 0px;
+  --border-divider: 1px solid #1A1A1A;
+  --border-rule-thick: 2px solid #1A1A1A;
+}
+```
+
+### System Font Fallbacks
+- **Sans-serif (if Inter fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Signature Recipe (Copy-Paste Starter)
+
+```html
+<div style="background: #F4DC2E; padding: 80px 60px; position: relative; overflow: hidden; font-family: 'Inter', sans-serif;">
+  <div style="position: absolute; inset: 0; background-image: radial-gradient(circle, rgba(26,26,26,0.12) 1.5px, transparent 1.5px); background-size: 16px 16px; pointer-events: none;"></div>
+  <div style="position: relative; z-index: 1;">
+    <h1 style="font-size: 64px; font-weight: 900; line-height: 1.08; letter-spacing: -1px; color: #1A1A1A; text-align: left; margin: 0 0 28px;">
+      Why do I feel
+      <span style="display: inline-block; background: #FFFFFF; font-weight: 900; font-style: italic; padding: 2px 14px 4px; border-radius: 4px;">stuck</span>
+      <br>in life?
+    </h1>
+    <div style="width: 80px; height: 2px; background: #1A1A1A; margin: 0 0 24px;"></div>
+    <p style="font-size: 28px; font-weight: 900; line-height: 1.15; letter-spacing: -0.5px; color: #1A1A1A; margin: 0 0 48px;">It's not always an easy question to answer.</p>
+    <div style="display: inline-flex; align-items: center; gap: 10px; background: #FFFFFF; padding: 14px 24px; border-radius: 999px;">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#1A1A1A" stroke-width="2.5" stroke-linecap="round"><circle cx="11" cy="11" r="7"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
+      <span style="font-size: 16px; font-weight: 500; color: #1A1A1A;">www.gooseworks.ai</span>
+    </div>
+  </div>
+</div>
+```

--- a/skills/composites/goose-graphics/styles/_full/ink-doodle-event.md
+++ b/skills/composites/goose-graphics/styles/_full/ink-doodle-event.md
@@ -1,0 +1,523 @@
+# Design Style: Ink Doodle Event
+
+## 1. Visual Theme & Atmosphere
+
+Ink Doodle Event is the visual language of a hand-pulled skate-zine poster that was drawn with a brush pen on a sheet of kraft paper, photographed under flat studio light, and tacked to the inside of a skate-shop window. It borrows from the DIY aesthetic of 1990s Bay Area skate culture, the loose-line cartooning of Matt Groening's early Life in Hell strips, and the calligraphic flourishes of mid-century wedding stationery — three references that should not work together and that precisely because of that collision create a flyer with enormous character. The surface is always a warm wheat-beige (`#EAD9AE`) that reads as kraft paper or sand. The ink is a single near-pure black (`#0E0E0E`). Every mark on the page looks as if it came from one of three tools: a brush pen (the loose illustrations), a calligraphic nib (the cursive script headline), or a typewriter ribbon (the date and address metadata). Nothing is mechanical, nothing is bright, and nothing is symmetric.
+
+The color story is almost absurdly narrow: one warm paper tone, one ink. The wheat background (`#EAD9AE`) is a mid-value warm beige that sits between raw sienna and oat — it is never yellow, never orange, and never approaching cream. The ink (`#0E0E0E`) is a near-black that reads as permanent marker rather than printer black — it has a touch of warmth so it feels ink-on-paper rather than screen-black-on-screen-white. That is the whole palette. There are no accent colors, no highlights, no secondary tones. The only tonal variation allowed comes from the halftone dot pattern inside the spiky sun icon — a field of black dots on the wheat surface that reads as mid-gray at a distance but resolves into dots up close. That halftone feel, borrowed from 1970s screen-printed gig posters, is what prevents the two-color palette from feeling sterile.
+
+The typographic system is three distinct voices. A flowing calligraphic script (Yellowtail) handles the one-word hero headline — "Sunday", "Saturday", "Friday", whatever the event day is — set at 140-160px with enormous descenders and swashes that the rest of the composition has to make space for. A classical body serif (Fraunces) in italic at weight 400 handles the small pieces of flavour text that flank the central illustration: "skate", "club", short tags, or quotes. A clean monospace (DM Mono) handles the hard metadata at the top of the frame: the date, the time, the edition number. The visual vocabulary is just as restricted: one hand-drawn loose-line character illustration (a dog's head with a skateboard, a cat stretching, a pigeon wearing sunglasses — always a character, never an object or a geometric shape), one halftone sun or spiky ornament, and the calligraphic headline. That is the entire kit. The feel is handmade, skate culture meets calligraphy, casual without being sloppy, charming without being cute.
+
+**Key Characteristics:**
+- Wheat/kraft paper background (`#EAD9AE`) — warm beige, sits between oat and raw sienna, never yellow, never cream
+- Ink black text and illustrations (`#0E0E0E`) — near-pure black with a whisper of warmth, reads as permanent marker
+- Yellowtail calligraphic script for the single-word hero headline — 140-160px, with enormous descender swashes that the layout must accommodate
+- Fraunces Italic at weight 400-500 for flanking flavour text ("skate", "club", quotes) — refined italic serif as a counterbalance to the loose illustration
+- DM Mono at weight 400 for top-row metadata (dates, times, edition numbers) — classical monospace energy, typewriter-ribbon feel
+- Hand-drawn loose single-stroke SVG illustrations — brush-pen stroke with `stroke-width: 6`, `stroke-linecap: round`, `stroke-linejoin: round`, no fills, intentionally asymmetric
+- Halftone dot-filled spiky sun icon as the secondary decorative element — dotted fill inside a spiky outline, 1970s screen-print energy
+- No cards, no borders, no rounded containers — the whole composition reads as a single sheet of paper with ink on it
+- No sans-serif fonts anywhere — the entire typographic system is serif, script, and monospace only
+- No saturated colors, no gradients, no shadows, no glass — the palette is wheat and ink and nothing else
+- Top-row metadata hugs the corners of the frame with the script headline overlapping between them — the date and time are placed at y≈6% from the top, the headline descends into and through them
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Wheat Paper** (`#EAD9AE`): Primary background. Warm kraft beige, mid-value. Sits between oat and raw sienna. Reads as a sheet of recycled paper under flat studio light. Never substitute a cream, buttermilk, or pure beige — the warmth and the slight green undertone are what keep it feeling like paper rather than a cheap manila folder.
+- **Ink Black** (`#0E0E0E`): Primary ink. Used for every piece of type, every illustration stroke, every halftone dot. Near-pure black with a trace of warmth so it reads as brush-pen ink rather than screen black. Never substitute pure `#000000` — it reads as plastic.
+
+### Accent
+This style has no accent colors. The palette is strictly two-color. The only permitted "third tone" is the optical mid-gray that emerges from halftone dot patterns — and that is a function of the black ink on the wheat paper, not a separate color.
+
+- **Wheat Highlight** (`#F0E1BA`): A very slightly lighter wheat used exclusively for rare paper-grain highlights in format variations. Use almost never.
+- **Wheat Shadow** (`#DCCA9C`): A very slightly darker wheat used exclusively for a subtle paper-edge vignette in poster formats. Use almost never.
+
+### Neutral Scale
+- **Ink 100** (`#0E0E0E`): Primary ink — all type, all illustration strokes, all halftone dots.
+- **Ink 80** (`rgba(14, 14, 14, 0.80)`): Secondary ink for supporting metadata where a whisper of recession is needed. Use rarely.
+- **Ink 60** (`rgba(14, 14, 14, 0.60)`): Tertiary annotations, hairline dividers, slide numbers. Use rarely.
+- **Ink 40** (`rgba(14, 14, 14, 0.40)`): Whisper accents and very quiet background texture overlays. Use almost never.
+- **Ink 20** (`rgba(14, 14, 14, 0.20)`): Reserved for halftone dot patterns and subtle paper-grain noise only.
+
+### Surface & Borders
+- **Surface Primary** (`#EAD9AE`): The flat wheat canvas. Edge-to-edge, never containered, never tinted.
+- **Surface Inset** (`rgba(14, 14, 14, 0.04)`): A barely-there ink wash for extremely rare inset moments. Use almost never — this style is unapologetically flat.
+- **Hairline Ink** (`rgba(14, 14, 14, 0.35)`): The only border treatment allowed. A 1px ink hairline that can separate the top metadata row from the central composition when a divider is explicitly needed. Use sparingly.
+- **Hairline Ink Strong** (`rgba(14, 14, 14, 0.55)`): A slightly heavier 1px ink divider for format-spanning rules. Use sparingly.
+
+### Shadow Colors
+This style has no drop shadows. Everything sits flat on the paper. The following are permitted only for rare special cases.
+
+- **Paper Grain** (`rgba(14, 14, 14, 0.06)`): A tissue-thin ink overlay that can be composited across the canvas as a print-grain / recycled-paper texture effect.
+- **Halftone Ink** (`#0E0E0E`): The ink color used inside halftone dot patterns — always at 100% opacity, never softened. Halftone effects come from dot density, not from color transparency.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Yellowtail&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=swap" rel="stylesheet">
+```
+
+- **Script Display**: `'Yellowtail', 'Pinyon Script', 'Brush Script MT', cursive` — used at 140-160px for the single-word hero headline. Yellowtail is a connected brush-script with generous descenders and swashes. Pick Yellowtail (never Dancing Script, never Great Vibes) — the brush-pen feel must feel hand-drawn, not printed.
+- **Italic Serif**: `'Fraunces', Georgia, 'Times New Roman', serif` — used italic at weight 400-500 for every piece of supporting body text, flanking labels ("skate", "club"), and classical serif metadata.
+- **Mono Metadata**: `'DM Mono', 'IBM Plex Mono', 'Courier Prime', Courier, monospace` — used at weight 400 for hard metadata: dates, times, edition numbers, small captions. Typewriter-ribbon feel.
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Script Hero | Yellowtail | 160px | 400 | 0.95 | -2px | The single-word calligraphic headline ("Sunday"). Extra top margin required for ascender loops. Extra bottom margin required for descender swashes. `padding-top: 40px; padding-bottom: 60px;` around the headline is standard. |
+| Script Secondary | Yellowtail | 96px | 400 | 1.00 | -1px | Smaller script role for non-hero slides where the headline still needs to sing. |
+| Flanking Italic | Fraunces Italic | 24px | 400 | 1.20 | 0.2px | The "skate" / "club" words that flank the central illustration. Mixed case. Italic is mandatory. Never set these in uppercase. |
+| Body Italic | Fraunces Italic | 20px | 400 | 1.50 | 0.2px | Rare long-form body text. Italic preserved. Mixed case. |
+| Body Roman | Fraunces | 18px | 400 | 1.55 | 0.2px | Long-form body copy when italic would be too ornate. Upright, mixed case. Use rarely. |
+| Top Metadata | DM Mono | 22px | 400 | 1.20 | 0.5px | The top-row date and time. Placed at the very top corners of the frame. Mixed case with numerals. |
+| Address Footer | Fraunces | 20px | 400 | 1.40 | 0.2px | The two-line address at the bottom of the frame. Upright, mixed case. Classical serif, never mono. |
+| Small Caption | DM Mono | 14px | 400 | 1.30 | 0.5px | Slide numbers, edition marks, footers. Mixed case. |
+| Framework Tag | Fraunces Italic | 16px | 500 | 1.20 | 0.5px | Small italic tags when a category label is needed. Rare. |
+
+### Principles
+- **Three voices, no sans-serif**: Script, italic serif, and mono. The entire typographic identity is defined by the absence of any sans-serif — the moment you reach for Inter, DM Sans, or Satoshi, the style collapses into a generic modern flyer.
+- **The one-word hero**: The Yellowtail script headline is always a single word. Two-word headlines break the calligraphic rhythm and force line breaks that the descender swashes cannot accommodate. If you need more words, they go in Fraunces italic below.
+- **Swash space is non-negotiable**: Yellowtail letters like "y", "g", "J", "S" carry huge descender and ascender flourishes. The layout must leave 40-60px of breathing room above and below the script headline so those swashes do not collide with other elements.
+- **Italic serif flanks the illustration**: The "skate" and "club" words (or whatever the equivalent flanking label is) are always set in Fraunces italic at 24px, placed on the left and right of the central illustration, visually gripping the art from both sides. Never stack them above or below — they always flank.
+- **Mono is reserved for metadata**: DM Mono only appears at the very top of the frame for the date and time, and occasionally for small captions. Never use mono for headlines, body, or addresses — it breaks the handmade feel.
+- **Mixed case always**: Every piece of type on the page is mixed case. The only exception is when the user supplies pre-uppercased content — never apply `text-transform: uppercase` to anything in this style.
+
+## 4. Component Patterns
+
+### Event Poster Layout (Full Composition)
+
+The full composition has four stacked zones: top metadata row (date + time), script headline, central illustration with flanking italic labels, and bottom address footer. This is the hero pattern for this style.
+
+```html
+<div style="position: relative; width: 1080px; height: 1080px; background-color: var(--color-wheat); padding: 60px; box-sizing: border-box; font-family: var(--font-body); color: var(--color-ink); overflow: hidden;">
+  <!-- Top metadata row -->
+  <div style="display: flex; justify-content: space-between; align-items: flex-start; width: 100%;">
+    <span style="font-family: var(--font-mono); font-size: 22px; font-weight: 400; color: var(--color-ink); letter-spacing: 0.5px;">08.16.2025</span>
+    <span style="font-family: var(--font-mono); font-size: 22px; font-weight: 400; color: var(--color-ink); letter-spacing: 0.5px;">1pm &ndash; 5pm</span>
+  </div>
+
+  <!-- Script headline -->
+  <h1 style="font-family: var(--font-script); font-size: 160px; font-weight: 400; line-height: 0.95; letter-spacing: -2px; color: var(--color-ink); text-align: center; margin: 20px 0 40px; padding: 0 20px;">Sunday</h1>
+
+  <!-- Central row: flanking italic + illustration -->
+  <div style="display: flex; align-items: center; justify-content: center; gap: 40px; margin: 20px 0 40px;">
+    <span style="font-family: var(--font-body); font-size: 24px; font-weight: 400; font-style: italic; color: var(--color-ink);">skate</span>
+    <!-- illustration slot (see Hand-drawn Ink Illustration component below) -->
+    <div style="width: 480px; height: 360px;"><!-- SVG inserted here --></div>
+    <span style="font-family: var(--font-body); font-size: 24px; font-weight: 400; font-style: italic; color: var(--color-ink);">club</span>
+  </div>
+
+  <!-- Bottom address footer -->
+  <div style="position: absolute; left: 60px; right: 60px; bottom: 60px; text-align: center; font-family: var(--font-body); font-size: 20px; font-weight: 400; line-height: 1.40; color: var(--color-ink);">
+    Waller Street Skatepark<br>
+    751 Stanyan St, San Francisco, CA 94117
+  </div>
+</div>
+```
+
+### Hand-drawn Ink Illustration Slot
+
+A loose single-stroke character drawing rendered as inline SVG. The example below is a dog's head with a skateboard balanced on top — the hero illustration of this style. Stroke must be `fill: none; stroke: #0E0E0E; stroke-width: 6; stroke-linecap: round; stroke-linejoin: round;`. The paths are intentionally asymmetric and loose — they should feel drawn in one motion, not assembled from geometric primitives. Never use perfect circles, rectangles, or mathematical curves.
+
+```html
+<svg viewBox="0 0 480 360" width="480" height="360" xmlns="http://www.w3.org/2000/svg" style="display: block;">
+  <g fill="none" stroke="#0E0E0E" stroke-width="6" stroke-linecap="round" stroke-linejoin="round">
+    <!-- Skateboard balanced on top of head -->
+    <path d="M 180 70 Q 200 58, 240 56 Q 285 54, 325 62 Q 345 66, 355 76 Q 345 88, 320 92 Q 280 96, 235 94 Q 195 92, 178 86 Q 168 78, 180 70 Z" />
+    <!-- Skateboard wheel (left) -->
+    <circle cx="205" cy="96" r="5" />
+    <!-- Skateboard wheel (right) -->
+    <circle cx="320" cy="98" r="5" />
+
+    <!-- Main dog head outline — one continuous loose curve -->
+    <path d="M 155 120
+             C 145 100, 155 90, 175 95
+             C 195 100, 215 110, 240 112
+             C 275 115, 305 120, 335 135
+             C 370 155, 395 185, 405 225
+             C 412 260, 400 290, 370 305
+             C 340 318, 310 312, 285 300
+             C 270 293, 260 290, 250 295
+             C 238 302, 225 310, 210 305
+             C 195 298, 185 282, 178 265
+             C 172 248, 165 230, 155 215
+             C 142 195, 135 175, 140 155
+             C 143 140, 148 128, 155 120 Z" />
+
+    <!-- Floppy left ear — loose hanging curve -->
+    <path d="M 160 135
+             C 130 155, 110 180, 105 215
+             C 102 240, 115 260, 140 265
+             C 160 268, 175 258, 180 240" />
+
+    <!-- Floppy right ear — shorter -->
+    <path d="M 330 130
+             C 355 140, 375 155, 385 175" />
+
+    <!-- Eye — simple dot -->
+    <circle cx="230" cy="180" r="4" fill="#0E0E0E" />
+
+    <!-- Nose — small filled blob -->
+    <circle cx="165" cy="245" r="9" fill="#0E0E0E" />
+
+    <!-- Mouth — loose curve -->
+    <path d="M 158 262 C 170 278, 190 282, 205 270" />
+
+    <!-- Collar line across the neck -->
+    <path d="M 280 310 C 310 320, 340 322, 365 315" />
+  </g>
+</svg>
+```
+
+### Halftone Spiky Sun Icon
+
+A radial sun with a spiky outline and a halftone dot pattern filling the interior. This is the secondary decorative element of the style — the 1970s screen-printed detail that prevents the two-color palette from feeling sterile. Place it near the illustration as a small accent (60-140px). The dot pattern is built with a `<defs><pattern>` block so the dots tile cleanly inside the spiky shape.
+
+```html
+<svg viewBox="0 0 200 200" width="140" height="140" xmlns="http://www.w3.org/2000/svg" style="display: block;">
+  <defs>
+    <pattern id="halftone-dots" x="0" y="0" width="10" height="10" patternUnits="userSpaceOnUse">
+      <circle cx="5" cy="5" r="2" fill="#0E0E0E" />
+    </pattern>
+  </defs>
+
+  <!-- Spiky sun outline — 12-point star-like shape, loose and hand-drawn -->
+  <path d="M 100 10
+           L 115 45 L 150 30 L 145 70
+           L 185 75 L 160 105 L 190 130
+           L 150 140 L 165 180 L 125 165
+           L 110 195 L 90 160 L 55 180
+           L 60 140 L 20 130 L 50 100
+           L 15 75 L 55 70 L 45 30
+           L 85 45 Z"
+        fill="url(#halftone-dots)"
+        stroke="#0E0E0E"
+        stroke-width="5"
+        stroke-linejoin="round" />
+</svg>
+```
+
+### Display Script Headline (Standalone)
+
+```html
+<h1 style="font-family: var(--font-script); font-size: 160px; font-weight: 400; line-height: 0.95; letter-spacing: -2px; color: var(--color-ink); text-align: center; margin: 0; padding: 40px 20px 60px;">Sunday</h1>
+```
+
+The 40px top / 60px bottom padding is load-bearing — it is the breathing room that Yellowtail's enormous descenders on "y", "g", and "J" need. Remove it and the swashes clip the layout below.
+
+### Top Metadata Row
+
+```html
+<div style="display: flex; justify-content: space-between; align-items: flex-start; width: 100%; font-family: var(--font-mono); font-size: 22px; font-weight: 400; color: var(--color-ink); letter-spacing: 0.5px;">
+  <span>08.16.2025</span>
+  <span>1pm &ndash; 5pm</span>
+</div>
+```
+
+The row is placed at the very top of the frame (y≈6% from the top edge). The script headline is then placed immediately below, and intentionally overlaps the metadata vertically — the calligraphic letterforms weave between the mono date and time. This is the signature composition move of the style.
+
+### Bottom Address Footer
+
+```html
+<div style="text-align: center; font-family: var(--font-body); font-size: 20px; font-weight: 400; line-height: 1.40; color: var(--color-ink);">
+  Waller Street Skatepark<br>
+  751 Stanyan St, San Francisco, CA 94117
+</div>
+```
+
+Always two lines: venue name on line one, full address on line two. Always classical serif (Fraunces upright, not italic, not mono). Always centered. Always at the very bottom of the frame with 60px bottom margin.
+
+### Flanking Italic Labels
+
+```html
+<div style="display: flex; align-items: center; justify-content: center; gap: 40px;">
+  <span style="font-family: var(--font-body); font-size: 24px; font-weight: 400; font-style: italic; color: var(--color-ink);">skate</span>
+  <div style="width: 480px; height: 360px;"><!-- illustration --></div>
+  <span style="font-family: var(--font-body); font-size: 24px; font-weight: 400; font-style: italic; color: var(--color-ink);">club</span>
+</div>
+```
+
+The two italic labels always flank the central illustration horizontally — one on each side, vertically centered. They are small compared to the illustration (24px vs. 360px) and they read as flavour text, not as headings. Common flanking pairings: "skate / club", "good / times", "hello / friend", "open / late", "first / edition".
+
+### Paper Grain Overlay
+
+```html
+<div style="position: absolute; inset: 0; pointer-events: none; opacity: 0.5;
+  background-image:
+    radial-gradient(circle at 20% 30%, rgba(14,14,14,0.06) 1px, transparent 1px),
+    radial-gradient(circle at 70% 80%, rgba(14,14,14,0.05) 1px, transparent 1px);
+  background-size: 7px 7px, 11px 11px;"></div>
+```
+
+A tissue-thin speckle overlay that emulates the grain of recycled kraft paper. Optional — apply only when the composition feels too clean and needs a whisper of texture.
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap — inside halftone dot patterns.
+- **8px**: Tight gap — between flanking italic label and adjacent element when space is constrained.
+- **16px**: Base gap — between the bottom of the script headline swashes and the central illustration.
+- **24px**: Small section — between top metadata row and the script headline.
+- **40px**: Flanking gap — between each italic flanking label and the central illustration.
+- **48px**: Section divider — between the central illustration block and the bottom address footer.
+- **60px**: Outer frame padding — the standard margin from the edge of the canvas to any content.
+- **80px**: Breathing room for script descenders — the vertical space needed below the Yellowtail headline for its swashes.
+- **120px**: Story format top/bottom safe zone — reserved for platform UI.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 960px |
+| Story (1080x1920) | 60px left/right, 120px top/bottom | 960px |
+
+### Alignment & Grid
+- **Primary alignment**: Centered. Everything in this style is centered along the vertical axis — the script headline, the illustration, the address footer. The only exceptions are the top metadata row (left date, right time) and rare compositions that call for an off-axis illustration.
+- **Vertical flow**: Top-row metadata → script headline → central illustration with flanking italic → bottom address footer. This top-to-bottom rhythm is the composition template of the style and should not be broken.
+- **No grid**: There is no column grid. The composition is a single centered column, and horizontal placement is driven by the content itself (the illustration sits center, the flanking italic labels sit immediately left and right of it).
+- **Overlap is good**: The script headline is intentionally allowed to overlap the top metadata row vertically — the calligraphic swashes of letters like "S" and "y" should weave between the date and time. This overlap is the signature move.
+- **Illustration gravity**: The central illustration is always the visual anchor — it occupies roughly 40-50% of the frame's height and is placed so its horizontal center sits at the exact center of the composition.
+- **No containers**: No cards, no borders, no backgrounds, no rounded corners. Every element sits directly on the wheat paper surface.
+
+## 6. Depth & Elevation
+
+This style is flat. There are no shadows, no elevations, no layered surfaces. The entire composition sits on a single plane — the wheat paper — with ink marks on top of it.
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, background `#EAD9AE` | The entire canvas. This is the only level. |
+| Hairline (Level 1) | `1px solid rgba(14,14,14,0.35)` | Rare ink hairline divider between top metadata and headline. |
+| Hairline Strong (Level 2) | `1px solid rgba(14,14,14,0.55)` | Slightly heavier hairline for format-spanning rules. Rare. |
+| Grain Overlay (Level 3) | `rgba(14,14,14,0.06)` speckle pattern | Optional paper-grain texture for hand-made feel. |
+| Halftone Fill (Level 4) | `#0E0E0E` dots at 10px spacing | Interior fill for the spiky sun and any other halftone decorative element. |
+
+### Border Treatments
+- **No containers**: This style has no cards and no bordered containers. The only "borders" that exist are hairline dividers between zones — and they should be used sparingly, only when a composition feels like it needs a structural rule.
+- **Hairline divider**: `1px solid rgba(14, 14, 14, 0.35)` — used to separate the top metadata row from the central composition when an explicit divider is needed. Default: no divider.
+- **Hairline strong**: `1px solid rgba(14, 14, 14, 0.55)` — used for format-spanning rules in infographic layouts.
+- **Illustration stroke**: `stroke: #0E0E0E; stroke-width: 6; stroke-linecap: round; stroke-linejoin: round;` — this is the canonical brush-pen stroke for every hand-drawn element. Never thinner than 5, never thicker than 8.
+
+### Surface Hierarchy
+1. **Paper** (`#EAD9AE`) — the wheat canvas, edge-to-edge.
+2. **Ink marks** (`#0E0E0E`) — type, illustrations, halftone dots, all sitting directly on the paper.
+3. **Halftone zones** — areas where the ink is broken into a dot pattern to create optical mid-gray.
+
+Depth does not come from shadows or layers. It comes from the density and weight of the ink marks — a thick brush-pen stroke reads as closer than a thin mono caption, and a halftone-dot field reads as further back than a solid ink line.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use Yellowtail for the one-word script hero headline at 140-160px. This is the single most important element of the style — nothing else carries the handmade calligraphic identity.
+- Use loose, asymmetric, hand-drawn SVG illustrations for the central character. Paths should feel drawn in one motion — never assemble illustrations from perfect circles, rectangles, or smooth Bezier curves. Intentional imperfection is the aesthetic.
+- Always use `stroke-width: 6; stroke-linecap: round; stroke-linejoin: round; fill: none;` for illustration strokes. This is the canonical brush-pen feel.
+- Use the halftone dot-filled spiky sun as a secondary decorative element — place it small (60-140px) near the central illustration for a 1970s screen-print accent.
+- Use the kraft wheat paper background (`#EAD9AE`) as the edge-to-edge canvas. This is the only background — never substitute a cream, buttermilk, or pure beige.
+- Use Fraunces italic at 24px for the small flanking labels that sit immediately left and right of the central illustration. These labels grip the illustration from both sides.
+- Use DM Mono for the top-row date and time metadata at 22px, placed in the top-left and top-right corners of the frame with 60px outer padding.
+- Use Fraunces upright for the two-line address footer at the bottom of the frame, always centered.
+- Allow the script headline to overlap the top metadata row vertically — the calligraphic swashes should weave through the date and time. This is the signature composition move.
+- Keep headlines to a single word whenever possible. Yellowtail's descenders do not work well across line breaks.
+- Leave 40-60px of breathing room above and below the script headline for swashes and descenders.
+
+### Don't
+- Don't use geometric precision in the illustrations. No perfect circles, no clean rectangles, no smooth symmetric curves. The whole point is that the drawings feel hand-made, brush-pen, one-continuous-motion. A dog's two ears should be different lengths. A sun's twelve spikes should be different sizes. Imperfection is the aesthetic.
+- Don't use any sans-serif font anywhere in the composition — not Inter, not DM Sans, not Satoshi, not Space Grotesk. The moment a sans-serif appears, the style collapses into a generic modern flyer. The system is strictly serif + script + mono.
+- Don't use saturated colors. No red, no blue, no green, no yellow accent, no gradient. The palette is wheat (`#EAD9AE`) and ink (`#0E0E0E`) and nothing else. Any third color breaks the identity.
+- Don't use drop shadows, glow effects, or elevation. This style is flat — every mark sits directly on the paper.
+- Don't use cards, borders, rounded containers, or backgrounds. The composition is a single wheat paper surface with ink marks on it.
+- Don't use pure black (`#000000`) for ink — always use `#0E0E0E`. Pure black reads as screen-plastic, not brush-pen ink.
+- Don't use pure white or cream for the background — always use the warm wheat `#EAD9AE`. Cream reads as stationery, wheat reads as kraft paper.
+- Don't use `text-transform: uppercase` on anything. The entire style is mixed case. If the reference shows uppercase, it is a case of the source content already being uppercase — never force it with CSS.
+- Don't use multi-word headlines in Yellowtail script. Keep the hero to a single word ("Sunday", "Saturday", "Summer", "Skate"). Multi-word calligraphic headlines collapse under their own descenders.
+- Don't use symmetric, mathematically-generated shapes for the halftone sun. The spiky outline should be irregular — 12-ish spikes of varying length, hand-drawn feel.
+- Don't place the illustration off-center. The central illustration is the visual anchor and always sits on the horizontal centerline.
+- Don't clutter the composition with more than one illustration and one halftone ornament. The visual vocabulary is intentionally restricted.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale**: Script Hero stays at 160px. Top metadata at 22px DM Mono. Flanking italic at 24px Fraunces italic. Address footer at 20px Fraunces upright.
+- **Padding**: 60px all sides. Content area is 960x960px.
+- **Cover slide**: Full event poster composition — top metadata row, script headline, central illustration with flanking italic labels, bottom address footer. The canonical layout.
+- **Content slides**: Swap the central illustration for a Fraunces italic body block at 32-40px, centered, 700px max-width. The top metadata row and bottom address footer can be replaced with slide-specific metadata (e.g., "Page 02 / 08" in DM Mono).
+- **CTA slide**: Single Yellowtail word centered at 180px (slightly larger than cover), with a small Fraunces italic subtitle below at 24px. Top metadata row can be dropped.
+- **Swipe indicator**: Small ink dots at the bottom center, 6px diameter with 8px gap, inactive at `rgba(14,14,14,0.25)` and active at `#0E0E0E`.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Full-scale hierarchy. Script Hero at 160px for the title section. Section headings in Fraunces italic at 48px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Section structure**: Each section is a vertical block with the Fraunces italic heading on top, a loose hand-drawn illustration or halftone ornament in the middle, and Fraunces upright body copy below. Sections are separated by 48px vertical gaps and an optional `1px solid rgba(14,14,14,0.35)` hairline divider.
+- **Vertical rhythm**: Alternate illustration-heavy sections with text-heavy sections to give the reader visual breathing room. Never stack three illustration sections in a row.
+- **Footer**: Fraunces upright 14px, centered, with an optional DM Mono edition marker.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Script Hero becomes 220px (from 160px). Flanking italic becomes 32px. Top metadata becomes 28px DM Mono. Address footer becomes 24px Fraunces upright.
+- **Padding**: 80px all sides. Content area is 1760x920px.
+- **Layout**: The widescreen format works best when the central illustration is placed off-center (say, 60% from the left) with the script headline centered and the flanking italic / metadata filling the remaining horizontal space. This is the only format where off-center illustration placement is allowed, because the wide canvas needs the horizontal rhythm.
+- **Title slides**: Top metadata row at y≈80px, Script Hero centered at y≈300px, central illustration at y≈500-900px, address footer at y≈980px.
+- **Content slides**: Fraunces italic heading at 56px left-aligned, Fraunces upright body at 22px left-aligned, optional small hand-drawn ornament in the right third.
+- **CTA slides**: Single Yellowtail word at 240px, centered, with a small Fraunces italic tagline below.
+
+### Poster (1080x1350px)
+- **Typography**: Script Hero at 180px (slightly larger than carousel to fill the taller canvas). Flanking italic at 26px. Top metadata at 24px DM Mono. Address footer at 22px Fraunces upright.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top sixth for the metadata row. Next third for the script headline and its breathing room. Middle third for the central illustration with flanking italic labels. Bottom fifth for the address footer.
+- **Vertical flow**: Reads top to bottom as a classic event poster. This is the format that most closely matches the canonical reference image.
+- **Grain overlay**: Apply the optional paper-grain overlay in this format more readily — posters benefit from the hand-made texture.
+
+### Story (1080x1920px)
+- **Typography scale up**: Script Hero becomes 180px (from 160px — only slightly larger because the vertical format needs breathing room more than it needs scale). Flanking italic becomes 26px Fraunces italic. Top metadata becomes 24px DM Mono. Address footer becomes 22px Fraunces upright.
+- **Padding**: 60px left/right, 120px top/bottom. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical text must sit inside y=160 to y=1760.
+- **Layout**: Single centered column. Content max-width 920px. The composition is vertically luxurious — cluster the event-poster elements in y=280 to y=1700, leaving generous wheat paper whitespace above and below.
+- **Cover slide**: Top metadata row at y≈200. Script Hero at y≈360-560 (with generous swash room). Central illustration at y≈680-1180. Flanking italic labels at the vertical midline of the illustration. Halftone spiky sun ornament near the illustration at 120px. Address footer at y≈1550-1640.
+- **Content slides**: One event detail per slide. Fraunces italic heading at 56px, body copy in Fraunces upright at 22px, single loose hand-drawn ornament at 200-300px below the body. Centered vertically within the safe zone.
+- **CTA slide**: Single Yellowtail word at 200px, centered at y≈800. Fraunces italic tagline below at 28px. No button — the call to action is the event itself. The address footer becomes the CTA by virtue of being the only thing telling you where to go.
+- **Progress indicator**: Thin ink segments at y≈80 (inside the top safe zone) — inactive in `rgba(14,14,14,0.25)`, active in `#0E0E0E`. Hairline height 2px, segments separated by 6px gaps.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Wheat Paper | `#EAD9AE` | Primary background, edge-to-edge canvas |
+| Ink Black | `#0E0E0E` | All type, all illustration strokes, all halftone dots |
+| Wheat Highlight | `#F0E1BA` | Rare paper-grain highlight |
+| Wheat Shadow | `#DCCA9C` | Rare paper-edge vignette |
+| Ink 80 | `rgba(14,14,14,0.80)` | Rare secondary ink |
+| Ink 60 | `rgba(14,14,14,0.60)` | Rare tertiary annotation |
+| Ink 40 | `rgba(14,14,14,0.40)` | Very rare whisper accents |
+| Ink 20 | `rgba(14,14,14,0.20)` | Halftone dot zones, paper-grain overlay |
+| Hairline Ink | `rgba(14,14,14,0.35)` | Rare hairline divider |
+| Hairline Ink Strong | `rgba(14,14,14,0.55)` | Rare format-spanning rule |
+| Paper Grain | `rgba(14,14,14,0.06)` | Optional kraft paper texture overlay |
+
+### Font Declarations
+
+```css
+/* Script display (the one-word hero headline) */
+font-family: 'Yellowtail', 'Pinyon Script', 'Brush Script MT', cursive;
+
+/* Italic serif body (flanking labels, body copy, address footer) */
+font-family: 'Fraunces', Georgia, 'Times New Roman', serif;
+
+/* Monospace metadata (dates, times, edition numbers) */
+font-family: 'DM Mono', 'IBM Plex Mono', 'Courier Prime', Courier, monospace;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Yellowtail&family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=DM+Mono:ital,wght@0,300;0,400;0,500;1,300;1,400;1,500&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors — Primary */
+  --color-wheat: #EAD9AE;
+  --color-ink: #0E0E0E;
+
+  /* Colors — Accent (rare) */
+  --color-wheat-highlight: #F0E1BA;
+  --color-wheat-shadow: #DCCA9C;
+
+  /* Colors — Neutral Scale */
+  --color-ink-80: rgba(14, 14, 14, 0.80);
+  --color-ink-60: rgba(14, 14, 14, 0.60);
+  --color-ink-40: rgba(14, 14, 14, 0.40);
+  --color-ink-20: rgba(14, 14, 14, 0.20);
+
+  /* Colors — Surfaces */
+  --color-surface-primary: #EAD9AE;
+  --color-surface-inset: rgba(14, 14, 14, 0.04);
+
+  /* Colors — Borders */
+  --color-hairline: rgba(14, 14, 14, 0.35);
+  --color-hairline-strong: rgba(14, 14, 14, 0.55);
+
+  /* Colors — Texture */
+  --color-paper-grain: rgba(14, 14, 14, 0.06);
+
+  /* Typography — Families */
+  --font-script: 'Yellowtail', 'Pinyon Script', 'Brush Script MT', cursive;
+  --font-body: 'Fraunces', Georgia, 'Times New Roman', serif;
+  --font-mono: 'DM Mono', 'IBM Plex Mono', 'Courier Prime', Courier, monospace;
+
+  /* Typography — Sizes */
+  --text-script-hero: 160px;
+  --text-script-secondary: 96px;
+  --text-flanking-italic: 24px;
+  --text-body-italic: 20px;
+  --text-body-roman: 18px;
+  --text-top-metadata: 22px;
+  --text-address-footer: 20px;
+  --text-small-caption: 14px;
+  --text-framework-tag: 16px;
+
+  /* Typography — Weights */
+  --weight-script: 400;
+  --weight-body: 400;
+  --weight-body-medium: 500;
+  --weight-mono: 400;
+
+  /* Typography — Line Heights */
+  --leading-script: 0.95;
+  --leading-flanking: 1.20;
+  --leading-body: 1.55;
+  --leading-address: 1.40;
+  --leading-mono: 1.20;
+
+  /* Typography — Letter Spacing */
+  --tracking-script: -2px;
+  --tracking-flanking: 0.2px;
+  --tracking-mono: 0.5px;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-base: 16px;
+  --space-small-section: 24px;
+  --space-flanking: 40px;
+  --space-section: 48px;
+  --space-outer: 60px;
+  --space-swash: 80px;
+  --space-story-safe: 120px;
+
+  /* Illustration Stroke */
+  --illustration-stroke-color: #0E0E0E;
+  --illustration-stroke-width: 6;
+  --illustration-stroke-linecap: round;
+  --illustration-stroke-linejoin: round;
+
+  /* Halftone */
+  --halftone-dot-color: #0E0E0E;
+  --halftone-dot-size: 2px;
+  --halftone-dot-spacing: 10px;
+}
+```
+
+### System Font Fallbacks
+- **Script (if Yellowtail fails to load):** `'Pinyon Script', 'Brush Script MT', cursive`
+- **Serif (if Fraunces fails to load):** `Georgia, 'Times New Roman', serif`
+- **Mono (if DM Mono fails to load):** `'IBM Plex Mono', 'Courier Prime', Courier, monospace`

--- a/skills/composites/goose-graphics/styles/_full/iridescent-y2k.md
+++ b/skills/composites/goose-graphics/styles/_full/iridescent-y2k.md
@@ -1,0 +1,552 @@
+# Design Style: Iridescent Y2K
+
+## 1. Visual Theme & Atmosphere
+
+Iridescent Y2K is a brutalist-meets-futurist poster language where utilitarian Swiss grids collide with a single dreamy chrome artifact. The canvas is a warm stone beige (`#ECE8DD`) — not white, not gray, but the dusty tone of recycled paper or a matte museum wall — and everything on it is set in rigid, rectangular, near-black architecture. Into that disciplined frame drops one thing: a liquid-metal iridescent blob smeared with hot pink, cyan, lavender, and pearl highlights. That single organic object carries the entire emotional weight of the composition. Everything else — the headline, the bordered metadata table, the footer — is deliberately severe, almost wire-frame, so that the blob reads as both product hero and light source.
+
+The typography is heavy, condensed geometric sans in near-black (`#111111`) — Archivo Black at display size, set in short stacked lines, left-aligned, with slightly negative tracking. The headline feels like a hot-stamped metal plate: oversized, structural, unapologetic. Supporting metadata runs in Space Mono at medium weight inside a thin-ruled 3-cell table that looks photocopied from a club flyer. The pairing mirrors the compositional tension: the chunky display face is the grid, the mono is the fine print, and the iridescent blob is the only soft, analog thing in the frame. This is the visual dialect of Apple's Vision Pro reveal, Nike Y2K lookbooks, and the cover of a Dover Street Market zine — pearlescent chrome inside brutalist scaffolding.
+
+The accent system is the iridescence itself. There is no secondary color to manage, no tag pills, no swatches — the only chromatic event on the page is the gradient blob, and its job is to be the surprise. Everywhere else, the design commits to near-black ink on stone beige with thin 1–2px rules. That restraint is what makes the blob feel expensive instead of decorative: it reads as a captured 3D render that happens to be sitting on a piece of paper, like a photographic negative of a dream pinned to a bulletin board.
+
+**Key Characteristics:**
+- Warm stone beige background (`#ECE8DD`) — dusty, slightly toasted, never white
+- Near-black ink (`#111111`) for all text, rules, and table borders — commanding but softer than pure black
+- Archivo Black for display headlines — heavy, condensed geometric sans, stacked 1–3 words per line, left-aligned, `-2px` tracking
+- Space Mono medium (500) for all metadata, labels, and footer text — technical, left-aligned or grid-aligned
+- Iridescent chrome blob as the one hero visual — conic/radial gradient of hot pink `#FF6EC7`, cyan `#8DEBFF`, lavender `#C79DFF`, pale pink `#FFE8F0`, and pearl `#F6F3FA`, masked into an organic `border-radius: 50% 40% 60% 30% / 40% 50% 30% 60%` morph shape with `filter: blur(0.5px)` for liquid softness
+- Bordered 3-cell metadata table at the bottom — thin 1.5px near-black rules forming rigid rectangular cells, no radius, no fill
+- Small tracked uppercase footer text at 11–12px, `letter-spacing: 1.5px`, sitting flush to bottom edge
+- Brutalist grid scaffolding: every element is either a heavy type block, a thin-ruled box, or the iridescent blob — nothing else competes
+- Sharp 0px corners everywhere except the blob — no rounded containers, no soft shadows, no pills
+- One flavor of iridescence only — never flat pink or flat cyan; the point is the gradient shift, not the hue
+- Left-aligned primary axis, with the 3-cell metadata table spanning full content width at the bottom
+- Zero decorative texture, zero photography, zero illustrations — the blob is the entire visual economy
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Stone Beige** (`#ECE8DD`): Primary background. A warm, dusty off-white with a faint yellow-gray undertone that reads as recycled card stock, not digital white. This is the canvas and nothing else uses it.
+- **Near-Black Ink** (`#111111`): Primary text, rule lines, table borders, headline fill. Softer than pure black, closer to a dark print ink.
+- **Iridescent Gradient** (multi-stop): Primary accent, applied only to the hero blob. See the five-stop gradient below.
+
+### Iridescent Gradient Stops
+- **Hot Pink** (`#FF6EC7`): Warm iridescence peak. Used as the dominant magenta-pink reflection in the blob.
+- **Cyan Shimmer** (`#8DEBFF`): Cool iridescence peak. The opposing chrome highlight, especially in recessed curves.
+- **Lavender Midtone** (`#C79DFF`): Purple bridge between the pink and cyan stops. Gives the blob its dreamy dusk quality.
+- **Pearl Pink** (`#FFE8F0`): Near-white highlight rim. Sits at the topmost curves of the blob for wet-plastic sheen.
+- **Pearl Lilac** (`#F6F3FA`): Soft neutral pearl. Used as the lowest-contrast stop to blend the gradient into the stone background.
+
+### Neutral Scale
+- **Ink Secondary** (`#2B2B2B`): Slightly softened near-black. Used for very small metadata where full near-black would feel too heavy.
+- **Ink Tertiary** (`#555555`): Quieter metadata, footer-adjacent text.
+- **Stone Darker** (`#D8D2C3`): Subtle inset for a recessed card surface. Used rarely — reserved for secondary containers.
+- **Stone Lighter** (`#F2EEE4`): Subtle inset for a lifted surface. Used rarely.
+- **Rule Gray** (`rgba(17,17,17,0.85)`): Primary border rule — a softened near-black that reads as crisp at 1.5px without feeling computed.
+
+### Surface & Borders
+- **Surface Primary** (`#ECE8DD`): Always the page background — containers do not have their own fill.
+- **Surface Inset** (`#E4DFD1`): Rare recessed surface, used only inside a metadata table cell that needs emphasis.
+- **Border Default** (`1.5px solid #111111`): The primary rule. Every table cell, every metadata container, every hairline divider uses this exact weight. The thickness is deliberate — thicker than a web default rule, thinner than a headline.
+- **Border Strong** (`2px solid #111111`): For the outer frame of the metadata table and section dividers. Slightly chunkier to sit alongside the heavy headline without feeling fragile.
+- **Divider Rule** (`1px solid rgba(17,17,17,0.4)`): Faint internal dividers when needed inside long cells.
+
+### Shadow Colors
+- **Blob Glow** (`rgba(255,110,199,0.25)`): The only shadow in the system. A faint pink-tinted ambient halo placed under the iridescent blob to anchor it to the canvas without creating a hard drop shadow.
+- **Blob Glow Deep** (`rgba(199,157,255,0.20)`): Optional lavender-tinted under-halo stacked below the pink halo for a slightly thicker atmospheric bloom.
+- **Shadow None** (`none`): The explicit rule for everything else. Headlines, tables, and text cast no shadows.
+
+### Texture
+- **No Texture**: This style uses no patterns, no dot grids, no noise, no paper grain. The warmth of the stone beige plus the organic blob provides all the tactility the composition needs.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Space+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Archivo Black', 'Arial Black', 'Helvetica Neue', Helvetica, Arial, sans-serif`
+- **Body / Metadata**: `'Space Mono', 'JetBrains Mono', 'Menlo', 'Consolas', monospace`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Archivo Black | 140px | 400 (native heavy) | 0.88 | -2px | The poster headline. Stacked 1–3 words per line, left-aligned. Archivo Black is only available at a single heavy weight. |
+| Display Medium | Archivo Black | 104px | 400 | 0.90 | -1.5px | Secondary title for slides and carousel hero cards. |
+| Display Small | Archivo Black | 72px | 400 | 0.92 | -1px | Section label on content slides. |
+| Subtitle | Space Mono | 18px | 500 | 1.45 | 0.4px | Support line under the display headline. Sentence case. |
+| Body | Space Mono | 14px | 500 | 1.55 | 0.3px | Standard body text in metadata cells and descriptions. |
+| Body Bold | Space Mono | 14px | 700 | 1.55 | 0.3px | Emphasis within mono body text. |
+| Metadata Label | Space Mono | 13px | 500 | 1.35 | 0.6px | Inside bordered table cells. Often uppercase. |
+| Metadata Value | Space Mono | 16px | 700 | 1.30 | 0.2px | Primary value in a metadata cell (time, date, status). |
+| Big Numbers | Archivo Black | 96px | 400 | 0.90 | -1.5px | Stats, countdowns, key metrics. |
+| Footer Text | Space Mono | 12px | 500 | 1.40 | 1.5px (uppercase) | Bottom-edge attribution, handles, venue. Always uppercase. |
+| CTA Text | Space Mono | 14px | 700 | 1.00 | 1.2px (uppercase) | Button text. Always uppercase, wide tracking. |
+
+### Principles
+- **Only one display face**: Archivo Black is the single display voice. Do not introduce a second display font under any circumstances. Its weight and rigidity are the backbone of the style.
+- **Mono everywhere else**: Every non-headline string — metadata, body, labels, footer — is set in Space Mono. The uniform mono voice across every supporting element is what makes the headline feel monumental by contrast.
+- **Stack short lines, don't wrap**: Headlines should be broken into 1–3 word lines with an explicit `<br>`. Lines should be roughly equal length for a solid rectangular type mass. Never run a headline as a single long line.
+- **Negative tracking on display**: Apply `letter-spacing: -2px` at 140px and scale proportionally (`-1.5px` at 104px, `-1px` at 72px). The chunky geometry needs tight packing to feel carved.
+- **Tight display leading**: `line-height: 0.88–0.92` for all display sizes. The letters nearly touch the line above — this is essential for the poster mass.
+- **Uppercase footers, mixed-case headlines**: Headlines are mixed case or all caps depending on the word (acronyms like "HOLO" read naturally in caps). Footers, CTAs, and table labels are always uppercase with 0.6–1.5px positive tracking for the utilitarian label feel.
+- **No italics, ever**: Neither Archivo Black nor the design language supports italic emphasis. Emphasis is achieved through the iridescent blob, not type styling.
+
+## 4. Component Patterns
+
+### Brutalist Headline Block
+
+```html
+<div style="display: block; text-align: left; padding: 0;">
+  <h1 style="font-family: var(--font-display); font-size: 140px; font-weight: 400; line-height: 0.88; letter-spacing: -2px; color: var(--color-ink); margin: 0; text-transform: uppercase;">
+    HOLO<br>PARTY
+  </h1>
+  <p style="font-family: var(--font-mono); font-size: 18px; font-weight: 500; line-height: 1.45; letter-spacing: 0.4px; color: var(--color-ink-secondary); margin: 24px 0 0; max-width: 560px;">
+    An iridescent night of chrome sound, liquid light, and free drinks until the blob melts.
+  </p>
+</div>
+```
+
+### Iridescent Blob Hero
+
+The hero visual of the entire style. Approximates a 3D chrome render in pure CSS using a layered conic-gradient for the iridescent shift and a radial-gradient for the pearl highlight, masked into an organic morphing shape.
+
+```html
+<div style="position: relative; width: 560px; height: 560px; margin: 0 auto; display: flex; align-items: center; justify-content: center;">
+  <!-- Ambient iridescent glow under the blob -->
+  <div style="
+    position: absolute;
+    inset: 40px;
+    background: radial-gradient(circle at 50% 55%, rgba(255,110,199,0.25) 0%, rgba(199,157,255,0.20) 35%, rgba(141,235,255,0.10) 60%, transparent 80%);
+    filter: blur(40px);
+    pointer-events: none;
+  "></div>
+
+  <!-- The blob itself -->
+  <div style="
+    position: relative;
+    width: 460px;
+    height: 460px;
+    border-radius: 52% 48% 58% 42% / 46% 54% 46% 54%;
+    background:
+      radial-gradient(circle at 35% 30%, #FFE8F0 0%, rgba(255,232,240,0) 28%),
+      radial-gradient(circle at 70% 75%, #F6F3FA 0%, rgba(246,243,250,0) 32%),
+      conic-gradient(from 210deg at 50% 50%,
+        #C79DFF 0%,
+        #FF6EC7 18%,
+        #FFE8F0 32%,
+        #8DEBFF 52%,
+        #C79DFF 70%,
+        #FF6EC7 85%,
+        #C79DFF 100%);
+    box-shadow:
+      inset 40px 60px 80px rgba(255,232,240,0.55),
+      inset -30px -50px 70px rgba(141,235,255,0.35),
+      inset 0 0 120px rgba(199,157,255,0.25);
+    filter: blur(0.5px) saturate(1.1);
+    animation: blobMorph 14s ease-in-out infinite;
+  "></div>
+</div>
+
+<style>
+  @keyframes blobMorph {
+    0%, 100% { border-radius: 52% 48% 58% 42% / 46% 54% 46% 54%; }
+    33%      { border-radius: 44% 56% 50% 50% / 58% 42% 58% 42%; }
+    66%      { border-radius: 60% 40% 44% 56% / 50% 60% 40% 50%; }
+  }
+</style>
+```
+
+### Bordered Metadata Table (3-cell)
+
+The rigid counterweight to the organic blob. Always sits at the bottom of the composition, spanning full content width. Top row holds two larger labels, bottom row holds three equal cells.
+
+```html
+<div style="width: 100%; border: 2px solid var(--color-ink); background: var(--color-bg);">
+  <!-- Top row: 2 cells -->
+  <div style="display: grid; grid-template-columns: 1fr 1fr; border-bottom: 1.5px solid var(--color-ink);">
+    <div style="padding: 20px 24px; border-right: 1.5px solid var(--color-ink);">
+      <p style="font-family: var(--font-mono); font-size: 28px; font-weight: 700; line-height: 1.10; letter-spacing: -0.2px; color: var(--color-ink); margin: 0; text-transform: uppercase;">Free<br>Drinks</p>
+    </div>
+    <div style="padding: 20px 24px; text-align: right;">
+      <p style="font-family: var(--font-mono); font-size: 16px; font-weight: 500; line-height: 1.30; letter-spacing: 0.3px; color: var(--color-ink-secondary); margin: 0 0 4px; text-transform: uppercase;">20 June 2030</p>
+      <p style="font-family: var(--font-mono); font-size: 26px; font-weight: 700; line-height: 1.10; letter-spacing: 0.2px; color: var(--color-ink); margin: 0;">5:00 PM</p>
+    </div>
+  </div>
+  <!-- Bottom row: 3 cells -->
+  <div style="display: grid; grid-template-columns: 1fr 1fr 1fr;">
+    <div style="padding: 18px 20px; border-right: 1.5px solid var(--color-ink); text-align: center;">
+      <p style="font-family: var(--font-mono); font-size: 13px; font-weight: 500; line-height: 1.35; letter-spacing: 0.6px; color: var(--color-ink); margin: 0; text-transform: uppercase;">DJ Drew Feig</p>
+    </div>
+    <div style="padding: 18px 20px; border-right: 1.5px solid var(--color-ink); text-align: center;">
+      <p style="font-family: var(--font-mono); font-size: 13px; font-weight: 500; line-height: 1.35; letter-spacing: 0.6px; color: var(--color-ink); margin: 0; text-transform: uppercase;">Live Music</p>
+    </div>
+    <div style="padding: 18px 20px; text-align: center;">
+      <p style="font-family: var(--font-mono); font-size: 13px; font-weight: 500; line-height: 1.35; letter-spacing: 0.6px; color: var(--color-ink); margin: 0; text-transform: uppercase;">Free Entry</p>
+    </div>
+  </div>
+</div>
+```
+
+### Numbered Item
+
+```html
+<div style="display: grid; grid-template-columns: 80px 1fr; gap: 24px; padding: 24px 0; border-top: 1.5px solid var(--color-ink);">
+  <div style="font-family: var(--font-display); font-size: 48px; font-weight: 400; line-height: 1.00; letter-spacing: -1px; color: var(--color-ink);">01</div>
+  <div>
+    <p style="font-family: var(--font-mono); font-size: 14px; font-weight: 700; line-height: 1.45; letter-spacing: 0.3px; color: var(--color-ink); margin: 0 0 6px; text-transform: uppercase;">Arrive Early</p>
+    <p style="font-family: var(--font-mono); font-size: 14px; font-weight: 500; line-height: 1.55; letter-spacing: 0.3px; color: var(--color-ink-secondary); margin: 0;">Doors at 5:00 PM. The iridescent room fills fast — line forms around the corner on Rimberio.</p>
+  </div>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="padding: 32px 24px; border: 2px solid var(--color-ink); text-align: left;">
+  <p style="font-family: var(--font-display); font-size: 96px; font-weight: 400; line-height: 0.90; letter-spacing: -1.5px; color: var(--color-ink); margin: 0;">4.2K</p>
+  <p style="font-family: var(--font-mono); font-size: 13px; font-weight: 500; line-height: 1.35; letter-spacing: 0.6px; color: var(--color-ink-secondary); margin: 12px 0 0; text-transform: uppercase;">RSVPs Since Drop</p>
+</div>
+```
+
+### Comparison Grid (2-column bordered)
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; border: 2px solid var(--color-ink);">
+  <div style="padding: 32px 28px; border-right: 1.5px solid var(--color-ink);">
+    <p style="font-family: var(--font-mono); font-size: 13px; font-weight: 500; letter-spacing: 0.6px; color: var(--color-ink-secondary); margin: 0 0 16px; text-transform: uppercase;">Analog Night</p>
+    <h3 style="font-family: var(--font-display); font-size: 40px; font-weight: 400; line-height: 0.92; letter-spacing: -0.8px; color: var(--color-ink); margin: 0 0 16px; text-transform: uppercase;">Dim Room<br>Warm Beer</h3>
+    <p style="font-family: var(--font-mono); font-size: 14px; font-weight: 500; line-height: 1.55; color: var(--color-ink-secondary); margin: 0;">The usual weekend. Nothing shimmers, nothing melts, nothing glows.</p>
+  </div>
+  <div style="padding: 32px 28px;">
+    <p style="font-family: var(--font-mono); font-size: 13px; font-weight: 500; letter-spacing: 0.6px; color: var(--color-ink-secondary); margin: 0 0 16px; text-transform: uppercase;">Holo Party</p>
+    <h3 style="font-family: var(--font-display); font-size: 40px; font-weight: 400; line-height: 0.92; letter-spacing: -0.8px; color: var(--color-ink); margin: 0 0 16px; text-transform: uppercase;">Chrome<br>Liquid Light</h3>
+    <p style="font-family: var(--font-mono); font-size: 14px; font-weight: 500; line-height: 1.55; color: var(--color-ink-secondary); margin: 0;">A room full of iridescent sound. Doors at 5. Free until they aren't.</p>
+  </div>
+</div>
+```
+
+### Quote Block
+
+```html
+<div style="padding: 40px 32px; border-left: 2px solid var(--color-ink); border-right: 2px solid var(--color-ink); border-top: 1.5px solid var(--color-ink); border-bottom: 1.5px solid var(--color-ink);">
+  <p style="font-family: var(--font-display); font-size: 56px; font-weight: 400; line-height: 0.95; letter-spacing: -1px; color: var(--color-ink); margin: 0 0 24px; text-transform: uppercase;">"The blob<br>is the party."</p>
+  <p style="font-family: var(--font-mono); font-size: 12px; font-weight: 500; letter-spacing: 1.5px; color: var(--color-ink-secondary); margin: 0; text-transform: uppercase;">— DJ Drew Feig, Rimberio Club</p>
+</div>
+```
+
+### Footer Block
+
+```html
+<div style="display: flex; justify-content: space-between; align-items: center; padding: 20px 0 0; border-top: 1.5px solid var(--color-ink); margin-top: 32px;">
+  <p style="font-family: var(--font-mono); font-size: 12px; font-weight: 500; letter-spacing: 1.5px; color: var(--color-ink); margin: 0; text-transform: uppercase;">@ReallyGreatSite</p>
+  <p style="font-family: var(--font-mono); font-size: 12px; font-weight: 500; letter-spacing: 1.5px; color: var(--color-ink); margin: 0; text-transform: uppercase;">Rimberio Club</p>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="text-align: left; padding: 48px 0;">
+  <h2 style="font-family: var(--font-display); font-size: 104px; font-weight: 400; line-height: 0.90; letter-spacing: -1.5px; color: var(--color-ink); margin: 0 0 32px; text-transform: uppercase;">Come<br>Melt</h2>
+  <a style="display: inline-block; padding: 18px 36px; border: 2px solid var(--color-ink); background: var(--color-bg); font-family: var(--font-mono); font-size: 14px; font-weight: 700; letter-spacing: 1.2px; color: var(--color-ink); text-decoration: none; text-transform: uppercase;">RSVP Now →</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap — between a tracked label and its adjacent value.
+- **8px**: Tight gap — between a metadata label and its value within a cell.
+- **12px**: Small gap — between a stat number and its caption.
+- **16px**: Base gap — between body lines in dense metadata.
+- **20px**: Cell padding — standard internal padding for metadata table cells.
+- **24px**: Medium gap — between the display headline and its subtitle.
+- **32px**: Section gap — between a hero block and the metadata table.
+- **48px**: Large gap — between major composition zones (headline / blob / table).
+- **60px**: Content padding — standard outer padding on carousel and poster formats.
+- **80px**: Max padding — slide-format outer padding and top-of-frame breathing room.
+- **120px**: Story outer padding — vertical breathing room for the 1080×1920 story format.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 960px |
+| **Story (1080x1920)** | **60px left/right, 120px top/bottom** | **960px** |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned for all headline and content blocks. The metadata table spans full content width and uses its own internal alignment (left for label cells, right for time cells, center for status cells).
+- **Grid**: The metadata table is always a strict grid — usually 2 cells on top, 3 cells on bottom, all sharing 1.5px near-black rules. No offset, no overlap, no negative space between cells.
+- **Hero zone**: The iridescent blob occupies the visual center of the composition, either directly below the headline or in a central inset. On posters, it sits inside a bordered frame. On stories, it sits free on the canvas with only its pink glow for support.
+- **Three-zone composition**: Every layout in this style follows a three-zone rhythm — (1) heavy headline block at top, (2) iridescent blob in the middle, (3) bordered metadata table at the bottom. Break this rhythm only for content-heavy slides, and even then preserve the headline-at-top rule.
+- **No centered body text**: Only the CTA text inside a button and the bottom row of the metadata table cells may be center-aligned. Everything else aligns left or to the grid.
+- **Full-bleed is forbidden**: Content never touches the outer edge of the frame. The stone beige canvas must always frame the composition on all four sides by at least the format's minimum padding.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, background `#ECE8DD` | Page canvas, base layer — the default for 95% of elements |
+| Ruled (Level 1) | `1.5px solid #111111` border, no shadow | Metadata table cells, content dividers |
+| Framed (Level 2) | `2px solid #111111` border, no shadow | Table outer frame, stat blocks, quote blocks |
+| Glowing (Level 3) | `radial-gradient(rgba(255,110,199,0.25), rgba(199,157,255,0.20), transparent)` blur 40px ambient halo | The iridescent blob only |
+| Overlay (Level 4) | Inset headline, `box-shadow: inset 40px 60px 80px rgba(255,232,240,0.55)` | Inset chrome treatments on display type (rare) |
+
+### Border Treatments
+- **Standard rule**: `1.5px solid #111111` with `border-radius: 0` — the primary rule for all dividers and internal cell borders. Never soften this into a gray.
+- **Frame rule**: `2px solid #111111` with `border-radius: 0` — used exclusively for the outer perimeter of the metadata table and any content block that acts as a "framed" unit.
+- **Faint divider**: `1px solid rgba(17,17,17,0.4)` — used very sparingly for tertiary internal dividers within long cells.
+- **No rounded corners**: Corner radius on any bordered element is always `0`. The only radius in this entire style is on the iridescent blob, where it is an organic morph, not a geometric rounding.
+
+### Surface Hierarchy
+On the stone beige canvas, depth is communicated almost entirely through border weight and the iridescent glow:
+1. **Background** (`#ECE8DD`) — the neutral canvas, completely flat.
+2. **Framed block** (`2px solid #111111`) — the strongest structural container. Metadata tables, stat displays, quote blocks.
+3. **Ruled block** (`1.5px solid #111111`) — internal divisions inside framed blocks.
+4. **Iridescent blob** — the only non-flat element in the entire system. Its halo is the only shadow this style permits.
+
+The rule: if it's not type, it's a straight black line. If it's not a straight black line, it's the blob.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use Archivo Black at 140px for the primary poster headline, stacked in 1–3 word lines with `line-height: 0.88` and `letter-spacing: -2px`.
+- Use Space Mono at 500 weight for all metadata, body, and table labels — this is the utilitarian voice of the system.
+- **Do use CSS conic-gradient and radial-gradient for the iridescent blob.** Layer a `conic-gradient(from 210deg, #C79DFF, #FF6EC7, #FFE8F0, #8DEBFF, #C79DFF)` with a radial pearl highlight on top, inside an organic `border-radius: 52% 48% 58% 42% / 46% 54% 46% 54%` mask. The gradient shift is the point.
+- Use a 3-cell bordered metadata table at the bottom of every composition where there is structured information to display — it's the signature structural component.
+- Use thin 1.5–2px near-black `#111111` rules with `border-radius: 0` for every bordered container.
+- Use the warm stone beige `#ECE8DD` as the background on every format. It is non-negotiable — never swap it for white or gray.
+- Use uppercase tracked small text (`letter-spacing: 1.5px`, 12px) for footers, handles, and venue attributions at the bottom edge.
+- Use the pink + lavender ambient glow (`radial-gradient(rgba(255,110,199,0.25), rgba(199,157,255,0.20), transparent)` blur 40px) under the blob to anchor it to the canvas — this is the only shadow the system permits.
+- Animate the blob's `border-radius` subtly (14s ease-in-out infinite) when the format supports animation — even a frozen render benefits from being designed with the morph in mind.
+- Break headlines into short stacked lines of roughly equal length to create a solid rectangular type mass.
+
+### Don't
+- **Don't use flat pink, flat cyan, or any single-hue accent.** The iridescence is the entire point. A flat pink blob is a mascot; a gradient blob is a signature.
+- Don't use any font other than Archivo Black for display or any font other than Space Mono for metadata/body. A second display face destroys the contrast that makes the headline feel monumental.
+- Don't use rounded corners on any container, card, table, or button. `border-radius: 0` is the rule. The only radius allowed anywhere is the organic morphing blob.
+- Don't use drop shadows on type, tables, or containers. The only shadow in the system is the blob's ambient iridescent halo.
+- Don't use white `#FFFFFF` or pure black `#000000`. The stone beige background and near-black ink are what give the style its warmth — pure values make it look digital.
+- Don't add a second accent color. No yellow pills, no green tags, no blue links — the blob is the only chromatic event.
+- Don't center-align headline text. Headlines are always left-aligned. Center alignment is reserved for CTA buttons and center-status table cells.
+- Don't use generous line-height on display type. `line-height: 0.88–0.92` is mandatory for the chunky mass effect.
+- Don't let the iridescent blob touch the edge of the frame. It always sits inside the padded content zone with breathing room.
+- Don't decorate with icons, emoji, illustrations, photos, or noise texture. The blob is the entire visual economy.
+- Don't use more than one iridescent blob in a single composition. The blob works because it's singular — a field of blobs becomes wallpaper.
+- Don't use italic type. Archivo Black has no italic, and the system does not want italic emphasis anywhere.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale down**: Display Hero becomes 104px (from 140px). Display Medium becomes 80px. Body stays 14px.
+- **Padding**: 60px on all sides. Content area is 960x960px.
+- **Cover slide**: Headline stacked top-left, iridescent blob center-right or center, metadata table spans full content width at bottom.
+- **Content slides**: Display Small headline at top-left, left-aligned content block, optional framed stat block, footer rule with handle on the left and page counter (e.g. "02/08") on the right.
+- **Swipe indicator**: Tiny 1.5px tracked uppercase "SWIPE →" in Space Mono at the bottom-right corner, 12px. No dots.
+- **Blob placement**: One blob per slide maximum. On cover slide it can sit at 60% of the frame height. On content slides it shrinks to ~280–320px and sits inline with content.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Full-scale hierarchy. Display Hero at 140px for the title section. Display Small at 72px for each section head.
+- **Padding**: 60px left/right. 80px top/bottom margins.
+- **Section rhythm**: Each section opens with a 72px Display Small section head, followed by a horizontal 1.5px rule, followed by the content block. 48px vertical gap between sections.
+- **Vertical flow**: Title section → iridescent blob hero → 3-cell metadata table summary → alternating numbered items and framed stat blocks → closing quote block → footer with handle and venue.
+- **Footer**: 1.5px rule across full content width, with tracked uppercase handle on the left and venue on the right.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 180px. Display Medium becomes 128px. Body becomes 16px. Metadata Value becomes 20px.
+- **Padding**: 80px on all sides. Content area is 1760x920px.
+- **Layout**: Two-zone horizontal split — headline + optional subtitle on the left ~55% of the frame, iridescent blob on the right ~45%. Metadata table spans full content width at the bottom.
+- **Title slides**: Headline left, blob right, no metadata table — just a tracked handle and date at the bottom.
+- **Content slides**: Display Small section head top-left, content block left-aligned below, small blob (240px) as a visual punctuation in the top-right corner, metadata table at bottom if needed.
+- **CTA slides**: Headline left, blob right, bordered CTA button below the headline, tracked venue attribution at the bottom.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 140px (cover-accurate). Display Medium at 104px. Body at 14px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top third for the stacked heavy headline (left-aligned). Middle third for the framed iridescent blob inside a 2px bordered box. Bottom third for the 3-cell metadata table plus a thin footer rule with handle and venue.
+- **Frame the blob**: On poster format the blob sits inside a `2px solid #111111` bordered rectangle — this replicates the reference composition exactly. The rectangle touches both side margins of the content area.
+- **Vertical flow**: Headline → framed blob → metadata table → footer handle/venue.
+
+### Story (1080x1920px) ← the tall format
+- **Typography scale up**: Display Hero becomes 168px (from 140px). Display Medium becomes 120px. Body stays 14px with metadata value at 18px. **Hero blob is ~30% larger than its poster size** — roughly 640×640 from the poster's 460×460 — to fill the tall frame with presence.
+- **Padding**: 60px left/right, **120px top/bottom** for generous vertical breathing room.
+- **Composition**: Four-zone vertical stack — (1) stacked heavy headline at the top-left, (2) generous empty stone beige breathing room, (3) oversized iridescent blob centered horizontally with its pink+lavender glow anchoring it to the canvas (no bordered frame — the blob sits free on the stone), (4) 3-cell bordered metadata table spanning full content width at the bottom, followed by a thin 1.5px footer rule with handle on the left and venue on the right.
+- **Hero blob treatment**: No bordered frame on the story format. The blob sits free with only its iridescent halo — this exploits the tall frame by letting the chrome organic shape breathe against the canvas the way a sculpture sits on a plinth.
+- **Vertical rhythm**: 48px gap between headline and blob zone, 64px gap between blob zone and metadata table, 20px gap between metadata table and footer rule. The empty space above and below the blob is load-bearing — it is the silence that makes the iridescence feel precious.
+- **Safe zones**: Top 120px and bottom 220px are reserved from story UI chrome (profile handle, reply box, progress bar). Keep the headline below the top 120px safe zone and the footer above the bottom 220px safe zone.
+- **Animation (optional)**: If the story output supports CSS animation, apply the 14s `blobMorph` keyframe animation to the blob. If static, capture the blob mid-morph at a frame that shows maximum iridescent shift (roughly 33% into the keyframe).
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Stone Beige | `#ECE8DD` | Primary background — the canvas |
+| Near-Black Ink | `#111111` | Primary text, rules, table borders |
+| Ink Secondary | `#2B2B2B` | Softened small metadata |
+| Ink Tertiary | `#555555` | Quieter metadata, supporting copy |
+| Stone Darker | `#D8D2C3` | Rare recessed surface |
+| Stone Lighter | `#F2EEE4` | Rare lifted surface |
+| Hot Pink | `#FF6EC7` | Iridescent gradient stop (warm peak) |
+| Cyan Shimmer | `#8DEBFF` | Iridescent gradient stop (cool peak) |
+| Lavender Midtone | `#C79DFF` | Iridescent gradient stop (bridge) |
+| Pearl Pink | `#FFE8F0` | Iridescent gradient stop (highlight rim) |
+| Pearl Lilac | `#F6F3FA` | Iridescent gradient stop (soft blend) |
+| Blob Glow | `rgba(255,110,199,0.25)` | Ambient pink halo under blob |
+| Blob Glow Deep | `rgba(199,157,255,0.20)` | Ambient lavender halo under blob |
+
+### Font Declarations
+
+```css
+/* Display (headlines only) */
+font-family: 'Archivo Black', 'Arial Black', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+
+/* Body / Metadata (everything else) */
+font-family: 'Space Mono', 'JetBrains Mono', 'Menlo', 'Consolas', monospace;
+```
+
+### Google Fonts Link
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Space+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-bg: #ECE8DD;
+  --color-ink: #111111;
+  --color-ink-secondary: #2B2B2B;
+  --color-ink-tertiary: #555555;
+
+  /* Colors -- Stone neutrals */
+  --color-stone-darker: #D8D2C3;
+  --color-stone-lighter: #F2EEE4;
+
+  /* Colors -- Iridescent gradient stops */
+  --color-iri-hot-pink: #FF6EC7;
+  --color-iri-cyan: #8DEBFF;
+  --color-iri-lavender: #C79DFF;
+  --color-iri-pearl-pink: #FFE8F0;
+  --color-iri-pearl-lilac: #F6F3FA;
+
+  /* Colors -- Ambient glow (blob only) */
+  --color-glow-pink: rgba(255, 110, 199, 0.25);
+  --color-glow-lavender: rgba(199, 157, 255, 0.20);
+  --color-glow-cyan: rgba(141, 235, 255, 0.10);
+
+  /* Colors -- Borders */
+  --color-border-default: #111111;
+  --color-border-strong: #111111;
+  --color-divider-faint: rgba(17, 17, 17, 0.4);
+
+  /* Typography -- Families */
+  --font-display: 'Archivo Black', 'Arial Black', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --font-mono: 'Space Mono', 'JetBrains Mono', 'Menlo', 'Consolas', monospace;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 140px;
+  --text-display-medium: 104px;
+  --text-display-small: 72px;
+  --text-big-number: 96px;
+  --text-subtitle: 18px;
+  --text-body: 14px;
+  --text-metadata-label: 13px;
+  --text-metadata-value: 16px;
+  --text-footer: 12px;
+  --text-cta: 14px;
+
+  /* Typography -- Weights */
+  --weight-display: 400;      /* Archivo Black is single-weight */
+  --weight-mono-regular: 400;
+  --weight-mono-medium: 500;
+  --weight-mono-bold: 700;
+
+  /* Typography -- Line Heights */
+  --leading-display-tight: 0.88;
+  --leading-display: 0.90;
+  --leading-display-loose: 0.92;
+  --leading-subtitle: 1.45;
+  --leading-body: 1.55;
+  --leading-metadata: 1.35;
+  --leading-footer: 1.40;
+
+  /* Typography -- Letter Spacing */
+  --track-display-tight: -2px;
+  --track-display: -1.5px;
+  --track-display-loose: -1px;
+  --track-subtitle: 0.4px;
+  --track-metadata: 0.6px;
+  --track-footer: 1.5px;
+  --track-cta: 1.2px;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-cell: 20px;
+  --space-medium: 24px;
+  --space-section: 32px;
+  --space-large: 48px;
+  --space-content: 60px;
+  --space-max: 80px;
+  --space-story: 120px;
+
+  /* Borders -- all radius is 0 except the blob */
+  --radius-none: 0;
+  --border-rule: 1.5px solid #111111;
+  --border-frame: 2px solid #111111;
+  --border-faint: 1px solid rgba(17, 17, 17, 0.4);
+
+  /* Iridescent blob composed values */
+  --blob-shape: 52% 48% 58% 42% / 46% 54% 46% 54%;
+  --blob-gradient:
+    radial-gradient(circle at 35% 30%, #FFE8F0 0%, rgba(255,232,240,0) 28%),
+    radial-gradient(circle at 70% 75%, #F6F3FA 0%, rgba(246,243,250,0) 32%),
+    conic-gradient(from 210deg at 50% 50%,
+      #C79DFF 0%,
+      #FF6EC7 18%,
+      #FFE8F0 32%,
+      #8DEBFF 52%,
+      #C79DFF 70%,
+      #FF6EC7 85%,
+      #C79DFF 100%);
+  --blob-inset-shadow:
+    inset 40px 60px 80px rgba(255,232,240,0.55),
+    inset -30px -50px 70px rgba(141,235,255,0.35),
+    inset 0 0 120px rgba(199,157,255,0.25);
+  --blob-halo: radial-gradient(circle at 50% 55%,
+    rgba(255,110,199,0.25) 0%,
+    rgba(199,157,255,0.20) 35%,
+    rgba(141,235,255,0.10) 60%,
+    transparent 80%);
+}
+```
+
+### System Font Fallbacks
+- **Display (if Archivo Black fails to load):** `'Arial Black', 'Helvetica Neue', Helvetica, Arial, sans-serif` — always bump to a 900-weight fallback.
+- **Body / Metadata (if Space Mono fails to load):** `'JetBrains Mono', 'Menlo', 'Consolas', monospace` — any fixed-width sans with a technical feel.

--- a/skills/composites/goose-graphics/styles/_full/magazine-red.md
+++ b/skills/composites/goose-graphics/styles/_full/magazine-red.md
@@ -1,0 +1,547 @@
+# Design Style: Magazine Red
+
+## 1. Visual Theme & Atmosphere
+
+Magazine Red is the design language of the modern editorial pitch deck — the visual equivalent of a startup founder who reads Monocle on the plane and keeps a stack of Fast Company back issues on the coffee table. It draws from the Swiss-influenced editorial tradition (think Yale School of Art, Aperture Magazine, Wallpaper* covers) but strips away the fussiness, leaving only the load-bearing elements: a warm cream paper stock, a single hot red accent, and display type so massive it nearly bursts the frame. The background is not white — it is a deliberate off-white cream (`#F2EEE2`), the color of uncoated book paper under warm gallery lighting. This single choice shifts the entire register away from "tech deck" toward "editorial artifact" and makes every other element feel more considered.
+
+The defining gesture is the massive tomato-red headline. Headlines are set in a heavy condensed sans at 180–240px, in ALL CAPS, in a saturated brick-tomato red (`#C33A1F`), and composed so they nearly fill the width of the frame. This is not a cautious headline — it is the headline as event. The chosen typeface is **Anton** (from Google Fonts), a contemporary condensed display sans with extreme weight that captures the industrial confidence of Druk Condensed or Knockout without the license. Anton's severe verticality means "PITCH DECK" on two lines reads as architecture. Body type is **Inter**, handling every supporting role — small tracked uppercase labels, captions, bracketed section numbers, and metadata — in a deep espresso brown-black (`#2B2119`) that reads warmer than true black against the cream.
+
+The accent system is ruthlessly restricted: red for display headlines and bracketed section markers, dark brown-black for body copy, cream for background, and nothing else. Decorative scaffolding comes from a small set of signature patterns: **bracketed numbers `[1]` `[2]` `[3]`** as numbered list markers, **parenthetical `(05)` page numbers** set in red condensed sans, **small tracked uppercase labels** ("INNOVATING SOLUTIONS FOR A CHANGING WORLD") that sit quietly in the corners, and **rectangular photo cutouts** with name/role captions set in all-caps sans below. Compositions lean into deliberate asymmetric whitespace — generous airspace above the headline, photos pushed to one side, a single red `(05)` anchoring the negative space on the opposite edge. The mood is confident-but-restrained editorial design: Paper & Ink quarterly meets a Series A deck built by someone with taste.
+
+**Key Characteristics:**
+- Warm cream paper background (`#F2EEE2`) — never white, never gray, always warm
+- Massive tomato-red condensed sans headlines (`#C33A1F`) in ALL CAPS, sized at 180–240px to fill frame width
+- Anton (or Oswald 700 fallback) for display — extreme vertical condensation, single weight
+- Inter for body, captions, labels, and metadata — weights 400–700
+- Bracketed section numbers `[1]` `[2]` in red display sans as list markers
+- Parenthetical page numbers `(05)` in red display sans as compositional anchors
+- Small tracked uppercase labels (2px letter-spacing, 12–14px) for corner metadata
+- Deep espresso brown-black (`#2B2119`) for all body text — warmer than true black
+- Rectangular photo cutouts with all-caps sans name/role captions below
+- Generous asymmetric whitespace — headlines live in the top third, photos in the bottom half
+- No borders, no shadows, no rounded corners — editorial flatness throughout
+- No gradients, no textures, no decorative glyphs beyond brackets and parentheses
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Cream Paper** (`#F2EEE2`): Primary background. A warm off-white with a slight yellow undertone that reads as uncoated book paper. Never use pure white.
+- **Espresso Black** (`#2B2119`): Primary text color. A warm brown-black that sits harmoniously with the cream background without creating the harsh contrast of pure black.
+- **Tomato Red** (`#C33A1F`): Primary accent. Used for all display headlines, bracketed numbers, parenthetical page numbers, and the single-accent emphasis role. The red of a well-worn Penguin Classics spine.
+
+### Accent
+- **Brick Red** (`#A82E17`): Hover/active state and a slightly darker variant for secondary emphasis when two reds must coexist.
+- **Rust Red** (`#B83327`): Alternative display headline tone — slightly deeper, used when headlines sit over photography or need extra weight.
+
+### Neutral Scale
+- **Cream Deep** (`#ECE6D6`): A slightly darker cream for subtle surface shifts — photo backgrounds, quiet panels.
+- **Paper Fold** (`#E4DCC8`): The warmest cream, used for inset cards or photo frame backgrounds when surface separation is needed.
+- **Ink Warm** (`#2B2119`): Body text (same as Espresso Black).
+- **Ink Medium** (`#4A3E33`): Secondary text, captions, subheadings, descriptive body copy.
+- **Ink Light** (`#7A6B5C`): Tertiary text, photo credit lines, quiet metadata.
+- **Ink Mute** (`rgba(43, 33, 25, 0.45)`): Page numbers and watermarks when not in red.
+
+### Surface & Borders
+- **Surface Primary** (`#F2EEE2`): The canvas itself — cards rarely exist in this style, content sits directly on the cream.
+- **Surface Inset** (`#ECE6D6`): Subtle inset zones when differentiation is needed.
+- **Surface Photo Frame** (`#E4DCC8`): Background for rectangular photo containers when a photo needs a quiet mat.
+- **Border Hairline** (`rgba(43, 33, 25, 0.15)`): Thin hairline rules for editorial dividers. Used sparingly.
+- **Border Rule** (`#2B2119`): Full-weight rule lines for the rare full-width divider — 1px solid.
+- **Divider Whitespace**: The preferred "divider" is actual whitespace, not a line. Use 48–80px vertical gaps instead of rules.
+
+### Shadow Colors
+- **Shadow None** (`none`): The default. This style is flat — no drop shadows on cards, no lift on photos, no elevation language.
+- **Shadow Paper** (`0 1px 2px rgba(43, 33, 25, 0.08)`): Optional whisper-shadow for photos only, to hint at paper lift. Use at most on hero photos.
+- **Shadow Photo** (`0 2px 12px rgba(43, 33, 25, 0.10)`): Maximum elevation allowed — reserved for a single featured photo per composition.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Anton&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Anton', 'Oswald', 'Bebas Neue', Impact, sans-serif`
+- **Body**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Massive Hero | Anton | 240px | 400 | 0.88 | -2px | Cover headlines — "PITCH DECK" scale. Nearly fills frame width. Always ALL CAPS red. |
+| Display Hero | Anton | 180px | 400 | 0.90 | -1.5px | Standard hero headlines — "OUR TEAM" scale. ALL CAPS red. |
+| Display Large | Anton | 120px | 400 | 0.92 | -1px | Section titles in compact formats. ALL CAPS red. |
+| Display Medium | Anton | 88px | 400 | 0.94 | -0.5px | Sub-sections and secondary headlines. ALL CAPS red. |
+| Big Number | Anton | 140px | 400 | 0.90 | -1px | Parenthetical `(05)` page numbers in red. |
+| Bracket Number | Anton | 56px | 400 | 1.0 | 0px | `[1]` `[2]` `[3]` list markers in red. |
+| Heading 1 | Inter | 28px | 700 | 1.25 | -0.2px | Body-set section headings. Espresso black. |
+| Heading 2 | Inter | 20px | 700 | 1.30 | 0px | Sub-headings within body content. |
+| Label Caps | Inter | 13px | 600 | 1.20 | 2px | Tracked uppercase corner labels — "PRESENTED BY / OLIVIA WILSON" |
+| Label Caps Small | Inter | 11px | 700 | 1.20 | 1.8px | Photo caption names and roles in ALL CAPS. |
+| Body Large | Inter | 18px | 500 | 1.55 | 0px | Intro paragraphs and lead copy. |
+| Body | Inter | 15px | 500 | 1.60 | 0px | Standard body text. Espresso black. |
+| Body Small | Inter | 13px | 500 | 1.55 | 0px | Description text in photo captions and side-columns. Ink medium. |
+| Subtitle Red | Inter | 16px | 700 | 1.30 | 0.5px | Tomato red, ALL CAPS — used as headline subtitles like "MARKETING EXPERTS AT YOUR SERVICE". |
+
+### Principles
+
+- **Red display type is the only scale-maximizer**: The Anton red headline should always be sized to nearly fill the frame width. If it fits comfortably with lots of room, it is too small. Measure fit by computing a font-size that yields a line that is 90–95% of the content-area width.
+- **Inter handles everything that is not a scream**: Every non-headline element — captions, labels, body copy, bracketed lists — uses Inter. The style's contrast comes from the extreme jump between 240px red Anton and 15px espresso Inter, not from mid-tier type experiments.
+- **Letter-spacing discipline**: Anton display headlines use negative tracking (-1px to -2px) because condensed capitals already feel tight; the negative value makes the line read as a single unit. Small uppercase labels go the other way, using +2px tracking for an editorial small-caps feel.
+- **No italics, no mixed case for red**: Red is reserved for ALL CAPS Anton display type, bracketed numbers, parenthetical page numbers, and the rare red subtitle. Never set body paragraphs in red.
+- **Line-height tight on display, loose on body**: Display headlines sit at 0.88–0.94 line-height so stacked lines kiss each other like a Swiss poster. Body text sits at 1.55–1.60 for generous reading rhythm.
+- **Uppercase for metadata only**: Mixed case is the default for body copy and headings set in Inter. ALL CAPS is reserved for the red display headline, small tracked corner labels, photo caption names/roles, and the red Inter subtitle.
+
+## 4. Component Patterns
+
+### Massive Red Headline (Cover Pattern)
+
+The signature pattern. A display headline set to nearly fill the frame, anchored in the top third, with tracked corner labels in the remaining corners.
+
+```html
+<div style="background-color: var(--color-bg); padding: 80px 100px; position: relative; min-height: 100vh; display: flex; flex-direction: column; justify-content: center;">
+  <!-- Top-left corner label -->
+  <div style="position: absolute; top: 80px; left: 100px; font-family: var(--font-body); font-size: 13px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: var(--color-ink); line-height: 1.4;">
+    INNOVATING<br>SOLUTIONS FOR A<br>CHANGING WORLD
+  </div>
+  <!-- Top-right corner label -->
+  <div style="position: absolute; top: 80px; right: 100px; font-family: var(--font-body); font-size: 13px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: var(--color-ink); line-height: 1.4; text-align: right;">
+    PRESENTED BY<br>OLIVIA WILSON
+  </div>
+  <!-- The massive red headline -->
+  <h1 style="font-family: var(--font-display); font-size: 240px; font-weight: 400; line-height: 0.88; letter-spacing: -2px; color: var(--color-red); margin: 0; text-transform: uppercase;">
+    PITCH<br>DECK
+  </h1>
+</div>
+```
+
+### Photo Grid with Captions (Team/Portrait Pattern)
+
+Three rectangular portrait cutouts in a horizontal row, each with an ALL CAPS role title and name below, aligned to form a small editorial type-block.
+
+```html
+<div style="padding: 80px 100px; background-color: var(--color-bg);">
+  <!-- Red headline -->
+  <h2 style="font-family: var(--font-display); font-size: 180px; font-weight: 400; line-height: 0.90; letter-spacing: -1.5px; color: var(--color-red); margin: 0 0 32px; text-transform: uppercase;">OUR TEAM</h2>
+  <!-- Red subtitle -->
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: var(--color-red); margin: 0 0 80px; line-height: 1.3;">
+    MARKETING &nbsp; EXPERTS<br>AT YOUR SERVICE
+  </p>
+  <!-- Photo grid -->
+  <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 48px; max-width: 720px;">
+    <!-- Portrait 1 -->
+    <div>
+      <div style="width: 100%; aspect-ratio: 3/4; background-color: var(--color-photo-frame); margin: 0 0 20px; overflow: hidden;">
+        <img src="portrait-1.jpg" style="width: 100%; height: 100%; object-fit: cover; display: block;" alt="">
+      </div>
+      <div style="display: flex; gap: 16px;">
+        <div style="font-family: var(--font-body); font-size: 11px; font-weight: 700; letter-spacing: 1.8px; text-transform: uppercase; color: var(--color-ink); line-height: 1.3;">CHEF<br>MARKETING<br>OFFICER</div>
+        <div style="font-family: var(--font-body); font-size: 11px; font-weight: 500; letter-spacing: 1.8px; text-transform: uppercase; color: var(--color-ink-medium); line-height: 1.3;">OLIVIA<br>WILSON</div>
+      </div>
+    </div>
+    <!-- Portrait 2 -->
+    <div>
+      <div style="width: 100%; aspect-ratio: 3/4; background-color: var(--color-photo-frame); margin: 0 0 20px; overflow: hidden;">
+        <img src="portrait-2.jpg" style="width: 100%; height: 100%; object-fit: cover; display: block;" alt="">
+      </div>
+      <div style="display: flex; gap: 16px;">
+        <div style="font-family: var(--font-body); font-size: 11px; font-weight: 700; letter-spacing: 1.8px; text-transform: uppercase; color: var(--color-ink); line-height: 1.3;">GRAPHIC<br>DESIGN</div>
+        <div style="font-family: var(--font-body); font-size: 11px; font-weight: 500; letter-spacing: 1.8px; text-transform: uppercase; color: var(--color-ink-medium); line-height: 1.3;">RICHARD<br>SANCHEZ</div>
+      </div>
+    </div>
+    <!-- Portrait 3 -->
+    <div>
+      <div style="width: 100%; aspect-ratio: 3/4; background-color: var(--color-photo-frame); margin: 0 0 20px; overflow: hidden;">
+        <img src="portrait-3.jpg" style="width: 100%; height: 100%; object-fit: cover; display: block;" alt="">
+      </div>
+      <div style="display: flex; gap: 16px;">
+        <div style="font-family: var(--font-body); font-size: 11px; font-weight: 700; letter-spacing: 1.8px; text-transform: uppercase; color: var(--color-ink); line-height: 1.3;">DIGITAL<br>MARKETING</div>
+        <div style="font-family: var(--font-body); font-size: 11px; font-weight: 500; letter-spacing: 1.8px; text-transform: uppercase; color: var(--color-ink-medium); line-height: 1.3;">AARON<br>LOEB</div>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+### Bracketed Numbered List Item
+
+The `[1]` `[2]` `[3]` pattern for checklist-style content. Red bracket number at large scale, title and body in espresso.
+
+```html
+<div style="display: flex; gap: 32px; padding: 40px 0; border-bottom: 1px solid var(--color-border-hairline);">
+  <div style="font-family: var(--font-display); font-size: 56px; font-weight: 400; line-height: 1.0; color: var(--color-red); flex-shrink: 0; min-width: 80px;">
+    [1]
+  </div>
+  <div style="flex: 1;">
+    <h3 style="font-family: var(--font-body); font-size: 28px; font-weight: 700; line-height: 1.25; letter-spacing: -0.2px; color: var(--color-ink); margin: 0 0 12px;">Research the Company</h3>
+    <p style="font-family: var(--font-body); font-size: 15px; font-weight: 500; line-height: 1.60; color: var(--color-ink-medium); margin: 0;">Understand the company's mission, values, and recent achievements before walking into the interview room.</p>
+  </div>
+</div>
+```
+
+### Parenthetical Page Number Anchor
+
+The `(05)` red number used as a compositional anchor in negative space, paired with a short body column.
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1.2fr; gap: 60px; align-items: start; padding: 80px 0;">
+  <div style="font-family: var(--font-display); font-size: 140px; font-weight: 400; line-height: 0.90; letter-spacing: -1px; color: var(--color-red);">
+    (05)
+  </div>
+  <div>
+    <p style="font-family: var(--font-body); font-size: 14px; font-weight: 500; line-height: 1.60; color: var(--color-ink-medium); margin: 0; max-width: 280px;">Our team of marketing professionals combines experience and passion to deliver results. From strategists to designers, every team member brings unique skills to the table.</p>
+  </div>
+</div>
+```
+
+### Editorial Photo Block with Caption
+
+A single large photo with an ALL CAPS name label and role below — the Paper-&-Ink magazine treatment.
+
+```html
+<figure style="margin: 0; padding: 0;">
+  <div style="width: 100%; aspect-ratio: 4/5; background-color: var(--color-photo-frame); margin: 0 0 24px; overflow: hidden;">
+    <img src="photo.jpg" style="width: 100%; height: 100%; object-fit: cover; display: block;" alt="">
+  </div>
+  <figcaption style="display: flex; justify-content: space-between; align-items: flex-start;">
+    <div style="font-family: var(--font-body); font-size: 11px; font-weight: 700; letter-spacing: 1.8px; text-transform: uppercase; color: var(--color-ink); line-height: 1.3;">
+      CHIEF<br>MARKETING<br>OFFICER
+    </div>
+    <div style="font-family: var(--font-body); font-size: 11px; font-weight: 500; letter-spacing: 1.8px; text-transform: uppercase; color: var(--color-ink-medium); line-height: 1.3; text-align: right;">
+      OLIVIA<br>WILSON
+    </div>
+  </figcaption>
+</figure>
+```
+
+### Red Subtitle Block
+
+The ALL CAPS red subtitle that appears below a massive red headline to give it editorial context.
+
+```html
+<div style="padding: 24px 0;">
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 700; letter-spacing: 0.5px; text-transform: uppercase; color: var(--color-red); margin: 0; line-height: 1.3;">
+    MARKETING &nbsp; EXPERTS<br>AT YOUR SERVICE
+  </p>
+</div>
+```
+
+### Interview Checklist Cover Pattern
+
+The `[Practical tips for confidence and success]` pattern — massive red headline stacked on three lines, tight bracketed subtitle below, small metadata label and a diagonal line element anchoring the top-right.
+
+```html
+<div style="background-color: var(--color-bg); padding: 80px; position: relative;">
+  <!-- Massive red stacked headline -->
+  <h1 style="font-family: var(--font-display); font-size: 160px; font-weight: 400; line-height: 0.92; letter-spacing: -1px; color: var(--color-red); margin: 0 0 28px; text-transform: none;">
+    Interview<br>Success<br>Checklist
+  </h1>
+  <!-- Bracketed subtitle -->
+  <p style="font-family: var(--font-display); font-size: 36px; font-weight: 400; line-height: 1.0; color: var(--color-ink); margin: 0 0 48px;">
+    [Practical tips for confidence and success]
+  </p>
+  <!-- Small metadata label with marker glyph -->
+  <div style="display: flex; align-items: flex-start; gap: 12px;">
+    <div style="width: 14px; height: 18px; background-color: var(--color-ink); clip-path: polygon(0 0, 100% 0, 100% 100%, 50% 75%, 0 100%); flex-shrink: 0; margin-top: 2px;"></div>
+    <div style="font-family: var(--font-body); font-size: 12px; font-weight: 700; letter-spacing: 1.8px; text-transform: uppercase; color: var(--color-ink); line-height: 1.4;">
+      SAVE THIS FOR<br>YOUR NEXT<br>INTERVIEW
+    </div>
+  </div>
+</div>
+```
+
+### Two-Column Content Block
+
+A simple two-column body layout — red headline on the left, body copy on the right.
+
+```html
+<div style="display: grid; grid-template-columns: 1.1fr 1fr; gap: 80px; align-items: start; padding: 60px 0;">
+  <h2 style="font-family: var(--font-display); font-size: 120px; font-weight: 400; line-height: 0.92; letter-spacing: -1px; color: var(--color-red); margin: 0; text-transform: uppercase;">
+    WHY<br>NOW
+  </h2>
+  <div style="padding-top: 12px;">
+    <h3 style="font-family: var(--font-body); font-size: 20px; font-weight: 700; line-height: 1.30; color: var(--color-ink); margin: 0 0 16px;">The market is shifting.</h3>
+    <p style="font-family: var(--font-body); font-size: 15px; font-weight: 500; line-height: 1.60; color: var(--color-ink-medium); margin: 0;">Every decade, a new medium reshapes who gets to distribute and who gets distributed. Right now, AI is the medium. The companies that act now will define the next generation.</p>
+  </div>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap — between inline icon/bullet and label text.
+- **8px**: Tight gap — within small label blocks and bracket-to-number spacing.
+- **12px**: Small gap — between small uppercase labels and their paired values.
+- **16px**: Base gap — between photo caption role and name columns.
+- **20px**: Caption gap — between photo and its caption block.
+- **24px**: Small section gap — between red headline and its red subtitle.
+- **32px**: Medium gap — between bracketed number and its body content in lists.
+- **48px**: Section gap — between major content blocks; vertical gap between list items; gap between photos in a grid.
+- **60px**: Large gap — column gap in two-column layouts.
+- **80px**: Section padding — outer padding on carousels, infographics, posters; large vertical rhythm between headline and photo grid.
+- **100px**: Wide outer padding — slides format outer padding.
+- **120px**: Story format horizontal padding.
+
+### Format Padding
+
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 80px all sides | 920px |
+| Infographic (1080xN) | 80px left/right, 100px top/bottom | 920px |
+| Slides (1920x1080) | 100px all sides | 1720px |
+| Poster (1080x1350) | 80px left/right, 100px top/bottom | 920px |
+| Story (1080x1920) | 120px left/right, 60px top/bottom | 840px |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned. This style is deeply left-aligned in keeping with editorial magazine layout tradition. Center-aligned composition is rarely used and only for the Massive Red Headline cover pattern when a single phrase (e.g., "OUR TEAM") is the only element on the canvas.
+- **Grid**: Two-column and three-column grids are the norm. Three-column for photo grids with captions, two-column for red-headline-left / body-right compositions.
+- **Corner labels**: Small tracked uppercase labels are anchored to the corners of the canvas via `position: absolute` with identical insets (typically 80px from top and side).
+- **Vertical rhythm**: The dominant rhythm is: generous top whitespace → massive red headline → short pause → red subtitle or bracketed subtitle → large gap → photo grid or body content.
+- **Content gravity**: On wide formats (slides, carousel), content pulls to the left edge. On tall formats (poster, story), content stacks vertically with the red headline anchoring the top third.
+- **Whitespace as divider**: The preferred separator between content blocks is whitespace, not a rule line. Reach for 48–80px of vertical air instead of a border.
+- **Photo aspect ratios**: Portrait photos use 3:4. Hero photos use 4:5. Landscape photos use 3:2. Rectangles with hard corners only — never rounded.
+
+## 6. Depth & Elevation
+
+Magazine Red is a flat style. It derives its visual energy from type scale and color contrast, not from shadows or elevation tricks. The entire elevation system is intentionally minimal.
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, cream background | The default — everything lives here |
+| Photo (Level 1) | No shadow, rectangular cutout on cream | Photo blocks sit flush with the canvas |
+| Inset (Level 2) | `background: #ECE6D6`, no shadow | Rare inset zones when surface differentiation is needed |
+| Photo Lift (Level 3) | `0 2px 12px rgba(43, 33, 25, 0.10)` | Maximum elevation — reserved for a single featured photo per composition |
+| — | — | — |
+
+### Border Treatments
+- **No-border default**: Cards, photos, and containers have no borders. Their edges are defined by whitespace and the implicit rectangle of their content.
+- **Hairline rule**: `1px solid rgba(43, 33, 25, 0.15)` — used only to separate list items in bracketed numbered lists. Never on container edges.
+- **Full rule**: `1px solid #2B2119` — used only for the rare full-width editorial divider between major sections. Avoid when possible; prefer whitespace.
+- **No rounded corners anywhere**: Border-radius is always `0`. Photo cutouts are strict rectangles. The one exception is the occasional illustrative shape that references a pinned-paper corner, but this is rare.
+
+### Surface Hierarchy
+The cream background is the stage, and the hierarchy comes from three levers only:
+1. **Type scale** — massive red display vs. small espresso body creates a 10× contrast that establishes order without any structural help.
+2. **Color** — red signals "this matters most"; espresso is the reading layer; cream is the quiet substrate.
+3. **Whitespace** — generous air around the headline makes the headline feel important; tight clustering around captions makes captions feel like supporting cast.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use Anton (or Oswald 700) for every display headline in tomato red (`#C33A1F`), ALL CAPS, sized at 180–240px to nearly fill the frame width — this is the style's defining gesture.
+- Use the warm cream background (`#F2EEE2`) as the canvas for every format — this is what makes the style read as editorial, not tech.
+- Use bracketed numbers `[1]` `[2]` `[3]` in red Anton at 56px as list markers for numbered content.
+- Use parenthetical page numbers like `(05)` in red Anton at 120–140px as compositional anchors in negative space.
+- Use small tracked uppercase labels (13px Inter 600, 2px letter-spacing) for corner metadata — "PRESENTED BY", "INNOVATING SOLUTIONS".
+- Use rectangular photo cutouts with hard corners and ALL CAPS caption blocks showing role + name in two columns.
+- Use generous asymmetric whitespace above headlines — never crowd the top edge.
+- Use Inter for every non-headline element — body, captions, labels, metadata.
+- Use espresso brown-black (`#2B2119`) for body text — it reads warmer than pure black against the cream.
+- Use negative letter-spacing (-1px to -2px) on all Anton display headlines for tight, architectural line reads.
+- Use line-height 0.88–0.94 on display headlines so stacked lines kiss each other.
+- Use left-alignment as the default for all content compositions.
+
+### Don't
+- Don't use pure white (`#ffffff`) as a background — the cream (`#F2EEE2`) is the identity. Pure white destroys the editorial feel.
+- Don't use pure black (`#000000`) for text — use espresso (`#2B2119`) for the warm editorial read.
+- Don't use rounded corners anywhere — photos, containers, dividers are all strict rectangles with `border-radius: 0`.
+- Don't use red for body text, captions, or any long-form reading content — red is reserved for display headlines, bracketed numbers, parenthetical numbers, and the occasional short red subtitle.
+- Don't use drop shadows on containers or cards — this style is flat.
+- Don't use decorative elements beyond brackets, parentheses, and the optional ALL CAPS labels — no icons, no illustrations, no dot grids, no gradients.
+- Don't use a second accent color — the palette is red, espresso, and cream. No blues, no yellows, no greens.
+- Don't use small display headlines — if the headline is under 120px, it is not doing its job. Scale it up or rethink the composition.
+- Don't mix cases in display headlines — they are always ALL CAPS (the one Interview Checklist variant uses sentence case but still at massive scale). Red is never set in lowercase body scale.
+- Don't use serif type for body — Inter is the only body typeface in this style.
+- Don't center-align body content — left-alignment is the rule. Center alignment is reserved for single-word cover compositions only.
+- Don't use borders on containers — whitespace is the separator, not a box.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale down**: Massive Hero becomes 180px (from 240px). Display Hero becomes 140px. Display Large stays at 120px. Body stays at 15px.
+- **Padding**: 80px on all sides. Content area is 920x920px.
+- **Cover slide**: Massive red Anton headline in ALL CAPS, stacked on two lines to nearly fill the 920px content width. Tracked corner labels in top-left and top-right (13px, 2px letter-spacing). Generous top whitespace (at least 140px before headline begins). No photo on cover — the headline is the art.
+- **Team/Photo slide**: Red headline top-left (e.g., "OUR TEAM" at 140px). Red subtitle below in 16px Inter 700 uppercase. Three portrait cutouts in a row below, each with ALL CAPS role/name caption. Optional `(05)` anchor in the far right column.
+- **Bracketed list slide**: Each `[1]` bracket at 56px red, with 28px Inter 700 heading and 15px body text beside it. Items separated by 48px vertical gaps and hairline dividers.
+- **Swipe indicator**: Small tracked uppercase page number in the bottom-right corner (e.g., "01 / 07" at 11px Inter 600, 1.8px tracking, espresso color).
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Massive Hero at 200px for the cover section. Display Hero at 160px for section dividers. Body copy at 15–16px.
+- **Padding**: 80px left/right. 100px top/bottom margins.
+- **Section spacing**: 80–100px vertical gap between sections. Dividers are always whitespace, never rules.
+- **Vertical rhythm**: Red display headline → red subtitle → photo or data block → bracketed numbered list → next red headline. Alternate between single-column body passages and multi-column photo/caption grids.
+- **Footer**: Small tracked uppercase byline and URL (11px Inter 600, 1.8px tracking) centered or left-aligned at the bottom, separated from the last section by 80px.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Massive Hero becomes 280px (from 240px). Display Hero becomes 220px. Display Large becomes 160px. Body Large becomes 22px. Body at 17px.
+- **Padding**: 100px on all sides. Content area is 1720x880px.
+- **Cover slides**: Massive red Anton headline left-aligned, filling roughly 70–80% of the horizontal width. Corner labels at top-left and top-right. Generous whitespace in the bottom-right where a `(05)` page anchor can sit.
+- **Content slides**: Two-column layout. Red headline on the left (120–160px), body content on the right (15–18px Inter). Left column anchors the composition; right column breathes.
+- **Team slides**: Red headline top-left, three or four portrait cutouts in a horizontal row below with ALL CAPS caption blocks. A single red `(05)` in the right sidebar as the compositional anchor.
+- **Section divider slides**: Single massive red headline on a cream background, centered horizontally, with no body content. Pure type as art.
+
+### Poster (1080x1350px)
+- **Typography**: Massive Hero at 200px. Display Hero at 160px. Body at 16px.
+- **Padding**: 80px left/right, 100px top/bottom.
+- **Composition**: Top third is the red display headline and bracketed or red subtitle. Middle third is a hero photo or bracketed numbered list. Bottom third is body content and the small tracked metadata label.
+- **Vertical flow**: Headline → subtitle → breathing room (80px) → photo or list → breathing room (60px) → body text → metadata label at bottom.
+- **CTA placement**: Small tracked uppercase label at the bottom-left, paired with a simple URL — no pill buttons, no rounded CTAs.
+
+### Story (1080x1920px)
+- **Typography**: Massive Hero becomes 240px for the hero headline (this is the "hero ~30% bigger" treatment for Story format — taller canvas demands larger display type to hold the proportion). Display Hero at 180px. Body at 17px. Bracket numbers at 64px.
+- **Padding**: 120px left/right, 60px top/bottom. Content area is 840x1800px.
+- **Composition**: The tall canvas splits naturally into three vertical zones. Top zone (640px tall): tracked corner labels and the massive red headline. Middle zone (640px tall): a single large portrait cutout (4:5 ratio) or a bracketed numbered list. Bottom zone (640px tall): body copy, red subtitle, and a tracked metadata label at the footer.
+- **Hero headline**: The hero red headline is set ~30% larger than in Carousel format — if Carousel uses 180px, Story uses 240px. The headline is anchored at the top zone (60px from the top) and left-aligned within the 840px content width.
+- **Photo treatment**: Story format benefits from one large 4:5 portrait cutout in the middle zone, 720px tall, extending nearly edge-to-edge within the 840px content width, with an ALL CAPS caption block directly below.
+- **Footer bar**: At the bottom of the canvas (60px from the bottom edge), a small tracked uppercase label — "SWIPE UP" or "@HANDLE" — in 13px Inter 600 with 2px letter-spacing, left-aligned. Optional `(01)` page anchor on the right.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Cream Paper | `#F2EEE2` | Primary background — warm off-white |
+| Tomato Red | `#C33A1F` | Display headlines, bracketed numbers, parenthetical numbers |
+| Espresso Black | `#2B2119` | Primary body text, labels, captions |
+| Ink Medium | `#4A3E33` | Secondary text, descriptive body copy |
+| Ink Light | `#7A6B5C` | Tertiary text, photo credits, quiet metadata |
+| Brick Red | `#A82E17` | Hover/active red, deeper accent variant |
+| Rust Red | `#B83327` | Alternative display red — deeper tone |
+| Cream Deep | `#ECE6D6` | Subtle inset background |
+| Paper Fold | `#E4DCC8` | Photo frame background |
+| Border Hairline | `rgba(43,33,25,0.15)` | Thin rule between list items |
+| Ink Mute | `rgba(43,33,25,0.45)` | Page numbers, watermarks |
+
+### Font Declarations
+
+```css
+/* Display (massive red headlines and bracketed numbers only) */
+font-family: 'Anton', 'Oswald', 'Bebas Neue', Impact, sans-serif;
+
+/* Body (everything else) */
+font-family: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Anton&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-bg: #F2EEE2;
+  --color-red: #C33A1F;
+  --color-ink: #2B2119;
+
+  /* Colors -- Accent */
+  --color-red-brick: #A82E17;
+  --color-red-rust: #B83327;
+
+  /* Colors -- Neutral Scale */
+  --color-cream-deep: #ECE6D6;
+  --color-photo-frame: #E4DCC8;
+  --color-ink-medium: #4A3E33;
+  --color-ink-light: #7A6B5C;
+  --color-ink-mute: rgba(43, 33, 25, 0.45);
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: #F2EEE2;
+  --color-surface-inset: #ECE6D6;
+  --color-surface-photo: #E4DCC8;
+
+  /* Colors -- Borders */
+  --color-border-hairline: rgba(43, 33, 25, 0.15);
+  --color-border-rule: #2B2119;
+
+  /* Colors -- Shadows */
+  --shadow-none: none;
+  --shadow-paper: 0 1px 2px rgba(43, 33, 25, 0.08);
+  --shadow-photo: 0 2px 12px rgba(43, 33, 25, 0.10);
+
+  /* Typography -- Families */
+  --font-display: 'Anton', 'Oswald', 'Bebas Neue', Impact, sans-serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-massive-hero: 240px;
+  --text-display-hero: 180px;
+  --text-display-large: 120px;
+  --text-display-medium: 88px;
+  --text-big-number: 140px;
+  --text-bracket-number: 56px;
+  --text-h1: 28px;
+  --text-h2: 20px;
+  --text-body-large: 18px;
+  --text-body: 15px;
+  --text-body-small: 13px;
+  --text-subtitle-red: 16px;
+  --text-label-caps: 13px;
+  --text-label-caps-small: 11px;
+
+  /* Typography -- Weights */
+  --weight-display: 400;
+  --weight-heading: 700;
+  --weight-body: 500;
+  --weight-label: 600;
+  --weight-label-strong: 700;
+
+  /* Typography -- Line Heights */
+  --leading-massive: 0.88;
+  --leading-display: 0.90;
+  --leading-display-large: 0.92;
+  --leading-display-medium: 0.94;
+  --leading-heading: 1.25;
+  --leading-body: 1.60;
+  --leading-label: 1.30;
+
+  /* Typography -- Letter Spacing */
+  --tracking-massive: -2px;
+  --tracking-display: -1.5px;
+  --tracking-display-large: -1px;
+  --tracking-heading: -0.2px;
+  --tracking-label: 2px;
+  --tracking-label-small: 1.8px;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-caption: 20px;
+  --space-headline-sub: 24px;
+  --space-list-gap: 32px;
+  --space-section: 48px;
+  --space-column: 60px;
+  --space-outer: 80px;
+  --space-wide: 100px;
+  --space-story: 120px;
+
+  /* Borders */
+  --radius-none: 0;
+  --border-hairline: 1px solid rgba(43, 33, 25, 0.15);
+  --border-rule: 1px solid #2B2119;
+}
+```
+
+### System Font Fallbacks
+- **Display (if Anton fails to load):** `'Oswald', 'Bebas Neue', Impact, 'Arial Narrow Bold', sans-serif`
+- **Body (if Inter fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/_full/masked-object-editorial.md
+++ b/skills/composites/goose-graphics/styles/_full/masked-object-editorial.md
@@ -1,0 +1,699 @@
+# Design Style: Masked Object Editorial
+
+## 1. Visual Theme & Atmosphere
+
+Masked Object Editorial is the design language of the modern premium consumer brand poster -- the visual equivalent of a magazine centerfold ad for a boutique wine, a craft spirit, a cold-pressed juice, or an artisan chocolate bar. The style draws from mid-century editorial advertising (think Bonnie Cashin-era Saks campaigns, vintage Italian vermouth posters, and contemporary brands like Haus, Ghia, and Flamingo Estate), but it runs on a single signature move that sets it apart from every other editorial style: the hero image is not a rectangle. It is a photograph clipped into the silhouette of the product itself -- a wine glass filled with grapes, a bottle filled with botanicals, a cocktail coupe filled with citrus. The surrounding canvas is a rich, saturated royal navy that makes the masked photograph read like a stained-glass window set into a velvet wall.
+
+The typography pairing is classic editorial tension: an italic transitional serif display face (Playfair Display Italic) set in pale cream against the navy, paired with a crisp modern sans (Inter) in pure white for body copy. The italic serif is the romance -- it carries the poetic headline ("From Grape to Glass", "From Garden to Glass", "From Bean to Bar") across two lines with generous descenders and calligraphic flourishes. The sans is the grounding -- three short declarative lines stacked in a right-hand column, each a single sentence, each ending in a period. The composition is intentionally asymmetric: the masked object occupies the left half, the headline and stacked body copy fill the right half, and a light powder blue footer band runs edge-to-edge along the bottom carrying the single call-to-action label in navy sans. The footer band is the only horizontal element on the entire canvas -- it anchors the composition the way a baseline anchors a page of type.
+
+The palette is restrained to four values: deep royal navy as the dominant surface, pale cream for the serif headline, pure white for body copy, and a light powder blue for the footer band. Nothing else. This restraint is load-bearing -- the style only works when the masked photograph carries all the color variance and the typography stays chromatically quiet. The effect is deliberate, poised, and slightly theatrical -- a brand that knows exactly what it is and has the confidence to tell you in three short lines.
+
+**Key Characteristics:**
+- Deep royal navy background (`#112A70`) as the dominant surface -- rich, saturated, never black
+- Pale cream (`#F5F0E6`) for the italic serif display headline -- warm, paper-like, never pure white
+- Pure white (`#FFFFFF`) for stacked sans body copy -- crisp and high-contrast
+- Light powder blue (`#B8D4E8`) for the full-width footer CTA band -- the only horizontal anchor
+- Playfair Display **italic** for headlines at 60-72px -- always italic, never upright
+- Inter 400-600 for stacked body copy and footer CTA -- short declarative lines, one per row
+- Photograph clipped into object silhouette as the hero -- the signature move, non-negotiable
+- Asymmetric half-and-half composition -- masked object left, headline + body right
+- Three-line body stack -- always 3 lines, always short declaratives, always period-terminated
+- No rectangular photo frames, no rounded-corner photo frames -- photos must be masked to shape
+- No drop shadows, no gradients, no decorative elements -- the mask is the entire visual interest
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Royal Navy** (`#112A70`): Primary background. A deep, saturated royal blue with just enough warmth to feel expensive rather than corporate. Runs edge-to-edge on every slide except the footer band.
+- **Pale Cream** (`#F5F0E6`): Primary display headline color. A warm off-white that reads as "vintage paper" against navy. Never pure white -- the warmth is what makes the italic serif feel editorial.
+- **Pure White** (`#FFFFFF`): Body copy color. Used only for the stacked Inter body copy on navy. The tonal split between cream headlines and white body is intentional and load-bearing.
+
+### Accent
+- **Powder Blue** (`#B8D4E8`): Footer band fill. A pale desaturated blue that reads as "sky" against the deep navy. Used exclusively for the full-width horizontal footer band at the bottom of every slide.
+- **Navy on Powder** (`#112A70`): Footer CTA text color. The same navy used for the background, dropped into the powder blue footer band to create a subtle recessive contrast.
+- **Deep Navy Shadow** (`#0A1F55`): Optional darker navy for recessed or inset areas. Rarely used -- only when a card needs to recede from the main navy surface.
+
+### Neutral Scale
+- **Cream Strong** (`#F5F0E6`): Same as display headline color -- the warmest neutral.
+- **Cream Soft** (`rgba(245, 240, 230, 0.75)`): Semi-transparent cream for secondary metadata and attributions.
+- **White Strong** (`#FFFFFF`): Pure white for body copy.
+- **White Muted** (`rgba(255, 255, 255, 0.65)`): Reduced-opacity white for captions and small type.
+- **Powder Text** (`rgba(17, 42, 112, 0.85)`): Navy text inside the footer band at slightly reduced opacity for secondary labels.
+- **Metadata Muted** (`rgba(245, 240, 230, 0.4)`): Low-priority labels, slide numbers, watermarks.
+
+### Surface & Borders
+- **Surface Primary** (`#112A70`): The navy canvas. There are no layered surfaces in this style -- the canvas is the only surface.
+- **Surface Footer** (`#B8D4E8`): The powder blue footer band -- the only other surface.
+- **Border Hairline** (`rgba(245, 240, 230, 0.18)`): Optional thin cream hairline for dividing sections within a slide. Used sparingly.
+- **Border Footer Top** (`rgba(17, 42, 112, 0.08)`): Optional 1px top edge on the footer band for a subtle inset. Usually omitted.
+
+### Shadow Colors
+The masked-object style uses essentially no shadows. The masked photograph is the entire depth cue. When shadow is absolutely needed (e.g., a CTA button inside the footer), use these:
+- **Shadow Subtle** (`rgba(10, 31, 85, 0.25)`): Barely-there navy shadow under the footer band.
+- **Shadow Medium** (`rgba(10, 31, 85, 0.40)`): Soft navy shadow for elevated CTA buttons.
+- **Shadow Deep** (`rgba(10, 31, 85, 0.55)`): Reserved for exceptional emphasis -- rarely used.
+
+### Texture
+No dot grids, no noise, no gradients. The navy surface is flat and uniform. The masked photograph supplies all of the visual texture on every slide.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400;1,500;1,600;1,700;1,800&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Playfair Display', Georgia, 'Times New Roman', serif`
+- **Body**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Style | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------|-------------|----------------|-------|
+| Display Hero | Playfair Display | 72px | 700 | **italic** | 1.05 | -0.5px | The signature headline. Always italic. Pale cream on navy. |
+| Display Large | Playfair Display | 60px | 700 | **italic** | 1.08 | -0.5px | Carousel hero headline. Always italic. |
+| Section Heading | Playfair Display | 48px | 700 | **italic** | 1.10 | -0.25px | Secondary headlines. Always italic. |
+| Sub-heading | Playfair Display | 36px | 600 | **italic** | 1.15 | 0px | Card titles, secondary emphasis. |
+| Body Large | Inter | 28px | 500 | normal | 1.30 | 0px | The stacked body copy -- 3 short declarative lines. |
+| Body | Inter | 22px | 500 | normal | 1.40 | 0px | Standard body for denser content slides. |
+| Body Small | Inter | 18px | 400 | normal | 1.50 | 0px | Metadata, descriptions, captions. |
+| Big Numbers | Playfair Display | 96px | 800 | **italic** | 1.00 | -1px | Statistics and key metrics. Always italic. |
+| Footer CTA | Inter | 22px | 600 | normal | 1.00 | 0.2px | Footer band text. Navy on powder blue. |
+| Small Caps Label | Inter | 13px | 600 | normal | 1.00 | 1.5px | Uppercase labels for metadata, never for body. |
+
+### Principles
+- **Italic-only display type**: This is the absolute rule of the style. Playfair Display is *only* used in italic. Upright Playfair is forbidden -- it loses the calligraphic romance that defines the look. If you catch yourself setting headline type upright, stop and italicize.
+- **Cream headlines, white body**: The tonal split between pale cream (`#F5F0E6`) for serif display and pure white (`#FFFFFF`) for sans body is a micro-detail that reads subconsciously as "designed by someone who cares." Do not collapse both to white.
+- **Three-line body stack**: Body copy is always 3 short declarative lines, each terminating in a period, each on its own line. "Real fruit. Real process. Real wine." This rhythm is the sans-serif counterpart to the italic headline's romance.
+- **Descender drama**: Playfair Display italic has long, curled descenders (especially on `f`, `g`, `p`, `y`). Give the headline generous line-height (1.05-1.15) so descenders do not collide with ascenders on the next line -- but not so much that the headline feels airy. The descenders should almost-but-not-quite kiss the next line.
+- **Short headlines only**: The display headline is 3-6 words maximum, ideally set over 2 lines. "From Grape to Glass." "Crafted for the Curious." "A Quiet Kind of Luxury." Longer than 6 words and the romance breaks.
+- **No ALL CAPS headlines**: This style is mixed case only for headlines. Uppercase is reserved for the rare small-caps label (13px Inter 600 with 1.5px letter-spacing). The italic serif in caps looks like a wedding invitation, not a poster.
+
+## 4. Component Patterns
+
+### Photo-Masked-To-Shape Hero (SIGNATURE)
+
+This is the defining move of the style. A photograph is clipped into the silhouette of an object -- a wine glass, a bottle, a coupe, a leaf, a product -- so that the image fills only the interior of the shape and the navy canvas shows through everywhere else. Two approaches are supported: CSS `mask-image` and SVG `<clipPath>`. Both are production-safe. Use whichever fits your rendering pipeline.
+
+**Approach 1 -- CSS `mask-image` with inline SVG:**
+
+```html
+<div style="
+  width: 360px;
+  height: 560px;
+  background-image: url('https://example.com/yellow-grapes.jpg');
+  background-size: cover;
+  background-position: center;
+  mask-image: url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 200 320%22><path d=%22M60 10 L140 10 Q150 10 150 20 L150 90 Q150 160 115 180 L115 280 L145 290 L145 310 L55 310 L55 290 L85 280 L85 180 Q50 160 50 90 L50 20 Q50 10 60 10 Z%22 fill=%22black%22/></svg>');
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 200 320%22><path d=%22M60 10 L140 10 Q150 10 150 20 L150 90 Q150 160 115 180 L115 280 L145 290 L145 310 L55 310 L55 290 L85 280 L85 180 Q50 160 50 90 L50 20 Q50 10 60 10 Z%22 fill=%22black%22/></svg>');
+  mask-repeat: no-repeat;
+  -webkit-mask-repeat: no-repeat;
+  mask-size: contain;
+  -webkit-mask-size: contain;
+  mask-position: center;
+  -webkit-mask-position: center;
+"></div>
+```
+
+**Approach 2 -- Inline SVG with `<clipPath>`:**
+
+```html
+<svg width="360" height="560" viewBox="0 0 200 320" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <clipPath id="wineglass-silhouette">
+      <path d="M60 10 L140 10 Q150 10 150 20 L150 90 Q150 160 115 180 L115 280 L145 290 L145 310 L55 310 L55 290 L85 280 L85 180 Q50 160 50 90 L50 20 Q50 10 60 10 Z" />
+    </clipPath>
+  </defs>
+  <image
+    href="https://example.com/yellow-grapes.jpg"
+    xlink:href="https://example.com/yellow-grapes.jpg"
+    x="0" y="0" width="200" height="320"
+    preserveAspectRatio="xMidYMid slice"
+    clip-path="url(#wineglass-silhouette)"
+  />
+</svg>
+```
+
+**Swapping the silhouette:** the `<path d="...">` value is the entire creative lever. Replace it with any SVG silhouette to switch from a wine glass to a bottle, a coupe glass, a leaf, a coffee cup, a hand, a fruit, a product render, or a logo mark. Export any shape from Figma/Illustrator as an SVG path and paste it in. The mask will clip any image to that silhouette automatically. Suggested silhouettes:
+- `wineglass` -- for wine, vermouth, champagne brands
+- `bottle` -- for spirits, sauces, beverages, beauty products
+- `coupe` or `cocktail-glass` -- for cocktails, non-alcoholic spirits
+- `leaf` or `botanical` -- for tea, CBD, herbal products
+- `hand` or `silhouette-bust` -- for fashion, beauty, lifestyle
+- `letterform` -- a large italic serif character clipped with a photo inside for typographic posters
+
+### Italic Serif Display Headline
+
+The defining typographic move. Playfair Display Italic, 60-72px, pale cream, always over 2 lines, always mixed case, always 3-6 words.
+
+```html
+<h1 style="
+  font-family: 'Playfair Display', Georgia, serif;
+  font-style: italic;
+  font-weight: 700;
+  font-size: 72px;
+  line-height: 1.05;
+  letter-spacing: -0.5px;
+  color: #F5F0E6;
+  margin: 0;
+">From Grape<br>to Glass</h1>
+```
+
+### Stacked Body Copy (3-Line Declarative)
+
+The sans-serif counterpart to the headline. Three short sentences, one per line, each terminated by a period, each at Inter 500 28px white on navy. Always exactly 3 lines -- not 2, not 4.
+
+```html
+<div style="
+  font-family: 'Inter', -apple-system, Helvetica, sans-serif;
+  font-size: 28px;
+  font-weight: 500;
+  line-height: 1.30;
+  color: #FFFFFF;
+">
+  <p style="margin: 0;">Real fruit.</p>
+  <p style="margin: 0;">Real process.</p>
+  <p style="margin: 0;">Real wine.</p>
+</div>
+```
+
+### Footer CTA Band
+
+Full-width horizontal band at the bottom of the slide, filled in powder blue (`#B8D4E8`), with the CTA label in navy Inter 600 centered or right-aligned inside. The band is the only non-navy horizontal element on the canvas and anchors the composition.
+
+```html
+<div style="
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: #B8D4E8;
+  padding: 32px 60px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+">
+  <span style="
+    font-family: 'Inter', -apple-system, Helvetica, sans-serif;
+    font-size: 22px;
+    font-weight: 600;
+    letter-spacing: 0.2px;
+    color: #112A70;
+  ">Shop Wildroot Wines</span>
+</div>
+```
+
+### Full Hero Slide Composition (Signature Layout)
+
+The canonical composition: masked photograph on the left, italic headline top-right, 3-line stacked body copy below-right, footer band edge-to-edge along the bottom.
+
+```html
+<div style="
+  position: relative;
+  width: 1080px;
+  height: 1080px;
+  background: #112A70;
+  overflow: hidden;
+  font-family: 'Inter', -apple-system, Helvetica, sans-serif;
+">
+  <!-- Masked photograph (left half) -->
+  <div style="
+    position: absolute;
+    left: 80px;
+    top: 200px;
+    width: 380px;
+    height: 640px;
+    background-image: url('https://example.com/yellow-grapes.jpg');
+    background-size: cover;
+    background-position: center;
+    mask-image: url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 200 320%22><path d=%22M60 10 L140 10 Q150 10 150 20 L150 90 Q150 160 115 180 L115 280 L145 290 L145 310 L55 310 L55 290 L85 280 L85 180 Q50 160 50 90 L50 20 Q50 10 60 10 Z%22 fill=%22black%22/></svg>');
+    -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 200 320%22><path d=%22M60 10 L140 10 Q150 10 150 20 L150 90 Q150 160 115 180 L115 280 L145 290 L145 310 L55 310 L55 290 L85 280 L85 180 Q50 160 50 90 L50 20 Q50 10 60 10 Z%22 fill=%22black%22/></svg>');
+    mask-repeat: no-repeat;
+    -webkit-mask-repeat: no-repeat;
+    mask-size: contain;
+    -webkit-mask-size: contain;
+    mask-position: center;
+    -webkit-mask-position: center;
+  "></div>
+
+  <!-- Italic headline (top right) -->
+  <h1 style="
+    position: absolute;
+    right: 80px;
+    top: 80px;
+    max-width: 520px;
+    font-family: 'Playfair Display', Georgia, serif;
+    font-style: italic;
+    font-weight: 700;
+    font-size: 72px;
+    line-height: 1.05;
+    letter-spacing: -0.5px;
+    color: #F5F0E6;
+    text-align: right;
+    margin: 0;
+  ">From Grape<br>to Glass</h1>
+
+  <!-- Stacked body copy (below headline, right) -->
+  <div style="
+    position: absolute;
+    right: 80px;
+    top: 460px;
+    max-width: 480px;
+    font-family: 'Inter', -apple-system, Helvetica, sans-serif;
+    font-size: 28px;
+    font-weight: 500;
+    line-height: 1.30;
+    color: #FFFFFF;
+    text-align: right;
+  ">
+    <p style="margin: 0;">Real fruit.</p>
+    <p style="margin: 0;">Real process.</p>
+    <p style="margin: 0;">Real wine.</p>
+  </div>
+
+  <!-- Footer CTA band (edge-to-edge bottom) -->
+  <div style="
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: #B8D4E8;
+    padding: 32px 80px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  ">
+    <span style="
+      font-family: 'Inter', -apple-system, Helvetica, sans-serif;
+      font-size: 22px;
+      font-weight: 600;
+      letter-spacing: 0.2px;
+      color: #112A70;
+    ">Shop Wildroot Wines</span>
+  </div>
+</div>
+```
+
+### Numbered Step Block
+
+For multi-slide carousels where a step or number is called out. The italic serif number is the visual anchor, the sans body explains.
+
+```html
+<div>
+  <p style="
+    font-family: 'Playfair Display', Georgia, serif;
+    font-style: italic;
+    font-weight: 800;
+    font-size: 96px;
+    line-height: 1.00;
+    letter-spacing: -1px;
+    color: #F5F0E6;
+    margin: 0 0 16px;
+  ">01</p>
+  <p style="
+    font-family: 'Inter', -apple-system, Helvetica, sans-serif;
+    font-size: 22px;
+    font-weight: 500;
+    line-height: 1.40;
+    color: #FFFFFF;
+    margin: 0;
+  ">Hand-pick the grapes.<br>Only the ripest clusters.<br>One vineyard. One season.</p>
+</div>
+```
+
+### Pull Quote (Italic-on-Italic)
+
+A large italic pullquote in pale cream, attributed in small-caps Inter below. No quotation marks -- the italic carries the attribution weight.
+
+```html
+<figure style="margin: 0;">
+  <p style="
+    font-family: 'Playfair Display', Georgia, serif;
+    font-style: italic;
+    font-weight: 500;
+    font-size: 48px;
+    line-height: 1.20;
+    color: #F5F0E6;
+    margin: 0 0 24px;
+  ">Wine is sunlight, held together by water.</p>
+  <figcaption style="
+    font-family: 'Inter', -apple-system, Helvetica, sans-serif;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: rgba(245, 240, 230, 0.75);
+    margin: 0;
+  ">GALILEO GALILEI</figcaption>
+</figure>
+```
+
+### Split Content Slide
+
+Half-and-half layout for content slides: masked object on one side, sans body copy with a small italic serif sub-heading on the other.
+
+```html
+<div style="
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 60px;
+  align-items: center;
+  padding: 80px;
+  background: #112A70;
+">
+  <!-- Masked object column -->
+  <div style="
+    width: 100%;
+    aspect-ratio: 1 / 1.5;
+    background-image: url('https://example.com/product.jpg');
+    background-size: cover;
+    mask-image: url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 200 320%22><path d=%22M60 10 L140 10 Q150 10 150 20 L150 90 Q150 160 115 180 L115 280 L145 290 L145 310 L55 310 L55 290 L85 280 L85 180 Q50 160 50 90 L50 20 Q50 10 60 10 Z%22 fill=%22black%22/></svg>');
+    -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 200 320%22><path d=%22M60 10 L140 10 Q150 10 150 20 L150 90 Q150 160 115 180 L115 280 L145 290 L145 310 L55 310 L55 290 L85 280 L85 180 Q50 160 50 90 L50 20 Q50 10 60 10 Z%22 fill=%22black%22/></svg>');
+    mask-repeat: no-repeat;
+    -webkit-mask-repeat: no-repeat;
+    mask-size: contain;
+    -webkit-mask-size: contain;
+  "></div>
+
+  <!-- Text column -->
+  <div>
+    <h2 style="
+      font-family: 'Playfair Display', Georgia, serif;
+      font-style: italic;
+      font-weight: 700;
+      font-size: 48px;
+      line-height: 1.10;
+      color: #F5F0E6;
+      margin: 0 0 32px;
+    ">Every bottle,<br>a story.</h2>
+    <div style="
+      font-family: 'Inter', -apple-system, Helvetica, sans-serif;
+      font-size: 22px;
+      font-weight: 500;
+      line-height: 1.40;
+      color: #FFFFFF;
+    ">
+      <p style="margin: 0;">Grown in Sonoma.</p>
+      <p style="margin: 0;">Pressed by hand.</p>
+      <p style="margin: 0;">Bottled at the estate.</p>
+    </div>
+  </div>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between stacked small labels.
+- **8px**: Tight gap -- between period-terminated lines in dense body stacks.
+- **16px**: Base gap -- between body lines at standard density.
+- **24px**: Small gap -- between a sub-heading and its body stack.
+- **32px**: Medium gap -- between the masked object edge and its caption.
+- **48px**: Section internal -- between the italic headline and the body stack.
+- **60px**: Standard outer padding -- most slide margins.
+- **80px**: Generous outer padding -- poster and slide margins, hero headline insets.
+- **120px**: Maximum top/bottom for Story format -- safe zone for platform UI.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 80px all sides | 920px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 100px all sides | 1720px |
+| Poster (1080x1350) | 80px left/right, 100px top/bottom | 920px |
+| Story (1080x1920) | 60px left/right, 120px top/bottom | 960px |
+
+### Alignment & Grid
+- **Primary alignment**: Asymmetric half-and-half. Masked object occupies one side (usually left), typography stack occupies the other. Content is right-aligned when the object is on the left, and vice-versa.
+- **Vertical anchor**: The footer band sits edge-to-edge at the absolute bottom of every slide, 72-96px tall depending on format. This is the one constant layout element.
+- **Headline placement**: The italic headline starts at the top of the type column, aligned to the top of the masked object (or slightly above it for drama).
+- **Body stack placement**: The 3-line body copy sits below the headline with 48-80px of breathing room, never collided with the headline.
+- **Grid column proportions**: When split 50/50, use equal columns. When the masked object is the star, use 45/55 (object/text) to give the type room to breathe.
+- **Content gravity**: On 1080x1080 the visual center of gravity is slightly high -- headlines sit in the top third, masked object spans middle, footer band anchors bottom. Do not center content vertically.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, flat `#112A70` navy | Canvas -- the default for every slide |
+| Mask-Only (Level 1) | No shadow, just the CSS/SVG mask revealing the photo | The signature hero visual -- depth from the mask itself |
+| Subtle (Level 2) | `0 2px 8px rgba(10, 31, 85, 0.25)` | Footer band top edge (optional) |
+| Elevated (Level 3) | `0 8px 24px rgba(10, 31, 85, 0.40)` | CTA buttons inside the footer band (rare) |
+| Overlay (Level 4) | `0 16px 40px rgba(10, 31, 85, 0.55)` | Reserved -- essentially unused in this style |
+
+### Border Treatments
+- **No borders on the canvas**: The style deliberately has no card borders, no bordered photo frames, no ruled dividers. The navy canvas and the masked photograph do all the structural work.
+- **Hairline divider (optional, rare)**: `1px solid rgba(245, 240, 230, 0.18)` -- only used to separate metadata blocks in dense content slides.
+- **Footer band top edge (optional)**: `1px solid rgba(17, 42, 112, 0.08)` -- an almost-invisible inset line along the top of the powder blue footer band. Usually omitted.
+- **Mask edges**: The edge of a masked photograph is its silhouette -- no stroke, no outline, no feathering. The silhouette meets the navy cleanly.
+
+### Surface Hierarchy
+On a navy canvas with a single accent band, elevation is communicated through three layers:
+1. **Navy canvas** (`#112A70`) -- the base. Every slide starts here.
+2. **Masked photograph** -- the hero visual. Depth comes from the image's internal tonal range, not from any shadow or border.
+3. **Powder blue footer band** (`#B8D4E8`) -- the one horizontal element that lifts up off the canvas. It is the only surface elevation in the entire system.
+
+Typography has its own tonal hierarchy on the canvas:
+1. **Italic cream headlines** (`#F5F0E6`) -- the highest visual priority.
+2. **Stacked white body** (`#FFFFFF`) -- secondary priority, crisper, cooler.
+3. **Muted cream metadata** (`rgba(245, 240, 230, 0.4)`) -- tertiary priority, recessed.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use deep royal navy (`#112A70`) as the dominant surface on every slide -- it is the colour foundation of the entire style.
+- Use the photo-to-shape mask as the hero visual -- this is the style's signature and MUST appear on at least one slide per carousel. Preferably the cover slide.
+- Pair italic Playfair Display serif at 60-72px with short Inter body stacks -- the italic/upright tension is the typographic identity.
+- Use a light powder blue (`#B8D4E8`) footer band at the bottom of every slide for the CTA -- the band is the only horizontal anchor on the canvas.
+- Use pale cream (`#F5F0E6`) for the italic headline and pure white (`#FFFFFF`) for body copy -- the tonal split is intentional and load-bearing.
+- Set body copy as exactly 3 short declarative lines, each ending in a period, stacked vertically. "Real fruit. Real process. Real wine."
+- Keep headlines to 3-6 words over 2 lines. "From Grape to Glass." "A Quieter Kind of Good." "From Bean to Bar."
+- Use generous line-height (1.05-1.15) on italic display to accommodate Playfair's long curled descenders without collision.
+- Compose asymmetrically: masked object on one half, typography on the other. Do not center the hero visual.
+- Swap the SVG silhouette to match the product or concept -- wine glass, bottle, coupe, leaf, cocktail, coffee cup, hand, letterform.
+
+### Don't
+- Don't use rectangular photo frames. Every photograph in this style must be masked into an object silhouette. A rectangular photo breaks the entire visual contract.
+- Don't use rounded-corner photo frames as a "close enough" substitute -- rounded rectangles are not silhouettes. Use an actual object shape.
+- Don't use pure white (`#FFFFFF`) for the headline -- always use pale cream (`#F5F0E6`). The warmth is the whole point.
+- Don't use upright (non-italic) Playfair Display for display headlines. The italic is the signature -- upright is a different style entirely.
+- Don't use ALL CAPS on the italic serif headline -- it becomes a wedding invitation, not a poster.
+- Don't use near-black or pure black (`#000000`) as the background -- the royal navy is not interchangeable with black. The warmth and saturation of `#112A70` are what make it read as "premium brand" rather than "funeral".
+- Don't use drop shadows on the masked photograph. The mask edge should meet the navy cleanly, with no feathering, no glow, no halo.
+- Don't add decorative elements (icons, borders, rules, dot grids, noise textures, gradients) to the canvas. The mask is the entire visual interest.
+- Don't use the powder blue footer band for anything other than a short CTA label. No logos, no social handles, no long copy -- one line of navy sans text only.
+- Don't stack 4+ lines of body copy. Three lines is the maximum. If you need more, split across slides.
+- Don't set the masked object at less than 30% of the slide height -- the silhouette needs physical presence on the canvas to read.
+- Don't use colors outside the 4-value palette (navy, cream, white, powder blue). Any additional color dilutes the identity.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale**: Display Hero at 72px, Display Large at 60px, Section Heading at 48px, Body Large at 28px, Body at 22px.
+- **Padding**: 80px on all sides except bottom (footer band takes the bottom 96px edge-to-edge).
+- **Content area**: 920x800px above the footer band, plus 96px footer band.
+- **Cover slide**: Masked object on the left half (380x640px silhouette), italic headline top-right, 3-line body stack mid-right, footer band edge-to-edge at bottom with CTA right-aligned.
+- **Content slides**: Alternate between split layouts (masked object + type column) and full-bleed typographic slides with a smaller masked object used as a visual accent in the corner.
+- **Step slides**: Big italic numeral (96px Playfair italic) in cream top-left, short 3-line body stack below in white.
+- **Swipe indicator**: Small cream dots at 8px diameter centered above the footer band. Active dot in pure cream, inactive in `rgba(245, 240, 230, 0.3)`.
+- **Footer band consistency**: The same powder blue footer band appears on every slide with the same CTA copy, anchoring the carousel visually.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Full-scale hierarchy. Display Hero at 72-80px for the top headline section.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Vertical flow**: Top third -- italic headline + intro body stack. Middle -- alternating masked-object sections with accompanying 3-line body stacks. Bottom third -- closing statement and footer band edge-to-edge at the base.
+- **Section rhythm**: 120px of vertical gap between masked-object sections. Each section has exactly one masked object and exactly one 3-line body stack.
+- **Masked objects in series**: Use the same silhouette across all sections for consistency, or switch between 2-3 related silhouettes (e.g., grape, glass, bottle) to tell a visual story.
+- **Footer band**: Full-width powder blue band at the very bottom, 96px tall, carrying a single CTA label.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero at 96px, Section Heading at 64px, Body Large at 32px. Big Numbers at 128px.
+- **Padding**: 100px on all sides except bottom (footer band 120px tall at the bottom edge).
+- **Content area**: 1720x860px above the footer band.
+- **Title slides**: Masked object left (480x820px silhouette), italic headline top-right at 96px, 3-line body stack mid-right at 32px, footer band edge-to-edge.
+- **Content slides**: Use a 60/40 split (type column wider than masked object) since the extra width accommodates longer stacked body copy. Left-align the type column.
+- **CTA slides**: Full-bleed navy, large italic headline centered, 3-line body stack below, extra-tall footer band (140px) with CTA centered.
+- **Asymmetry**: The wide aspect ratio makes asymmetric compositions sing -- use dramatic 30/70 splits with the masked object small-but-commanding on one side.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 84px, Section Heading at 56px, Body Large at 28px.
+- **Padding**: 80px left/right, 100px top/bottom.
+- **Composition**: Top quarter -- italic headline alone, cream on navy, generous breathing room. Middle half -- the signature masked object as the hero centerpiece, up to 600px tall. Bottom quarter -- 3-line body stack + footer band edge-to-edge at the absolute bottom.
+- **Vertical flow**: Read top-to-bottom. The masked object dominates the middle, with the headline above and the body stack + footer below.
+- **Silhouette presence**: On poster format the masked object should be physically large -- at least 500px tall -- so its silhouette reads from a distance. The poster format is where this style looks most like a traditional advertising poster.
+- **Footer band**: 96px tall powder blue band at the very bottom.
+
+### Story (1080x1920px)
+- **Typography scale**: Display Hero at 84px in Playfair Display 700 italic. Body Large at 32px in Inter 500. Footer CTA at 26px in Inter 600.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 200px bottom reserved for platform UI (profile avatar, progress bar, reply input). The footer band should sit inside the bottom safe zone -- flush with y=1720 (not y=1920) -- so it is not clipped by the reply input.
+- **Layout**: Single centered column. Content max-width 960px. The masked object is the full-width hero, vertically dominant -- up to 900px tall. The italic headline sits above the masked object in the top third, the 3-line body stack sits below it in the lower third, and the powder blue footer band sits at y=1720 to y=1820.
+- **Cover slide**: Italic headline at 84px cream, centered, top of content zone (y≈280). Masked object below (centered, 800-900px tall). Three-line body stack below the object (centered, white Inter 500 32px). Footer band with CTA in navy at the bottom of the safe zone.
+- **Content slides**: One concept per slide. Smaller masked object (500px tall) centered, with a short italic headline above and a 3-line body stack below. Keep total type + image height inside y=280 to y=1680.
+- **CTA slide**: Full-bleed navy, large italic headline centered, 3-line body stack, and the powder blue footer band elevated slightly (at y=1640) with a pill-shaped CTA button inside it.
+- **Progress indicator**: Thin cream segments at the top of the safe zone -- inactive in `rgba(245, 240, 230, 0.25)`, active in `#F5F0E6`. The cream-on-navy keeps the progress bar legible without competing with the headline.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Royal Navy | `#112A70` | Primary background -- every slide, edge-to-edge |
+| Pale Cream | `#F5F0E6` | Italic serif display headlines |
+| Pure White | `#FFFFFF` | Sans body copy (stacked 3-line declaratives) |
+| Powder Blue | `#B8D4E8` | Full-width footer band fill |
+| Navy on Powder | `#112A70` | Footer CTA label text (same as background) |
+| Deep Navy Shadow | `#0A1F55` | Optional inset areas, rarely used |
+| Cream Soft | `rgba(245, 240, 230, 0.75)` | Attributions, secondary metadata |
+| Cream Muted | `rgba(245, 240, 230, 0.40)` | Slide numbers, watermarks |
+| Hairline Cream | `rgba(245, 240, 230, 0.18)` | Optional rare divider line |
+
+### Font Declarations
+
+```css
+/* Display (italic headlines only -- NEVER upright) */
+font-family: 'Playfair Display', Georgia, 'Times New Roman', serif;
+font-style: italic;
+
+/* Body (stacked sans copy and footer CTA) */
+font-family: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+font-style: normal;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400;1,500;1,600;1,700;1,800&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-bg: #112A70;
+  --color-navy: #112A70;
+  --color-cream: #F5F0E6;
+  --color-white: #FFFFFF;
+
+  /* Colors -- Accent */
+  --color-powder: #B8D4E8;
+  --color-navy-deep: #0A1F55;
+
+  /* Colors -- Neutral Scale */
+  --color-cream-strong: #F5F0E6;
+  --color-cream-soft: rgba(245, 240, 230, 0.75);
+  --color-white-strong: #FFFFFF;
+  --color-white-muted: rgba(255, 255, 255, 0.65);
+  --color-powder-text: rgba(17, 42, 112, 0.85);
+  --color-metadata-muted: rgba(245, 240, 230, 0.40);
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: #112A70;
+  --color-surface-footer: #B8D4E8;
+
+  /* Colors -- Borders */
+  --color-border-hairline: rgba(245, 240, 230, 0.18);
+  --color-border-footer-top: rgba(17, 42, 112, 0.08);
+
+  /* Colors -- Shadows */
+  --shadow-subtle: rgba(10, 31, 85, 0.25);
+  --shadow-medium: rgba(10, 31, 85, 0.40);
+  --shadow-deep: rgba(10, 31, 85, 0.55);
+
+  /* Typography -- Families */
+  --font-display: 'Playfair Display', Georgia, 'Times New Roman', serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 72px;
+  --text-display-large: 60px;
+  --text-section-heading: 48px;
+  --text-sub-heading: 36px;
+  --text-body-large: 28px;
+  --text-body: 22px;
+  --text-body-small: 18px;
+  --text-big-number: 96px;
+  --text-footer-cta: 22px;
+  --text-small-caps: 13px;
+
+  /* Typography -- Weights */
+  --weight-display: 700;
+  --weight-display-extra: 800;
+  --weight-sub-heading: 600;
+  --weight-body-medium: 500;
+  --weight-body-regular: 400;
+  --weight-cta: 600;
+  --weight-small-caps: 600;
+
+  /* Typography -- Styles (CRITICAL) */
+  --style-display: italic;  /* Playfair is ALWAYS italic in this style */
+  --style-body: normal;
+
+  /* Typography -- Line Heights */
+  --leading-display-hero: 1.05;
+  --leading-display-large: 1.08;
+  --leading-section: 1.10;
+  --leading-sub-heading: 1.15;
+  --leading-body-large: 1.30;
+  --leading-body: 1.40;
+  --leading-body-small: 1.50;
+  --leading-number: 1.00;
+
+  /* Typography -- Letter Spacing */
+  --tracking-display: -0.5px;
+  --tracking-section: -0.25px;
+  --tracking-body: 0px;
+  --tracking-cta: 0.2px;
+  --tracking-small-caps: 1.5px;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-base: 16px;
+  --space-small: 24px;
+  --space-medium: 32px;
+  --space-section: 48px;
+  --space-standard: 60px;
+  --space-large: 80px;
+  --space-max: 120px;
+
+  /* Borders & Radii */
+  --radius-none: 0;
+  --radius-pill: 9999px;
+
+  /* Footer band */
+  --footer-height-carousel: 96px;
+  --footer-height-slides: 120px;
+  --footer-height-story: 100px;
+  --footer-padding-y: 32px;
+  --footer-padding-x: 80px;
+}
+```
+
+### System Font Fallbacks
+- **Serif (if Playfair Display fails to load):** `Georgia, 'Times New Roman', serif` -- and still set `font-style: italic`.
+- **Sans-serif (if Inter fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`.
+
+### Quick Start Checklist for Agents
+1. Set the canvas background to `#112A70` royal navy.
+2. Pick an SVG silhouette (wine glass, bottle, leaf, product, letterform) and drop the path into a `mask-image` or `<clipPath>`.
+3. Apply the mask to a `<div>` with `background-image: url(photo)` or an `<image>` inside the SVG.
+4. Set the italic Playfair Display headline in `#F5F0E6` at 60-72px, 3-6 words, 2 lines.
+5. Add the 3-line sans body stack in `#FFFFFF` at Inter 500 28px -- each line ends with a period.
+6. Drop in the full-width powder blue (`#B8D4E8`) footer band at the bottom with a single navy Inter 600 CTA label.
+7. Verify: no rectangular photos, no upright serif, no pure white headlines, no drop shadows on the mask, no colors outside the 4-value palette.

--- a/skills/composites/goose-graphics/styles/_full/matt-gray.md
+++ b/skills/composites/goose-graphics/styles/_full/matt-gray.md
@@ -1,0 +1,442 @@
+# Design Style: Matt Gray
+
+## 1. Visual Theme & Atmosphere
+
+Matt Gray is the design language of the modern founder-creator -- the visual equivalent of a high-engagement Instagram carousel that teaches, persuades, and converts. Inspired by the personal brand aesthetic of Matt Gray (@matthgray), this style combines the authority of classic serif typography with the clarity of modern sans-serif body text, all set against a light gray canvas that feels like premium paper stock viewed on a screen. The light gray background (`#ececec`) is not white -- it is the muted, slightly industrial tone of a concrete studio wall, creating a calm, distraction-free reading surface.
+
+The dual typeface system -- Playfair Display for display headlines and Inter for body text -- creates a distinctive tension between editorial gravitas and startup clarity. Playfair Display is a transitional serif with high contrast between thick and thin strokes, designed for display use. At large sizes (48px+), its elegant letterforms command attention the way a magazine cover commands a newsstand. The signature move is setting key phrases in italic Playfair Display coloured in deep forest green (`#2d5a1e`) -- this italic-green treatment transforms ordinary headlines into memorable, brand-defining statements. "How to build *a personal brand*" -- the italic green words are the hook, the promise, the thing the audience came for. Inter handles everything below the headline: body text, labels, tags, and CTAs. At weight 500-700, Inter is crisp, readable, and authoritative without being cold.
+
+The accent system uses two elements: deep forest green (`#2d5a1e`) for italic headline emphasis and small decorative dots, and soft yellow-lime (`#e5f59e`) for pill-shaped tags that label categories, steps, and callouts. The yellow tags are the visual shorthand for "this is a framework" -- they signal structure, steps, and actionable takeaways. Together, the green italic type and yellow pill tags are the most recognisable elements of this style. A subtle dot-grid texture on title and CTA slides adds depth and craft without competing with content. Cards use thin borders (`rgba(0,0,0,0.12)`) with 12px rounded corners, creating structured content areas that feel like notebook sections.
+
+**Key Characteristics:**
+- Light gray background (`#ececec`) as the dominant surface -- not white, not dark, just neutral enough to let content breathe
+- Near-black (`#1a1a1a`) for all primary text -- maximum contrast without pure black harshness
+- Playfair Display for headlines -- classic serif authority, weight 700-800
+- Inter for body text, labels, and CTAs -- modern sans-serif clarity
+- Deep forest green (`#2d5a1e`) for italic headline emphasis -- the signature "hook word" treatment
+- Soft yellow-lime (`#e5f59e`) for pill tags -- category labels, step numbers, framework markers
+- Dot-grid texture on hero/CTA slides -- subtle craft detail using CSS radial-gradient
+- Thin-bordered cards with 12px radius -- structured without being rigid
+- Dark pill CTA buttons -- near-black background, white text, fully rounded (40px radius)
+- Bold, direct body text -- Inter at weight 600-700 for a confident, no-fluff voice
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Light Gray** (`#ececec`): Primary background. A neutral, slightly warm gray that reads as modern and premium.
+- **Near-Black** (`#1a1a1a`): Primary text colour. Bold and commanding without the flatness of pure black.
+- **Forest Green** (`#2d5a1e`): Primary accent. Used exclusively for italic headline emphasis words and small decorative dots.
+
+### Accent
+- **Yellow-Lime** (`#e5f59e`): Tag pill fills for categories, step labels, and framework markers. The visual shorthand for "actionable structure."
+- **Dark Green** (`#1e4015`): Hover/active state for green interactive elements.
+- **Light Green** (`#d4e8d0`): Subtle green tint for backgrounds or hover states when needed.
+
+### Neutral Scale
+- **Card White** (`rgba(255,255,255,0.3)`): Semi-transparent white for card backgrounds -- lets the gray canvas show through.
+- **Card Border** (`rgba(0,0,0,0.12)`): Standard thin border for cards and containers.
+- **Secondary Text** (`#4a4a4a`): Descriptions, subtitles, and supporting copy.
+- **Tertiary Text** (`#777777`): Timestamps, metadata, and low-priority labels.
+- **Muted Text** (`rgba(0,0,0,0.25)`): Slide numbers and watermarks.
+- **Border Strong** (`rgba(0,0,0,0.18)`): Higher-contrast border for prominent containers.
+
+### Surface & Borders
+- **Surface Primary** (`rgba(255,255,255,0.3)`): Card and container background.
+- **Surface Inset** (`rgba(255,255,255,0.15)`): Recessed areas and inset panels.
+- **Surface Tag** (`#e5f59e`): Yellow-lime fill for pill tags.
+- **Border Default** (`rgba(0,0,0,0.12)`): Standard card border.
+- **Border Accent** (`rgba(45,90,30,0.3)`): Green-tinted border for featured elements.
+- **Divider Rule** (`rgba(0,0,0,0.08)`): Subtle divider lines.
+
+### Shadow Colors
+- **Shadow Subtle** (`rgba(0,0,0,0.04)`): Barely-there ambient shadow.
+- **Shadow Medium** (`rgba(0,0,0,0.08)`): Standard card shadow.
+- **Shadow Deep** (`rgba(0,0,0,0.12)`): High-elevation elements.
+
+### Texture
+- **Dot Grid**: `radial-gradient(circle, rgba(0,0,0,0.06) 1.5px, transparent 1.5px)` at `32px 32px` spacing. Applied to title slides and CTA slides for subtle texture.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400;1,500;1,600;1,700;1,800&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Playfair Display', Georgia, 'Times New Roman', serif`
+- **Body**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Playfair Display | 72px | 700 | 1.10 | -1px | Cover headlines. Key phrases in italic green. |
+| Section Heading | Playfair Display | 48px | 700 | 1.15 | -0.5px | Major section titles. Italic green for emphasis words. |
+| Sub-heading | Playfair Display | 32px | 600 | 1.20 | 0px | Card headings, subsection titles |
+| Body Large | Inter | 22px | 500 | 1.55 | 0px | Subtitles and lead paragraphs |
+| Body | Inter | 18px | 600 | 1.55 | 0px | Standard body text -- bolder than typical for confident voice |
+| Body Bold | Inter | 18px | 700 | 1.55 | 0px | Emphasis body text, closing statements |
+| Small / Caption | Inter | 14px | 500 | 1.50 | 0.2px | Metadata, attributions, timestamps |
+| Big Numbers | Playfair Display | 64px | 800 | 1.00 | -0.5px | Statistics and key metrics |
+| Tag Label | Inter | 14px | 600 | 1.00 | 0px | Yellow pill tag text |
+| Framework Label | Inter | 14px | 500 | 1.00 | 2px | Uppercase bordered label ("GOOSEWORKS", "FRAMEWORK") |
+| CTA Text | Inter | 16px | 700 | 1.00 | 0.3px | Button text |
+
+### Principles
+- **Serif/sans-serif tension**: Playfair Display for headlines creates editorial authority. Inter for everything else creates startup clarity. The contrast is the style's identity.
+- **Italic green as the hook**: The most distinctive element. In any headline, identify the key promise or emotional phrase and set it in `font-style: italic; color: #2d5a1e`. This is not decorative -- it is the visual equivalent of a hook in a tweet.
+- **Bold body text**: Inter at weight 600-700 for body text creates a confident, direct voice. This is not a style for light, airy reading -- it is a style for frameworks, steps, and action.
+- **Mixed case always**: Headlines and body are always mixed case. Uppercase is reserved only for small framework labels and the bordered label at the top of title slides.
+- **Generous but not extreme spacing**: This style uses more moderate spacing than minimalist styles -- content is dense enough to feel valuable, but not so dense it overwhelms.
+
+## 4. Component Patterns
+
+### Title Block (Cover / Header Section)
+
+```html
+<div style="background-color: var(--color-bg); padding: 80px 60px; text-align: center; position: relative;">
+  <!-- Dot grid texture -->
+  <div style="position: absolute; inset: 0; background-image: radial-gradient(circle, rgba(0,0,0,0.06) 1.5px, transparent 1.5px); background-size: 32px 32px; pointer-events: none;"></div>
+  <div style="position: relative; z-index: 1;">
+    <div style="display: inline-block; font-family: var(--font-body); font-size: 14px; font-weight: 500; letter-spacing: 2px; text-transform: uppercase; color: var(--color-near-black); border: 1px solid rgba(0,0,0,0.12); padding: 8px 24px; background: rgba(255,255,255,0.5); margin: 0 0 48px;">FRAMEWORK</div>
+    <h1 style="font-family: var(--font-display); font-size: 72px; font-weight: 700; line-height: 1.10; letter-spacing: -1px; color: var(--color-near-black); margin: 0 0 32px;">How to build<br><em style="color: var(--color-green);">a personal brand</em><br>(in just 7 days)</h1>
+    <p style="font-family: var(--font-body); font-size: 22px; font-weight: 500; line-height: 1.55; color: var(--color-secondary); max-width: 650px; margin: 0 auto;">A step-by-step framework for founders who want to build in public.</p>
+  </div>
+</div>
+```
+
+### Numbered Item with Yellow Tag
+
+```html
+<div style="padding: 32px 0;">
+  <span style="display: inline-block; background: var(--color-yellow-tag); font-family: var(--font-body); font-size: 14px; font-weight: 600; padding: 6px 16px; border-radius: 20px; color: var(--color-near-black); margin: 0 0 12px;">Step 1</span>
+  <p style="font-family: var(--font-body); font-size: 18px; font-weight: 700; line-height: 1.55; color: var(--color-near-black); margin: 0;">Build your personal brand.<br>Attention is the new oil.<br>Your personal brand is the pipeline.</p>
+</div>
+```
+
+### Bordered Card with Tag
+
+```html
+<div style="border: 1px solid rgba(0,0,0,0.12); border-radius: 12px; padding: 28px 24px; background: rgba(255,255,255,0.3);">
+  <span style="display: inline-block; background: var(--color-yellow-tag); font-family: var(--font-body); font-size: 14px; font-weight: 600; padding: 6px 16px; border-radius: 20px; color: var(--color-near-black); margin: 0 0 12px;">1. Writing</span>
+  <p style="font-family: var(--font-body); font-size: 18px; font-weight: 600; line-height: 1.55; color: var(--color-near-black); margin: 0;">It's your superpower.<br>SEO is writing. Sales is writing. Hiring is writing.<br>Audience growth is writing.</p>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="text-align: center; padding: 40px 24px; border: 1px solid rgba(0,0,0,0.12); border-radius: 12px; background: rgba(255,255,255,0.3);">
+  <p style="font-family: var(--font-display); font-size: 64px; font-weight: 800; line-height: 1.00; letter-spacing: -0.5px; color: var(--color-green); margin: 0 0 8px;">47%</p>
+  <span style="display: inline-block; background: var(--color-yellow-tag); font-family: var(--font-body); font-size: 14px; font-weight: 600; padding: 6px 16px; border-radius: 20px; color: var(--color-near-black); margin: 0 0 12px;">FASTER RESPONSE</span>
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 500; line-height: 1.55; color: var(--color-secondary); max-width: 280px; margin: 0 auto;">Teams respond to leads nearly twice as fast with AI-powered workflows.</p>
+</div>
+```
+
+### Comparison Grid
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0; border: 1px solid rgba(0,0,0,0.12); border-radius: 12px; overflow: hidden;">
+  <div style="padding: 40px 32px; background: rgba(255,255,255,0.3);">
+    <span style="display: inline-block; background: rgba(0,0,0,0.06); font-family: var(--font-body); font-size: 14px; font-weight: 600; padding: 6px 16px; border-radius: 20px; color: var(--color-secondary); margin: 0 0 16px;">Without AI</span>
+    <h3 style="font-family: var(--font-display); font-size: 32px; font-weight: 600; line-height: 1.20; color: var(--color-near-black); margin: 0 0 16px;">Manual & Fragmented</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 500; line-height: 1.55; color: var(--color-secondary); margin: 0;">Slack threads, spreadsheets, and context-switching between a dozen tabs.</p>
+  </div>
+  <div style="padding: 40px 32px; background: rgba(255,255,255,0.3); border-left: 1px solid rgba(0,0,0,0.12);">
+    <span style="display: inline-block; background: var(--color-yellow-tag); font-family: var(--font-body); font-size: 14px; font-weight: 600; padding: 6px 16px; border-radius: 20px; color: var(--color-near-black); margin: 0 0 16px;">With Goose</span>
+    <h3 style="font-family: var(--font-display); font-size: 32px; font-weight: 600; line-height: 1.20; color: var(--color-near-black); margin: 0 0 16px;">Orchestrated & Autonomous</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 500; line-height: 1.55; color: var(--color-secondary); margin: 0;">AI coworkers handle research, drafting, and follow-up. Your team focuses on decisions.</p>
+  </div>
+</div>
+```
+
+### Quote Block
+
+```html
+<div style="padding: 48px 40px; border-left: 3px solid var(--color-green); background: rgba(255,255,255,0.3); border-radius: 0 12px 12px 0;">
+  <p style="font-family: var(--font-display); font-size: 32px; font-weight: 400; font-style: italic; line-height: 1.35; color: var(--color-near-black); margin: 0 0 24px;">"It felt less like configuring software and more like onboarding a new team member."</p>
+  <div style="display: flex; align-items: center; gap: 12px;">
+    <div style="width: 32px; height: 3px; background: var(--color-green); border-radius: 2px;"></div>
+    <p style="font-family: var(--font-body); font-size: 14px; font-weight: 600; letter-spacing: 1px; text-transform: uppercase; color: var(--color-tertiary); margin: 0;">SARAH CHEN, VP OPERATIONS</p>
+  </div>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="text-align: center; padding: 60px 40px; position: relative;">
+  <!-- Dot grid texture -->
+  <div style="position: absolute; inset: 0; background-image: radial-gradient(circle, rgba(0,0,0,0.06) 1.5px, transparent 1.5px); background-size: 32px 32px; pointer-events: none;"></div>
+  <div style="position: relative; z-index: 1;">
+    <span style="display: inline-block; background: var(--color-yellow-tag); font-family: var(--font-body); font-size: 14px; font-weight: 600; padding: 8px 20px; border-radius: 20px; color: var(--color-near-black); margin: 0 0 32px;">gooseworks.ai</span>
+    <h2 style="font-family: var(--font-display); font-size: 64px; font-weight: 700; line-height: 1.10; letter-spacing: -0.5px; color: var(--color-near-black); margin: 0 0 28px;">Meet your<br><em style="color: var(--color-green);">new coworker</em></h2>
+    <p style="font-family: var(--font-body); font-size: 22px; font-weight: 500; line-height: 1.60; color: var(--color-secondary); max-width: 600px; margin: 0 auto 44px;">Deploy your first AI coworker in minutes. Start free, scale when ready.</p>
+    <a style="display: inline-block; background: var(--color-near-black); color: #ffffff; font-family: var(--font-body); font-size: 16px; font-weight: 700; letter-spacing: 0.3px; text-decoration: none; padding: 20px 52px; border-radius: 40px;">Get Started Free</a>
+  </div>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between icon and inline label.
+- **8px**: Tight gap -- between tag and adjacent text, between stat number and label.
+- **12px**: Small gap -- between tag pill and body text within a card.
+- **16px**: Base gap -- between body paragraphs, between list items in compact mode.
+- **24px**: Medium gap -- between components within a section.
+- **28px**: Card internal padding -- standard padding inside bordered cards.
+- **32px**: Section internal -- gap between heading and first content block.
+- **40px**: Content gap -- between cards in a layout, between major content elements.
+- **48px**: Section divider -- vertical space between major content blocks.
+- **80px**: Maximum section padding -- cover slides and CTA areas.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 960px |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned for content slides. Center-aligned for title slides and CTA slides.
+- **Grid**: Bordered cards can stack vertically or use a 2-column grid for the bottom row (1 card spanning full width on top, 2 cards side-by-side below -- the Matt Gray "focus grid" pattern).
+- **Yellow pill tags**: Always inline-block, rounded 20px, placed above the content they label.
+- **Vertical rhythm**: Maintain consistent 40-48px gaps between top-level sections. Use 12px gaps between tag and body within a card.
+- **Content gravity**: On widescreen slides (1920x1080), content slides use left-aligned layouts with ~70% width. Title/CTA slides are centered.
+- **Dot grid texture**: Applied via CSS pseudo-element on title slides and CTA slides only. Never on content-heavy slides.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, background `#ececec` | Page canvas, base layer |
+| Card (Level 1) | `1px solid rgba(0,0,0,0.12)` + `rgba(255,255,255,0.3)` bg | Standard bordered cards |
+| Subtle (Level 2) | `0 2px 8px rgba(0,0,0,0.06)` | Hover states on cards |
+| Elevated (Level 3) | `0 8px 24px rgba(0,0,0,0.10)` | Featured cards, dropdowns |
+| Overlay (Level 4) | `0 16px 40px rgba(0,0,0,0.15)` | Modals and overlays |
+
+### Border Treatments
+- **Standard card border**: `1px solid rgba(0,0,0,0.12)` with `border-radius: 12px` -- the primary container definition method. Thin, visible, structural.
+- **Framework label border**: `1px solid rgba(0,0,0,0.12)` with no border-radius (or minimal) -- for the rectangular "FRAMEWORK" / "GOOSEWORKS" label at the top of title slides.
+- **Connected cards**: Cards in a focus grid share borders. Top card has `border-radius: 12px 12px 0 0`. Bottom-left has `border-radius: 0 0 0 12px`. Bottom-right has `border-radius: 0 0 12px 0`. Shared edges collapse to a single 1px line.
+- **Divider line**: `1px solid rgba(0,0,0,0.08)` -- for separating content sections within a single slide.
+
+### Surface Hierarchy
+On light gray backgrounds, elevation comes from border definition and subtle transparency:
+1. **Background** (`#ececec`) -- the neutral canvas.
+2. **Card** (`rgba(255,255,255,0.3)`) -- containers are slightly lighter than the canvas, defined primarily by their border.
+3. **Tag** (`#e5f59e`) -- yellow-lime tags sit above everything as the highest-contrast surface element.
+4. **CTA Button** (`#1a1a1a`) -- dark buttons are the strongest visual anchor on any slide.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use Playfair Display italic in forest green (`#2d5a1e`) for the key phrase in every headline -- this is the single most important visual element of the style.
+- Use yellow-lime (`#e5f59e`) pill tags for all category labels, step numbers, and framework markers -- they are the structural scaffolding of the content.
+- Use Inter at weight 600-700 for body text -- this style speaks with confidence and directness.
+- Use the dot-grid texture on title and CTA slides -- it adds craft and depth to otherwise minimal slides.
+- Use the bordered "FRAMEWORK" label at the top of title slides -- it signals the content type.
+- Use dark pill buttons (`#1a1a1a`, white text, 40px radius) for CTAs -- the dark button against the light gray canvas is a strong focal point.
+- Use the "focus grid" card layout: one full-width card on top, two half-width cards below, all sharing borders.
+- Include a bold closing statement at the bottom of content slides -- a punchy one-liner that reinforces the lesson.
+- Keep cards at 12px border-radius -- rounded enough to feel modern, square enough to feel structured.
+
+### Don't
+- Don't use green for anything other than italic headline emphasis and small decorative dots -- it is not a general-purpose accent.
+- Don't use the dot-grid texture on content-heavy slides -- it competes with dense text and card layouts.
+- Don't use light body text weights (300-400) -- this style demands bold, direct communication at weight 600+.
+- Don't use serif type (Playfair Display) for body text -- reserve it strictly for headlines and big numbers.
+- Don't use sharp corners (0px radius) on cards -- always use 12px radius.
+- Don't use coloured backgrounds for cards -- always use semi-transparent white (`rgba(255,255,255,0.3)`).
+- Don't use blue, red, or other accent colours -- only green and yellow-lime. The restricted palette is the identity.
+- Don't center-align body text on content slides -- only title and CTA slides are centered.
+- Don't use decorative elements beyond the dot grid and green dots -- no icons, no emoji, no illustrations.
+- Don't use more than 3 cards per slide -- each card needs room to deliver its point.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale down**: Display Hero becomes 56px (from 72px). Section Heading becomes 40px. Body stays 18px.
+- **Padding**: 60px on all sides. Content area is 960x960px.
+- **Cover slide**: Bordered "FRAMEWORK" label centered at top. Headline centered with italic green hook phrase. Dot-grid texture. Subtitle below in secondary text.
+- **Content slides**: Left-aligned. Yellow pill tag above body text. Bold Inter body. Closing bold statement at bottom.
+- **Card slides**: Focus grid layout (1 card top, 2 cards bottom) or single full-width card.
+- **Swipe indicator**: Small gray dots at bottom center, 8px diameter. Active dot in forest green.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Full-scale hierarchy. Display Hero at 72px for the title section.
+- **Padding**: 60px left/right. 80px top/bottom margins.
+- **Section spacing**: 48px vertical gap between sections. No decorative rules -- card borders provide structure.
+- **Vertical rhythm**: Alternate between full-width sections and focus grid card layouts. Use yellow-tagged steps for sequential content.
+- **Footer**: Secondary text, 14px Inter, with a closing bold statement.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 88px. Section Heading becomes 56px. Body Large becomes 22px.
+- **Padding**: 80px on all sides. Content area is 1760x920px.
+- **Layout**: Title/CTA slides are centered with dot-grid texture. Content slides are left-aligned with ~70% width.
+- **Title slides**: Bordered label at top. Serif headline with italic green hook. Subtitle below. Yellow tag for metadata.
+- **Content slides**: Section heading (serif, left-aligned). Bold intro line. Focus grid cards with yellow tags. Bold closing statement.
+- **CTA slides**: Yellow tag at top. Serif headline with italic green. Subtitle. Dark pill button. Dot-grid texture.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 64px. Section Heading at 40px. Body at 18px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top third for headline with bordered label and italic green hook. Middle third for focus grid cards with yellow tags. Bottom third for bold closing statement and CTA.
+- **Vertical flow**: Content reads top-to-bottom. Cards provide structural rhythm.
+- **CTA placement**: Bottom zone, centered, dark pill button with yellow tag above.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Hero becomes 72px in Playfair Display 700-800 (approximately 30% larger than Carousel 56px). Section Heading becomes 52px. Body Large becomes 22px in Inter 500-600. Pill tag text stays at Inter 600 14px uppercase.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical text must sit inside y=160 to y=1760.
+- **Layout**: Single centered column. Content max-width 920px. Vertical center of gravity -- cluster hero content in y=400 to y=1500 range. Light gray background (`#ececec`) runs edge-to-edge, with an optional subtle dot-grid radial-gradient texture on cover and CTA slides for the signature craft detail.
+- **Cover slide**: Soft yellow-lime (`#e5f59e`) pill tag at the top of the content block (the framework marker). Below it, the hero Playfair Display headline at 72px with the signature move: 2-3 words set in *italic Playfair Display* coloured in deep forest green (`#2d5a1e`) -- the hook phrase. The italic-green words are the entire reason this slide exists. A short Inter 500 supporting line sits below in near-black.
+- **Content slides**: One numbered framework step per slide. Yellow pill tag at top (`STEP 02` or similar). Thin-bordered card with 12px radius holding the Playfair Display heading at 48-52px (italic-green hook optional) and Inter 600 body below. Small forest-green dot decorations flank the heading for craft. Cards feel like notebook sections.
+- **CTA slide**: Dot-grid texture background. Yellow pill tag above the headline. Playfair Display CTA headline at 56px with an italic-green hook word. Dark near-black pill button (40px radius) with white Inter 700 CTA text. A thin bordered card frames the whole CTA block.
+- **Progress indicator**: Thin segments at the top of the safe zone -- inactive in `rgba(0,0,0,0.12)`, active in near-black (`#1a1a1a`). The dark-on-gray keeps the structural rhythm without competing with the forest-green accent.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Light Gray | `#ececec` | Primary background |
+| Near-Black | `#1a1a1a` | Primary text, CTA button fill |
+| Forest Green | `#2d5a1e` | Italic headline emphasis, decorative dots |
+| Dark Green | `#1e4015` | Hover/active state for green elements |
+| Yellow-Lime | `#e5f59e` | Tag pill fills |
+| Card White | `rgba(255,255,255,0.3)` | Card backgrounds |
+| Card Border | `rgba(0,0,0,0.12)` | Card and container borders |
+| Secondary Text | `#4a4a4a` | Descriptions, subtitles |
+| Tertiary Text | `#777777` | Metadata, attributions |
+| Muted | `rgba(0,0,0,0.25)` | Slide numbers |
+
+### Font Declarations
+
+```css
+/* Display (headlines only) */
+font-family: 'Playfair Display', Georgia, 'Times New Roman', serif;
+
+/* Body (everything else) */
+font-family: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400;1,500;1,600;1,700;1,800&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-bg: #ececec;
+  --color-near-black: #1a1a1a;
+  --color-green: #2d5a1e;
+
+  /* Colors -- Accent */
+  --color-yellow-tag: #e5f59e;
+  --color-dark-green: #1e4015;
+  --color-light-green: #d4e8d0;
+
+  /* Colors -- Neutral Scale */
+  --color-card-white: rgba(255, 255, 255, 0.3);
+  --color-card-border: rgba(0, 0, 0, 0.12);
+  --color-secondary: #4a4a4a;
+  --color-tertiary: #777777;
+  --color-muted: rgba(0, 0, 0, 0.25);
+  --color-border-strong: rgba(0, 0, 0, 0.18);
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: rgba(255, 255, 255, 0.3);
+  --color-surface-inset: rgba(255, 255, 255, 0.15);
+  --color-surface-tag: #e5f59e;
+
+  /* Colors -- Borders */
+  --color-border-default: rgba(0, 0, 0, 0.12);
+  --color-border-accent: rgba(45, 90, 30, 0.3);
+  --color-divider: rgba(0, 0, 0, 0.08);
+
+  /* Colors -- Shadows */
+  --shadow-subtle: rgba(0, 0, 0, 0.04);
+  --shadow-medium: rgba(0, 0, 0, 0.08);
+  --shadow-deep: rgba(0, 0, 0, 0.12);
+
+  /* Typography -- Families */
+  --font-display: 'Playfair Display', Georgia, 'Times New Roman', serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 72px;
+  --text-section-heading: 48px;
+  --text-sub-heading: 32px;
+  --text-body-large: 22px;
+  --text-body: 18px;
+  --text-small: 14px;
+  --text-big-number: 64px;
+  --text-tag: 14px;
+  --text-cta: 16px;
+
+  /* Typography -- Weights */
+  --weight-display: 700;
+  --weight-display-extra: 800;
+  --weight-sub-heading: 600;
+  --weight-body: 600;
+  --weight-body-bold: 700;
+  --weight-body-medium: 500;
+  --weight-tag: 600;
+  --weight-cta: 700;
+
+  /* Typography -- Line Heights */
+  --leading-display: 1.10;
+  --leading-heading: 1.15;
+  --leading-sub-heading: 1.20;
+  --leading-body-large: 1.55;
+  --leading-body: 1.55;
+  --leading-small: 1.50;
+  --leading-number: 1.00;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-medium: 24px;
+  --space-card-padding: 28px;
+  --space-large: 32px;
+  --space-gap: 40px;
+  --space-section: 48px;
+  --space-max: 80px;
+
+  /* Borders */
+  --radius-card: 12px;
+  --radius-tag: 20px;
+  --radius-cta: 40px;
+
+  /* Texture */
+  --dot-grid: radial-gradient(circle, rgba(0,0,0,0.06) 1.5px, transparent 1.5px);
+  --dot-grid-size: 32px 32px;
+}
+```
+
+### System Font Fallbacks
+- **Serif (if Playfair Display fails to load):** `Georgia, 'Times New Roman', serif`
+- **Sans-serif (if Inter fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/_full/midnight-editorial.md
+++ b/skills/composites/goose-graphics/styles/_full/midnight-editorial.md
@@ -1,0 +1,428 @@
+# Design Style: Midnight Editorial
+
+## 1. Visual Theme & Atmosphere
+
+Midnight Editorial draws from the tradition of luxury magazine design -- the kind of publication where every spread is a composition, where white space is replaced by the authority of darkness. The near-black canvas (`#0d0d0d`) is not mere absence of light; it is a deliberate stage that forces every element placed upon it to earn its presence. Warm cream text (`#f5f0e8`) floats against this darkness like type on heavy black stock, creating a reading experience that feels intimate, considered, and expensive. This is the design language of Monocle after hours, of a Kinfolk issue printed in negative, of the programme for an invitation-only event.
+
+The typographic pairing of Playfair Display and Inter creates the tension that makes this style work. Playfair Display -- a transitional serif with high contrast between thick and thin strokes -- delivers headlines that carry the authority of engraved letterpress plates. Its serifs are sharp, its bowls generous, its italic forms genuinely calligraphic. Against this, Inter provides clean, highly legible sans-serif body text that never competes with the display type. The contrast between serif display and sans-serif body mirrors the editorial convention of magazine design: the headline seduces, the body informs. At display sizes (64px+), Playfair Display runs at weight 700 with moderate negative letter-spacing (-1px), creating dense headline blocks that command attention without crowding.
+
+Copper (`#c17f59`) is the accent that elevates this system from dark-mode-generic to genuinely editorial. It is not gold (too flashy), not bronze (too dull), but a warm metallic tone that reads as luxurious without ostentation -- the colour of a foil-stamped spine, of aged hardware on a leather portfolio. Used sparingly for accent lines, numbering, and interactive elements, copper creates focal points that guide the eye without breaking the mood. The secondary muted gold (`#a89067`) provides a quieter companion for borders, secondary labels, and decorative rules. Together they establish a warm metallic vocabulary against the cool darkness. Subtle `1px solid rgba(245,240,232,0.1)` borders create structure through whisper-thin lines, while box shadows use warm-tinted RGBA values to preserve the palette's warmth even in depth effects.
+
+**Key Characteristics:**
+- Near-black background (`#0d0d0d`) as the dominant surface -- darkness as a design decision, not a dark-mode toggle
+- Warm cream (`#f5f0e8`) for all primary text -- softer and warmer than white, reducing eye strain on dark surfaces
+- Playfair Display at weight 700 for all display type -- sharp transitional serifs for editorial authority
+- Inter at weight 300-400 for body text -- clean, highly legible sans-serif that defers to the serif headlines
+- Copper (`#c17f59`) as the singular accent colour for numbering, rules, CTAs, and focal points
+- Muted gold (`#a89067`) as secondary accent for borders, captions, and quiet emphasis
+- Negative letter-spacing at display sizes (-1px at 64px, -0.5px at 40px) for tight, editorial headline blocks
+- Warm-tinted shadows using `rgba(197,127,89,0.08)` -- elevation that stays on-palette
+- Thin horizontal rules and generous vertical spacing to create an unhurried, magazine-like rhythm
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Midnight** (`#0d0d0d`): Primary background. Near-black with a neutral undertone -- darker than charcoal, warmer than pure `#000000`.
+- **Cream** (`#f5f0e8`): Primary text colour. A warm off-white with subtle yellow undertone that softens contrast and adds warmth.
+- **Copper** (`#c17f59`): Primary accent. Used for numbering, horizontal rules, CTA buttons, and focal-point elements. The signature colour.
+
+### Accent
+- **Muted Gold** (`#a89067`): Secondary accent for borders, captions, sub-labels, and decorative lines. Quieter than copper.
+- **Warm White** (`#ede7db`): Tertiary accent for hover states and high-emphasis body text. Slightly darker than cream.
+- **Deep Copper** (`#9a6347`): Darker copper for hover/active states on interactive elements.
+
+### Neutral Scale
+- **Charcoal** (`#1a1a1a`): Elevated surface -- cards, containers, content panels sitting above the midnight background.
+- **Dark Gray** (`#2a2a2a`): Secondary surface for nested containers, input fields, and inset areas.
+- **Medium Gray** (`#4a4a4a`): Disabled text, placeholder content, and subtle dividers.
+- **Soft Gray** (`#6b6b6b`): Tertiary text for timestamps, metadata, and low-priority labels.
+- **Light Gray** (`#8a8a8a`): Used sparingly for de-emphasized captions on dark surfaces.
+
+### Surface & Borders
+- **Surface Primary** (`#1a1a1a`): Card and container background.
+- **Surface Inset** (`#141414`): Recessed areas, code blocks, and inset panels.
+- **Border Default** (`rgba(245,240,232,0.1)`): Standard whisper-thin border for cards and dividers.
+- **Border Accent** (`rgba(193,127,89,0.3)`): Copper-tinted border for active or featured elements.
+- **Border Strong** (`rgba(245,240,232,0.2)`): Higher-contrast border for prominent containers.
+- **Divider Rule** (`#c17f59`): Solid copper for horizontal accent rules (typically 2px height).
+
+### Shadow Colors
+- **Shadow Warm** (`rgba(197,127,89,0.08)`): Primary shadow -- copper-tinted ambient glow for on-palette elevation.
+- **Shadow Deep** (`rgba(0,0,0,0.4)`): Deep shadow for high-elevation elements like modals.
+- **Shadow Soft** (`rgba(0,0,0,0.2)`): Standard shadow layer for cards and containers.
+- **Shadow Ambient** (`rgba(197,127,89,0.04)`): Subtle warm ambient for barely-there lift.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400;1,700&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Playfair Display', Georgia, 'Times New Roman', serif`
+- **Body**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Playfair Display | 72px | 700 | 1.05 | -1.5px | Cover headlines, single impactful statement |
+| Section Heading | Playfair Display | 48px | 700 | 1.10 | -1px | Major section titles |
+| Sub-heading | Playfair Display | 32px | 700 | 1.15 | -0.5px | Subsection titles, card headings |
+| Body Large | Inter | 20px | 300 | 1.60 | 0px | Lead paragraphs, introductions |
+| Body | Inter | 16px | 400 | 1.65 | 0px | Standard reading text |
+| Small / Caption | Inter | 13px | 400 | 1.50 | 0.3px | Metadata, attributions, timestamps |
+| Big Numbers | Playfair Display | 64px | 900 | 1.00 | -1px | Statistics, key metrics, hero data |
+| Numbered Label | Inter | 14px | 600 | 1.00 | 2px | Uppercase step labels ("01 -- STRATEGY") |
+| CTA Text | Inter | 15px | 600 | 1.00 | 0.8px | Button and call-to-action text, uppercase |
+
+### Principles
+- **Serif/sans-serif tension**: Playfair Display owns the headlines; Inter owns everything else. Never use Inter for display headings or Playfair for body text.
+- **Light body, heavy display**: Inter at 300-400 weight keeps body text airy and readable. Playfair at 700-900 weight creates dense, authoritative headlines. The weight contrast reinforces the hierarchy.
+- **Tracking opens at small sizes**: Negative letter-spacing for display type (-1.5px to -0.5px) creates tight editorial blocks. Body text uses neutral tracking. Captions and labels use positive tracking (0.3px-2px) for legibility at small sizes.
+- **Generous line height for body**: 1.60-1.65 for body text creates a relaxed, magazine-like reading rhythm on dark backgrounds where dense text becomes fatiguing.
+- **Uppercase sparingly**: Reserve uppercase + wide tracking for numbered labels and CTA buttons only. Headlines are always mixed case.
+
+## 4. Component Patterns
+
+### Title Block (Cover / Header Section)
+
+```html
+<div style="background-color: var(--color-midnight); padding: 80px 60px; text-align: center;">
+  <div style="width: 60px; height: 2px; background: var(--color-copper); margin: 0 auto 32px;"></div>
+  <h1 style="font-family: var(--font-display); font-size: 72px; font-weight: 700; line-height: 1.05; letter-spacing: -1.5px; color: var(--color-cream); margin: 0 0 24px;">The Future of<br>Autonomous Work</h1>
+  <p style="font-family: var(--font-body); font-size: 20px; font-weight: 300; line-height: 1.60; color: var(--color-muted-gold); max-width: 600px; margin: 0 auto;">How AI coworkers are reshaping the way teams operate, collaborate, and deliver results.</p>
+  <div style="width: 60px; height: 2px; background: var(--color-copper); margin: 40px auto 0;"></div>
+</div>
+```
+
+### Numbered Item
+
+```html
+<div style="display: flex; gap: 24px; align-items: flex-start; padding: 32px 0; border-bottom: 1px solid var(--color-border-default);">
+  <span style="font-family: var(--font-display); font-size: 48px; font-weight: 700; line-height: 1.00; color: var(--color-copper); min-width: 72px;">01</span>
+  <div>
+    <p style="font-family: var(--font-body); font-size: 14px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: var(--color-muted-gold); margin: 0 0 8px;">SIGNAL-BASED OUTBOUND</p>
+    <h3 style="font-family: var(--font-display); font-size: 32px; font-weight: 700; line-height: 1.15; letter-spacing: -0.5px; color: var(--color-cream); margin: 0 0 12px;">Find buyers before they find you</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-soft-gray); margin: 0;">Monitor hiring signals, funding events, and tech stack changes to identify high-intent prospects the moment they enter the market.</p>
+  </div>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="text-align: center; padding: 40px 24px; background: var(--color-charcoal); border: 1px solid var(--color-border-default); border-radius: 4px;">
+  <p style="font-family: var(--font-display); font-size: 64px; font-weight: 900; line-height: 1.00; letter-spacing: -1px; color: var(--color-copper); margin: 0 0 8px;">47%</p>
+  <p style="font-family: var(--font-body); font-size: 14px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: var(--color-cream); margin: 0 0 12px;">FASTER RESPONSE</p>
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-soft-gray); max-width: 280px; margin: 0 auto;">Teams using AI coworkers respond to inbound leads nearly twice as fast as manual workflows.</p>
+</div>
+```
+
+### Comparison Grid
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2px; background: var(--color-border-default); border-radius: 4px; overflow: hidden;">
+  <div style="background: var(--color-charcoal); padding: 40px 32px;">
+    <p style="font-family: var(--font-body); font-size: 13px; font-weight: 400; letter-spacing: 0.3px; color: var(--color-muted-gold); margin: 0 0 16px;">Without Goose</p>
+    <h3 style="font-family: var(--font-display); font-size: 32px; font-weight: 700; line-height: 1.15; letter-spacing: -0.5px; color: var(--color-cream); margin: 0 0 16px;">Manual & Fragmented</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-soft-gray); margin: 0;">Teams juggle Slack threads, spreadsheets, and context-switching between a dozen tabs to coordinate basic workflows.</p>
+  </div>
+  <div style="background: var(--color-charcoal); padding: 40px 32px; border-left: 2px solid var(--color-copper);">
+    <p style="font-family: var(--font-body); font-size: 13px; font-weight: 400; letter-spacing: 0.3px; color: var(--color-copper); margin: 0 0 16px;">With Goose</p>
+    <h3 style="font-family: var(--font-display); font-size: 32px; font-weight: 700; line-height: 1.15; letter-spacing: -0.5px; color: var(--color-cream); margin: 0 0 16px;">Orchestrated & Autonomous</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-soft-gray); margin: 0;">AI coworkers handle research, drafting, and follow-up autonomously. Your team focuses on decisions, not busywork.</p>
+  </div>
+</div>
+```
+
+### List Item
+
+```html
+<div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0; border-bottom: 1px solid var(--color-border-default);">
+  <div style="width: 40px; height: 40px; min-width: 40px; display: flex; align-items: center; justify-content: center; border: 1px solid var(--color-border-accent); border-radius: 4px; color: var(--color-copper); font-size: 18px;">&#9670;</div>
+  <div>
+    <h4 style="font-family: var(--font-display); font-size: 22px; font-weight: 700; line-height: 1.20; color: var(--color-cream); margin: 0 0 8px;">Persistent Memory</h4>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-soft-gray); margin: 0;">Every agent maintains its own filesystem, notes, and learned preferences across sessions. Context is never lost.</p>
+  </div>
+</div>
+```
+
+### Quote Block
+
+```html
+<div style="padding: 48px 40px; border-left: 2px solid var(--color-copper); background: var(--color-surface-inset);">
+  <p style="font-family: var(--font-display); font-size: 32px; font-weight: 400; font-style: italic; line-height: 1.35; letter-spacing: -0.5px; color: var(--color-cream); margin: 0 0 24px;">"It felt less like configuring software and more like onboarding a new team member."</p>
+  <div style="display: flex; align-items: center; gap: 12px;">
+    <div style="width: 32px; height: 2px; background: var(--color-copper);"></div>
+    <p style="font-family: var(--font-body); font-size: 14px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: var(--color-muted-gold); margin: 0;">SARAH CHEN, VP OPERATIONS</p>
+  </div>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="text-align: center; padding: 60px 40px; background: var(--color-charcoal); border: 1px solid var(--color-border-accent); border-radius: 4px;">
+  <h2 style="font-family: var(--font-display); font-size: 40px; font-weight: 700; line-height: 1.10; letter-spacing: -0.75px; color: var(--color-cream); margin: 0 0 16px;">Ready to meet your team?</h2>
+  <p style="font-family: var(--font-body); font-size: 18px; font-weight: 300; line-height: 1.60; color: var(--color-soft-gray); max-width: 480px; margin: 0 auto 32px;">Deploy your first AI coworker in under five minutes. No setup fees, no long-term commitments.</p>
+  <a style="display: inline-block; background: var(--color-copper); color: var(--color-midnight); font-family: var(--font-body); font-size: 15px; font-weight: 600; letter-spacing: 0.8px; text-transform: uppercase; text-decoration: none; padding: 16px 40px; border-radius: 4px;">Get Started</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between icon and inline label.
+- **8px**: Tight gap -- between sub-label and heading, between stat number and label.
+- **12px**: Small gap -- between heading and body text within a component.
+- **16px**: Base gap -- between body paragraphs, between list items in compact mode.
+- **24px**: Medium gap -- between components within a section, standard list item padding.
+- **32px**: Section internal -- padding inside cards and containers, gap between grouped items.
+- **48px**: Section divider -- vertical space between major content blocks.
+- **60px**: Large section padding -- top/bottom padding for hero and CTA blocks.
+- **80px**: Maximum section padding -- cover slides and high-impact hero areas.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 960px |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned text for body content. Center-aligned for hero titles, stats, and CTA blocks.
+- **Grid**: Use a simple 2-column grid for comparison layouts. Single-column for narrative and list content. 3-column for stat grids on widescreen slides.
+- **Horizontal rules**: 2px tall, copper (`#c17f59`), 60px wide, centered -- used as section dividers and decorative accents above/below headlines.
+- **Vertical rhythm**: Maintain consistent 48px gaps between top-level sections. Use 24px gaps between items within a section.
+- **Content gravity**: On widescreen slides (1920x1080), anchor content to the left two-thirds of the frame. Leave the right third as breathing room or for supporting imagery.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, background `#0d0d0d` | Page canvas, base layer |
+| Subtle (Level 1) | `rgba(0,0,0,0.2) 0px 2px 8px` | Slight lift for list items on hover |
+| Card (Level 2) | `rgba(0,0,0,0.3) 0px 8px 24px, rgba(197,127,89,0.04) 0px 0px 12px` | Standard card and container elevation |
+| Featured (Level 3) | `rgba(0,0,0,0.4) 0px 16px 40px, rgba(197,127,89,0.08) 0px 0px 20px` | Featured cards, quote blocks, hero elements |
+| Overlay (Level 4) | `rgba(0,0,0,0.6) 0px 24px 60px` | Modals, overlays, high-priority popups |
+
+### Border Treatments
+- **Standard border**: `1px solid rgba(245,240,232,0.1)` -- barely visible cream line that defines edges without adding visual weight.
+- **Active border**: `1px solid rgba(193,127,89,0.3)` -- copper-tinted border for featured or active containers.
+- **Accent rule**: `2px solid #c17f59` -- solid copper line used as a left-border accent on quote blocks and featured items, or as horizontal dividers.
+- **Divider line**: `1px solid rgba(245,240,232,0.06)` -- nearly invisible separator for dense list content.
+
+### Surface Hierarchy
+On dark backgrounds, elevation is communicated through lightness rather than shadows alone:
+1. **Background** (`#0d0d0d`) -- the darkest layer, the canvas.
+2. **Surface** (`#1a1a1a`) -- cards and containers step up by becoming slightly lighter.
+3. **Inset** (`#141414`) -- recessed areas sit between background and surface, subtly darker than cards.
+4. **Elevated** (`#2a2a2a`) -- the highest non-overlay surface, used for nested content inside cards.
+
+Copper-tinted ambient shadows (`rgba(197,127,89,0.04-0.08)`) add warmth to elevation and prevent the dark-on-dark layering from feeling cold or lifeless.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use copper (`#c17f59`) exclusively as the accent colour -- it is the entire chromatic identity of this style.
+- Use Playfair Display only for display headings (32px and above) and big numbers -- never for body text or UI labels.
+- Keep body text in Inter at weight 300-400 -- lightness keeps the reading experience relaxed and editorial.
+- Use horizontal copper rules (2px, 60px wide) as section dividers -- they are the visual punctuation of this style.
+- Maintain generous line height (1.60-1.65) for body text -- dark backgrounds demand more breathing room.
+- Use uppercase + wide letter-spacing (2px) only for small labels and numbered item categories.
+- Add warm-tinted shadows (`rgba(197,127,89,...)`) to elevation effects to stay on-palette.
+- Use `border-left: 2px solid #c17f59` on quote blocks and comparison "preferred" sides.
+- Limit each slide/section to one focal stat or headline -- editorial design lets single ideas breathe.
+
+### Don't
+- Don't use more than 2 accent colours per slide -- copper and muted gold only. No blues, greens, or reds.
+- Don't use Playfair Display below 22px -- its high-contrast serifs become illegible at small sizes.
+- Don't use pure white (`#ffffff`) for text -- always use cream (`#f5f0e8`) to preserve the warm tone.
+- Don't use pure black (`#000000`) for backgrounds -- always use `#0d0d0d` for the subtle warmth difference.
+- Don't apply bold weight (600+) to Inter body text -- it breaks the light, airy reading feel.
+- Don't use rounded corners above 4px -- this style is sharp and architectural, not soft and friendly.
+- Don't center-align body paragraphs -- only headlines, stats, and CTAs should be centered.
+- Don't use gradients -- this is a flat, editorial palette. Depth comes from layering surfaces, not colour blends.
+- Don't place more than 3 stat numbers in a single row -- each number needs space to command attention.
+- Don't use decorative icons or emoji -- if an icon is needed, use a simple geometric shape (diamond, line, dot) in copper.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale down**: Display Hero becomes 56px (from 72px). Section Heading becomes 40px. Sub-heading stays 32px. Body stays 16px.
+- **Padding**: 60px on all sides. Content area is 960x960px.
+- **Cover slide**: Title centered vertically and horizontally. Copper rule above and below. Subtitle in muted gold.
+- **Content slides**: Left-aligned text. One concept per slide. Number in copper (48px Playfair) at top-left; content below.
+- **Stat slides**: Single stat centered. Big number at 72px. Label and description below.
+- **Swipe indicator**: Small muted gold dots at bottom center, 8px diameter, 12px gap.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Uses full-scale type hierarchy. Display Hero at 72px for the title section.
+- **Padding**: 60px left/right. 80px top/bottom margins.
+- **Section spacing**: 64px vertical gap between major sections. Copper rules (60px wide, centered) between sections.
+- **Vertical rhythm**: Alternate between full-width sections and 2-column grids. Use numbered items for sequential content, stat displays for key metrics, and quote blocks for testimonials.
+- **Footer**: Muted gold text, 13px Inter, with a final copper rule above.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 80px. Section Heading becomes 56px. Body Large becomes 22px.
+- **Padding**: 80px on all sides. Content area is 1760x920px.
+- **Layout**: Left-heavy composition. Title and body text occupy the left 60% of the frame. Right 40% is breathing room or supporting content (stats, small illustrations).
+- **Title slides**: Headline centered on frame. Copper rule centered. Subtitle below.
+- **Content slides**: 2-column max for comparisons. Single column for narrative.
+- **Stat slides**: Up to 3 stats in a row, evenly spaced across the full width.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 64px. Section Heading at 40px. Body at 16px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top third for headline. Middle third for key content (stats, list, or comparison). Bottom third for CTA or closing statement.
+- **Vertical flow**: Content reads top-to-bottom with clear sections. Copper rules separate the three zones.
+- **CTA placement**: Always in the bottom zone, centered, with generous padding above.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Hero becomes 72px in Playfair Display 700 with -1px letter-spacing (approximately 30% larger than Carousel 56px). Section Heading becomes 52px. Body Large becomes 22px in Inter 300-400. Copper numbering and labels scale to 16px with wide tracking.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical text must sit inside y=160 to y=1760.
+- **Layout**: Single centered column. Content max-width 920px. Vertical center of gravity -- cluster hero content in y=400 to y=1500 range. Near-black (`#0d0d0d`) canvas runs edge-to-edge like heavy black stock. Generous vertical breathing room between elements preserves the unhurried magazine rhythm.
+- **Cover slide**: Thin copper (`#c17f59`) horizontal rule 60px wide centered above the headline. Playfair Display headline at 72px in warm cream, tight -1px tracking, 2-3 lines deep. Copper rule below. Subtitle in Inter 300 at 22px in muted gold below the second rule. The whole composition whispers -- like the opening spread of a private members' magazine.
+- **Content slides**: Copper uppercase label at 16px with 2px tracking at the top of the content block. Playfair Display sub-heading at 52px in cream with italic pull-quote treatment when apt. Inter 300-400 body at 22px in cream below. A single thin copper rule separates heading from body. One idea per slide, heavily rested on whitespace.
+- **CTA slide**: Playfair Display headline at 56px centered in the middle zone. Short Inter 300 subtitle. Copper pill button (`#c17f59`) with cream Inter 600 uppercase text and a warm `rgba(197,127,89,0.2)` glow shadow. Thin copper rule closes the composition below.
+- **Progress indicator**: Whisper-thin segments 1px tall at the top of the safe zone -- inactive at `rgba(245,240,232,0.15)`, active in solid copper. No glow, no animation -- just letterpress-quiet structural marks.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Midnight | `#0d0d0d` | Primary background |
+| Cream | `#f5f0e8` | Primary text |
+| Copper | `#c17f59` | Accent: numbers, rules, CTAs, focal points |
+| Muted Gold | `#a89067` | Secondary accent: borders, captions, labels |
+| Warm White | `#ede7db` | Hover state text, high-emphasis body |
+| Deep Copper | `#9a6347` | Hover/active state for copper elements |
+| Charcoal | `#1a1a1a` | Card/container surface |
+| Surface Inset | `#141414` | Recessed panels, code blocks |
+| Dark Gray | `#2a2a2a` | Nested containers, elevated surfaces |
+| Medium Gray | `#4a4a4a` | Disabled text, subtle dividers |
+| Soft Gray | `#6b6b6b` | Tertiary text, descriptions |
+| Light Gray | `#8a8a8a` | De-emphasized captions |
+
+### Font Declarations
+
+```css
+font-family: 'Playfair Display', Georgia, 'Times New Roman', serif;
+font-family: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400;1,700&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors — Primary */
+  --color-midnight: #0d0d0d;
+  --color-cream: #f5f0e8;
+  --color-copper: #c17f59;
+
+  /* Colors — Accent */
+  --color-muted-gold: #a89067;
+  --color-warm-white: #ede7db;
+  --color-deep-copper: #9a6347;
+
+  /* Colors — Neutral Scale */
+  --color-charcoal: #1a1a1a;
+  --color-dark-gray: #2a2a2a;
+  --color-medium-gray: #4a4a4a;
+  --color-soft-gray: #6b6b6b;
+  --color-light-gray: #8a8a8a;
+
+  /* Colors — Surfaces */
+  --color-surface-primary: #1a1a1a;
+  --color-surface-inset: #141414;
+
+  /* Colors — Borders */
+  --color-border-default: rgba(245, 240, 232, 0.1);
+  --color-border-accent: rgba(193, 127, 89, 0.3);
+  --color-border-strong: rgba(245, 240, 232, 0.2);
+  --color-divider-rule: #c17f59;
+
+  /* Colors — Shadows */
+  --shadow-warm: rgba(197, 127, 89, 0.08);
+  --shadow-deep: rgba(0, 0, 0, 0.4);
+  --shadow-soft: rgba(0, 0, 0, 0.2);
+  --shadow-ambient: rgba(197, 127, 89, 0.04);
+
+  /* Typography — Families */
+  --font-display: 'Playfair Display', Georgia, 'Times New Roman', serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography — Sizes */
+  --text-display-hero: 72px;
+  --text-section-heading: 48px;
+  --text-sub-heading: 32px;
+  --text-body-large: 20px;
+  --text-body: 16px;
+  --text-small: 13px;
+  --text-big-number: 64px;
+  --text-label: 14px;
+  --text-cta: 15px;
+
+  /* Typography — Weights */
+  --weight-display: 700;
+  --weight-display-heavy: 900;
+  --weight-body-light: 300;
+  --weight-body: 400;
+  --weight-label: 600;
+
+  /* Typography — Line Heights */
+  --leading-display: 1.05;
+  --leading-heading: 1.10;
+  --leading-sub-heading: 1.15;
+  --leading-body-large: 1.60;
+  --leading-body: 1.65;
+  --leading-small: 1.50;
+  --leading-number: 1.00;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-medium: 24px;
+  --space-large: 32px;
+  --space-section: 48px;
+  --space-hero: 60px;
+  --space-max: 80px;
+
+  /* Borders */
+  --radius-standard: 4px;
+
+  /* Shadows — Composed */
+  --shadow-card: rgba(0,0,0,0.3) 0px 8px 24px, rgba(197,127,89,0.04) 0px 0px 12px;
+  --shadow-featured: rgba(0,0,0,0.4) 0px 16px 40px, rgba(197,127,89,0.08) 0px 0px 20px;
+}
+```
+
+### System Font Fallbacks
+- **Serif (if Playfair Display fails to load):** `Georgia, 'Times New Roman', serif`
+- **Sans-serif (if Inter fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/_full/mint-pixel-corporate.md
+++ b/skills/composites/goose-graphics/styles/_full/mint-pixel-corporate.md
@@ -1,0 +1,554 @@
+# Design Style: Mint Pixel Corporate
+
+## 1. Visual Theme & Atmosphere
+
+Mint Pixel Corporate is the design language of a friendly corporate newsletter — the visual equivalent of a Canva business-tips template that a mid-market ops team actually wants to open on a Monday morning. It pairs the warmth of a Mailchimp campaign with the quietly branded structure of a printed internal magazine, and it gets its identity from one unusual choice: **tiny pixel-art staircases of green squares**, scattered in the corners of every slide like Minecraft blocks that escaped into a business deck. The feel is corporate-friendly rather than corporate-sterile. Think of a family-run design agency pitching to a regional bank, or a LinkedIn Learning course on sustainable leadership — polite, upbeat, and unmistakably templated in the best possible way.
+
+The palette runs on a **two-background variant system**. Cover slides are set on a saturated **forest green** (`#207A3E`) canvas with light cream typography, anchoring the deck with editorial weight. Content slides flip to a pale **mint cream** (`#EAF4C3`) canvas — an almost-pastel yellow-green that reads as airy, nostalgic, and unmistakably "wellness brochure." Inside both variants, the same accent machinery does the work: saturated **lime green** (`#A4D23C`) blocks, rounded rectangles, and a short dark forest green (`#1E6B3A`) for shadow offsets and pixel accents. The lime and forest tones nest together — lime always sits in front, forest always behind — creating a shallow 2-tone offset that makes every photo, headline slab, and decorative square look gently extruded from the page.
+
+Typography is a single humanist sans (**Nunito**) used at 400/600/700 for everything from the 40px section heading down to the 12px metadata strip. There is no serif anywhere in the system — the friendliness comes entirely from Nunito's slightly rounded terminals and warm x-height, reinforced by **justified body text** that gives every content slide the quiet gravity of a printed newsletter column. The signature decorative elements — the pixel staircase clusters, the lime-green asterisk/snowflake glyph inside a tiny square, the offset photo containers with a colored rectangle peeking out behind — are small, repeatable, and deeply load-bearing. Skip them and the style collapses into any other mint-and-green template. Commit to them and the deck instantly reads as "Mint Pixel Corporate."
+
+**Key Characteristics:**
+- Two-background variant system: forest green (`#207A3E`) cover + pale mint cream (`#EAF4C3`) content slides — never mix on the same slide
+- Pixel staircase corner decorations: 4-6 small 16-24px squares in lime (`#A4D23C`) + forest (`#1E6B3A`), arranged in a staircase/pixel-art stagger
+- Lime green (`#A4D23C`) for headline slab backgrounds, accent squares, and the photo offset rectangle
+- Dark forest green (`#1E6B3A`) for text on mint backgrounds, pixel accents, and the photo offset base
+- Cream (`#F5F8E6`) for all text on the forest green cover
+- Nunito at 700 for headlines, 400 for justified body text, 600 for metadata strip — no serif anywhere
+- Offset photo containers: rounded-corner image with a lime green rectangle peeking out ~20px down/right as a color shadow
+- Lime green square (32-40px) containing a white asterisk glyph (`❋` or `*`) as a decorative accent
+- 3-column header metadata strip ("Brand | Category | Date") at top of every content slide with thin vertical dividers
+- Justified body text (`text-align: justify`) — never left-ragged on content slides
+- Headlines sit inside a full-width or half-width lime green rounded rectangle slab
+- Footer row with author name (left) and handle (right), separated by a vertical divider
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Forest Green** (`#207A3E`): Cover slide background. A saturated, friendly forest green — the exact shade of a healthy houseplant in good light.
+- **Mint Cream** (`#EAF4C3`): Content slide background. A pale yellow-green, almost pastel lime. The slide surface for every non-cover page.
+- **Dark Forest** (`#1E6B3A`): Primary text color on mint backgrounds, pixel accent color, and the darker half of the offset photo container. Slightly deeper than the cover background so it reads as type weight, not camouflage.
+
+### Accent
+- **Lime Green** (`#A4D23C`): The primary accent. Used for headline slab backgrounds, pixel corner squares, offset photo rectangles, and asterisk accent squares. Saturated but not neon.
+- **Lime Light** (`#B4DC48`): Slightly brighter lime used for hover/active states and secondary pixel squares for depth variation within a staircase cluster.
+- **Cream** (`#F5F8E6`): Text color on the forest green cover. A warm off-white with a hint of the same yellow-green as the mint background.
+
+### Neutral Scale
+- **Text Primary Mint** (`#1E6B3A`): Dark forest for all body text on mint content slides.
+- **Text Primary Cover** (`#F5F8E6`): Cream for all text on the forest green cover.
+- **Text Secondary** (`#3E8A4E`): A mid forest tone for metadata, captions, and the header strip on mint slides.
+- **Text Muted** (`#6BA36B`): Softer mid-green for tertiary metadata on cover (e.g., "December, 2028" subdued variant).
+- **Border Soft** (`rgba(30, 107, 58, 0.2)`): Thin dividers in the header strip and footer row.
+- **Border Strong** (`rgba(30, 107, 58, 0.4)`): Higher-contrast divider for separators that need to carry weight.
+
+### Surface & Borders
+- **Surface Cover** (`#207A3E`): Primary cover surface.
+- **Surface Content** (`#EAF4C3`): Primary content slide surface.
+- **Surface Slab** (`#A4D23C`): Lime green rectangle slab behind headlines and as photo offset background.
+- **Surface Photo Offset** (`#1E6B3A`): Dark forest rectangle used as the secondary offset layer behind photos for two-tone depth.
+- **Border Slab** (`rgba(30, 107, 58, 0.0)`): Lime slabs are borderless — they rely on the mint background for separation.
+- **Divider Vertical** (`1px solid rgba(30, 107, 58, 0.25)`): Thin vertical rule between header strip columns and footer name/handle.
+
+### Shadow Colors
+- **Shadow Pixel** (`#1E6B3A`): Used as an offset "color shadow" — not a blur, just a solid dark forest square peeking out from behind a lime element.
+- **Shadow Ambient** (`rgba(30, 107, 58, 0.08)`): Very light forest-tinted ambient shadow for elevated photo containers.
+- **Shadow Deep** (`rgba(30, 107, 58, 0.15)`): Slightly deeper variant for featured cards and headline slabs if additional lift is needed.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Nunito:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Nunito', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Body**: `'Nunito', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+Mint Pixel Corporate uses a single-family system. Nunito carries headlines, body, metadata, and accents. The friendliness comes from its slightly rounded terminals, warm x-height, and wide apertures — it is the humanist sans that looks most like a hand-lettered business card without drifting into comic-sans territory.
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Cover Hero | Nunito | 52px | 700 | 1.15 | -0.3px | Cover slide headline on forest green. Cream text. Mixed case. |
+| Section Heading | Nunito | 40px | 700 | 1.18 | -0.2px | Content slide headline inside lime slab. Dark forest text. |
+| Sub-heading | Nunito | 28px | 700 | 1.25 | 0px | Secondary headlines and large callouts. |
+| Body Large | Nunito | 18px | 400 | 1.60 | 0px | Intro paragraphs and lead copy. Justified. |
+| Body | Nunito | 16px | 400 | 1.65 | 0px | Standard body text. Always `text-align: justify` on content slides. |
+| Body Bold | Nunito | 16px | 700 | 1.65 | 0px | Emphasis words inside body copy. |
+| Metadata | Nunito | 12px | 600 | 1.40 | 0.3px | Header strip ("Arowwai Industries", "Business Tips", "December, 2028"). Mixed case. |
+| Footer Label | Nunito | 13px | 600 | 1.40 | 0.2px | Author name and handle at bottom. |
+| Small / Caption | Nunito | 12px | 500 | 1.50 | 0px | Photo captions and auxiliary labels. |
+| Big Number | Nunito | 64px | 800 | 1.00 | -0.5px | Statistics and key metrics on content slides. |
+| CTA Text | Nunito | 14px | 700 | 1.00 | 0.3px | Button labels. |
+
+### Principles
+- **Single family discipline**: Every text element uses Nunito. Do not mix in a serif, a monospace, or a display font. The consistency is what makes the system feel templated-in-a-good-way.
+- **Weight as hierarchy**: Use weight (400/600/700/800) rather than font family to establish hierarchy. Headlines are 700. Body is 400. Metadata is 600 to stand apart from body.
+- **Justified body text is mandatory**: On every content slide, body paragraphs use `text-align: justify` with `hyphens: auto`. This is the clearest visual tell of the style — left-ragged body text instantly breaks the look.
+- **Moderate headline size**: Headlines sit around 40-52px — large enough to command, small enough to fit inside a lime slab without overflowing. Never scale past 64px.
+- **Mixed case always**: Headlines and body are mixed case with sentence-case capitalization. Uppercase is reserved only for nothing — even the metadata strip uses Title Case.
+- **Tight tracking on headlines, neutral on body**: Headlines use `-0.2px` to `-0.3px` letter-spacing to tighten the rounded letterforms. Body stays at 0px.
+- **Line height for warmth**: Body at 1.60-1.65 creates airy, newsletter-column reading. Headlines at 1.15-1.18 keep them compact inside the lime slab.
+
+## 4. Component Patterns
+
+### Title Block -- Cover Slide (forest green variant)
+
+```html
+<div style="background-color: var(--color-cover-bg); padding: 60px 60px 80px; position: relative; min-height: 900px; display: flex; flex-direction: column;">
+  <!-- Header metadata strip -->
+  <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; align-items: center; gap: 0; padding-bottom: 48px;">
+    <div style="font-family: var(--font-body); font-size: 12px; font-weight: 600; color: var(--color-cream); opacity: 0.85;">Arowwai Industries</div>
+    <div style="text-align: center; font-family: var(--font-body); font-size: 12px; font-weight: 600; color: var(--color-cream); opacity: 0.85; border-left: 1px solid rgba(245,248,230,0.35); border-right: 1px solid rgba(245,248,230,0.35); padding: 4px 0;">Business Tips</div>
+    <div style="text-align: right; font-family: var(--font-body); font-size: 12px; font-weight: 600; color: var(--color-cream); opacity: 0.85;">December, 2028</div>
+  </div>
+
+  <!-- Hero headline -->
+  <h1 style="font-family: var(--font-display); font-size: 52px; font-weight: 700; line-height: 1.15; letter-spacing: -0.3px; color: var(--color-cream); text-align: center; margin: 24px 0 40px;">Leadership and<br>Business Lessons for<br>Sustainable Growth</h1>
+
+  <!-- Offset photo container (see dedicated component below) -->
+  <div style="flex: 1;"><!-- photo with pixel decorations goes here --></div>
+
+  <!-- Footer row -->
+  <div style="display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 16px; padding-top: 40px;">
+    <div style="font-family: var(--font-body); font-size: 13px; font-weight: 600; color: var(--color-cream); opacity: 0.85;">Hannah Morales</div>
+    <div style="width: 1px; height: 16px; background: rgba(245,248,230,0.35);"></div>
+    <div style="text-align: right; font-family: var(--font-body); font-size: 13px; font-weight: 600; color: var(--color-cream); opacity: 0.85;">@reallygreatsite</div>
+  </div>
+</div>
+```
+
+### Title Block -- Content Slide (mint variant)
+
+```html
+<div style="background-color: var(--color-content-bg); padding: 48px 60px 60px; position: relative; min-height: 900px; display: flex; flex-direction: column;">
+  <!-- Header metadata strip -->
+  <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; align-items: center; gap: 0; padding-bottom: 40px;">
+    <div style="font-family: var(--font-body); font-size: 12px; font-weight: 600; color: var(--color-text-secondary);">Arowwai Industries</div>
+    <div style="text-align: center; font-family: var(--font-body); font-size: 12px; font-weight: 600; color: var(--color-text-secondary); border-left: 1px solid rgba(30,107,58,0.25); border-right: 1px solid rgba(30,107,58,0.25); padding: 4px 0;">Business Tips</div>
+    <div style="text-align: right; font-family: var(--font-body); font-size: 12px; font-weight: 600; color: var(--color-text-secondary);">December, 2028</div>
+  </div>
+
+  <!-- Headline inside lime slab -->
+  <div style="background: var(--color-lime); border-radius: 12px; padding: 40px 44px; margin: 32px 0 40px;">
+    <h2 style="font-family: var(--font-display); font-size: 40px; font-weight: 700; line-height: 1.18; letter-spacing: -0.2px; color: var(--color-text-primary); margin: 0;">Lead with Long-<br>Term Vision</h2>
+  </div>
+
+  <!-- Body (justified) -->
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-text-primary); text-align: justify; hyphens: auto; max-width: 640px; margin: 0;">Sustainable growth begins with clarity of direction. Strong leaders focus not only on short-term results but also on long-term impact. A clear vision helps teams stay aligned, make better decisions, and build momentum that lasts beyond temporary success.</p>
+
+  <!-- Footer row -->
+  <div style="margin-top: auto; display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 16px; padding-top: 40px;">
+    <div style="font-family: var(--font-body); font-size: 13px; font-weight: 600; color: var(--color-text-secondary);">Hannah Morales</div>
+    <div style="width: 1px; height: 16px; background: rgba(30,107,58,0.3);"></div>
+    <div style="text-align: right; font-family: var(--font-body); font-size: 13px; font-weight: 600; color: var(--color-text-secondary);">@reallygreatsite</div>
+  </div>
+</div>
+```
+
+### Pixel Staircase Corner (the signature)
+
+A cluster of 4-6 small squares arranged in a staircase/pixel-art stagger. Place in slide corners, next to headline slabs, and beside photos. Mix lime and dark forest squares for depth.
+
+```html
+<!-- Top-left pixel staircase (descending) -->
+<div style="position: absolute; top: 120px; left: 60px; width: 80px; height: 80px;">
+  <div style="position: absolute; top: 0; left: 0; width: 28px; height: 28px; background: var(--color-lime); border-radius: 2px;"></div>
+  <div style="position: absolute; top: 0; left: 32px; width: 20px; height: 20px; background: var(--color-dark-forest); border-radius: 2px;"></div>
+  <div style="position: absolute; top: 32px; left: 20px; width: 16px; height: 16px; background: var(--color-lime); border-radius: 2px;"></div>
+  <div style="position: absolute; top: 40px; left: 40px; width: 24px; height: 24px; background: var(--color-dark-forest); border-radius: 2px;"></div>
+</div>
+
+<!-- Small 3-square staircase (bottom-right of a photo) -->
+<div style="position: absolute; bottom: -12px; right: -12px; width: 60px; height: 60px;">
+  <div style="position: absolute; top: 0; right: 28px; width: 16px; height: 16px; background: var(--color-lime); border-radius: 2px;"></div>
+  <div style="position: absolute; top: 12px; right: 12px; width: 20px; height: 20px; background: var(--color-dark-forest); border-radius: 2px;"></div>
+  <div style="position: absolute; bottom: 0; right: 0; width: 24px; height: 24px; background: var(--color-lime); border-radius: 2px;"></div>
+</div>
+```
+
+**Rules for the staircase:**
+- Always 3-6 squares. Never a single isolated square (looks like a bullet point); never more than 6 (looks like a mosaic).
+- Squares are 14-28px. Mix at least two sizes per cluster.
+- Alternate lime and dark forest — never two lime touching without a dark forest between, never two dark forests touching.
+- Each square has `border-radius: 2px` (softened, not sharp — matches the rounded headline slab).
+- Staircase direction varies per corner: top-left descends down-and-right, top-right descends down-and-left, etc.
+- Use at least one staircase cluster per slide. Two clusters on content slides is standard.
+
+### Offset Photo Container
+
+A photo in a rounded rectangle with a lime green rectangle peeking out ~20px down/right behind it, plus an optional dark forest rectangle at the opposite offset. This is the "Canva stacked photo" pattern.
+
+```html
+<div style="position: relative; display: inline-block; width: 360px; height: 240px; margin: 20px 20px 32px 0;">
+  <!-- Lime offset rectangle (back layer) -->
+  <div style="position: absolute; top: 20px; left: 20px; width: 100%; height: 100%; background: var(--color-lime); border-radius: 12px;"></div>
+  <!-- Dark forest offset rectangle (secondary back layer) -->
+  <div style="position: absolute; top: -12px; left: -12px; width: 60px; height: 60px; background: var(--color-dark-forest); border-radius: 4px;"></div>
+  <!-- Photo (front layer) -->
+  <img src="PHOTO_URL" alt="" style="position: relative; width: 100%; height: 100%; object-fit: cover; border-radius: 12px; display: block;">
+</div>
+```
+
+**Rules:**
+- The lime rectangle is always offset 16-24px in one diagonal direction (typically down-right).
+- Photos are always rounded 12px. Lime offset matches the same radius.
+- Optional dark forest "corner block" can be added at the opposite corner for extra two-tone depth.
+- Pair every offset photo with at least one pixel staircase cluster near its corner.
+
+### Asterisk Square Accent
+
+A small lime-green square containing a white or dark forest asterisk/snowflake glyph. Used as a decorative "dot" near headlines, photos, or section breaks.
+
+```html
+<div style="display: inline-flex; align-items: center; justify-content: center; width: 40px; height: 40px; background: var(--color-lime); border-radius: 4px; font-family: var(--font-body); font-size: 24px; font-weight: 700; color: var(--color-cream); line-height: 1;">❋</div>
+```
+
+**Variants:**
+- 32px square + 18px glyph: inline accent near body text.
+- 40px square + 24px glyph: near headlines and photos (standard).
+- 56px square + 32px glyph: prominent cover slide accent.
+- Glyph options: `❋`, `✳`, `✤`, or a plain `*`. The `❋` (eight-pointed snowflake) is the closest to the reference.
+- On the forest cover, glyph is cream (`#F5F8E6`); on mint content slides, glyph is cream or dark forest depending on contrast.
+
+### Header Metadata Strip
+
+A 3-column top bar with brand name, category, and date separated by thin vertical dividers. Mandatory on every content slide.
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr 1fr; align-items: center; gap: 0; padding-bottom: 40px;">
+  <div style="font-family: var(--font-body); font-size: 12px; font-weight: 600; color: var(--color-text-secondary);">Arowwai Industries</div>
+  <div style="text-align: center; font-family: var(--font-body); font-size: 12px; font-weight: 600; color: var(--color-text-secondary); border-left: 1px solid rgba(30,107,58,0.25); border-right: 1px solid rgba(30,107,58,0.25); padding: 4px 0;">Business Tips</div>
+  <div style="text-align: right; font-family: var(--font-body); font-size: 12px; font-weight: 600; color: var(--color-text-secondary);">December, 2028</div>
+</div>
+```
+
+**Rules:**
+- Always 3 columns, equal width, grid-based (not flex with justify-between — must be true thirds).
+- Left column: brand name, left-aligned. Middle: category, center-aligned. Right: date, right-aligned.
+- Vertical dividers are `1px solid rgba(30,107,58,0.25)` on the middle column's left and right borders.
+- Text is Nunito 12px, weight 600, mixed case, color `--color-text-secondary` on mint or cream with 0.85 opacity on cover.
+
+### Numbered Item
+
+```html
+<div style="display: flex; gap: 20px; padding: 20px 0;">
+  <div style="flex-shrink: 0; display: flex; align-items: center; justify-content: center; width: 40px; height: 40px; background: var(--color-lime); border-radius: 8px; font-family: var(--font-body); font-size: 20px; font-weight: 800; color: var(--color-text-primary);">1</div>
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-text-primary); text-align: justify; hyphens: auto; margin: 0;">Sustainable growth begins with clarity of direction. Strong leaders focus not only on short-term results but also on long-term impact.</p>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="display: inline-block; padding: 28px 36px; background: var(--color-lime); border-radius: 12px; text-align: left;">
+  <p style="font-family: var(--font-display); font-size: 64px; font-weight: 800; line-height: 1.00; letter-spacing: -0.5px; color: var(--color-text-primary); margin: 0 0 4px;">47%</p>
+  <p style="font-family: var(--font-body); font-size: 14px; font-weight: 600; line-height: 1.40; color: var(--color-text-primary); margin: 0; text-transform: none;">Faster response times</p>
+</div>
+```
+
+### Quote Block
+
+```html
+<div style="padding: 36px 40px; background: var(--color-lime); border-radius: 12px; position: relative;">
+  <p style="font-family: var(--font-body); font-size: 22px; font-weight: 700; line-height: 1.40; color: var(--color-text-primary); margin: 0 0 20px; text-align: justify; hyphens: auto;">"It felt less like configuring software and more like onboarding a new team member."</p>
+  <div style="display: flex; align-items: center; gap: 12px;">
+    <div style="width: 24px; height: 2px; background: var(--color-text-primary); border-radius: 1px;"></div>
+    <p style="font-family: var(--font-body); font-size: 12px; font-weight: 600; letter-spacing: 0.3px; color: var(--color-text-primary); margin: 0;">Sarah Chen, VP Operations</p>
+  </div>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="text-align: center; padding: 60px 40px; background: var(--color-content-bg); position: relative;">
+  <h2 style="font-family: var(--font-display); font-size: 40px; font-weight: 700; line-height: 1.18; letter-spacing: -0.2px; color: var(--color-text-primary); margin: 0 0 20px;">Meet your new coworker</h2>
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.60; color: var(--color-text-primary); max-width: 520px; margin: 0 auto 36px;">Deploy your first AI coworker in minutes. Start free, scale when ready.</p>
+  <a style="display: inline-block; background: var(--color-lime); color: var(--color-text-primary); font-family: var(--font-body); font-size: 14px; font-weight: 700; letter-spacing: 0.3px; text-decoration: none; padding: 16px 40px; border-radius: 28px;">Get Started Free</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap — pixel staircase inter-square spacing, badge internal padding.
+- **8px**: Tight gap — between metadata strip label and divider, numbered item icon gap.
+- **12px**: Small gap — between headline lines, between footer name and divider.
+- **16px**: Base gap — between body paragraphs, between pixel cluster squares in some arrangements.
+- **20px**: Photo offset distance — the canonical "stacked photo" offset value.
+- **24px**: Medium gap — between section heading and body text, between headline slab and next element.
+- **32px**: Block gap — between headline slab and body copy, between metadata strip and headline on content slides.
+- **40px**: Section gap — between major content blocks, between header strip and headline, between body and footer.
+- **48px**: Large section gap — between cover header strip and hero headline.
+- **60px**: Outer padding — standard left/right canvas padding.
+- **80px**: Maximum padding — vertical padding on cover and Story formats.
+- **120px**: Story format horizontal padding (wider canvas for 1080x1920).
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 960px |
+| **Story (1080x1920)** | **120px left/right, 60px top/bottom** | **840px** |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned for headlines and body on content slides; center-aligned for cover slide hero. Body text is always `text-align: justify`.
+- **Grid**: The header metadata strip is always a 3-column grid (`1fr 1fr 1fr`). The footer row is a 3-column grid (`1fr auto 1fr`) with a vertical divider in the middle.
+- **Headline slab width**: Lime headline slabs are either full-width (left and right aligned to content max-width) or partial-width (60-75% of content area) leaving room for a photo or pixel cluster beside them.
+- **Photo placement**: Offset photo containers sit top-left, top-right, or inline-left of a body paragraph. Never centered.
+- **Pixel staircase anchoring**: Every slide has at least one pixel cluster near a corner. Content slides typically have two (diagonally opposite corners).
+- **Vertical rhythm**: Maintain 32-40px gaps between headline slab and body, 40-48px gaps between major sections.
+- **Content gravity on Story format**: On 1080x1920, stack elements vertically with more breathing room — headline slab, offset photo, body, pixel accent — each separated by 48-60px.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, solid background color | Canvas (cover or mint), most slides |
+| Color Offset (Level 1) | `20px` lime or dark forest solid rectangle offset behind an element | Photo containers, the signature "stacked" effect |
+| Soft (Level 2) | `0 4px 12px rgba(30,107,58,0.08)` | Optional subtle lift on headline slabs |
+| Elevated (Level 3) | `0 8px 24px rgba(30,107,58,0.12)` | Featured quote blocks, CTA buttons on hover |
+| Overlay (Level 4) | `0 16px 40px rgba(30,107,58,0.18)` | Modals or floating callouts (rarely used) |
+
+### Border Treatments
+- **No visible borders on slabs**: Lime headline slabs and photo containers have zero border — they rely on color contrast against the mint background.
+- **Thin metadata dividers**: `1px solid rgba(30,107,58,0.25)` for vertical dividers in the header strip and footer row.
+- **Pixel square rounding**: All pixel-cluster squares use `border-radius: 2px` — softened enough to harmonize with the rounded slabs, sharp enough to still read as pixel-art.
+- **Slab corner radius**: Lime headline slabs and photo containers use `border-radius: 12px`. Small asterisk accent squares use `border-radius: 4px`. Buttons use `border-radius: 28px`.
+- **No stroke-based dividers on body**: Do not use horizontal rules (`<hr>`) — sections are separated by whitespace and color-block transitions, never by lines.
+
+### Surface Hierarchy
+Depth in Mint Pixel Corporate is communicated through **color offset**, not through blur shadows:
+1. **Background** (mint `#EAF4C3` or cover `#207A3E`) — flat canvas.
+2. **Color offset layer** (lime `#A4D23C` or dark forest `#1E6B3A`) — solid rectangle peeking out behind a photo or slab, creating a 2-tone "stacked" effect. This is the primary depth signal.
+3. **Foreground element** (photo, headline slab, body text) — sits above the offset.
+4. **Pixel accents** (staircase clusters, asterisk squares) — float on top, structurally decorative, never functional.
+Blur shadows are almost never used. When they are, they are subtle and tinted with dark forest for palette consistency.
+
+## 7. Do's and Don'ts
+
+### Do
+- **Use the pixel staircase corner decoration on every slide.** It is the signature — at least one cluster of 3-6 lime and dark forest squares per slide, usually two on content slides in diagonally opposite corners.
+- **Use the two-background variant system strictly.** Cover slide uses forest green (`#207A3E`). All content slides use mint cream (`#EAF4C3`). Never mix a forest element into a mint slide or vice versa beyond the lime accent system.
+- **Always include the 3-column header metadata strip on content slides.** `Brand Name | Category | Date` with thin vertical dividers between columns.
+- **Use justified body text (`text-align: justify; hyphens: auto;`) on every content slide.** Left-ragged body text instantly breaks the look.
+- **Use lime green (`#A4D23C`) as the primary accent for headline slabs, photo offsets, and accent squares.** It is the only saturated color on mint slides.
+- **Use Nunito for everything.** Headlines at 700, body at 400, metadata at 600. No serif, no monospace, no secondary display font.
+- **Use the offset photo container pattern.** A photo with a lime rectangle peeking 20px down-right behind it, optionally with a dark forest corner block at the opposite offset.
+- **Include the asterisk glyph (`❋`) inside a small lime square** as a decorative accent near headlines or photos — at least once per deck.
+- **Set headlines inside a lime rounded rectangle slab** rather than letting them float on the mint canvas.
+- **Use dark forest (`#1E6B3A`) as the only text color on mint slides.** Cream (`#F5F8E6`) is the only text color on the cover.
+- **Keep headlines at 40-52px.** Moderate scale, never massive.
+- **Include the author name + handle footer row** with a vertical divider between them on every slide.
+
+### Don't
+- **Don't use serif fonts.** Playfair, Cormorant, Fraunces — any serif will kill the friendly newsletter feel. Nunito only.
+- **Don't use saturated colors outside the forest + lime + mint system.** No blues, no reds, no oranges, no purples. Even within green, stay on the exact forest/lime/mint triad.
+- **Don't skip the pixel staircase decoration.** It is the identity. A Mint Pixel Corporate slide without pixel clusters is just a beige Canva template.
+- **Don't use left-ragged body text.** Always justify.
+- **Don't use massive 72px+ headlines.** The style is moderate-scale — headlines top out at 52px on the cover, 40px on content slides.
+- **Don't mix the two backgrounds on a single slide.** Forest green is cover-only. Mint is content-only.
+- **Don't use sharp corners on photos, slabs, or buttons.** Everything has `border-radius: 12px` (slabs/photos) or `border-radius: 4px` (small accents) or `border-radius: 28px` (buttons).
+- **Don't use drop-shadow blur for depth.** Use the color-offset stacked pattern — a solid lime or dark forest rectangle behind an element — as the primary depth signal.
+- **Don't use a single pixel square by itself** — it reads as a bullet point. Always 3-6 squares in a cluster.
+- **Don't use uppercase headlines or body text.** Mixed case only.
+- **Don't skip the header metadata strip on content slides.** The "Brand | Category | Date" bar is load-bearing.
+- **Don't use emoji or illustrative icons.** The asterisk glyph (`❋`) is the only decorative glyph in the system.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale**: Cover Hero at 52px. Section Heading (content) at 40px. Body at 16px. Metadata at 12px.
+- **Padding**: 60px on all sides. Content area is 960x960px.
+- **Cover slide**: Forest green background. Header metadata strip at top in cream. Hero headline centered in cream, 3 lines max. Offset photo container below, centered or left-aligned with pixel staircase clusters in corners. Footer row at bottom with name/handle.
+- **Content slides**: Mint cream background. Header metadata strip (mandatory). Lime headline slab below strip (full or partial width). Justified body paragraph under slab. Optional offset photo in top-right or top-left. Pixel staircase clusters in 2 diagonal corners. Footer row at bottom.
+- **Swipe indicator**: Small 8px dark forest squares at bottom center, active one in lime — matching the pixel aesthetic.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Cover Hero at 52px for the top section. Section Heading at 40px for each block.
+- **Padding**: 60px left/right, 80px top/bottom. Vertical content flows continuously.
+- **Top section**: Forest green "cover" band (300-400px tall) with title and metadata strip, followed by mint cream sections below.
+- **Section spacing**: 60px vertical gap between mint content sections. Each section gets its own lime headline slab and justified body paragraph.
+- **Pixel clusters**: Place 1 cluster per section, alternating corners down the page to create rhythm.
+- **Footer**: Mint band with footer row (name + handle) and a pixel staircase cluster in each bottom corner.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Cover Hero at 72px. Section Heading at 56px. Body Large at 20px. Body at 18px. Metadata at 14px.
+- **Padding**: 80px on all sides. Content area is 1760x920px.
+- **Layout**: Two-column friendly. Left column holds the lime headline slab + justified body paragraph; right column holds the offset photo container with pixel staircase clusters around it.
+- **Cover slide**: Forest green full-bleed. Centered hero title. Offset photo below title, 50-60% width, with pixel clusters. Footer row at bottom.
+- **Content slides**: Mint background. Header strip at top (mandatory). Left: lime slab headline + justified body. Right: offset photo with pixel clusters. Footer row at bottom.
+- **CTA slides**: Mint background. Centered headline in lime slab, short body, lime rounded button, pixel clusters in all four corners.
+
+### Poster (1080x1350px)
+- **Typography**: Cover Hero at 60px. Section Heading at 44px. Body at 17px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top third for metadata strip + hero headline (inside lime slab if mint variant, or cream type if forest variant). Middle third for offset photo container (larger — up to 480px wide). Bottom third for justified body paragraph and footer row.
+- **Vertical flow**: Reads top-to-bottom. Pixel staircase clusters appear at least in 2 corners (typically top-left and bottom-right).
+- **Variant choice**: Forest green for event/announcement posters; mint for editorial/content posters.
+
+### Story (1080x1920px)
+- **Typography scale up (~30% bigger than carousel)**: Cover Hero at **68px** (52 × 1.3). Section Heading at **52px** (40 × 1.3). Body Large at **22px**. Body at **20px** (16 × 1.25 for legibility at arm's length on phone). Metadata at **14px**. Footer at **16px**.
+- **Padding**: **120px left/right, 60px top/bottom**. Content area is 840x1800px. The wider side padding keeps content in the "safe zone" clear of phone UI overlays (profile pic, reply bar, tap zones).
+- **Cover slide (forest green)**: Metadata strip at top in cream. Hero headline centered, 3-4 lines, cream type at 68px. Offset photo container mid-canvas, ~720px tall. Pixel staircase clusters in all 4 corners. Footer row with name/handle near bottom.
+- **Content slide (mint)**: Metadata strip at top. Lime headline slab spanning near-full-width below strip. Offset photo below slab, 640x480. Justified body paragraph below photo with generous 22px body size. Pixel clusters in top-left and bottom-right corners. Asterisk square accent beside the photo or headline. Footer row at bottom.
+- **Layout notes**: Because Story is tall and narrow, stack elements vertically with 60-80px gaps between blocks. Avoid side-by-side photo + text layouts — they squeeze on a 9:16 canvas. Pixel clusters get ~30% larger (20-36px squares vs 14-28px on carousel) to match the bigger hero.
+- **Safe zones**: Keep critical content (headline, body) between 280px from top and 300px from bottom on 1920px height to clear Instagram/TikTok UI chrome. The header strip sits just inside this safe zone, and the footer row sits just above it.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Forest Green | `#207A3E` | Cover slide background |
+| Mint Cream | `#EAF4C3` | Content slide background |
+| Dark Forest | `#1E6B3A` | Primary text on mint, pixel accent, photo offset dark layer |
+| Lime Green | `#A4D23C` | Headline slabs, photo offset, pixel accent, accent squares |
+| Lime Light | `#B4DC48` | Secondary pixel squares, hover/active states |
+| Cream | `#F5F8E6` | Text on forest green cover |
+| Text Secondary | `#3E8A4E` | Metadata strip, captions on mint |
+| Text Muted | `#6BA36B` | Tertiary metadata |
+| Border Soft | `rgba(30, 107, 58, 0.2)` | Header strip dividers |
+| Border Strong | `rgba(30, 107, 58, 0.4)` | Prominent dividers |
+| Shadow Ambient | `rgba(30, 107, 58, 0.08)` | Subtle lift on photos |
+| Shadow Deep | `rgba(30, 107, 58, 0.15)` | Elevated cards |
+
+### Font Declarations
+
+```css
+/* Display and body (single family) */
+font-family: 'Nunito', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Nunito:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-cover-bg: #207A3E;
+  --color-content-bg: #EAF4C3;
+  --color-dark-forest: #1E6B3A;
+  --color-text-primary: #1E6B3A;
+  --color-cream: #F5F8E6;
+
+  /* Colors -- Accent */
+  --color-lime: #A4D23C;
+  --color-lime-light: #B4DC48;
+
+  /* Colors -- Neutral Scale */
+  --color-text-secondary: #3E8A4E;
+  --color-text-muted: #6BA36B;
+
+  /* Colors -- Surfaces */
+  --color-surface-cover: #207A3E;
+  --color-surface-content: #EAF4C3;
+  --color-surface-slab: #A4D23C;
+  --color-surface-photo-offset: #1E6B3A;
+
+  /* Colors -- Borders */
+  --color-border-soft: rgba(30, 107, 58, 0.2);
+  --color-border-strong: rgba(30, 107, 58, 0.4);
+  --color-divider-vertical: rgba(30, 107, 58, 0.25);
+  --color-divider-cover: rgba(245, 248, 230, 0.35);
+
+  /* Colors -- Shadows */
+  --shadow-ambient: rgba(30, 107, 58, 0.08);
+  --shadow-medium: rgba(30, 107, 58, 0.12);
+  --shadow-deep: rgba(30, 107, 58, 0.18);
+
+  /* Typography -- Families */
+  --font-display: 'Nunito', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-body: 'Nunito', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-cover-hero: 52px;
+  --text-section-heading: 40px;
+  --text-sub-heading: 28px;
+  --text-body-large: 18px;
+  --text-body: 16px;
+  --text-body-small: 14px;
+  --text-metadata: 12px;
+  --text-footer: 13px;
+  --text-big-number: 64px;
+  --text-cta: 14px;
+
+  /* Typography -- Weights */
+  --weight-light: 300;
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --weight-bold: 700;
+  --weight-extrabold: 800;
+
+  /* Typography -- Line Heights */
+  --leading-hero: 1.15;
+  --leading-heading: 1.18;
+  --leading-sub-heading: 1.25;
+  --leading-body-large: 1.60;
+  --leading-body: 1.65;
+  --leading-metadata: 1.40;
+  --leading-number: 1.00;
+
+  /* Typography -- Tracking */
+  --tracking-hero: -0.3px;
+  --tracking-heading: -0.2px;
+  --tracking-body: 0px;
+  --tracking-metadata: 0.3px;
+  --tracking-cta: 0.3px;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-photo-offset: 20px;
+  --space-medium: 24px;
+  --space-block: 32px;
+  --space-section: 40px;
+  --space-large: 48px;
+  --space-outer: 60px;
+  --space-max: 80px;
+  --space-story-outer: 120px;
+
+  /* Borders */
+  --radius-slab: 12px;
+  --radius-photo: 12px;
+  --radius-pixel: 2px;
+  --radius-accent: 4px;
+  --radius-button: 28px;
+
+  /* Shadows (composed) */
+  --shadow-soft: 0 4px 12px rgba(30, 107, 58, 0.08);
+  --shadow-elevated: 0 8px 24px rgba(30, 107, 58, 0.12);
+  --shadow-overlay: 0 16px 40px rgba(30, 107, 58, 0.18);
+}
+```
+
+### System Font Fallbacks
+- **Sans-serif (if Nunito fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/_full/paper-and-ink.md
+++ b/skills/composites/goose-graphics/styles/_full/paper-and-ink.md
@@ -1,0 +1,464 @@
+# Design Style: Paper & Ink
+
+## 1. Visual Theme & Atmosphere
+
+Paper & Ink is the design language of the printed word at its most refined -- the tradition of literary magazines, broadsheet newspapers, and beautifully typeset books brought into digital form. The off-white background (`#faf8f5`) is not simply white; it is the warm cream of quality uncoated stock, the kind of paper you encounter in a first-edition hardcover or the pages of The New York Times Magazine. Every design decision in this system traces back to the conventions of print typography: generous margins, careful leading, hairline rules as structural punctuation, and the quiet authority of well-set serif type.
+
+The typographic pairing of Cormorant Garamond and Lora creates a system rooted entirely in serif tradition. Cormorant Garamond is the display face -- an elegant, high-contrast serif inspired by Claude Garamond's sixteenth-century designs but redrawn for digital with sharper detail and more dramatic proportions. At display sizes (40px+), its fine hairlines and generous swashes create headlines that feel genuinely literary, as if set in hot metal. Lora is the body companion -- a contemporary serif designed specifically for screen reading, with sturdy serifs and well-balanced proportions that remain legible at 16px on any device. The contrast between Cormorant's delicate display elegance and Lora's workmanlike reliability mirrors the structure of a well-designed book: the title page seduces, the body text serves.
+
+Deep red (`#c41e3a`) is the sole accent colour -- the crimson of a dropped capital letter in an illuminated manuscript, of the masthead of a storied newspaper. Used for drop caps, pull quote marks, accent rules, and call-to-action elements, it provides the only chromatic punctuation in an otherwise monochrome palette. Warm gray (`#6b6560`) handles secondary text, captions, and metadata with the quiet dignity of printer's gray. The entire palette is deliberately restrained: black, cream, red, gray. This is a system that believes ornament is distraction and that the best design is invisible, letting the content command every ounce of attention.
+
+Drop caps (CSS `::first-letter`), pull quotes with oversized quotation marks, and thin hairline rules (1px borders) are the decorative vocabulary -- borrowed directly from centuries of editorial print design.
+
+**Key Characteristics:**
+- Off-white/cream background (`#faf8f5`) -- the colour of quality uncoated paper, warm and easy on the eyes
+- True black (`#000000`) for primary text -- no charcoal softening, this style has the confidence to use full black
+- Cormorant Garamond for all display type (40px+) -- high-contrast, elegant serif with genuine literary presence
+- Lora for all body text -- sturdy, screen-optimized serif that reads beautifully at text sizes
+- Deep red (`#c41e3a`) as the singular accent colour for drop caps, rules, pull quotes, and CTAs
+- Warm gray (`#6b6560`) for secondary text, captions, timestamps, and metadata
+- Hairline rules (`1px solid`) as structural dividers -- the visual punctuation of editorial layout
+- Drop caps using CSS `::first-letter` at 4-5x the body text size, coloured in deep red
+- Pull quotes with large decorative quotation marks in deep red, set in Cormorant Garamond italic
+- Generous margins and white space -- content breathes in the tradition of book design
+- Serif throughout -- no sans-serif anywhere in the system
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Paper** (`#faf8f5`): Primary background. The warm cream of quality uncoated stock.
+- **Ink** (`#000000`): Primary text colour. True black for maximum authority and readability.
+- **Deep Red** (`#c41e3a`): Primary accent. Drop caps, pull quote marks, accent rules, CTAs, and focal points.
+
+### Accent
+- **Dark Red** (`#9e1830`): Hover/active state for deep red elements. Richer and more saturated.
+- **Light Red** (`rgba(196,30,58,0.08)`): Background tint for highlighted blocks and featured callouts.
+- **Red Rule** (`#c41e3a`): Solid red for horizontal accent rules and drop cap colour.
+
+### Neutral Scale
+- **True Black** (`#000000`): Headlines, primary body text, and high-emphasis elements.
+- **Near Black** (`#1a1a18`): Secondary headlines and subheadings on lighter backgrounds.
+- **Warm Gray** (`#6b6560`): Secondary text for captions, bylines, timestamps, and metadata.
+- **Medium Gray** (`#9a9590`): Placeholder text, disabled elements, and de-emphasized content.
+- **Light Gray** (`#c8c4c0`): Hairline rules, borders, and structural dividers.
+- **Pale Gray** (`#e8e5e0`): Background for inset panels, blockquotes, and recessed areas.
+- **Off-White** (`#f4f1ec`): Alternate surface for subtle section differentiation.
+
+### Surface & Borders
+- **Surface Primary** (`#faf8f5`): The default page background.
+- **Surface Inset** (`#f4f1ec`): Recessed panels, sidebar backgrounds, and blockquote containers.
+- **Surface Highlight** (`rgba(196,30,58,0.05)`): Very faint red wash for featured content areas.
+- **Border Hairline** (`#c8c4c0`): Standard `1px solid` hairline rule for section dividers and table borders.
+- **Border Strong** (`#000000`): Black `1px solid` for top-of-article rules and major structural borders.
+- **Border Accent** (`#c41e3a`): Red `1px solid` or `2px solid` for accent rules and featured borders.
+- **Border Faint** (`#e8e5e0`): Barely visible divider for dense list content.
+
+### Shadow Colors
+- **Shadow Soft** (`rgba(0,0,0,0.06)`): Minimal shadow for barely-there lift. Used sparingly.
+- **Shadow Medium** (`rgba(0,0,0,0.10)`): Moderate shadow for modal or overlay contexts.
+- **Shadow Deep** (`rgba(0,0,0,0.15)`): Maximum shadow depth -- still subtle, print design avoids heavy shadows.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Cormorant Garamond', Garamond, 'Times New Roman', serif`
+- **Body**: `'Lora', Georgia, 'Times New Roman', serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Cormorant Garamond | 72px | 700 | 1.05 | -1px | Cover headlines, major feature titles |
+| Section Heading | Cormorant Garamond | 48px | 700 | 1.10 | -0.5px | Major section titles |
+| Sub-heading | Cormorant Garamond | 32px | 600 | 1.20 | 0px | Subsection titles, card headings |
+| Body Large | Lora | 20px | 400 | 1.70 | 0px | Lead paragraphs, article introductions |
+| Body | Lora | 16px | 400 | 1.75 | 0.1px | Standard reading text |
+| Small / Caption | Lora | 13px | 400 | 1.50 | 0.3px | Bylines, timestamps, metadata |
+| Big Numbers | Cormorant Garamond | 72px | 700 | 1.00 | -1px | Statistics, key metrics |
+| Pull Quote | Cormorant Garamond | 36px | 400 | 1.35 | 0px | Italic. Featured quotations with large marks |
+| Drop Cap | Cormorant Garamond | 80px | 700 | 0.85 | 0px | CSS ::first-letter, deep red colour |
+| Byline Label | Lora | 12px | 600 | 1.00 | 1.5px | Uppercase bylines ("BY SARAH CHEN") |
+| CTA Text | Lora | 15px | 600 | 1.00 | 0.5px | Button text, calls to action |
+
+### Principles
+- **Serif throughout**: Cormorant Garamond for display, Lora for body. No sans-serif anywhere. This is an explicitly serif system.
+- **Display vs. body contrast**: Cormorant Garamond's high-contrast, elegant forms handle display sizes (32px+). Lora's sturdier design handles body text (20px and below). Never swap them.
+- **Generous line height**: 1.70-1.75 for body text creates a classical, book-like reading rhythm. The generous leading is not wasted space -- it is a core feature of the reading experience.
+- **Drop caps**: Use CSS `::first-letter` on the first paragraph of major sections. Set in Cormorant Garamond at 700 weight, approximately 5x the body size, coloured in deep red (`#c41e3a`), floated left with right margin.
+- **Uppercase sparingly**: Reserved for bylines and small structural labels only. Headlines are always mixed case in the tradition of book titling.
+- **Italic for quotation**: Pull quotes use Cormorant Garamond italic at 36px. The italic forms of Cormorant are genuinely calligraphic and beautiful at display sizes.
+
+## 4. Component Patterns
+
+### Title Block (Cover / Header Section)
+
+```html
+<div style="background-color: #faf8f5; padding: 80px 60px; text-align: center;">
+  <div style="width: 100%; height: 1px; background: #000000; margin: 0 0 32px;"></div>
+  <p style="font-family: 'Lora', Georgia, serif; font-size: 12px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase; color: #6b6560; margin: 0 0 20px;">The Gooseworks Report</p>
+  <h1 style="font-family: 'Cormorant Garamond', Garamond, serif; font-size: 72px; font-weight: 700; line-height: 1.05; letter-spacing: -1px; color: #000000; margin: 0 0 20px;">The Future of<br>Autonomous Work</h1>
+  <div style="width: 40px; height: 2px; background: #c41e3a; margin: 0 auto 20px;"></div>
+  <p style="font-family: 'Lora', Georgia, serif; font-size: 20px; font-weight: 400; line-height: 1.70; color: #6b6560; max-width: 540px; margin: 0 auto;">How AI coworkers are reshaping the way teams operate, collaborate, and deliver results.</p>
+  <div style="width: 100%; height: 1px; background: #000000; margin: 40px 0 0;"></div>
+</div>
+```
+
+### Feature Block with Drop Cap
+
+```html
+<div style="background-color: #faf8f5; padding: 48px 60px; max-width: 720px;">
+  <h2 style="font-family: 'Cormorant Garamond', Garamond, serif; font-size: 32px; font-weight: 600; line-height: 1.20; color: #000000; margin: 0 0 24px;">Persistent Memory Across Sessions</h2>
+  <p style="font-family: 'Lora', Georgia, serif; font-size: 16px; font-weight: 400; line-height: 1.75; letter-spacing: 0.1px; color: #000000; margin: 0;">
+    <span style="float: left; font-family: 'Cormorant Garamond', Garamond, serif; font-size: 80px; font-weight: 700; line-height: 0.85; color: #c41e3a; margin: 0 12px 0 0; padding-top: 4px;">E</span>very agent maintains its own filesystem, notes, and learned preferences across sessions. Context is never lost between conversations, enabling a continuity of work that transforms how teams interact with their AI coworkers.</p>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="text-align: center; padding: 48px 32px; background: #faf8f5; border-top: 1px solid #c8c4c0; border-bottom: 1px solid #c8c4c0;">
+  <p style="font-family: 'Cormorant Garamond', Garamond, serif; font-size: 72px; font-weight: 700; line-height: 1.00; letter-spacing: -1px; color: #c41e3a; margin: 0 0 8px;">47%</p>
+  <p style="font-family: 'Lora', Georgia, serif; font-size: 12px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase; color: #000000; margin: 0 0 16px;">Faster Response</p>
+  <p style="font-family: 'Lora', Georgia, serif; font-size: 16px; font-weight: 400; line-height: 1.75; color: #6b6560; max-width: 320px; margin: 0 auto;">Teams using AI coworkers respond to inbound leads nearly twice as fast as manual workflows.</p>
+</div>
+```
+
+### Comparison Grid
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0; border-top: 1px solid #000000; border-bottom: 1px solid #000000;">
+  <div style="padding: 40px 32px; border-right: 1px solid #c8c4c0;">
+    <p style="font-family: 'Lora', Georgia, serif; font-size: 12px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase; color: #6b6560; margin: 0 0 16px;">Without Goose</p>
+    <h3 style="font-family: 'Cormorant Garamond', Garamond, serif; font-size: 32px; font-weight: 600; line-height: 1.20; color: #000000; margin: 0 0 16px;">Manual & Fragmented</h3>
+    <p style="font-family: 'Lora', Georgia, serif; font-size: 16px; font-weight: 400; line-height: 1.75; color: #6b6560; margin: 0;">Teams juggle Slack threads, spreadsheets, and context-switching between a dozen tabs to coordinate basic workflows.</p>
+  </div>
+  <div style="padding: 40px 32px; border-left: 2px solid #c41e3a;">
+    <p style="font-family: 'Lora', Georgia, serif; font-size: 12px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase; color: #c41e3a; margin: 0 0 16px;">With Goose</p>
+    <h3 style="font-family: 'Cormorant Garamond', Garamond, serif; font-size: 32px; font-weight: 600; line-height: 1.20; color: #000000; margin: 0 0 16px;">Orchestrated & Autonomous</h3>
+    <p style="font-family: 'Lora', Georgia, serif; font-size: 16px; font-weight: 400; line-height: 1.75; color: #6b6560; margin: 0;">AI coworkers handle research, drafting, and follow-up autonomously. Your team focuses on decisions, not busywork.</p>
+  </div>
+</div>
+```
+
+### List Item
+
+```html
+<div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0; border-bottom: 1px solid #e8e5e0;">
+  <span style="font-family: 'Cormorant Garamond', Garamond, serif; font-size: 24px; font-weight: 700; color: #c41e3a; min-width: 28px; line-height: 1.20;">&#8226;</span>
+  <div>
+    <h4 style="font-family: 'Cormorant Garamond', Garamond, serif; font-size: 24px; font-weight: 600; line-height: 1.25; color: #000000; margin: 0 0 8px;">Multi-Channel Access</h4>
+    <p style="font-family: 'Lora', Georgia, serif; font-size: 16px; font-weight: 400; line-height: 1.75; color: #6b6560; margin: 0;">Reach your AI coworkers through Slack, Telegram, WhatsApp, or the web -- wherever your team already works.</p>
+  </div>
+</div>
+```
+
+### Pull Quote Block
+
+```html
+<div style="padding: 48px 60px; border-top: 1px solid #c8c4c0; border-bottom: 1px solid #c8c4c0; text-align: center; background: #faf8f5;">
+  <span style="font-family: 'Cormorant Garamond', Garamond, serif; font-size: 80px; font-weight: 700; line-height: 0.5; color: #c41e3a; display: block; margin-bottom: 8px;">&#8220;</span>
+  <p style="font-family: 'Cormorant Garamond', Garamond, serif; font-size: 36px; font-weight: 400; font-style: italic; line-height: 1.35; color: #000000; max-width: 640px; margin: 0 auto 24px;">It felt less like configuring software and more like onboarding a new team member.</p>
+  <div style="width: 40px; height: 1px; background: #c41e3a; margin: 0 auto 16px;"></div>
+  <p style="font-family: 'Lora', Georgia, serif; font-size: 12px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase; color: #6b6560; margin: 0;">Sarah Chen, VP Operations</p>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="text-align: center; padding: 60px 40px; background: #faf8f5; border-top: 2px solid #000000; border-bottom: 2px solid #000000;">
+  <h2 style="font-family: 'Cormorant Garamond', Garamond, serif; font-size: 48px; font-weight: 700; line-height: 1.10; letter-spacing: -0.5px; color: #000000; margin: 0 0 16px;">Ready to meet your team?</h2>
+  <p style="font-family: 'Lora', Georgia, serif; font-size: 18px; font-weight: 400; line-height: 1.70; color: #6b6560; max-width: 480px; margin: 0 auto 32px;">Deploy your first AI coworker in under five minutes. No setup fees, no long-term commitments.</p>
+  <a style="display: inline-block; background: #c41e3a; color: #faf8f5; font-family: 'Lora', Georgia, serif; font-size: 15px; font-weight: 600; letter-spacing: 0.5px; text-decoration: none; padding: 14px 36px; border-radius: 0px;">Get Started</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between inline elements and tight label pairs.
+- **8px**: Tight gap -- between stat number and label, between rule and adjacent text.
+- **12px**: Small gap -- between icon and text in list items.
+- **16px**: Base gap -- between body paragraphs, standard text spacing.
+- **20px**: Medium-small gap -- between heading and subtitle in title blocks.
+- **24px**: Medium gap -- between components within a section, list item padding.
+- **32px**: Section internal -- padding inside content blocks, gap between grid columns.
+- **40px**: Large internal -- padding in title blocks between rules and content.
+- **48px**: Section divider -- vertical space between major content sections.
+- **60px**: Large section padding -- hero, CTA, and pull quote vertical padding.
+- **80px**: Maximum section padding -- cover pages and high-impact title sections.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 720px (narrow column) |
+| Slides (1920x1080) | 80px all sides | 1200px (narrow for readability) |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 720px (narrow column) |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned for body text, always. Center-aligned for title blocks, stats, pull quotes, and CTA sections.
+- **Narrow column**: Body text should not exceed 720px wide (approximately 65-75 characters per line), following classical typographic measure.
+- **Hairline rules**: `1px solid #c8c4c0` as section dividers between major content blocks. `1px solid #000000` for strong structural borders (top of page, top of article).
+- **Red accent rules**: `2px solid #c41e3a` used sparingly as decorative punctuation -- below title block headings, on preferred side of comparison grids.
+- **Vertical rhythm**: Consistent 48px gaps between major sections. Hairline rules sit between sections, serving as visual punctuation.
+- **Margins over padding**: Prefer generous margins around content rather than padded containers. Content should sit on the paper, not inside boxes.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, background `#faf8f5` | Page canvas -- the default and dominant state |
+| Subtle (Level 1) | `rgba(0,0,0,0.04) 0px 1px 4px` | Barely perceptible lift for interactive elements on hover |
+| Card (Level 2) | `rgba(0,0,0,0.06) 0px 2px 8px` | Rare -- only for modal contexts or overlay panels |
+| Overlay (Level 3) | `rgba(0,0,0,0.10) 0px 4px 16px` | Modals and floating panels. Maximum shadow depth in this system. |
+
+### Border Treatments
+- **Hairline rule**: `1px solid #c8c4c0` -- the primary structural element. Used between sections, above and below pull quotes, and as table borders.
+- **Strong rule**: `1px solid #000000` or `2px solid #000000` -- used at the top of the page and for major structural breaks.
+- **Accent rule**: `2px solid #c41e3a` -- deep red accent line. Used below title headings, on featured borders, and as small horizontal marks (40px wide, centered).
+- **Faint divider**: `1px solid #e8e5e0` -- barely visible line for list items and dense content separation.
+- **No border-radius**: This style uses 0px border-radius on everything. Sharp, square corners are fundamental to the print/editorial aesthetic.
+
+### Surface Hierarchy
+Print-inspired design is almost entirely flat. Depth is communicated through rules and whitespace, not shadows:
+1. **Paper** (`#faf8f5`) -- the primary surface. Nearly everything sits on this layer.
+2. **Off-White** (`#f4f1ec`) -- a slightly darker cream for inset panels, blockquote backgrounds, and sidebar areas.
+3. **Pale Gray** (`#e8e5e0`) -- the darkest background surface, used for recessed input fields or de-emphasized zones.
+4. **Highlight** (`rgba(196,30,58,0.05)`) -- the faintest red wash for featured content callouts.
+
+Shadows are almost never used. The structural vocabulary is hairline rules, whitespace, and typographic scale -- the same tools that print designers have relied on for centuries.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use Cormorant Garamond for all display headings (32px+) and pull quotes -- its elegant, high-contrast forms are the visual signature.
+- Use Lora for all body text (20px and below) -- designed for screen readability with sturdy serifs.
+- Apply drop caps (CSS `::first-letter`) to opening paragraphs of major sections, set in Cormorant Garamond 700, deep red.
+- Use hairline rules (`1px solid #c8c4c0`) between every major section -- they are the structural glue of this style.
+- Use deep red (`#c41e3a`) sparingly but consistently: drop caps, pull quote marks, accent rules, CTAs.
+- Keep body text columns narrow (max 720px) -- classical typographic measure for comfortable reading.
+- Use generous line height (1.70-1.75) for body text -- the spacious leading of well-set book type.
+- Center pull quotes with oversized quotation marks in deep red for editorial drama.
+- Use 0px border-radius on all elements -- sharp corners are non-negotiable.
+- Frame content with strong rules at page/section boundaries (top and bottom).
+
+### Don't
+- Don't use sans-serif fonts anywhere -- Cormorant Garamond and Lora are the entire typographic system. No exceptions.
+- Don't use rounded corners on any element -- this is a print-inspired style. Corners are always square.
+- Don't use shadows for standard content -- depth comes from rules and whitespace, not box-shadows.
+- Don't use Cormorant Garamond below 24px -- its fine hairlines become indistinct at small sizes. Switch to Lora.
+- Don't use more than one accent colour -- deep red is the only chromatic element. No blues, greens, or purples.
+- Don't use bold body text (Lora 700) for emphasis in paragraphs -- use italic (Lora 400 italic) instead, in the tradition of book typography.
+- Don't use coloured backgrounds or gradient backgrounds -- the paper colour (`#faf8f5`) is the only surface. Content sits on paper, period.
+- Don't crowd content into cards or containers -- this style uses open layouts with rules as separators, not boxed components.
+- Don't use decorative icons or emoji -- if visual markers are needed, use typographic ornaments (bullet, em dash, pilcrow) in deep red.
+- Don't set body text wider than 720px -- long lines are the cardinal sin of typography.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale down**: Display Hero becomes 56px (from 72px). Section Heading becomes 40px. Sub-heading stays 32px. Body stays 16px.
+- **Padding**: 60px on all sides. Content area is 960x960px.
+- **Cover slide**: Title centered vertically. Strong black rule at top and bottom. Publication-style label in uppercase above headline. Red accent rule (40px) below headline. Subtitle in warm gray.
+- **Content slides**: Left-aligned text. Drop cap on opening paragraph. One concept per slide with a hairline rule at the top.
+- **Stat slides**: Single stat centered. Big number in deep red (Cormorant Garamond 72px). Label in uppercase Lora. Hairline rules above and below.
+- **Swipe indicator**: Small black dots at bottom center, 6px diameter, 12px gap. Simple and unadorned.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Uses full-scale type hierarchy. Display Hero at 72px for the title section.
+- **Padding**: 60px left/right. 80px top/bottom. Content column capped at 720px, centered.
+- **Section spacing**: 48px vertical gap between major sections. Hairline rules between every section.
+- **Vertical rhythm**: Title block with strong rules top and bottom. Body sections with drop caps. Pull quotes centered with oversized red quotation marks. Stat sections framed by hairline rules. CTA at bottom with strong black borders.
+- **Footer**: Warm gray text, 12px Lora, centered. Simple horizontal rule above.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 80px. Section Heading becomes 56px. Body Large becomes 22px.
+- **Padding**: 80px on all sides. Content max-width capped at 1200px, centered for readability.
+- **Layout**: Center-biased composition. Content occupies the central column with generous margins on both sides -- like an open book spread.
+- **Title slides**: Headline centered. Strong black rule at top of frame, red accent rule below headline. Subtitle in warm gray.
+- **Content slides**: 2-column for comparisons (divided by a hairline rule, not a gap). Single narrow column for narrative.
+- **Stat slides**: Up to 3 stats in a row, separated by vertical hairline rules. Each stat: big number in red, label in uppercase black.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 64px. Section Heading at 40px. Body at 16px.
+- **Padding**: 60px left/right, 80px top/bottom. Content column capped at 720px.
+- **Composition**: Top quarter for title block with strong rules. Middle half for body content with drop cap, pull quote, or stat. Bottom quarter for CTA with strong rules.
+- **Vertical flow**: Strong rules delineate the three zones. The middle section can hold a centred pull quote with large red quotation marks for visual impact.
+- **CTA placement**: Centered in the bottom zone. Button in deep red with square corners. Framed by strong black rules above and below.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Hero becomes 72px in Cormorant Garamond with its signature high-contrast strokes (approximately 30% larger than Carousel 56px). Section Heading becomes 52px. Body Large becomes 22px in Lora -- still screen-optimized serif, never sans-serif. Drop caps scale to roughly 120-140px in deep red.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical text must sit inside y=160 to y=1760. Inside the safe zone, content column capped at 820px for comfortable measure.
+- **Layout**: Single centered column with book-margin whitespace. Vertical center of gravity -- cluster hero content in y=400 to y=1500 range. Warm cream background (`#faf8f5`) runs edge-to-edge like the page of a first-edition hardcover.
+- **Cover slide**: 1px full-width hairline black rule at the top of the content zone. Cormorant Garamond headline at 72px in ink-black, centered, 2-3 lines deep with generous leading. Below it, a Lora italic subtitle at 22px in warm gray. A second hairline rule closes the composition. Everything is quiet authority -- the typography is the decoration.
+- **Content slides**: One idea per slide. Lead each slide with a deep red (`#c41e3a`) drop cap at 120-140px set in Cormorant Garamond, the opening paragraph flowing in Lora at 22px alongside it. Alternatively, a pull quote in Cormorant Garamond italic at 56px with oversized deep red quotation marks floating above and below. Thin 1px hairline rules separate sections.
+- **CTA slide**: Thin black hairline rules frame top and bottom of the content zone. Cormorant Garamond headline at 56px centered, Lora italic subtitle at 20px. Deep red button with square corners (no border-radius -- the printed-press mindset forbids it) and Cormorant Garamond CTA text in cream.
+- **Progress indicator**: 1px hairline segmented rules at the top of the safe zone -- inactive at `#6b6560` (warm gray), active in deep red (`#c41e3a`). Feels like the folio marks along the top of a well-set book page.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Paper | `#faf8f5` | Primary background |
+| Ink | `#000000` | Primary text |
+| Deep Red | `#c41e3a` | Accent: drop caps, rules, pull quotes, CTAs |
+| Dark Red | `#9e1830` | Hover/active state for red elements |
+| Near Black | `#1a1a18` | Secondary headlines |
+| Warm Gray | `#6b6560` | Secondary text, captions, metadata |
+| Medium Gray | `#9a9590` | Placeholder, disabled text |
+| Light Gray | `#c8c4c0` | Hairline rules, standard borders |
+| Pale Gray | `#e8e5e0` | Faint dividers, inset backgrounds |
+| Off-White | `#f4f1ec` | Alternate surface, recessed panels |
+
+### Font Declarations
+
+```css
+font-family: 'Cormorant Garamond', Garamond, 'Times New Roman', serif;
+font-family: 'Lora', Georgia, 'Times New Roman', serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600;1,700&family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&display=swap" rel="stylesheet">
+```
+
+### Drop Cap CSS
+
+```css
+.drop-cap::first-letter {
+  font-family: 'Cormorant Garamond', Garamond, serif;
+  font-size: 5em;
+  font-weight: 700;
+  color: #c41e3a;
+  float: left;
+  line-height: 0.85;
+  margin: 0 12px 0 0;
+  padding-top: 4px;
+}
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-paper: #faf8f5;
+  --color-ink: #000000;
+  --color-deep-red: #c41e3a;
+
+  /* Colors -- Accent */
+  --color-dark-red: #9e1830;
+  --color-light-red: rgba(196, 30, 58, 0.08);
+  --color-red-rule: #c41e3a;
+
+  /* Colors -- Neutral Scale */
+  --color-near-black: #1a1a18;
+  --color-warm-gray: #6b6560;
+  --color-medium-gray: #9a9590;
+  --color-light-gray: #c8c4c0;
+  --color-pale-gray: #e8e5e0;
+  --color-off-white: #f4f1ec;
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: #faf8f5;
+  --color-surface-inset: #f4f1ec;
+  --color-surface-highlight: rgba(196, 30, 58, 0.05);
+
+  /* Colors -- Borders */
+  --color-border-hairline: #c8c4c0;
+  --color-border-strong: #000000;
+  --color-border-accent: #c41e3a;
+  --color-border-faint: #e8e5e0;
+
+  /* Colors -- Shadows */
+  --shadow-soft: rgba(0, 0, 0, 0.06);
+  --shadow-medium: rgba(0, 0, 0, 0.10);
+  --shadow-deep: rgba(0, 0, 0, 0.15);
+
+  /* Typography -- Families */
+  --font-display: 'Cormorant Garamond', Garamond, 'Times New Roman', serif;
+  --font-body: 'Lora', Georgia, 'Times New Roman', serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 72px;
+  --text-section-heading: 48px;
+  --text-sub-heading: 32px;
+  --text-body-large: 20px;
+  --text-body: 16px;
+  --text-small: 13px;
+  --text-big-number: 72px;
+  --text-pull-quote: 36px;
+  --text-drop-cap: 80px;
+  --text-byline: 12px;
+  --text-cta: 15px;
+
+  /* Typography -- Weights */
+  --weight-display: 700;
+  --weight-heading: 600;
+  --weight-body: 400;
+  --weight-body-medium: 500;
+  --weight-label: 600;
+
+  /* Typography -- Line Heights */
+  --leading-display: 1.05;
+  --leading-heading: 1.10;
+  --leading-sub-heading: 1.20;
+  --leading-body-large: 1.70;
+  --leading-body: 1.75;
+  --leading-small: 1.50;
+  --leading-number: 1.00;
+  --leading-pull-quote: 1.35;
+  --leading-drop-cap: 0.85;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-medium-small: 20px;
+  --space-medium: 24px;
+  --space-large: 32px;
+  --space-xl: 40px;
+  --space-section: 48px;
+  --space-hero: 60px;
+  --space-max: 80px;
+
+  /* Borders */
+  --radius-standard: 0px;
+
+  /* Layout */
+  --measure-body: 720px;
+  --measure-wide: 960px;
+  --measure-slide: 1200px;
+
+  /* Shadows -- Composed */
+  --shadow-card: rgba(0,0,0,0.06) 0px 2px 8px;
+  --shadow-overlay: rgba(0,0,0,0.10) 0px 4px 16px;
+}
+```
+
+### System Font Fallbacks
+- **Display serif (if Cormorant Garamond fails to load):** `Garamond, 'Times New Roman', serif`
+- **Body serif (if Lora fails to load):** `Georgia, 'Times New Roman', serif`

--- a/skills/composites/goose-graphics/styles/_full/pastel-organic-shapes.md
+++ b/skills/composites/goose-graphics/styles/_full/pastel-organic-shapes.md
@@ -1,0 +1,495 @@
+# Design Style: Pastel Organic Shapes
+
+## 1. Visual Theme & Atmosphere
+
+Pastel Organic Shapes is the design language of the soft-spoken content creator -- the visual equivalent of a handmade riso print scanned onto cream paper. It draws from the tradition of mid-century editorial illustration, Japanese stationery design, and the modern feminine-neutral creator aesthetic that dominates Instagram carousels from lifestyle brands, coaching studios, and boutique creative agencies. The signature move is the large pale pistachio circle positioned half off the edge of the frame -- a single bold organic shape that does all the structural heavy lifting while the rest of the composition breathes. This is the opposite of dense, information-rich design. It is confidence through restraint.
+
+The warm cream background (`#F5F1E6`) is not white -- it is the color of unbleached paper, a slight yellow-cream wash that softens every other element on the page. Against this cream, the pale pistachio green (`#DCEAB4`) reads as gentle, not bright. The greens in this palette are always desaturated, always tinted slightly gray, always pale enough that black text reads cleanly when placed on top. The typography pairing is Playfair Display (a classic Didone-influenced serif with high stroke contrast) set in ALL CAPS at weight 400 with generous letter-spacing, paired with Inter for the small uppercase sans metadata labels. Setting a serif in all caps is unusual -- it sacrifices readability for monumentality -- but at the carousel scale of 3-4 stacked lines, it creates the feeling of a quiet declaration chiseled into stone.
+
+The composition logic is organic-shape-first. Every slide is built around one signature pistachio circle extending off the right edge of the frame, with a smaller cream oval or circle sitting as the content container. Text lives inside the shapes. The shapes are the grid. Body text is centered when short and left-aligned inside the cream oval when longer. A thin-outlined arrow indicator in the top-right corner telegraphs "swipe next" without any heavy UI chrome. The feel is editorial, gentle, and feminine-neutral -- think a natural-wellness brand's launch kit, a ceramics studio's social feed, or a coaching practice's welcome guide.
+
+**Key Characteristics:**
+- Warm cream background (`#F5F1E6`) -- unbleached-paper tone, the foundation of the palette
+- Pale pistachio (`#DCEAB4`) as the ONLY color accent -- no reds, no blues, no secondary colors
+- Large pistachio circle positioned half off-frame at the right edge -- THE signature move
+- Smaller cream/off-white circle or oval as the content container, often overlapping the pistachio
+- Playfair Display serif headlines in ALL CAPS, weight 400, letter-spacing 2-3px, centered
+- Inter small-caps uppercase for metadata labels (`@handle`, `STUDIO NAME`) at bottom
+- Near-black text (`#1A1A1A`) -- not pure black, just enough contrast for cream surfaces
+- Thin-outlined arrow in rounded-rectangle container in the top-right as swipe-next indicator
+- Maximum 2 shapes per slide -- restraint is the aesthetic
+- Generous whitespace dominates the layout -- 50%+ of the frame is negative space
+- No shadows, no gradients, no textures -- perfectly flat cream-and-pistachio composition
+- Circles and ovals only -- no sharp rectangular cards, no hard right angles on containers
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Warm Cream** (`#F5F1E6`): Primary background. A soft, slightly yellow-warm cream that reads as unbleached paper. Always the base layer.
+- **Near-Black** (`#1A1A1A`): Primary text color. All headlines, body text, and arrow icons. Never pure black -- the `#1A` gives it a gentler feel against cream.
+- **Pale Pistachio** (`#DCEAB4`): Primary accent and signature shape color. Used for the large off-frame circle. Pale, desaturated, and slightly gray-green -- never saturated.
+
+### Accent
+- **Lighter Cream** (`#FAF7EC`): Inner cream oval / content container color. One step lighter than the background so it reads as a distinct surface without needing a border.
+- **Deeper Pistachio** (`#C9DDA0`): Hover/active state for pistachio elements, or a subtle 1px outline inside the main pistachio shape if needed.
+- **Pistachio Outline** (`#BFD390`): Thin line color for the optional outline frame around the entire slide (as seen in the references).
+
+### Neutral Scale
+- **Text Primary** (`#1A1A1A`): Headlines and primary body copy.
+- **Text Secondary** (`#4A4A4A`): Body copy inside the cream oval when set at smaller sizes.
+- **Text Metadata** (`#5C5C5C`): The bottom row uppercase labels (`@REALLYGREATSITE`, `STUDIO SHOWDE`).
+- **Text Muted** (`rgba(26,26,26,0.5)`): Slide numbers, watermarks, low-priority metadata.
+- **Outline Thin** (`rgba(26,26,26,0.35)`): The thin outline around the arrow indicator.
+
+### Surface & Borders
+- **Surface Background** (`#F5F1E6`): Primary canvas.
+- **Surface Container** (`#FAF7EC`): Inner cream oval content container.
+- **Surface Accent** (`#DCEAB4`): Large pistachio signature shape.
+- **Border Thin** (`rgba(26,26,26,0.4)`): Outline for the arrow indicator and (optional) thin frame around the slide.
+- **Border Subtle** (`rgba(26,26,26,0.12)`): Divider rules if needed -- rarely used.
+- **Divider Rule** (`rgba(26,26,26,0.08)`): Barely-there horizontal rules, used sparingly.
+
+### Shadow Colors
+This style is almost entirely shadow-free. Depth is communicated via shape layering and color contrast, not elevation.
+- **Shadow None** (`transparent`): Default -- no shadow on any element.
+- **Shadow Whisper** (`rgba(26,26,26,0.03)`): Barely perceptible, only for the cream oval content container if additional separation is needed.
+- **Shadow Subtle** (`rgba(26,26,26,0.06)`): Reserved for poster/print adaptations where slight depth helps.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Playfair Display', Georgia, 'Times New Roman', serif`
+- **Body**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Case | Notes |
+|------|------|------|--------|-------------|----------------|------|-------|
+| Display Hero | Playfair Display | 56px | 400 | 1.18 | 2px | UPPERCASE | Main carousel headline, 3-4 lines stacked tight |
+| Section Heading | Playfair Display | 40px | 400 | 1.20 | 1.5px | UPPERCASE | Slide subheadings inside cream oval |
+| Sub-heading | Playfair Display | 28px | 400 | 1.25 | 1px | UPPERCASE | Small headline inside cream oval container |
+| Inner Headline | Playfair Display | 20px | 500 | 1.30 | 0.5px | UPPERCASE | Tight headline in small circle container |
+| Body Large | Inter | 16px | 400 | 1.65 | 0.3px | normal | Body text inside cream oval when longer |
+| Body | Inter | 13px | 400 | 1.65 | 0.5px | UPPERCASE | Sparse body copy inside small circle container |
+| Metadata | Inter | 12px | 500 | 1.40 | 1.5px | UPPERCASE | Bottom row labels -- `@handle`, `STUDIO NAME` |
+| Caption | Inter | 11px | 500 | 1.40 | 1px | UPPERCASE | Slide numbers, small labels |
+| Big Numbers | Playfair Display | 72px | 400 | 1.00 | 1px | -- | Statistics and key metrics |
+
+### Principles
+
+- **Serif in ALL CAPS is the signature.** Setting Playfair Display in uppercase at weight 400 with generous tracking transforms readable type into quiet monuments. Every primary headline follows this rule. Mixed case is never used for main headlines.
+- **Letter-spacing scales with size.** At 56px the tracking is ~2px. At smaller sizes like 20px it tightens to 0.5px. At metadata-level 12px it widens again to 1.5px (because tight-tracked small caps read as cramped).
+- **Light weights only.** Playfair Display is used at 400 and occasionally 500. Never 700 or 800. The headline authority comes from size and tracking, not weight -- this is what keeps the style feeling gentle.
+- **Inter is the quiet partner.** Inter never headlines. It handles metadata, small-body, and the rare label. When used, it is always uppercase, tracked, and at weight 400-500. Mixed-case Inter appears only for body-large inside the cream oval when copy is longer.
+- **Line height is breathing room.** Headlines at 1.18-1.30 leading feel tight but not cramped. Body copy inside the oval sits at 1.65 to give sparse paragraphs air.
+- **Center everything short, left-align everything long.** Headlines, metadata, and short labels are centered. The moment body copy exceeds ~3 lines inside the cream oval, switch to left-alignment so the ragged edge doesn't fight the organic shape.
+
+## 4. Component Patterns
+
+### Slide Frame (Optional Outer Outline)
+
+```html
+<div style="position: relative; width: 1080px; height: 1080px; background-color: var(--color-bg); overflow: hidden; box-sizing: border-box; padding: 60px;">
+  <!-- Optional thin outlined frame seen in the references -->
+  <div style="position: absolute; inset: 40px; border: 1.5px solid var(--color-pistachio-outline); pointer-events: none;"></div>
+  <!-- Content goes here -->
+</div>
+```
+
+### Circle Container (Signature Off-Frame Pistachio)
+
+The core signature move. A large pale pistachio circle positioned so half (or slightly more) of it extends off the right edge of the frame. Achieve it with absolute positioning and a huge `border-radius`. The circle is sized roughly equal to the slide height so only ~55-60% of it is visible.
+
+```html
+<div style="position: absolute; top: 50%; right: -540px; transform: translateY(-50%); width: 1080px; height: 1080px; background-color: var(--color-pistachio); border-radius: 50%;"></div>
+```
+
+Variations by edge:
+- **Right edge (default):** `right: -540px`
+- **Left edge mirror:** `left: -540px`
+- **Bottom-right corner:** `right: -400px; bottom: -400px; top: auto; transform: none;`
+
+Sizing ratio: the circle diameter should be 90-100% of the slide's shortest dimension.
+
+### Inner Cream Oval (Content Container)
+
+A smaller, centered cream circle or oval that holds the tight headline + body text. Sits adjacent to or overlapping the pistachio shape. Its background is one step lighter than the canvas so it reads as a distinct surface without needing any border.
+
+```html
+<div style="position: absolute; left: 140px; top: 50%; transform: translateY(-50%); width: 340px; height: 340px; background-color: var(--color-cream-light); border-radius: 50%; display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 48px; box-sizing: border-box; text-align: center;">
+  <h3 style="font-family: var(--font-display); font-size: 20px; font-weight: 500; line-height: 1.30; letter-spacing: 0.5px; text-transform: uppercase; color: var(--color-near-black); margin: 0 0 16px;">It's time to delegate.</h3>
+  <p style="font-family: var(--font-body); font-size: 12px; font-weight: 400; line-height: 1.65; letter-spacing: 1px; text-transform: uppercase; color: var(--color-near-black); margin: 0;">Your business grows faster when you let others share the load.</p>
+</div>
+```
+
+To make it an oval instead of a circle, use unequal width/height and `border-radius: 50%` -- the browser will render an ellipse automatically.
+
+### Swipe Arrow Indicator (Corner)
+
+A thin-outlined arrow inside a rounded-rectangle container, positioned in the top-right corner as a "swipe next" indicator. The outline is the only drawn stroke on the slide.
+
+```html
+<div style="position: absolute; top: 80px; right: 80px; width: 56px; height: 56px; border: 1.5px solid var(--color-border-thin); border-radius: 14px; display: flex; align-items: center; justify-content: center;">
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M5 12H19" stroke="#1A1A1A" stroke-width="1.5" stroke-linecap="round"/>
+    <path d="M13 6L19 12L13 18" stroke="#1A1A1A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </svg>
+</div>
+```
+
+### Hero Headline Block (Centered ALL CAPS Serif)
+
+For cover slides. A 3-4 line serif headline stacked tight, centered, in ALL CAPS.
+
+```html
+<div style="position: absolute; top: 140px; left: 100px; right: 100px; text-align: center;">
+  <h1 style="font-family: var(--font-display); font-size: 56px; font-weight: 400; line-height: 1.18; letter-spacing: 2px; text-transform: uppercase; color: var(--color-near-black); margin: 0;">
+    Stop wasting<br>
+    precious time<br>
+    on tasks that<br>
+    don't move<br>
+    the needle
+  </h1>
+</div>
+```
+
+### Metadata Footer (Bottom Row)
+
+Tracked uppercase sans labels at the bottom of every slide. Left slot is the handle, right slot is the studio/brand.
+
+```html
+<div style="position: absolute; bottom: 80px; left: 80px; right: 80px; display: flex; justify-content: space-between; align-items: center;">
+  <span style="font-family: var(--font-body); font-size: 12px; font-weight: 500; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-metadata);">@reallygreatsite</span>
+  <span style="font-family: var(--font-body); font-size: 12px; font-weight: 500; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-metadata);">Studio Showde</span>
+</div>
+```
+
+### Quote Block (Inside Cream Oval)
+
+When the content is a quote or longer paragraph, use left-alignment inside a larger cream oval.
+
+```html
+<div style="position: absolute; left: 120px; top: 50%; transform: translateY(-50%); width: 420px; height: 420px; background-color: var(--color-cream-light); border-radius: 50%; display: flex; flex-direction: column; justify-content: center; padding: 72px; box-sizing: border-box;">
+  <p style="font-family: var(--font-display); font-size: 20px; font-weight: 400; font-style: italic; line-height: 1.45; color: var(--color-near-black); margin: 0 0 20px; text-align: left;">"It felt less like configuring software and more like onboarding a new team member."</p>
+  <p style="font-family: var(--font-body); font-size: 11px; font-weight: 500; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-metadata); margin: 0; text-align: left;">Sarah Chen, VP Ops</p>
+</div>
+```
+
+### Numbered Step (Inside Small Circle)
+
+```html
+<div style="position: relative; width: 280px; height: 280px; background-color: var(--color-cream-light); border-radius: 50%; display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 40px; box-sizing: border-box; text-align: center;">
+  <span style="font-family: var(--font-display); font-size: 48px; font-weight: 400; line-height: 1.00; color: var(--color-near-black); margin: 0 0 8px;">01</span>
+  <p style="font-family: var(--font-body); font-size: 11px; font-weight: 500; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-near-black); margin: 0; line-height: 1.50;">Identify the<br>time-wasters</p>
+</div>
+```
+
+### Big Number Stat
+
+```html
+<div style="text-align: center;">
+  <p style="font-family: var(--font-display); font-size: 72px; font-weight: 400; line-height: 1.00; color: var(--color-near-black); margin: 0 0 12px;">47%</p>
+  <p style="font-family: var(--font-body); font-size: 12px; font-weight: 500; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-metadata); margin: 0;">Faster Response</p>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+
+- **4px**: Micro gap -- inside arrow icon.
+- **8px**: Tight gap -- between stat number and its label.
+- **12px**: Small gap -- between headline lines and sub-label inside the cream oval.
+- **16px**: Base gap -- between paragraphs inside the cream oval.
+- **24px**: Medium gap -- between metadata row items.
+- **40px**: Oval inner padding -- standard padding inside the inner cream oval.
+- **48px**: Oval inner padding (large) -- for larger cream ovals holding more copy.
+- **60px**: Slide outer padding -- default outer frame padding.
+- **80px**: Slide outer padding (wide) -- for content slides with more breathing room.
+- **120px**: Story outer padding -- 1080x1920 story-format padding.
+
+### Format Padding
+
+| Format | Outer Padding | Content Max-Width | Hero Circle Size |
+|--------|---------------|-------------------|------------------|
+| Carousel (1080x1080) | 80px all sides | 920px | 1080px (100% of slide height) |
+| Infographic (1080xN) | 60px left/right, 100px top/bottom | 960px | 800px (scaled per section) |
+| Slides (1920x1080) | 120px all sides | 1680px | 1400px |
+| Poster (1080x1350) | 80px left/right, 100px top/bottom | 920px | 1100px |
+| **Story (1080x1920)** | **120px left/right, 60px top/bottom** | **840px** | **1400px (~30% bigger than carousel)** |
+
+### Alignment & Grid
+
+- **Primary alignment**: Centered for all headlines and metadata. Left-aligned for body copy that exceeds ~3 lines inside the cream oval.
+- **No grid system.** The composition is shape-driven, not column-driven. Every slide is built around one off-frame pistachio circle and one inner cream oval. Position these two shapes first, then place text inside them.
+- **Two shapes max.** Never more than one pistachio shape and one cream oval per slide. If a slide feels empty, that is correct -- whitespace is the point.
+- **The signature position.** On 90% of slides, the pistachio circle extends off the right edge with the cream oval centered-left. Invert occasionally (pistachio off the left, oval right) to keep a carousel visually varied.
+- **Vertical center line.** The cream oval always sits on the vertical midline of the slide unless a slide places its headline at the top (cover slide), in which case the oval moves to the bottom third.
+- **Arrow in the same corner.** The swipe arrow is always top-right on carousel slides. Never moves.
+- **Metadata stays pinned.** The metadata footer is always at the bottom, with `@handle` on the left and `brand name` on the right, on every slide except the final CTA slide.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow. Background `#F5F1E6` | Page canvas, base layer |
+| Shape (Level 1) | No shadow. Pistachio circle sits on the canvas by color contrast alone | Large signature pistachio shape |
+| Container (Level 2) | No shadow. Cream oval `#FAF7EC` sits on canvas by one-step lighter color | Inner cream oval content container |
+| Whisper (Level 3) | `0 2px 12px rgba(26,26,26,0.03)` | Rare -- only if cream oval needs more separation in print output |
+| Subtle (Level 4) | `0 4px 20px rgba(26,26,26,0.06)` | Reserved for poster print adaptations |
+
+### Border Treatments
+
+- **No borders on shapes.** Circles and ovals never have borders. Their edge comes from color contrast alone. This is a strict rule.
+- **Frame outline (optional)** : `1.5px solid rgba(26,26,26,0.35)` -- a thin outline inset 40px from the slide edge, creating a subtle frame. Seen in both references. Optional per slide.
+- **Arrow container outline**: `1.5px solid rgba(26,26,26,0.4)` with `border-radius: 14px` -- the only hard-edged element on the slide.
+- **No divider rules.** Content is separated by whitespace and shape, never by lines.
+
+### Surface Hierarchy
+
+On cream backgrounds, depth comes from color layering, not shadows:
+1. **Background** (`#F5F1E6`) -- warm cream canvas, the base of everything.
+2. **Pistachio Shape** (`#DCEAB4`) -- the large signature shape sits above the canvas purely via color contrast.
+3. **Cream Oval** (`#FAF7EC`) -- the inner container sits above the pistachio via a one-step lighter cream. On the canvas directly, the one-step lightness still reads.
+4. **Text** (`#1A1A1A`) -- near-black text is the highest-contrast element on every slide.
+5. **Arrow Outline** (`rgba(26,26,26,0.4)`) -- the thin-outlined arrow is the only hard geometric element.
+
+The total effect is a quiet layering of tinted creams with one gentle green shape and one small interactive element. There is never a drop shadow on a shape in this style.
+
+## 7. Do's and Don'ts
+
+### Do
+
+- **Use ALL CAPS on serif headlines** -- this is unusual but it is the signature of the style. Every primary headline is Playfair Display at weight 400 in uppercase with 1.5-2px letter-spacing.
+- **Use pistachio (`#DCEAB4`) as the ONLY color accent.** No secondary colors. No reds, blues, yellows, or oranges. The restricted palette is the identity.
+- **Keep shapes organic** (circles and ovals only). Never rectangles, never sharp cards, never hard right-angled containers for content. Content lives inside circles.
+- **Position the pistachio circle half off-frame.** Use absolute positioning with a negative `right: -540px` value so the circle extends beyond the slide edge. This off-frame composition is the single most important visual move.
+- **Keep the pistachio PALE.** The green must be desaturated and slightly gray. A saturated pistachio kills the style instantly. If in doubt, lighten and desaturate further.
+- **Use the thin-outlined arrow in the top-right corner** as a swipe-next indicator. It is the one interactive-looking element on every slide.
+- **Use tracked uppercase Inter at 12px** for the bottom-row metadata (`@handle`, `STUDIO NAME`). Letter-spacing 1.5px.
+- **Let whitespace dominate** -- 50%+ of every slide should be empty cream canvas. Sparse layouts are correct.
+- **Use at most 2 shapes per slide** (one pistachio, one cream). More shapes destroy the restraint that defines the style.
+- **Center short text, left-align long text.** Headlines and metadata are centered. The moment body copy inside a cream oval exceeds ~3 lines, switch to left-alignment.
+- **Use weight 400** for Playfair Display headlines. The monumentality comes from size and tracking, not weight.
+
+### Don't
+
+- **Don't center-align body text if it's long.** Inside a cream oval, long copy (4+ lines) must be left-aligned so the ragged right edge doesn't fight the organic shape.
+- **Don't use more than 2 shapes per slide.** One pistachio, one cream oval. That is the budget.
+- **Don't make the pistachio saturated.** It must be pale. If it competes visually with the headline text, desaturate it further.
+- **Don't use Playfair Display at weight 700 or above.** Heavy serifs break the gentle atmosphere. Stick to 400-500.
+- **Don't use mixed-case headlines.** Uppercase is the rule for serif display type in this style.
+- **Don't add borders to circles or ovals.** Their edge comes from color contrast. A border on the pistachio shape would kill the organic feel.
+- **Don't use drop shadows on shapes.** The style is flat. Depth comes from color layering alone.
+- **Don't introduce secondary colors** -- no reds, blues, yellows, oranges, or purples. Cream and pistachio only.
+- **Don't use rectangular content cards.** Everything lives inside circles or ovals. Rectangles are reserved for the slide frame itself and the arrow container.
+- **Don't use tight leading on body copy.** Body text at 1.65 line height gives sparse paragraphs the air they need.
+- **Don't fill the slide.** If a slide feels "too empty," you are doing it right. Resist the urge to add elements.
+- **Don't use decorative icons, emoji, or illustrations.** The only non-text element is the swipe arrow.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+
+- **Typography scale**: Display Hero at 56px. Section Heading at 40px. Sub-heading at 28px. Body inside cream oval at 13px uppercase or 16px mixed-case. Metadata at 12px.
+- **Padding**: 80px on all sides. Optional inset frame at 40px from the edge.
+- **Composition**: One pistachio circle (1080px diameter) positioned at `right: -540px` so half extends off-frame. One cream oval (340px circle or 340x280px ellipse) centered-left at roughly `left: 140px, top: 50%`.
+- **Cover slide**: Full 3-4 line ALL CAPS headline stacked tight, centered, in the left half of the slide. Pistachio circle on the right. Optional cream oval with a secondary phrase at bottom-left.
+- **Content slides**: Headline sits inside the cream oval. Pistachio circle is decoration. Body copy follows underneath in uppercase 13px or mixed-case 16px left-aligned.
+- **Final CTA slide**: Larger cream oval (420px) centered with CTA text. Pistachio circle behind. No bottom metadata -- replaced with a single centered handle.
+- **Swipe indicator**: Thin-outlined arrow in a 56x56px rounded-rectangle container in the top-right corner at `top: 80px, right: 80px`.
+
+### Infographic (1080px wide, variable height)
+
+- **Typography**: Display Hero at 64px. Section Heading at 44px. Body at 16px mixed-case.
+- **Padding**: 60px left/right, 100px top/bottom.
+- **Composition**: Vertical flow of 4-6 sections. Each section is a single "hero" with a cream oval or circle holding the section content. Alternate the pistachio circle side -- top section has it on the right, next on the left, next on the right. This creates a gentle zig-zag rhythm down the page.
+- **Section spacing**: 120px vertical gap between sections. The large whitespace is a feature.
+- **Footer**: Metadata row at the very bottom. No elaborate closing CTA -- keep the style's quiet-exit tradition.
+
+### Slides (1920x1080px)
+
+- **Typography scale up**: Display Hero at 88px. Section Heading at 64px. Body inside cream oval at 20px mixed-case or 16px uppercase. Metadata at 16px.
+- **Padding**: 120px on all sides.
+- **Layout**: Horizontal composition -- the pistachio circle is even larger (1400-1500px) and extends off the right edge. Cream oval is larger too (500px diameter) and positioned left-of-center.
+- **Title slides**: Headline centered on the left half at 88px, pistachio circle right. Arrow indicator moved to bottom-right.
+- **Content slides**: Cream oval is the focal point, positioned center-left. Pistachio circle fills the right third of the frame.
+- **CTA slides**: Extra large cream oval (600px) dead-center. Pistachio circle behind, partially visible on both sides if needed.
+
+### Poster (1080x1350px)
+
+- **Typography**: Display Hero at 64px. Section Heading at 44px. Body at 14-16px.
+- **Padding**: 80px left/right, 100px top/bottom.
+- **Composition**: Top third -- headline centered in ALL CAPS. Middle third -- pistachio circle + cream oval composition. Bottom third -- body copy and CTA.
+- **Vertical flow**: Content reads top-to-bottom. The pistachio circle in the middle acts as a visual anchor.
+- **CTA placement**: Bottom zone, centered, small tracked uppercase label. No dark button -- the style never uses buttons. If a link is needed, it appears as uppercase underlined text.
+
+### Story (1080x1920px) -- Vertical Mobile
+
+- **Typography scale**: Display Hero at 72px (larger than carousel to account for tall format). Section Heading at 48px. Body inside cream oval at 14px uppercase or 18px mixed-case. Metadata at 14px.
+- **Padding**: 120px left/right, 60px top/bottom. The wider horizontal padding keeps the headline reading as a narrow column, which matches the style's elegant feel.
+- **Hero circle size**: ~1400px (roughly 30% bigger than the carousel's 1080px hero) so the off-frame pistachio circle remains the dominant shape at the tall aspect ratio. Position it at `right: -700px; top: 50%; transform: translateY(-50%)` or `bottom: -500px` for a bottom-anchored variant.
+- **Composition**: The pistachio circle occupies roughly the lower-right quadrant or extends from the right edge across the middle vertical. The cream oval sits either above-center (if the pistachio is bottom) or center-left (if the pistachio is right).
+- **Layout**: Headline top-third, centered ALL CAPS across the full content width (~840px). Cream oval center of slide holding the secondary phrase. Pistachio circle anchoring the bottom-right. Metadata at the bottom safe area (above the ~180px Instagram UI overlay zone).
+- **Safe zones**: Reserve top 140px and bottom 240px for Instagram UI (profile, reply, reactions). Keep all critical text inside the middle 1540px vertical zone.
+- **Swipe arrow**: Not needed for stories (single-screen format). Replace with a small uppercase "SWIPE UP" or "TAP" label in the bottom safe zone if a CTA is needed.
+- **Story-specific convention**: Because the format is taller, the pistachio circle can be rotated to sit at the bottom-right corner (`right: -500px; bottom: -500px; top: auto; transform: none`) with the cream oval centered above it, creating a stacked vertical composition unique to story format.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Warm Cream | `#F5F1E6` | Primary background |
+| Lighter Cream | `#FAF7EC` | Inner cream oval content container |
+| Pale Pistachio | `#DCEAB4` | Large off-frame signature circle |
+| Deeper Pistachio | `#C9DDA0` | Hover/active state for pistachio |
+| Pistachio Outline | `#BFD390` | Optional thin outline frame |
+| Near-Black | `#1A1A1A` | Primary text, arrow icon |
+| Text Secondary | `#4A4A4A` | Body copy in cream oval |
+| Text Metadata | `#5C5C5C` | Bottom-row tracked labels |
+| Text Muted | `rgba(26,26,26,0.5)` | Slide numbers |
+| Border Thin | `rgba(26,26,26,0.4)` | Arrow container outline |
+| Outline Thin | `rgba(26,26,26,0.35)` | Optional frame outline |
+
+### Font Declarations
+
+```css
+/* Display (headlines only, always UPPERCASE, weight 400) */
+font-family: 'Playfair Display', Georgia, 'Times New Roman', serif;
+
+/* Body (metadata, small labels, long-form copy in oval) */
+font-family: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;1,400;1,600&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-bg: #F5F1E6;
+  --color-cream-light: #FAF7EC;
+  --color-pistachio: #DCEAB4;
+  --color-near-black: #1A1A1A;
+
+  /* Colors -- Accent */
+  --color-pistachio-deep: #C9DDA0;
+  --color-pistachio-outline: #BFD390;
+
+  /* Colors -- Neutral Scale */
+  --color-text-primary: #1A1A1A;
+  --color-text-secondary: #4A4A4A;
+  --color-metadata: #5C5C5C;
+  --color-text-muted: rgba(26, 26, 26, 0.5);
+
+  /* Colors -- Surfaces */
+  --color-surface-bg: #F5F1E6;
+  --color-surface-container: #FAF7EC;
+  --color-surface-accent: #DCEAB4;
+
+  /* Colors -- Borders */
+  --color-border-thin: rgba(26, 26, 26, 0.4);
+  --color-border-outline: rgba(26, 26, 26, 0.35);
+  --color-border-subtle: rgba(26, 26, 26, 0.12);
+  --color-divider: rgba(26, 26, 26, 0.08);
+
+  /* Colors -- Shadows (almost never used) */
+  --shadow-none: transparent;
+  --shadow-whisper: 0 2px 12px rgba(26, 26, 26, 0.03);
+  --shadow-subtle: 0 4px 20px rgba(26, 26, 26, 0.06);
+
+  /* Typography -- Families */
+  --font-display: 'Playfair Display', Georgia, 'Times New Roman', serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 56px;
+  --text-section-heading: 40px;
+  --text-sub-heading: 28px;
+  --text-inner-headline: 20px;
+  --text-body-large: 16px;
+  --text-body: 13px;
+  --text-metadata: 12px;
+  --text-caption: 11px;
+  --text-big-number: 72px;
+
+  /* Typography -- Weights */
+  --weight-display: 400;
+  --weight-display-mid: 500;
+  --weight-body: 400;
+  --weight-metadata: 500;
+
+  /* Typography -- Line Heights */
+  --leading-display: 1.18;
+  --leading-heading: 1.20;
+  --leading-sub-heading: 1.25;
+  --leading-inner: 1.30;
+  --leading-body: 1.65;
+  --leading-metadata: 1.40;
+  --leading-number: 1.00;
+
+  /* Typography -- Letter Spacing */
+  --tracking-display: 2px;
+  --tracking-heading: 1.5px;
+  --tracking-sub: 1px;
+  --tracking-inner: 0.5px;
+  --tracking-body: 0.5px;
+  --tracking-metadata: 1.5px;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-medium: 24px;
+  --space-oval-padding: 40px;
+  --space-oval-padding-lg: 48px;
+  --space-outer: 60px;
+  --space-outer-wide: 80px;
+  --space-story: 120px;
+
+  /* Borders */
+  --radius-circle: 50%;
+  --radius-arrow: 14px;
+  --border-thin: 1.5px;
+
+  /* Signature Shape Sizing */
+  --circle-hero-carousel: 1080px;
+  --circle-hero-story: 1400px;
+  --circle-hero-slides: 1500px;
+  --circle-offset-right: -540px;
+  --circle-offset-story: -700px;
+  --oval-content-carousel: 340px;
+  --oval-content-story: 380px;
+  --oval-content-slides: 500px;
+}
+```
+
+### System Font Fallbacks
+- **Serif (if Playfair Display fails to load):** `Georgia, 'Times New Roman', serif`
+- **Sans-serif (if Inter fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/_full/peach-pop.md
+++ b/skills/composites/goose-graphics/styles/_full/peach-pop.md
@@ -1,0 +1,459 @@
+# Design Style: Peach Pop
+
+## 1. Visual Theme & Atmosphere
+
+Peach Pop is the design language of modern DTC beauty and wellness brands -- the visual equivalent of a curated shelfie on a warm morning, a skincare routine laid out on a marble countertop, a playful unboxing video filmed in golden hour light. The warm peach canvas (`#fce8d8`) is not simply a background; it is the colour of flushed skin, of ripe apricots, of a sun-warmed blush compact. Every element placed upon it inherits that gentle warmth, creating compositions that feel fresh, approachable, and confidently feminine without being precious.
+
+The typographic system pairs two distinct voices: Space Mono for testimonials and featured text, and DM Sans for attribution and supporting copy. Space Mono -- a fixed-width typeface with geometric personality -- delivers testimonial quotes in uppercase with wide tracking, giving customer words the authority of a product label or packaging callout. Its monospaced letterforms feel intentional and designed, like text stamped onto a product box. DM Sans, a clean geometric sans-serif, handles names, labels, and smaller text with quiet professionalism. This mono-plus-sans pairing is a hallmark of contemporary DTC brands that want to feel both editorial and accessible -- think Glossier's packaging meets a tech-forward skincare startup.
+
+Cornflower blue (`#3B9BFF`) is the accent that electrifies this otherwise warm palette. It arrives as bold geometric blocks -- checkerboard patterns and offset squares -- flanking the central product image, creating a visual pop that is impossible to scroll past. The blue is not decorative filler; it is a strategic contrast agent. Against the warm peach, it creates maximum chromatic tension without conflict, the way a bright blue sky frames a terracotta building. Blue five-pointed stars serve as rating indicators, reinforcing the accent colour's role as the voice of social proof and trust. The overall effect is playful, confident, and clean -- a brand that takes its formulations seriously but never takes itself too seriously.
+
+**Key Characteristics:**
+- Warm peach background (`#fce8d8`) as the dominant surface -- the warmth of sun-kissed skin, not sterile white
+- Near-black (`#1a1a2e`) for primary text -- a deep navy-black that is softer than pure black
+- Cornflower blue (`#3B9BFF`) as the sole accent colour for stars, decorative blocks, and interactive elements
+- Space Mono (monospace) for testimonial headlines -- uppercase, tracked, bold, stamp-like authority
+- DM Sans for attribution text and supporting labels -- clean, geometric, quietly professional
+- Geometric block patterns (checkerboard/offset squares) as decorative framing elements in the accent blue
+- Rounded corners (12-16px) on product images and photo containers
+- Flat design with minimal shadow -- depth comes from colour contrast and geometric layering, not elevation
+- Star ratings in accent blue (`#3B9BFF`) as a recurring social proof motif
+- Center-aligned testimonial text blocks arranged in a 2x2 grid around a central product image
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Peach** (`#fce8d8`): Primary background. A warm, rosy off-white with pink-orange undertone, like the inside of a seashell or the lightest peach skin.
+- **Dark Navy** (`#1a1a2e`): Primary text colour. A near-black with cool blue undertone -- softer than true black, crisp against the warm background.
+- **Cornflower Blue** (`#3B9BFF`): Primary accent. Used for star ratings, geometric decorative blocks, interactive elements, and all emphasis. The singular pop colour.
+
+### Accent
+- **Deep Blue** (`#2878D0`): Darker blue for hover/active states on interactive elements and pressed geometric blocks.
+- **Light Peach** (`#fdd9c4`): Slightly deeper peach for subtle emphasis, borders, and hover states on the warm surface.
+- **Pale Blue** (`#8CC5FF`): Lighter tint of the accent for backgrounds of secondary containers or subtle highlights.
+
+### Neutral Scale
+- **Cream** (`#fef4ec`): Elevated surface -- cards, photo containers, and content panels sitting above the peach background.
+- **Blush** (`#f5d6c3`): Secondary surface for nested containers and inset areas.
+- **Warm Border** (`#e8c4ad`): Visible border for dividers and structural lines.
+- **Dusty Rose** (`#b89a8a`): Disabled text, placeholder content, and subtle dividers.
+- **Warm Gray** (`#8a7668`): Tertiary text for timestamps, metadata, and low-priority labels.
+- **Cocoa** (`#5c4a3e`): Secondary body text and descriptions.
+
+### Surface & Borders
+- **Surface Primary** (`#fef4ec`): Card and photo container background.
+- **Surface Inset** (`#f8e4d2`): Recessed areas and inset panels within the peach canvas.
+- **Border Default** (`rgba(26,26,46,0.10)`): Standard subtle border for cards and dividers.
+- **Border Accent** (`rgba(59,155,255,0.3)`): Blue-tinted border for active or featured elements.
+- **Border Strong** (`rgba(26,26,46,0.18)`): Higher-contrast border for prominent containers.
+- **Divider Rule** (`#3B9BFF`): Solid blue for accent rules and decorative lines (typically 3px height).
+
+### Shadow Colors
+- **Shadow Warm** (`rgba(26,26,46,0.06)`): Primary shadow -- cool-tinted ambient for subtle elevation.
+- **Shadow Deep** (`rgba(26,26,46,0.14)`): Deep shadow for high-elevation elements like modals.
+- **Shadow Soft** (`rgba(26,26,46,0.04)`): Nearly invisible shadow for cards and containers.
+- **Shadow Blue** (`rgba(59,155,255,0.06)`): Subtle blue ambient glow for accent-adjacent elements.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Space Mono', 'Courier New', monospace`
+- **Body**: `'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Space Mono | 56px | 700 | 1.10 | 2px | Uppercase, hero statement, monospaced impact |
+| Section Heading | Space Mono | 36px | 700 | 1.15 | 1.5px | Uppercase, major section titles |
+| Testimonial Quote | Space Mono | 22px | 700 | 1.30 | 1px | Uppercase, customer quotes -- the signature element |
+| Sub-heading | DM Sans | 28px | 700 | 1.25 | -0.25px | Subsection titles, product names |
+| Body Large | DM Sans | 20px | 400 | 1.65 | 0px | Lead paragraphs, introductions |
+| Body | DM Sans | 16px | 400 | 1.65 | 0.1px | Standard reading text |
+| Attribution | DM Sans | 13px | 400 | 1.40 | 1.5px | Uppercase, customer names below quotes |
+| Small / Caption | DM Sans | 12px | 400 | 1.50 | 0.3px | Metadata, footnotes |
+| Big Numbers | Space Mono | 64px | 700 | 1.00 | 0px | Statistics, key metrics |
+| CTA Text | DM Sans | 15px | 700 | 1.00 | 0.5px | Button and call-to-action text |
+
+### Principles
+- **Monospace for authority**: Space Mono in uppercase with generous tracking transforms customer quotes into design elements with the weight of packaging copy. The monospaced grid gives each word equal visual presence.
+- **Sans-serif for support**: DM Sans handles all secondary text -- names, labels, body copy. Its geometric simplicity never competes with the monospace headlines.
+- **Uppercase is the default for display text**: All Space Mono usage is uppercase with positive letter-spacing (1-2px). This is non-negotiable -- it is the signature of the style.
+- **Attribution in small caps style**: Customer names appear in DM Sans at 13px, uppercase, with wide tracking (1.5px), creating a quiet label that feels like fine print on a product box.
+- **Generous line height for mono**: Monospace text at 1.30 line height ensures multi-line testimonials remain readable despite the inherently wider letterforms.
+- **Weight contrast, not size contrast**: Headlines and quotes both use weight 700 in Space Mono. Hierarchy comes from size and tracking changes, not weight variation within the mono family.
+
+## 4. Component Patterns
+
+### Title Block (Cover / Header Section)
+
+```html
+<div style="background-color: var(--color-peach); padding: 80px 60px; text-align: center;">
+  <div style="display: flex; justify-content: center; gap: 6px; margin-bottom: 20px;">
+    <span style="color: var(--color-blue); font-size: 24px;">&#9733;</span>
+    <span style="color: var(--color-blue); font-size: 24px;">&#9733;</span>
+    <span style="color: var(--color-blue); font-size: 24px;">&#9733;</span>
+    <span style="color: var(--color-blue); font-size: 24px;">&#9733;</span>
+    <span style="color: var(--color-blue); font-size: 24px;">&#9733;</span>
+  </div>
+  <h1 style="font-family: var(--font-display); font-size: 56px; font-weight: 700; line-height: 1.10; letter-spacing: 2px; text-transform: uppercase; color: var(--color-dark-navy); margin: 0 0 24px;">What Our Customers Say</h1>
+  <p style="font-family: var(--font-body); font-size: 20px; font-weight: 400; line-height: 1.65; color: var(--color-cocoa); max-width: 540px; margin: 0 auto;">Real reviews from real people who made the switch.</p>
+</div>
+```
+
+### Testimonial Card (Signature Element)
+
+```html
+<div style="text-align: center; padding: 32px 24px;">
+  <div style="display: flex; justify-content: center; gap: 4px; margin-bottom: 16px;">
+    <span style="color: var(--color-blue); font-size: 18px;">&#9733;</span>
+    <span style="color: var(--color-blue); font-size: 18px;">&#9733;</span>
+    <span style="color: var(--color-blue); font-size: 18px;">&#9733;</span>
+    <span style="color: var(--color-blue); font-size: 18px;">&#9733;</span>
+    <span style="color: var(--color-blue); font-size: 18px;">&#9733;</span>
+  </div>
+  <p style="font-family: var(--font-display); font-size: 22px; font-weight: 700; line-height: 1.30; letter-spacing: 1px; text-transform: uppercase; color: var(--color-dark-navy); margin: 0 0 12px;">The only serum I actually finish.</p>
+  <p style="font-family: var(--font-body); font-size: 13px; font-weight: 400; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-warm-gray); margin: 0;">Bianca Vieira</p>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="text-align: center; padding: 40px 24px; background: var(--color-cream); border-radius: 16px;">
+  <p style="font-family: var(--font-display); font-size: 64px; font-weight: 700; line-height: 1.00; color: var(--color-blue); margin: 0 0 8px;">97%</p>
+  <p style="font-family: var(--font-display); font-size: 14px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-dark-navy); margin: 0 0 12px;">Would Recommend</p>
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-cocoa); max-width: 280px; margin: 0 auto;">Based on 2,400+ verified customer reviews collected over the past year.</p>
+</div>
+```
+
+### Comparison Grid
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 3px; background: var(--color-warm-border); border-radius: 16px; overflow: hidden;">
+  <div style="background: var(--color-cream); padding: 40px 32px;">
+    <p style="font-family: var(--font-body); font-size: 13px; font-weight: 400; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-warm-gray); margin: 0 0 16px;">Before</p>
+    <h3 style="font-family: var(--font-display); font-size: 22px; font-weight: 700; line-height: 1.30; letter-spacing: 1px; text-transform: uppercase; color: var(--color-dark-navy); margin: 0 0 16px;">Dull & Uneven</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-cocoa); margin: 0;">Inconsistent texture, visible pores, and a tired complexion that no amount of concealer could fix.</p>
+  </div>
+  <div style="background: var(--color-cream); padding: 40px 32px; border-left: 3px solid var(--color-blue);">
+    <p style="font-family: var(--font-body); font-size: 13px; font-weight: 400; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-blue); margin: 0 0 16px;">After</p>
+    <h3 style="font-family: var(--font-display); font-size: 22px; font-weight: 700; line-height: 1.30; letter-spacing: 1px; text-transform: uppercase; color: var(--color-dark-navy); margin: 0 0 16px;">Smooth & Glowing</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-cocoa); margin: 0;">Visibly refined pores, even tone, and a natural radiance after just four weeks of daily use.</p>
+  </div>
+</div>
+```
+
+### Geometric Accent Block (Decorative)
+
+```html
+<div style="position: relative; display: flex; gap: 8px; flex-wrap: wrap; width: 120px;">
+  <div style="width: 52px; height: 52px; background: var(--color-blue); border-radius: 4px;"></div>
+  <div style="width: 52px; height: 52px; background: var(--color-blue); border-radius: 4px;"></div>
+  <div style="width: 52px; height: 52px; background: var(--color-blue); border-radius: 4px;"></div>
+  <div style="width: 52px; height: 52px; background: transparent;"></div>
+  <div style="width: 52px; height: 52px; background: transparent;"></div>
+  <div style="width: 52px; height: 52px; background: var(--color-blue); border-radius: 4px;"></div>
+</div>
+```
+
+### Product Image Container
+
+```html
+<div style="max-width: 320px; margin: 0 auto; border-radius: 16px; overflow: hidden; background: var(--color-cream);">
+  <img src="product.jpg" style="width: 100%; height: auto; display: block; border-radius: 16px;" alt="Product image" />
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="text-align: center; padding: 60px 40px; background: var(--color-cream); border: 1px solid rgba(59,155,255,0.3); border-radius: 16px;">
+  <div style="display: flex; justify-content: center; gap: 4px; margin-bottom: 20px;">
+    <span style="color: var(--color-blue); font-size: 20px;">&#9733;</span>
+    <span style="color: var(--color-blue); font-size: 20px;">&#9733;</span>
+    <span style="color: var(--color-blue); font-size: 20px;">&#9733;</span>
+    <span style="color: var(--color-blue); font-size: 20px;">&#9733;</span>
+    <span style="color: var(--color-blue); font-size: 20px;">&#9733;</span>
+  </div>
+  <h2 style="font-family: var(--font-display); font-size: 36px; font-weight: 700; line-height: 1.15; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-dark-navy); margin: 0 0 16px;">Try It Risk-Free</h2>
+  <p style="font-family: var(--font-body); font-size: 18px; font-weight: 400; line-height: 1.65; color: var(--color-cocoa); max-width: 420px; margin: 0 auto 32px;">Join thousands of happy customers. 30-day money-back guarantee.</p>
+  <a style="display: inline-block; background: var(--color-blue); color: #ffffff; font-family: var(--font-body); font-size: 15px; font-weight: 700; letter-spacing: 0.5px; text-decoration: none; padding: 16px 40px; border-radius: 12px;">Shop Now</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between star icons in a rating row.
+- **8px**: Tight gap -- between geometric blocks in decorative patterns.
+- **12px**: Small gap -- between testimonial text and attribution name.
+- **16px**: Base gap -- between star row and testimonial text, between body paragraphs.
+- **24px**: Medium gap -- between components within a section, standard card internal padding.
+- **32px**: Section internal -- padding inside testimonial cards, gap between grouped items.
+- **48px**: Section divider -- vertical space between major content blocks.
+- **60px**: Large section padding -- top/bottom padding for hero and CTA blocks.
+- **80px**: Maximum section padding -- cover slides and high-impact hero areas.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 960px |
+
+### Alignment & Grid
+- **Primary alignment**: Center-aligned for all testimonial blocks, star ratings, and headlines. Left-aligned only for longer body paragraphs in editorial contexts.
+- **Grid**: Use a 2x2 grid for testimonial layouts with a central product image. 2-column for comparison layouts. Single-column for narrative content.
+- **Geometric accents**: Blue block clusters are positioned at the left and right edges of the composition, flanking the central content. They occupy roughly 15-20% of the horizontal space on each side.
+- **Vertical rhythm**: Maintain consistent 48px gaps between top-level sections. Use 16px gaps between items within a testimonial card (stars > text > name).
+- **Content gravity**: The central axis is dominant. Product images and key content anchor to the vertical center. Testimonials distribute evenly in the four quadrants around the center.
+- **Symmetry**: The overall composition is symmetrical across the vertical axis. Left-side decorative blocks mirror right-side blocks. Top testimonials mirror bottom testimonials.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, background `#fce8d8` | Page canvas, base layer -- the default for this style |
+| Subtle (Level 1) | `rgba(26,26,46,0.04) 0px 2px 8px` | Slight lift for photo containers on hover |
+| Card (Level 2) | `rgba(26,26,46,0.06) 0px 6px 20px, rgba(59,155,255,0.04) 0px 0px 10px` | Product image containers and featured cards |
+| Featured (Level 3) | `rgba(26,26,46,0.10) 0px 12px 32px, rgba(59,155,255,0.06) 0px 0px 16px` | Hero product showcases, modal-like overlays |
+| Overlay (Level 4) | `rgba(26,26,46,0.18) 0px 20px 48px` | Full overlays and popups |
+
+### Border Treatments
+- **Standard border**: `1px solid rgba(26,26,46,0.10)` -- barely visible, cool-neutral line for subtle structure.
+- **Active border**: `1px solid rgba(59,155,255,0.3)` -- blue-tinted border for featured or active containers.
+- **Accent rule**: `3px solid #3B9BFF` -- blue line used as a left-border accent on comparison "preferred" sides or as horizontal dividers.
+- **Divider line**: `1px solid rgba(26,26,46,0.06)` -- nearly invisible separator between list items.
+
+### Surface Hierarchy
+This style is predominantly flat. Depth is communicated through colour contrast rather than elevation:
+1. **Background** (`#fce8d8`) -- the warm peach canvas, the foundation.
+2. **Surface** (`#fef4ec`) -- photo containers and cards step up by becoming lighter and less saturated.
+3. **Accent blocks** (`#3B9BFF`) -- geometric blue elements sit visually "on top" through pure chromatic contrast, not shadow.
+4. **Product image** -- the photo itself, framed by the lighter surface container with rounded corners, is the focal point at the highest perceived depth.
+
+Shadows are used sparingly. The style achieves layering through colour temperature shifts (warm background to cooler card surfaces) and the bold contrast of blue geometric elements.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use cornflower blue (`#3B9BFF`) as the only accent colour -- it is the singular pop that defines this style against the warm peach.
+- Use Space Mono in uppercase with letter-spacing of 1-2px for all testimonial headlines and display text -- the monospaced uppercase treatment is the signature.
+- Use DM Sans at weight 400 for attribution names and body text -- its quiet geometry supports without competing.
+- Use five-pointed star ratings (&#9733;) in `#3B9BFF` as the standard social proof element -- stars always appear above the testimonial text.
+- Use rounded corners (12-16px) on all photo containers and cards -- they soften the geometric rigour of the blue blocks.
+- Use geometric blue block patterns (checkerboard or offset squares, ~50px blocks with ~8px gaps) as decorative framing elements on the left and right sides.
+- Centre-align all testimonial cards -- quote text, star ratings, and attribution names are all centred.
+- Keep the palette to three primary colours only: peach (`#fce8d8`), dark navy (`#1a1a2e`), and blue (`#3B9BFF`).
+- Maintain at least 48px separation between testimonial cards to prevent visual crowding.
+
+### Don't
+- Don't introduce additional accent colours (no green, orange, red, or purple) -- the blue-on-peach contrast is the entire identity.
+- Don't use Space Mono in lowercase or mixed case -- it must always be uppercase with positive letter-spacing.
+- Don't use heavy drop shadows -- this is a flat, colour-driven style. Maximum shadow opacity is 0.10 for card-level elements.
+- Don't use pure white (`#ffffff`) for backgrounds -- always use peach (`#fce8d8`) or cream (`#fef4ec`) to maintain warmth.
+- Don't use pure black (`#000000`) for text -- use dark navy (`#1a1a2e`) for warm-cool balance.
+- Don't place geometric blue blocks in the centre of the composition -- they are edge/framing elements only.
+- Don't use serif fonts anywhere -- the mono-plus-sans pairing is the complete typographic system.
+- Don't make geometric accent blocks rounded -- they should have minimal border-radius (0-4px) to contrast with the rounded photo containers.
+- Don't use gradients on the background -- the peach should be a solid, flat colour.
+- Don't set testimonial text below 18px -- monospace text loses readability at small sizes.
+- Don't use more than 5 stars in a rating -- the five-star row is the standard unit.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale down**: Display Hero becomes 44px (from 56px). Testimonial Quote stays 22px. Attribution stays 13px.
+- **Padding**: 60px on all sides. Content area is 960x960px.
+- **Cover slide**: Title centered vertically. Star row above title. Geometric blue blocks on left and right edges.
+- **Testimonial slides**: One testimonial per slide, centered. Stars above, quote in the middle, name below. Geometric blocks on edges for brand continuity.
+- **Product slide**: Product image centered with rounded container. 2-3 testimonial excerpts arranged around it.
+- **Swipe indicator**: Small blue dots at bottom center, 8px diameter, 12px gap. Active dot in `#3B9BFF`, inactive in `rgba(59,155,255,0.3)`.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Full-scale hierarchy. Display Hero at 56px for the title section.
+- **Padding**: 60px left/right, 80px top/bottom margins.
+- **Section spacing**: 64px vertical gap between major sections. Thin blue rule (3px, 60px wide, centered) between sections.
+- **Testimonial grid**: Arrange testimonials in 2-column grid. Each card has stars, quote, and name. Alternate with stat displays and product images.
+- **Geometric accents**: Blue block clusters at the top and bottom of the infographic, and optionally flanking the product image mid-page.
+- **Footer**: Warm gray text, 12px DM Sans, with a final blue rule above.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 64px. Testimonial Quote becomes 28px. Body Large becomes 22px.
+- **Padding**: 80px on all sides. Content area is 1760x920px.
+- **Layout**: Symmetric composition. Title slides centred. Content slides can use 2-column or 3-column grids.
+- **Title slides**: Headline centered. Star row above. Geometric blocks flanking the text block.
+- **Testimonial slides**: 2-3 testimonials side by side with product image between them.
+- **Stat slides**: Up to 3 stats in a row, each in a rounded container on cream background.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 48px. Testimonial Quote at 22px. Body at 16px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top zone for headline with star ratings. Middle zone for product image flanked by geometric blue blocks. Bottom zone for 2-4 testimonial cards in a 2x2 grid.
+- **Vertical flow**: Stars and headline at top, product image in the optical centre, testimonials below. Geometric accents on the left and right edges of the middle zone.
+- **CTA placement**: Below the testimonial grid, centered, with blue button and generous padding above.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Hero becomes 56px in Space Mono uppercase with wide tracking (approximately 30% larger than Carousel 44px). Testimonial Quote becomes 28px in Space Mono uppercase. Attribution in DM Sans at 16px. Star ratings in blue at 28px.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical text must sit inside y=160 to y=1760.
+- **Layout**: Single centered column. Content max-width 920px. Vertical center of gravity -- cluster hero content in y=400 to y=1500 range. Warm peach background (`#fce8d8`) runs edge-to-edge so the sun-kissed-skin warmth fills the tall frame.
+- **Cover slide**: Row of cornflower blue (`#3B9BFF`) stars centered above the headline. Space Mono uppercase headline at 56px with wide letter-spacing in dark navy (`#1a1a2e`), stacked in 2-3 lines. Blue geometric checkerboard or offset-square blocks flank the headline to the left and right, creating the signature chromatic tension against the peach canvas. DM Sans attribution below.
+- **Content slides**: One testimonial per slide. Space Mono testimonial quote at 28px uppercase in dark navy centered, with a product image or photo container (12-16px radius) above or below. Blue geometric blocks decorate the edges. A horizontal row of blue star ratings sits above or below the quote. Keep the composition flat -- depth comes from color contrast and geometric layering, not shadows.
+- **CTA slide**: Blue geometric blocks on both vertical edges. Space Mono headline at 44px centered in dark navy. Short DM Sans supporting copy. Bright blue (`#3B9BFF`) pill button with peach or white DM Sans 700 CTA text.
+- **Progress indicator**: Row of blue filled squares (not circles -- the geometric square IS the motif) at the top of the safe zone, 8px squares with 6px gap. Inactive squares at 30% opacity, active at full opacity. Consistent with the checkerboard vocabulary.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Peach | `#fce8d8` | Primary background |
+| Dark Navy | `#1a1a2e` | Primary text |
+| Cornflower Blue | `#3B9BFF` | Accent: stars, geometric blocks, CTAs, focal points |
+| Deep Blue | `#2878D0` | Hover/active state for blue elements |
+| Light Peach | `#fdd9c4` | Subtle emphasis, borders |
+| Pale Blue | `#8CC5FF` | Secondary highlights, light backgrounds |
+| Cream | `#fef4ec` | Card/container surface, photo frames |
+| Surface Inset | `#f8e4d2` | Recessed panels |
+| Blush | `#f5d6c3` | Nested containers, elevated surfaces |
+| Warm Border | `#e8c4ad` | Structural borders |
+| Dusty Rose | `#b89a8a` | Disabled text, subtle dividers |
+| Warm Gray | `#8a7668` | Tertiary text, attribution names |
+| Cocoa | `#5c4a3e` | Secondary text, body descriptions |
+
+### Font Declarations
+
+```css
+/* Display / Testimonials */
+font-family: 'Space Mono', 'Courier New', monospace;
+
+/* Body / Attribution */
+font-family: 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-peach: #fce8d8;
+  --color-dark-navy: #1a1a2e;
+  --color-blue: #3B9BFF;
+
+  /* Colors -- Accent */
+  --color-deep-blue: #2878D0;
+  --color-light-peach: #fdd9c4;
+  --color-pale-blue: #8CC5FF;
+
+  /* Colors -- Neutral Scale */
+  --color-cream: #fef4ec;
+  --color-blush: #f5d6c3;
+  --color-warm-border: #e8c4ad;
+  --color-dusty-rose: #b89a8a;
+  --color-warm-gray: #8a7668;
+  --color-cocoa: #5c4a3e;
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: #fef4ec;
+  --color-surface-inset: #f8e4d2;
+
+  /* Colors -- Borders */
+  --color-border-default: rgba(26, 26, 46, 0.10);
+  --color-border-accent: rgba(59, 155, 255, 0.3);
+  --color-border-strong: rgba(26, 26, 46, 0.18);
+  --color-divider-rule: #3B9BFF;
+
+  /* Colors -- Shadows */
+  --shadow-warm: rgba(26, 26, 46, 0.06);
+  --shadow-deep: rgba(26, 26, 46, 0.14);
+  --shadow-soft: rgba(26, 26, 46, 0.04);
+  --shadow-blue: rgba(59, 155, 255, 0.06);
+
+  /* Typography -- Families */
+  --font-display: 'Space Mono', 'Courier New', monospace;
+  --font-body: 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 56px;
+  --text-section-heading: 36px;
+  --text-testimonial: 22px;
+  --text-sub-heading: 28px;
+  --text-body-large: 20px;
+  --text-body: 16px;
+  --text-attribution: 13px;
+  --text-small: 12px;
+  --text-big-number: 64px;
+  --text-cta: 15px;
+
+  /* Typography -- Weights */
+  --weight-display: 700;
+  --weight-heading: 700;
+  --weight-body: 400;
+  --weight-body-light: 300;
+  --weight-label: 400;
+  --weight-cta: 700;
+
+  /* Typography -- Line Heights */
+  --leading-display: 1.10;
+  --leading-heading: 1.15;
+  --leading-testimonial: 1.30;
+  --leading-sub-heading: 1.25;
+  --leading-body-large: 1.65;
+  --leading-body: 1.65;
+  --leading-attribution: 1.40;
+  --leading-small: 1.50;
+  --leading-number: 1.00;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-medium: 24px;
+  --space-large: 32px;
+  --space-section: 48px;
+  --space-hero: 60px;
+  --space-max: 80px;
+
+  /* Borders */
+  --radius-standard: 16px;
+  --radius-small: 12px;
+  --radius-block: 4px;
+  --radius-none: 0px;
+
+  /* Shadows -- Composed */
+  --shadow-card: rgba(26,26,46,0.06) 0px 6px 20px, rgba(59,155,255,0.04) 0px 0px 10px;
+  --shadow-featured: rgba(26,26,46,0.10) 0px 12px 32px, rgba(59,155,255,0.06) 0px 0px 16px;
+}
+```
+
+### System Font Fallbacks
+- **Monospace (if Space Mono fails to load):** `'Courier New', Courier, monospace`
+- **Sans-serif (if DM Sans fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/_full/product-minimal.md
+++ b/skills/composites/goose-graphics/styles/_full/product-minimal.md
@@ -1,0 +1,453 @@
+# Design Style: Product Minimal
+
+## 1. Visual Theme & Atmosphere
+
+Product Minimal is the design language of quiet luxury product pages -- the visual equivalent of a silver sedan photographed on a studio floor with nothing else in the frame. This is the aesthetic of Apple's product detail pages, Lucid Motors' hero sections, Nothing's marketing site, and Airbnb at its cleanest. Where other minimal styles lean on typography or negative space as the hero, Product Minimal hands the entire stage to a single product photograph. The page exists to frame the object, not to compete with it. Everything -- the type, the colour palette, the chrome -- recedes so the product can sit forward.
+
+The canvas is pure, uncompromised white (`#FFFFFF`). Unlike most refined design systems that warm white slightly to avoid clinical harshness, Product Minimal insists on genuine `#FFFFFF` because the product photo sets the temperature: the subtle shadow cast beneath the object, the soft reflection on its surfaces, the ambient warmth of studio lighting -- these read correctly only against true white. Warm off-whites muddy the photograph and make the object feel like it is sitting on paper rather than floating in a seamless infinity backdrop. The drop-shadow beneath the product (`filter: drop-shadow(0 24px 48px rgba(0,0,0,0.08))`) is the only "depth" on the page and it belongs to the photo, not the layout.
+
+Typography is deliberately a single family, set quietly. Inter at weight 700 carries the headline; Inter at weight 400 carries the body in a softer gray (`#555555`); Inter at weight 500 underlines the URL that functions as the page's only call to action. There are no buttons with fills, no coloured accents, no icons, no dividers except a single 1px footer rule. The typographic move is to stay out of the photo's way -- tight tracking, modest sizes, generous whitespace, centered alignment below the hero image. When the product is the brand, the words are the caption. Think of the pages where a premium brand simply writes "A New Standard in Motion" under an image of the thing itself and trusts you to know the rest.
+
+**Key Characteristics:**
+- Pure white background (`#FFFFFF`) -- one of the only styles where genuine `#FFFFFF` is correct, because the product photo sets the temperature
+- Near-black (`#1A1A1A`) for headlines, medium gray (`#555555`) for body, muted gray (`#777777`) for the underlined URL
+- Product photo occupies ~60% of the frame vertically and anchors the composition
+- Subtle drop-shadow under product (`filter: drop-shadow(0 24px 48px rgba(0,0,0,0.08))`) -- the only depth cue in the layout
+- Inter as the single typeface at weights 400, 500, 700 -- no secondary family
+- Headline Inter 700 at ~36px with tight tracking (-0.5px)
+- Body Inter 400 at ~18px in softer gray, line-height 1.55
+- Underlined URL at Inter 500, muted gray, replaces the filled-button CTA pattern
+- Only two text colours plus a URL gray -- never more
+- Centered alignment below the product photo; the photo itself is horizontally centered in its container
+- Only one decorative mark permitted: a thin 1px rule above the footer
+- Massive whitespace padding around the product photo -- let it breathe in its own studio
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Pure White** (`#FFFFFF`): Primary background. Genuinely pure white -- this is one of the very few styles where the canvas is not warmed. The product photograph carries all the temperature.
+- **Near-Black** (`#1A1A1A`): Primary headline colour. Warm enough to avoid the hardness of absolute black, dark enough to command attention beneath the photograph.
+- **Body Gray** (`#555555`): Body copy colour. A softer mid-gray that recedes behind the headline and keeps the paragraph from competing with the product.
+
+### Accent
+- **URL Gray** (`#777777`): Muted gray for the underlined URL "button" -- quieter than body text because it is a subtle CTA, not a visual anchor.
+- **URL Hover** (`#1A1A1A`): On hover, the URL darkens to near-black -- the only interactive colour shift in the system.
+
+### Neutral Scale
+- **Photo Shadow** (`rgba(0,0,0,0.08)`): The soft drop-shadow cast beneath the product photograph.
+- **Footer Rule** (`rgba(0,0,0,0.08)`): The single 1px rule above the footer text -- the only structural line in the entire layout.
+- **Metadata Gray** (`#999999`): Timestamps, attributions, and footer caption text.
+- **Disabled Gray** (`#CCCCCC`): Disabled state for the underlined URL.
+- **Photo Frame** (`#FAFAFA`): Optional barely-there tint for the photo container when you need to suggest a container without actually drawing one. Use sparingly.
+
+### Surface & Borders
+- **Surface Primary** (`#FFFFFF`): The canvas itself -- there are no other surfaces. Cards, containers, and panels are all simply the white canvas.
+- **Border Default** (none): Borders are forbidden on content elements. The product photo needs no frame.
+- **Divider Rule** (`1px solid rgba(0,0,0,0.08)`): Used exclusively for the footer rule.
+- **URL Underline** (`1px solid #777777`): The underline beneath the CTA URL. Matches the URL's own colour.
+
+### Shadow Colors
+- **Product Drop Shadow** (`rgba(0,0,0,0.08)`): The soft shadow beneath the product photograph -- large, diffuse, warm-neutral.
+- **Shadow Micro** (`rgba(0,0,0,0.04)`): Reserved for optional hover lift on the CTA URL underline.
+- **Shadow None** (`none`): The default. Every container is flat. Every card is flat. Only the product photo has a shadow.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Body**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Inter | 48px | 700 | 1.15 | -0.75px | Rare -- used only for cover posters without a product photo above |
+| Headline | Inter | 36px | 700 | 1.20 | -0.5px | The signature headline beneath the product photo |
+| Sub-heading | Inter | 24px | 700 | 1.25 | -0.25px | Secondary statements, section titles |
+| Body Large | Inter | 20px | 400 | 1.55 | 0px | Lead paragraphs when used without a hero photo |
+| Body | Inter | 18px | 400 | 1.55 | 0px | Standard paragraph beneath the headline -- soft gray |
+| Small / Caption | Inter | 14px | 400 | 1.50 | 0.1px | Footer text, timestamps, fine print |
+| URL CTA | Inter | 16px | 500 | 1.00 | 0px | The underlined URL that replaces the filled-button CTA |
+| Footer Label | Inter | 12px | 400 | 1.50 | 0.3px | Footer metadata below the rule |
+| Big Numbers | Inter | 56px | 700 | 1.00 | -1px | Rare -- used only when a stat replaces the hero photo |
+
+### Principles
+- **Single family, three weights**: Inter 400 for body, Inter 500 for the URL CTA, Inter 700 for headlines. No other weights. No other families. The restraint is the identity.
+- **Headlines stay modest**: The headline is 36px, not 72px. Product Minimal headlines are captions to the photograph -- they never compete with it. If the product photo is absent, scale up to 48px, never more.
+- **Tight but not extreme tracking**: -0.5px at 36px, -0.75px at 48px. Headlines read tight and confident, but they are not "engineered" the way Space Grotesk or geometric sans headlines are. Inter stays warm.
+- **Body in gray, not black**: Body text is always `#555555`, never near-black. The contrast drop keeps the paragraph soft and caption-like beneath the headline.
+- **Center alignment below the product**: Headline, body, and URL are always center-aligned below the product photo. This is non-negotiable -- it is the signature composition.
+- **Mixed case always**: No uppercase headlines, no uppercase labels. Product Minimal is a quiet style; it does not shout.
+- **Underlined URL instead of buttons**: The CTA is always a plain underlined URL in Inter 500 medium-weight gray. No fills, no borders, no pills, no radii. This is the one pattern the style is most opinionated about.
+
+## 4. Component Patterns
+
+### Product Photo Hero
+
+```html
+<div style="background: var(--color-bg); padding: 80px 60px 40px; text-align: center;">
+  <div style="max-width: 720px; margin: 0 auto;">
+    <img
+      src="[product.jpg]"
+      alt="[Product name]"
+      style="display: block; width: 100%; height: auto; max-height: 560px; object-fit: contain; filter: drop-shadow(0 24px 48px rgba(0,0,0,0.08));"
+    />
+  </div>
+</div>
+```
+
+### Centered Headline Block
+
+```html
+<div style="background: var(--color-bg); padding: 40px 60px 80px; text-align: center;">
+  <h1 style="font-family: var(--font-body); font-size: 36px; font-weight: 700; line-height: 1.20; letter-spacing: -0.5px; color: var(--color-near-black); margin: 0 0 20px;">A New Standard in Motion</h1>
+  <p style="font-family: var(--font-body); font-size: 18px; font-weight: 400; line-height: 1.55; color: var(--color-body-gray); max-width: 520px; margin: 0 auto 28px;">Introducing a new approach to automotive design, where performance, comfort, and technology meet to shape the future of driving.</p>
+  <a href="https://newcar.co" style="display: inline-block; font-family: var(--font-body); font-size: 16px; font-weight: 500; line-height: 1.00; color: var(--color-url-gray); text-decoration: underline; text-underline-offset: 4px; text-decoration-thickness: 1px;">newcar.co</a>
+</div>
+```
+
+### Underlined URL Button
+
+```html
+<a
+  href="https://newcar.co"
+  style="display: inline-block; font-family: var(--font-body); font-size: 16px; font-weight: 500; line-height: 1.00; color: var(--color-url-gray); text-decoration: underline; text-underline-offset: 4px; text-decoration-thickness: 1px; background: none; border: none; padding: 0;"
+>newcar.co</a>
+```
+
+### Thin Footer Rule
+
+```html
+<div style="padding: 32px 60px 40px; text-align: center;">
+  <div style="width: 100%; max-width: 720px; height: 1px; background: rgba(0,0,0,0.08); margin: 0 auto 20px;"></div>
+  <p style="font-family: var(--font-body); font-size: 12px; font-weight: 400; line-height: 1.50; letter-spacing: 0.3px; color: var(--color-metadata); margin: 0;">&copy; 2026 Newcar Inc. All rights reserved.</p>
+</div>
+```
+
+### Full Product Page Composition
+
+```html
+<div style="background: var(--color-bg); min-height: 100%; display: flex; flex-direction: column;">
+  <!-- Product photo (~60% of frame) -->
+  <div style="flex: 0 0 auto; padding: 80px 60px 40px; text-align: center;">
+    <div style="max-width: 720px; margin: 0 auto;">
+      <img src="[product.jpg]" alt="[Product]" style="display: block; width: 100%; height: auto; max-height: 560px; object-fit: contain; filter: drop-shadow(0 24px 48px rgba(0,0,0,0.08));" />
+    </div>
+  </div>
+  <!-- Centered headline block -->
+  <div style="flex: 1 1 auto; padding: 20px 60px 40px; text-align: center;">
+    <h1 style="font-family: var(--font-body); font-size: 36px; font-weight: 700; line-height: 1.20; letter-spacing: -0.5px; color: var(--color-near-black); margin: 0 0 20px;">A New Standard in Motion</h1>
+    <p style="font-family: var(--font-body); font-size: 18px; font-weight: 400; line-height: 1.55; color: var(--color-body-gray); max-width: 520px; margin: 0 auto 28px;">Introducing a new approach to automotive design, where performance, comfort, and technology meet to shape the future of driving.</p>
+    <a href="https://newcar.co" style="display: inline-block; font-family: var(--font-body); font-size: 16px; font-weight: 500; color: var(--color-url-gray); text-decoration: underline; text-underline-offset: 4px; text-decoration-thickness: 1px;">newcar.co</a>
+  </div>
+</div>
+```
+
+### Caption Pair (Photo + One-Liner)
+
+```html
+<div style="text-align: center; padding: 40px 60px;">
+  <div style="max-width: 600px; margin: 0 auto 32px;">
+    <img src="[product.jpg]" alt="[Product]" style="display: block; width: 100%; height: auto; filter: drop-shadow(0 24px 48px rgba(0,0,0,0.08));" />
+  </div>
+  <p style="font-family: var(--font-body); font-size: 24px; font-weight: 700; line-height: 1.25; letter-spacing: -0.25px; color: var(--color-near-black); max-width: 520px; margin: 0 auto;">Engineered for the road ahead.</p>
+</div>
+```
+
+### Quiet Stat Display
+
+```html
+<div style="text-align: center; padding: 60px 40px;">
+  <p style="font-family: var(--font-body); font-size: 56px; font-weight: 700; line-height: 1.00; letter-spacing: -1px; color: var(--color-near-black); margin: 0 0 12px;">412 mi</p>
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.55; color: var(--color-body-gray); max-width: 320px; margin: 0 auto;">Projected EPA range on a single charge.</p>
+</div>
+```
+
+### Two-Up Product Grid
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 60px; padding: 60px;">
+  <div style="text-align: center;">
+    <img src="[product-a.jpg]" alt="[Product A]" style="display: block; width: 100%; height: auto; filter: drop-shadow(0 24px 48px rgba(0,0,0,0.08)); margin: 0 0 24px;" />
+    <h3 style="font-family: var(--font-body); font-size: 20px; font-weight: 700; line-height: 1.25; letter-spacing: -0.25px; color: var(--color-near-black); margin: 0 0 8px;">Sedan</h3>
+    <p style="font-family: var(--font-body); font-size: 14px; font-weight: 400; line-height: 1.50; color: var(--color-body-gray); margin: 0;">Designed for the long haul.</p>
+  </div>
+  <div style="text-align: center;">
+    <img src="[product-b.jpg]" alt="[Product B]" style="display: block; width: 100%; height: auto; filter: drop-shadow(0 24px 48px rgba(0,0,0,0.08)); margin: 0 0 24px;" />
+    <h3 style="font-family: var(--font-body); font-size: 20px; font-weight: 700; line-height: 1.25; letter-spacing: -0.25px; color: var(--color-near-black); margin: 0 0 8px;">Coupe</h3>
+    <p style="font-family: var(--font-body); font-size: 14px; font-weight: 400; line-height: 1.50; color: var(--color-body-gray); margin: 0;">Built for the drive itself.</p>
+  </div>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between text-decoration underline and baseline (via `text-underline-offset`).
+- **8px**: Tight gap -- rarely used in this style; the smallest practical gap is 12px.
+- **12px**: Small gap -- between a big number and its label in a stat display.
+- **20px**: Base gap -- between headline and body paragraph.
+- **28px**: Medium gap -- between body paragraph and URL CTA.
+- **32px**: Inter-element gap -- between the photo shadow and the headline that sits below it.
+- **40px**: Section internal -- padding above the headline block when it sits beneath a product photo.
+- **60px**: Outer horizontal padding -- the standard left/right padding for every format.
+- **80px**: Outer vertical padding -- the standard top/bottom padding, and the minimum breathing room above a product photo.
+- **120px**: Maximum padding -- reserved for Story formats and posters where the photo needs to float even more.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 960px |
+| Story (1080x1920) | 60px left/right, 120px top/bottom | 960px |
+
+### Alignment & Grid
+- **Primary alignment**: Centered for everything. Headlines, body, URLs, photos, and footer text all center-align along the vertical axis. This is the one place Product Minimal is rigid.
+- **Grid**: Single column by default. Two-column grid permitted only for side-by-side product comparisons, and even then only with centered content within each column.
+- **Vertical rhythm**: Photo occupies the top ~60% of the frame. Headline + body + URL occupy the next ~30%. Footer (if present) occupies the final ~10%. Gaps between these zones are 40-48px, never less.
+- **Content gravity**: Pull everything toward the vertical centre of the frame. There is no left-heavy or right-heavy composition in this style.
+- **Generous outer padding**: 60px minimum on all sides, scaling up on larger formats. The photo needs a studio, and the studio needs walls.
+- **Photo-first composition**: Every page, poster, and slide begins with the product photo. If there is no product photo, use a different style.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, no border, background `#FFFFFF` | Every layout container, every text block, every card |
+| Photo Shadow (Level 1) | `filter: drop-shadow(0 24px 48px rgba(0,0,0,0.08))` | The product photograph -- the only elevated element on the page |
+| Hover Micro (Level 2) | `text-decoration-color` darkens from `#777777` to `#1A1A1A` | URL CTA hover state |
+| Rule (Level 3) | `1px solid rgba(0,0,0,0.08)` as divider | Footer rule only |
+| Overlay (Level 4) | `0 16px 40px rgba(0,0,0,0.12)` | Modals and lightboxes when absolutely necessary |
+
+### Border Treatments
+- **No borders on content**: Cards, containers, and text blocks are never bordered. The product photo needs no frame.
+- **Footer rule**: `1px solid rgba(0,0,0,0.08)` spanning the content max-width above footer text. This is the only rule permitted in the layout.
+- **URL underline**: `text-decoration: underline; text-decoration-thickness: 1px; text-underline-offset: 4px;` -- the underline is the CTA.
+- **No rounded corners**: Product Minimal has no rounded elements. The photo has no rounded frame. The URL has no pill. The footer rule has no radius. Everything is either a flat line or a photograph.
+
+### Surface Hierarchy
+On pure white backgrounds, hierarchy is communicated entirely through the product photo's drop-shadow and typographic weight:
+1. **Canvas** (`#FFFFFF`) -- the entire surface. Nothing else steps up.
+2. **Photo** (`drop-shadow(0 24px 48px rgba(0,0,0,0.08))`) -- the only elevated element. It floats above everything.
+3. **Headline** (`#1A1A1A`, weight 700) -- the typographic anchor beneath the photo.
+4. **Body** (`#555555`, weight 400) -- recedes from the headline.
+5. **URL** (`#777777`, weight 500, underlined) -- the quiet CTA, lower contrast than body.
+
+This is one of the few styles where depth is delivered almost entirely by the photograph. The layout contributes nothing beyond whitespace. That is the point.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use pure white (`#FFFFFF`) as the background -- this is one of the very few styles where genuine pure white is correct, because the product photograph sets the temperature.
+- Let the product photo occupy roughly the top 60% of the frame -- the composition exists to frame the object.
+- Apply `filter: drop-shadow(0 24px 48px rgba(0,0,0,0.08))` to every product photo -- the subtle shadow is what makes it feel studio-lit rather than pasted on.
+- Use Inter for everything -- a single family at weights 400, 500, and 700. No secondary typeface.
+- Center-align the headline, body, and URL beneath the product photo. Always.
+- Use underlined URLs (`#777777`, Inter 500, underlined with `text-underline-offset: 4px`) as the CTA pattern. This replaces filled buttons entirely.
+- Keep headlines modest in size (36px) -- they are captions to the photograph, not competing statements.
+- Use `#555555` for body copy, never near-black -- the softer gray keeps the paragraph from overpowering the headline.
+- Let the product photo breathe with massive whitespace -- 60-80px minimum padding on every side of the image container.
+- Use `object-fit: contain` on the product photo so it never crops or stretches -- the object must be presented whole.
+- Include exactly one decorative mark: a 1px rule above the footer, if a footer exists at all.
+
+### Don't
+- Don't use coloured backgrounds -- not warm whites, not light grays, not tinted anything. Pure white only.
+- Don't use filled button CTAs -- no pills, no rectangles, no rounded buttons. The CTA is always a plain underlined URL.
+- Don't use more than two text colours (`#1A1A1A` for headline + `#555555` for body). The URL's `#777777` is the only third colour permitted.
+- Don't add any coloured accents -- no blue, no green, no brand red. This is a chromatically neutral style.
+- Don't add borders to any content element -- cards, containers, and text blocks are never bordered. The product photo needs no frame.
+- Don't use rounded corners anywhere -- not on the photo, not on the footer rule, not on any imagined button (because there are no buttons).
+- Don't decorate -- no icons, no emoji, no illustrations, no patterns, no gradients, no textures. Every decorative element should be cut before shipping.
+- Don't left-align the headline block -- Product Minimal is always center-aligned below the photo.
+- Don't scale the headline above 48px -- headlines are captions, not hero type. If you want type-hero, use a different style.
+- Don't use body text heavier than weight 400 -- the softer weight keeps the paragraph caption-like.
+- Don't use the headline and body at the same colour -- the contrast drop between `#1A1A1A` and `#555555` is load-bearing.
+- Don't place anything beside the product photo -- no sidebars, no callouts, no floating stats. The photo owns its row.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale**: Headline at 36px, Body at 18px, URL CTA at 16px. These are the baseline values -- carousel is the reference format for this style.
+- **Padding**: 60px on all sides. Content area is 960x960px.
+- **Cover slide**: Product photo fills the top ~60% of the slide (approximately 600px tall, centered). Headline centered at ~20px below the photo, body at ~20px below the headline, URL at ~28px below the body. Entire text block sits in the bottom ~35% of the slide.
+- **Content slides**: One product, one idea per slide. Photo + headline + one-sentence body. No list content, no comparison grids, no stat rows.
+- **Photo treatment**: Always `object-fit: contain` on a max-height of approximately 560px. `filter: drop-shadow(0 24px 48px rgba(0,0,0,0.08))`.
+- **Swipe indicator**: Omit entirely, or use tiny 4px gray dots (`rgba(0,0,0,0.12)`) at the very bottom centre with an active dot in near-black. The style prefers no indicator if the platform allows.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Headline at 40px, Sub-heading at 24px, Body at 18px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Section spacing**: 120px vertical gap between product sections -- more breathing room than any other style, because each product photo needs its own studio.
+- **Vertical rhythm**: Alternate between full-width product photos and quiet caption blocks beneath them. Never place two product photos side-by-side without massive vertical separation.
+- **Footer**: Thin 1px rule at `rgba(0,0,0,0.08)`, followed by 12px Inter 400 metadata text in `#999999`, centered.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Headline becomes 56px with -0.75px tracking. Sub-heading becomes 32px. Body Large becomes 22px.
+- **Padding**: 80px on all sides. Content area is 1760x920px.
+- **Layout**: Product photo centered horizontally, occupying roughly the left 60% of the frame OR the full top 55% of the frame. Headline and body stacked beside the photo (right 40%) or beneath it (bottom 40%).
+- **Photo treatment**: Max height 720px, `object-fit: contain`, drop-shadow unchanged from baseline.
+- **Title slides**: Product photo centered in the top half. Headline + body + URL stacked in the bottom half, centered.
+- **Content slides**: Single product focus. Optional two-up product grid only when the comparison is the entire point of the slide.
+
+### Poster (1080x1350px)
+- **Typography**: Headline at 40px. Sub-heading at 24px. Body at 18px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top ~65% for the product photo (approximately 780px tall). Middle ~25% for centered headline + body + URL. Bottom ~10% for optional footer rule + metadata.
+- **Vertical flow**: Strictly top-to-bottom. The photo is the anchor; everything else captions it.
+- **CTA placement**: URL centered below body, ~28px gap. Never a button.
+
+### Story (1080x1920px)
+- **Typography scale up**: Headline becomes approximately 46-48px (hero type ~30% bigger than Carousel 36px) in Inter 700 with -0.75px tracking. Sub-heading becomes 30px. Body Large becomes 22px in Inter 400. URL CTA stays at Inter 500 18px underlined.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical content must sit inside y=160 to y=1760.
+- **Layout**: Single centered column. Content max-width 960px. Vertical center of gravity -- the product photo should occupy the upper-middle third (roughly y=280 to y=1180), with the headline block clustering in y=1240 to y=1600. Pure white (`#FFFFFF`) runs edge-to-edge with no tint or texture.
+- **Cover slide**: Product photo centered horizontally, approximately 900px tall max, sitting in y=280 to y=1180 with the signature `filter: drop-shadow(0 24px 48px rgba(0,0,0,0.08))` beneath it. Below the photo (starting around y=1260), the Inter 700 headline at 46-48px with tight -0.75px tracking in near-black, then a 22px Inter 400 body paragraph in `#555555` with max-width 720px, then an 18px Inter 500 underlined URL in `#777777`. Every element is center-aligned along the vertical axis.
+- **Content slides**: One product, one caption per slide. Photo in the upper zone, headline + body + URL stacked below. No numbered steps, no bordered cards, no framework tags -- this style refuses structural chrome.
+- **CTA slide**: If a dedicated CTA slide is needed, it uses the same composition as the cover: a product photo above a headline and URL. The URL itself is the CTA -- there is no button. A thin 1px `rgba(0,0,0,0.08)` footer rule may sit just above the bottom safe zone with 12px metadata beneath it.
+- **Progress indicator**: If required by the platform, use tiny 3px-tall segmented bars at the top of the safe zone. Inactive segments in `rgba(0,0,0,0.08)`, active segment in near-black (`#1A1A1A`). Absolute minimum chrome -- the style prefers no indicator if the platform permits.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Pure White | `#FFFFFF` | Primary background -- genuinely pure white |
+| Near-Black | `#1A1A1A` | Primary headline colour, URL hover state |
+| Body Gray | `#555555` | Body paragraph colour |
+| URL Gray | `#777777` | Underlined URL CTA colour |
+| Metadata Gray | `#999999` | Footer metadata, timestamps, fine print |
+| Disabled Gray | `#CCCCCC` | Disabled URL states |
+| Photo Frame | `#FAFAFA` | Optional barely-there photo container tint (rare) |
+| Photo Shadow | `rgba(0,0,0,0.08)` | Drop-shadow beneath the product photograph |
+| Footer Rule | `rgba(0,0,0,0.08)` | The single 1px rule above footer text |
+
+### Font Declarations
+
+```css
+/* Display and body share a single family */
+font-family: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-bg: #FFFFFF;
+  --color-near-black: #1A1A1A;
+  --color-body-gray: #555555;
+
+  /* Colors -- Accent (muted URL system) */
+  --color-url-gray: #777777;
+  --color-url-hover: #1A1A1A;
+
+  /* Colors -- Neutral Scale */
+  --color-metadata: #999999;
+  --color-disabled: #CCCCCC;
+  --color-photo-frame: #FAFAFA;
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: #FFFFFF;
+
+  /* Colors -- Borders */
+  --color-border-none: transparent;
+  --color-divider-rule: rgba(0, 0, 0, 0.08);
+  --color-url-underline: #777777;
+
+  /* Colors -- Shadows */
+  --shadow-photo: rgba(0, 0, 0, 0.08);
+  --shadow-micro: rgba(0, 0, 0, 0.04);
+  --shadow-overlay: rgba(0, 0, 0, 0.12);
+
+  /* Typography -- Families */
+  --font-display: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 48px;
+  --text-headline: 36px;
+  --text-sub-heading: 24px;
+  --text-body-large: 20px;
+  --text-body: 18px;
+  --text-small: 14px;
+  --text-footer: 12px;
+  --text-url-cta: 16px;
+  --text-big-number: 56px;
+
+  /* Typography -- Weights */
+  --weight-headline: 700;
+  --weight-url: 500;
+  --weight-body: 400;
+
+  /* Typography -- Line Heights */
+  --leading-headline: 1.20;
+  --leading-sub-heading: 1.25;
+  --leading-body-large: 1.55;
+  --leading-body: 1.55;
+  --leading-small: 1.50;
+  --leading-number: 1.00;
+
+  /* Typography -- Letter Spacing */
+  --tracking-display-hero: -0.75px;
+  --tracking-headline: -0.5px;
+  --tracking-sub-heading: -0.25px;
+  --tracking-body: 0px;
+  --tracking-footer: 0.3px;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 12px;
+  --space-small: 20px;
+  --space-base: 28px;
+  --space-medium: 32px;
+  --space-large: 40px;
+  --space-horizontal: 60px;
+  --space-vertical: 80px;
+  --space-story: 120px;
+
+  /* Borders */
+  --radius-none: 0px;
+  --border-footer-rule: 1px solid rgba(0, 0, 0, 0.08);
+  --border-url-underline: 1px solid #777777;
+
+  /* Shadows -- Composed */
+  --shadow-product: drop-shadow(0 24px 48px rgba(0, 0, 0, 0.08));
+  --shadow-rule: 1px solid rgba(0, 0, 0, 0.08);
+  --shadow-overlay-modal: 0 16px 40px rgba(0, 0, 0, 0.12);
+
+  /* Photo sizing */
+  --photo-max-height-carousel: 560px;
+  --photo-max-height-slide: 720px;
+  --photo-max-height-poster: 780px;
+  --photo-max-height-story: 900px;
+}
+```
+
+### System Font Fallbacks
+- **Sans-serif (if Inter fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/_full/retro-line-art.md
+++ b/skills/composites/goose-graphics/styles/_full/retro-line-art.md
@@ -1,0 +1,513 @@
+# Design Style: Retro Line Art
+
+## 1. Visual Theme & Atmosphere
+
+Retro Line Art is the visual language of a Parisian cocktail-menu poster printed on thick cotton card — the kind of boutique invitation you would slide into an envelope for a speakeasy opening. It borrows from mid-century lounge posters, 1960s cafe signage, and Didone-era fashion-magazine typography, then strips the execution back to two ink colors: a dusty powder blue background and cream-white type-and-line-art floating on top. Every piece of art on the page is drawn as if it came off a single nib pen — thin, continuous, decorative, a little imperfect — and every piece of type is set as if it were being printed in metal on an old proof press. The overall feel is hand-made, boutique, and unapologetically retro without tipping into kitsch.
+
+The color story is deliberately narrow and deliberately desaturated. The powder blue (`#7BA3C6`) is not a sky blue and not a navy — it is a dusty, mid-value, slightly gray-leaning blue that reads as if it were mixed from a jar of ink and a drop of warm water. Cream (`#F5F0E6`) is the second ink — never pure white, always warmed toward bone or parchment — and it is used for every piece of type, every line-art stroke, and every corner label. The restricted two-color treatment is the whole aesthetic: the moment a third ink color appears, the poster stops reading as a vintage menu and starts reading as a modern flyer. The only "third color" allowed is a darker blue-shadow (`#5A84AA`) used exclusively as an offset echo behind a single display letter — the stylized "P" in the poster's massive PARTY word is printed twice, with the back copy offset two or three pixels down-and-right, to simulate a misregistered two-color press run.
+
+The typographic system is a classic Didone-display-italic paired with a massive Didone-display-upright, bookended by a tracked-wide geometric sans for all the small metadata around the edges. A refined italic serif (Cormorant Garamond Italic at weight 500) handles the "script" word at the top of the composition — "Cocktail" — flowing across the page with dramatic entry and exit strokes. Below it, a muscular Didone upright (Playfair Display at weight 900) handles the massive display word — "PARTY" — set so large it fills nearly half the horizontal width of the poster, with one stylized drop-shadow letter providing the single moment of visual imperfection. For every other piece of text on the page — the club name, the date, the entrance fee, the address, the RSVP — a clean geometric sans (DM Sans at weight 500-700) is set in all caps with 1.5px of positive letter-spacing, arranged as four corner-metadata strips that frame the central illustration. The decorative language is just as restricted: a single hand-drawn cocktail glass rendered as a cream line-art SVG fills the lower portion of the canvas, and small sparkle glyphs (✦ ✧ + ×) are scattered around it like tiny stars. That is the entire vocabulary — two colors, three type roles, one illustration, and a handful of sparkles.
+
+**Key Characteristics:**
+- Dusty powder blue background (`#7BA3C6`) — desaturated, mid-value, never bright-sky, never navy
+- Cream/bone text color (`#F5F0E6`) — never pure white, always warmed toward parchment
+- Darker blue shadow-ink (`#5A84AA`) reserved exclusively for offset echo on one display letter
+- Cormorant Garamond Italic at weight 500 for the "script" word — the refined Didone-italic display treatment
+- Playfair Display at weight 900 for massive upright display words — set at 180-240px
+- DM Sans at weights 500-700 for all small metadata — all caps, 1.5-2px positive tracking
+- Hand-drawn single-stroke SVG line-art illustrations in cream stroke on blue — no fills, thin 2-2.5px strokes
+- Sparkle glyphs (✦ ✧ + ×) at 20-32px scattered as decorative accents, never more than 6 per composition
+- Corner metadata strips — three labels arranged in a row (left / center / right) across the top of every slide
+- Echo offset shadow on one display letter — achieved with CSS `text-shadow: 4px 4px 0 var(--color-blue-shadow)` or a duplicated absolute-positioned element
+- No cards, no borders, no rounded corners — the composition reads as a single flat printed sheet
+- Italic script word always overlaps or underlaps the upright display word — the two headline words are intentionally entangled, not stacked cleanly
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Powder Blue** (`#7BA3C6`): Primary background. Dusty, slightly gray-leaning mid-blue. The whole poster sits on this surface. Never use a bright or saturated blue in its place.
+- **Cream** (`#F5F0E6`): Primary ink color. Used for every piece of type, every line-art stroke, every label. Warmed toward bone/parchment — never pure white.
+- **Blue Shadow** (`#5A84AA`): A darker desaturated blue used exclusively for the offset echo behind one display letter. Also usable for very subtle background gradations if needed. Never used for type or illustration strokes.
+
+### Accent
+- **Cream Glow** (`#FAF5EB`): A slightly lighter cream for micro-highlights on sparkle glyphs and occasional emphasis. Use sparingly — the composition reads as two-color, not three.
+- **Blue Mid** (`#6E9BC0`): An alternate background tone 3-4 steps darker than Powder Blue. Used for format variations where a slightly moodier canvas is wanted (e.g., Story format).
+- **Ink Dark** (`#3D5A75`): A deep blue-gray used only for very dense cluster effects (never for text). Reserve for decorative grit.
+
+### Neutral Scale
+- **Cream 100** (`#F5F0E6`): Primary ink — all type, all line art.
+- **Cream 80** (`rgba(245, 240, 230, 0.80)`): Secondary labels and supporting metadata.
+- **Cream 60** (`rgba(245, 240, 230, 0.60)`): Tertiary annotations, slide numbers, footers.
+- **Cream 40** (`rgba(245, 240, 230, 0.40)`): Hairline dividers and whisper accents.
+- **Cream 20** (`rgba(245, 240, 230, 0.20)`): Only for very subtle decorative grain or dotted pattern overlays.
+
+### Surface & Borders
+- **Surface Primary** (`#7BA3C6`): The flat canvas. Never tinted, never gradient-ed except in intentional moments of the Story format.
+- **Surface Inset** (`rgba(90, 132, 170, 0.25)`): A very quiet inset panel for rare container treatments. Use almost never — this style is flat.
+- **Hairline Cream** (`rgba(245, 240, 230, 0.35)`): The only border treatment allowed. 1px cream hairlines separate metadata strips from the central illustration when needed.
+- **Hairline Cream Strong** (`rgba(245, 240, 230, 0.55)`): A slightly heavier 1px cream divider for format-spanning rules.
+
+### Shadow Colors
+- **Echo Shadow** (`#5A84AA`): The offset echo shadow — solid color, no blur, used with an offset of 4-6px down-and-right behind one display letter.
+- **Soft Blur** (`rgba(61, 90, 117, 0.25)`): A whisper-soft blue shadow at 12px blur for the very rare case you need a hint of depth on a container. Almost never used.
+- **Grain Overlay** (`rgba(61, 90, 117, 0.10)`): A tissue-thin blue-gray shadow that can be composited across the canvas as a print-grain effect.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Playfair+Display:ital,wght@0,400;0,700;0,800;0,900;1,400;1,700;1,900&family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Script Display**: `'Cormorant Garamond', 'Playfair Display', Georgia, serif` — used italic, weight 500, for the "Cocktail" word
+- **Display**: `'Playfair Display', Georgia, 'Times New Roman', serif` — used upright, weight 900, for the "PARTY" word
+- **Body/Metadata**: `'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif` — used all caps, weight 500-700, for every piece of small text
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Script Display | Cormorant Garamond Italic | 160px | 500 | 1.00 | -2px | The "Cocktail" script word. Italic is mandatory. Overlaps with Upright Display below. |
+| Upright Display | Playfair Display | 240px | 900 | 0.95 | -6px | The massive "PARTY" display word. Upright only. One letter gets the offset echo shadow. |
+| Section Heading | Playfair Display | 88px | 900 | 1.00 | -2px | Smaller display role for non-hero slides. Still upright, still all caps. |
+| Sub-heading | Cormorant Garamond Italic | 56px | 500 | 1.10 | -0.5px | Secondary italic script for subtitle/intro lines. |
+| Metadata Strip | DM Sans | 14px | 600 | 1.25 | 1.8px | Corner labels. All caps. The 1.8px positive tracking is non-negotiable. |
+| Metadata Bold | DM Sans | 16px | 700 | 1.20 | 1.5px | Emphasized corner labels — "STARTING AT 08:00PM", "20 OCT". All caps. |
+| Body | DM Sans | 18px | 500 | 1.55 | 0.3px | Rare body-text use. Mixed case allowed only when absolutely needed. |
+| Big Number | Playfair Display | 120px | 900 | 1.00 | -3px | Big metric display. Same treatment as upright display. |
+| Caption | DM Sans | 12px | 500 | 1.30 | 1.5px | Slide numbers, footers, addresses. All caps. |
+| CTA Text | DM Sans | 14px | 700 | 1.20 | 2px | All caps CTA — no button chrome, just underlined or flanked by dashes. |
+
+### Principles
+- **Two-serif tension, one-sans frame**: The style's identity lives in the clash between Cormorant Garamond Italic (elegant, flowing, script-like) and Playfair Display at weight 900 (muscular, monumental, upright). DM Sans exists only to frame those two serifs with small all-caps metadata — it never carries the emotional weight of the composition.
+- **Italic + upright entangled, never stacked**: The script word and the upright display word must visually overlap or tuck into each other. Never set them as two tidy centered lines. The "Cocktail" should flow across the top of "PARTY" with descenders that kiss the tops of the upright letters.
+- **All-caps corner metadata is the frame**: Every piece of small text on the canvas is set in all caps with 1.5-2px positive tracking. Mixed case is almost never used. The uniform all-caps treatment is what makes the composition read as a printed poster rather than a web page.
+- **One letter gets the echo shadow, never more**: The offset echo shadow is applied to exactly one letter per composition — typically the dominant letter of the display word (the "P" in "PARTY"). Applying it to multiple letters destroys the hand-set-type illusion.
+- **Negative tracking on display, positive tracking on metadata**: Display serifs are always tightly tracked (-2 to -6px) to feel confidently set. Metadata sans is always loosely tracked (+1.5 to +2px) to feel like printer's caps-and-small-caps. Never reverse this.
+- **Line heights are tight on display, generous on metadata**: Display type runs at 0.95-1.00 line height so upright and italic words can overlap. Metadata runs at 1.20-1.30 to give each small label room to breathe inside its corner.
+
+## 4. Component Patterns
+
+### Corner Metadata Strip (top-of-canvas frame)
+
+Three labels arranged in a row across the top of every slide — typically a left label, a center label, and a right label. This pattern appears on every slide of this style and functions as the visual frame for the central composition.
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr 1fr; align-items: start; padding: 0 0 48px 0;">
+  <div style="text-align: left;">
+    <p style="font-family: var(--font-sans); font-size: 16px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-cream); margin: 0; line-height: 1.20;">BORCELLE<br>CLUB</p>
+  </div>
+  <div style="text-align: center;">
+    <p style="font-family: var(--font-sans); font-size: 16px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-cream); margin: 0; line-height: 1.20;">20 OCT</p>
+  </div>
+  <div style="text-align: right;">
+    <p style="font-family: var(--font-sans); font-size: 16px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-cream); margin: 0; line-height: 1.20;">ENTRANCE<br>20$</p>
+  </div>
+</div>
+```
+
+### Headline Block (Script + Echo-Shadow Display)
+
+The signature move — an italic script word flowing above a massive upright display word, with one letter of the display word receiving the offset echo shadow. The script and upright are deliberately entangled via negative top-margin on the upright.
+
+```html
+<div style="text-align: center; position: relative;">
+  <h1 style="font-family: var(--font-script); font-size: 160px; font-weight: 500; font-style: italic; line-height: 1.00; letter-spacing: -2px; color: var(--color-cream); margin: 0; position: relative; z-index: 2;">Cocktail</h1>
+  <h2 style="font-family: var(--font-display); font-size: 240px; font-weight: 900; line-height: 0.95; letter-spacing: -6px; color: var(--color-cream); margin: -60px 0 0 0; position: relative; z-index: 1;">
+    <span style="position: relative; display: inline-block;">
+      <span style="position: absolute; left: 5px; top: 5px; color: var(--color-blue-shadow); z-index: 0;">P</span>
+      <span style="position: relative; z-index: 1;">P</span>
+    </span>ARTY
+  </h2>
+</div>
+```
+
+Alternative single-element echo using `text-shadow`:
+
+```html
+<h2 style="font-family: var(--font-display); font-size: 240px; font-weight: 900; line-height: 0.95; letter-spacing: -6px; color: var(--color-cream); text-shadow: 5px 5px 0 var(--color-blue-shadow); margin: 0;">PARTY</h2>
+```
+
+### Line Art Illustration Slot (inline SVG cocktail glass)
+
+A hand-drawn single-stroke line-art illustration embedded inline as an SVG. Strokes are cream, 2-2.5px wide, no fills. The illustration fills the lower portion of the canvas and is the visual anchor of the composition. The SVG below is a reference cocktail glass — replace the `<path>` data with any hand-drawn line art that matches the brief (wine glass, martini, champagne coupe, lemon wedge, olive, palm frond, etc.).
+
+```html
+<div style="display: flex; justify-content: center; align-items: center; padding: 32px 0;">
+  <svg viewBox="0 0 400 480" width="340" height="408" xmlns="http://www.w3.org/2000/svg" style="display: block;">
+    <g fill="none" stroke="var(--color-cream)" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
+      <!-- Lemon slice wedge on rim -->
+      <circle cx="110" cy="180" r="48"/>
+      <line x1="110" y1="132" x2="110" y2="228"/>
+      <line x1="62" y1="180" x2="158" y2="180"/>
+      <line x1="76" y1="146" x2="144" y2="214"/>
+      <line x1="144" y1="146" x2="76" y2="214"/>
+      <!-- Coupe glass bowl -->
+      <path d="M 60 200 Q 200 360 340 200"/>
+      <ellipse cx="200" cy="200" rx="140" ry="18"/>
+      <!-- Liquid surface decoration -->
+      <path d="M 90 215 Q 200 250 310 215" stroke-dasharray="4 6"/>
+      <!-- Stem -->
+      <line x1="200" y1="340" x2="200" y2="440"/>
+      <!-- Base -->
+      <ellipse cx="200" cy="445" rx="70" ry="8"/>
+      <line x1="130" y1="445" x2="270" y2="445"/>
+    </g>
+  </svg>
+</div>
+```
+
+For other subjects, use the same pattern: `<svg>` with `fill="none"` and `stroke="var(--color-cream)"` at `stroke-width="2.2"`. Always embed inline so the stroke color inherits the theme variable. Never use raster illustrations — always SVG.
+
+### Sparkle Glyph Cluster
+
+Scattered decorative sparkles around the central illustration. Use Unicode glyphs (✦ ✧ + ×) set in Playfair Display or Cormorant Garamond at 20-32px in cream. Absolute-positioned relative to the parent composition.
+
+```html
+<div style="position: relative;">
+  <span style="position: absolute; top: 40px; right: 80px; font-family: var(--font-display); font-size: 28px; color: var(--color-cream); opacity: 0.9;">✦</span>
+  <span style="position: absolute; top: 120px; left: 60px; font-family: var(--font-display); font-size: 20px; color: var(--color-cream); opacity: 0.8;">+</span>
+  <span style="position: absolute; top: 200px; right: 140px; font-family: var(--font-display); font-size: 24px; color: var(--color-cream); opacity: 0.85;">✧</span>
+  <span style="position: absolute; bottom: 80px; left: 120px; font-family: var(--font-display); font-size: 22px; color: var(--color-cream); opacity: 0.8;">×</span>
+  <span style="position: absolute; bottom: 140px; right: 60px; font-family: var(--font-display); font-size: 26px; color: var(--color-cream); opacity: 0.9;">✦</span>
+</div>
+```
+
+Rules: 4-6 sparkles per composition, never more. Mix the four glyph shapes (no single-shape clusters). Vary the sizes between 18-32px. Keep opacity between 0.75-0.95 so they feel hand-placed, not machine-uniform.
+
+### Bottom Metadata Strip (triple-column footer)
+
+A mirror of the Corner Metadata Strip, placed at the bottom of the canvas. Three labels in a row — typically time/address on the left, venue detail in the center, contact on the right.
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr 1fr; align-items: end; padding: 48px 0 0 0;">
+  <div style="text-align: left;">
+    <p style="font-family: var(--font-sans); font-size: 18px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-cream); margin: 0 0 8px; line-height: 1.20;">STARTING<br>AT 08:00PM</p>
+    <p style="font-family: var(--font-sans); font-size: 12px; font-weight: 500; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-cream-80); margin: 0; line-height: 1.30;">123 ANYWHERE ST.<br>ANY CITY ST 12345</p>
+  </div>
+  <div style="text-align: center;">
+    <p style="font-family: var(--font-sans); font-size: 16px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-cream); margin: 0; line-height: 1.30;">DRINKS<br>LIVE MUSIC</p>
+  </div>
+  <div style="text-align: right;">
+    <p style="font-family: var(--font-sans); font-size: 16px; font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-cream); margin: 0; line-height: 1.30;">RSVP TO OLIVIA<br>+123-456-7890</p>
+  </div>
+</div>
+```
+
+### Stat Display (Big Number + Italic Caption)
+
+```html
+<div style="text-align: center; padding: 40px 24px;">
+  <p style="font-family: var(--font-display); font-size: 160px; font-weight: 900; line-height: 1.00; letter-spacing: -4px; color: var(--color-cream); text-shadow: 5px 5px 0 var(--color-blue-shadow); margin: 0 0 12px;">47</p>
+  <p style="font-family: var(--font-script); font-size: 42px; font-weight: 500; font-style: italic; line-height: 1.20; color: var(--color-cream); margin: 0 0 16px;">cocktails served</p>
+  <p style="font-family: var(--font-sans); font-size: 14px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-cream-80); margin: 0;">OPENING NIGHT · 20 OCT</p>
+</div>
+```
+
+### Quote Block (Italic Script + Attribution)
+
+```html
+<div style="padding: 48px 40px; text-align: center;">
+  <p style="font-family: var(--font-script); font-size: 56px; font-weight: 500; font-style: italic; line-height: 1.15; color: var(--color-cream); margin: 0 0 32px;">"The martini drinker says more with a raised eyebrow than most people say in a paragraph."</p>
+  <div style="display: flex; align-items: center; justify-content: center; gap: 16px;">
+    <div style="width: 48px; height: 1px; background: var(--color-cream); opacity: 0.6;"></div>
+    <p style="font-family: var(--font-sans); font-size: 14px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: var(--color-cream); margin: 0;">OLIVIA WILDE</p>
+    <div style="width: 48px; height: 1px; background: var(--color-cream); opacity: 0.6;"></div>
+  </div>
+</div>
+```
+
+### CTA Block (No Button Chrome)
+
+The CTA is never a filled button. It is a piece of all-caps cream type flanked by horizontal rules or small sparkles — the composition itself is the CTA.
+
+```html
+<div style="text-align: center; padding: 60px 40px;">
+  <p style="font-family: var(--font-script); font-size: 72px; font-weight: 500; font-style: italic; line-height: 1.10; color: var(--color-cream); margin: 0 0 32px;">Join us</p>
+  <div style="display: flex; align-items: center; justify-content: center; gap: 20px;">
+    <div style="width: 64px; height: 1px; background: var(--color-cream);"></div>
+    <p style="font-family: var(--font-sans); font-size: 16px; font-weight: 700; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-cream); margin: 0;">RSVP TO OLIVIA · +123-456-7890</p>
+    <div style="width: 64px; height: 1px; background: var(--color-cream);"></div>
+  </div>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap — between a sparkle glyph and a metadata label.
+- **8px**: Tight gap — between a big number and its caption.
+- **12px**: Small gap — between metadata label lines inside a corner strip.
+- **16px**: Base gap — between metadata rows.
+- **24px**: Medium gap — between sparkle clusters and their anchoring illustration.
+- **32px**: Line-art-to-type gap — between the line-art illustration and the nearest type block.
+- **48px**: Frame gap — between the corner metadata strip and the main headline.
+- **60px**: Outer padding (carousel, poster, infographic).
+- **80px**: Outer padding (slides, generous formats).
+- **120px**: Outer padding (Story format, generous vertical framing).
+
+### Format Padding
+| Format | Dimensions | Outer Padding | Content Max-Width |
+|--------|------------|---------------|-------------------|
+| Carousel | 1080x1080 | 60px all sides | 960px |
+| Infographic | 1080xN | 60px left/right, 80px top/bottom | 960px |
+| Slides | 1920x1080 | 80px all sides | 1760px |
+| Poster | 1080x1350 | 60px left/right, 80px top/bottom | 960px |
+| Story | 1080x1920 | 120px left/right, 60px top/bottom | 840px |
+
+### Alignment & Grid
+- **Primary alignment**: Centered for the main headline and illustration. The corner metadata strips use a 3-column grid with left / center / right text alignment.
+- **Grid**: The canvas is a single centered column with a 3-column metadata row at top and a 3-column metadata row at bottom. No card grids. No sidebar layouts.
+- **Vertical rhythm**: Top metadata strip → 48px gap → headline block → 32px gap → line-art illustration → 48px gap → bottom metadata strip. This rhythm is consistent across every format.
+- **Illustration gravity**: The line-art illustration is always the visual anchor. Place it in the lower-center of the canvas, occupying roughly 40-50% of the vertical space.
+- **Sparkle placement**: Sparkles are scattered around the illustration, not the type. Never place sparkles on top of or immediately adjacent to a display word — they should feel like they are orbiting the line art.
+- **No borders, no cards**: This style has no bordered containers. Every element sits directly on the powder blue canvas.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, background `#7BA3C6` | The entire canvas. This style is 95% flat. |
+| Offset Echo (Level 1) | `text-shadow: 5px 5px 0 #5A84AA` | Exactly one display letter per composition. |
+| Hairline Divider (Level 2) | `1px solid rgba(245, 240, 230, 0.35)` | The only border treatment. Horizontal dividers between metadata and central composition when needed. |
+| Soft Blue Glow (Level 3) | `0 0 24px rgba(90, 132, 170, 0.35)` | Very rare. Only for the center sparkle in a sparkle cluster, to suggest a twinkle. |
+| Print Grain (Level 4) | Repeating `radial-gradient(circle, rgba(61, 90, 117, 0.08) 1px, transparent 1.5px) 3px 3px` | Optional tissue-thin noise overlay across the whole canvas. Use to sell the printed-paper illusion. |
+
+### Border Treatments
+- **Hairline cream rule**: `1px solid rgba(245, 240, 230, 0.35)` — the only border. Used for horizontal dividers between corner metadata strips and the central illustration on very dense slides. Never used on cards or containers because this style has no cards.
+- **Hairline cream rule strong**: `1px solid rgba(245, 240, 230, 0.55)` — a slightly heavier rule for full-width dividers when a stronger separation is needed (e.g., between two sections of an infographic).
+- **No container borders**: There are no bordered cards, no rounded rectangles, no panel frames. Every visual structure in this style is achieved through typography, illustration, and whitespace.
+- **No shadows on containers**: Containers do not exist. If they did, they would not cast shadows.
+
+### Surface Hierarchy
+All depth in this style comes from typography weight and line-art density, not from lighting or shadow. The hierarchy from most prominent to least:
+1. **Upright Display Word** (`Playfair Display 900`, cream, one letter with echo shadow) — the single strongest element on any composition.
+2. **Script Display Word** (`Cormorant Garamond Italic 500`, cream) — the second strongest. Entangled with the display word above it.
+3. **Line-art Illustration** (cream stroke on blue, 2.2px) — the visual anchor, but subordinate to type.
+4. **Corner Metadata** (DM Sans all-caps, cream, 14-18px) — the frame that defines the edges of the composition.
+5. **Sparkle Glyphs** (20-32px cream, 0.75-0.95 opacity) — the atmospheric dressing. Whisper-level, never dominant.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use the powder blue background (`#7BA3C6`) for every canvas. This is the single most identifiable element of the style.
+- Use cream (`#F5F0E6`) — never pure white — for every piece of type and every illustration stroke.
+- Set the "script" display word in Cormorant Garamond Italic at weight 500, and set the "upright" display word in Playfair Display at weight 900. The two-serif tension is the identity.
+- Entangle the script word and the upright display word with negative margins — they should visually overlap, never stack cleanly.
+- Apply the offset echo shadow (`text-shadow: 5px 5px 0 var(--color-blue-shadow)`) to exactly one letter per composition — typically the dominant letter of the display word.
+- Embed line-art illustrations as inline SVG with `fill="none"`, `stroke="var(--color-cream)"`, and `stroke-width="2.2"` — always hand-drawn, always single-stroke, always cream on blue.
+- Use three-column corner metadata strips (top-of-canvas and bottom-of-canvas) to frame every composition. This is the structural signature.
+- Set every piece of small text in all caps with 1.5-2px positive letter-spacing using DM Sans at weight 600-700.
+- Scatter 4-6 sparkle glyphs (✦ ✧ + ×) around the line-art illustration, mixing shapes and varying sizes between 18-32px.
+- Leave generous whitespace around the central illustration. This style is quiet — let the blue canvas breathe.
+- Use negative tracking (-2 to -6px) on display type and positive tracking (+1.5 to +2px) on metadata sans. Never reverse this rule.
+
+### Don't
+- Don't use pure white (`#ffffff`) anywhere — always use cream (`#F5F0E6`). Pure white destroys the vintage-print illusion.
+- Don't use a bright sky blue or a navy blue — only the specific dusty `#7BA3C6` works. Oversaturated blues make the composition look like a modern flyer.
+- Don't use filled SVG illustrations — strokes only. Fills turn the line art into clip art.
+- Don't apply the echo shadow to more than one letter per composition. Multiple echoes look like a video-game glitch.
+- Don't use bordered cards, rounded rectangles, or container backgrounds. This style is flat and every element sits directly on the canvas.
+- Don't use mixed case for metadata. All small text is always all caps with positive tracking.
+- Don't stack the script word and the upright word as two tidy centered lines — they must visually overlap.
+- Don't use modern geometric sans (Inter, Space Grotesk, etc.) for display — only Cormorant Garamond Italic and Playfair Display work for headlines.
+- Don't use a third color beyond powder blue, cream, and blue-shadow. The restricted two-color treatment is the entire identity.
+- Don't use more than 6 sparkles per composition. Sparkle overcrowding destroys the hand-placed feel.
+- Don't apply drop shadows with blur radius — the offset echo is always solid, zero blur, zero spread.
+- Don't use raster illustrations, photography, or icon sets. Only hand-drawn inline SVG line art belongs in this style.
+- Don't add decorative UI elements like dot grids, progress bars, or swipe indicators. The corner metadata strips are the only frame this composition needs.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale**: Script Display scales down to 120px. Upright Display scales down to 180px. Section Heading scales to 72px. Metadata stays at 14-16px.
+- **Padding**: 60px on all sides. Content area is 960x960px.
+- **Cover slide**: Corner metadata strip at top (3 labels). Script + upright headline entangled in the center (top half). Line-art illustration in the lower half. Bottom metadata strip. 4-6 sparkles scattered around the illustration.
+- **Content slides**: Top metadata strip with the slide's topic label as the center cell. Main content in the middle — typically a script-italic phrase followed by a single upright display word. Line-art decoration or sparkles at the bottom.
+- **Card slides**: This style does not use card grids. For a "multi-item" slide, use a vertical list of script-italic phrases with a single upright display word as the title.
+- **Swipe indicator**: Tiny cream hairlines at the bottom center — 3-5 short dashes (24x1px each, 8px gap), with the active dash slightly thicker. No dots.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Full-scale hierarchy. Script Display at 140px, Upright Display at 200-220px for the hero section. Section headings at 88px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Section spacing**: 80px vertical gap between sections. Use 1px cream hairline dividers (`rgba(245, 240, 230, 0.35)`) only between very dense sections.
+- **Vertical rhythm**: Each section has its own corner metadata strip at the top, its own centered headline, and its own supporting line-art illustration. Treat every section as a mini-poster.
+- **Footer**: Bottom metadata strip with a closing all-caps line and a script-italic sign-off above it.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Script Display at 180px, Upright Display at 280-300px. Section Heading at 120px. Metadata at 18-20px.
+- **Padding**: 80px on all sides. Content area is 1760x920px.
+- **Layout**: Centered composition — corner metadata strip at top, entangled script+upright headline in the center-left, line-art illustration in the center-right, sparkles scattered between. The 16:9 ratio invites a left/right split rather than a strict top/bottom split.
+- **Title slides**: Top metadata strip. Massive centered headline with the upright word receiving the echo shadow. Line-art illustration to the right of or behind the headline. Bottom metadata strip.
+- **Content slides**: Smaller section heading (top-left). Script-italic supporting line below. Line-art illustration anchored to the right side. Corner metadata continues to frame.
+- **CTA slides**: Script "Join us" at top center. Single centered line-art illustration. Bottom metadata strip with the RSVP line flanked by cream hairline rules.
+
+### Poster (1080x1350px)
+- **Typography**: Script Display at 140px, Upright Display at 220-240px. Section Heading at 100px. Metadata at 16-18px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top zone (120px) for the 3-column corner metadata strip. Upper-middle zone for the entangled script + upright headline. Lower-middle zone for the line-art illustration (largest and most prominent here — the illustration takes 45-50% of the canvas height). Bottom zone (140px) for the bottom metadata strip.
+- **Vertical flow**: Top metadata → 48px → headline → 32px → illustration → 48px → bottom metadata.
+- **CTA placement**: Bottom metadata's right cell is typically the RSVP / contact line. No separate CTA button.
+
+### Story (1080x1920px)
+- **Dimensions**: 1080 wide by 1920 tall — vertical 9:16 format for mobile stories.
+- **Padding**: 120px left/right, 60px top/bottom. The 120px horizontal padding is generous to give the vertical composition room to breathe.
+- **Typography scale up**: Hero is roughly 30% larger than carousel. Script Display at 160px, Upright Display at 240px (matching the carousel hero dimensions proportionally scaled up). Section Heading at 100px. Metadata at 16-18px.
+- **Composition**: The vertical ratio demands a single-column, top-to-bottom flow. Top zone (240px) for the 3-column corner metadata strip. Upper-middle zone (500-600px) for the entangled script + upright headline — treat this as the most dramatic moment of the whole story. Middle zone (700-800px) for the line-art illustration, centered and larger than in any other format — this is the hero. Lower zone (300px) for the bottom metadata strip.
+- **Illustration sizing**: The line-art illustration in Story format is roughly 1.3x larger than in the carousel hero (matching the ~30% upscale note). Aim for an SVG rendered at 640-720px wide inside the 840px content column.
+- **Sparkle placement**: 5-7 sparkles scattered down the full length of the composition — one cluster near the headline, one cluster around the illustration, one tiny sparkle near the bottom metadata.
+- **Bottom metadata**: The 3-column footer remains but is slightly more compact. The Story format benefits from a cream hairline rule (`1px solid rgba(245, 240, 230, 0.35)`) above the bottom metadata strip to define the footer zone.
+- **Mobile-first considerations**: Avoid elements in the extreme top 120px and extreme bottom 240px of the canvas (these zones are often cropped or covered by platform UI on Instagram/TikTok Stories).
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Powder Blue | `#7BA3C6` | Primary background canvas |
+| Cream | `#F5F0E6` | Primary ink — all type, all line art |
+| Blue Shadow | `#5A84AA` | Offset echo shadow on one display letter |
+| Cream Glow | `#FAF5EB` | Micro-highlights on sparkles |
+| Blue Mid | `#6E9BC0` | Alternate canvas for Story format |
+| Ink Dark | `#3D5A75` | Dense decorative grit only |
+| Cream 80 | `rgba(245, 240, 230, 0.80)` | Secondary metadata labels |
+| Cream 60 | `rgba(245, 240, 230, 0.60)` | Tertiary annotations, slide numbers |
+| Cream 40 | `rgba(245, 240, 230, 0.40)` | Hairline dividers |
+| Hairline Cream | `rgba(245, 240, 230, 0.35)` | The only allowed border |
+
+### Font Declarations
+
+```css
+/* Script Display (italic serif — "Cocktail") */
+font-family: 'Cormorant Garamond', 'Playfair Display', Georgia, serif;
+font-style: italic;
+font-weight: 500;
+
+/* Upright Display (massive Didone — "PARTY") */
+font-family: 'Playfair Display', Georgia, 'Times New Roman', serif;
+font-weight: 900;
+
+/* Metadata Sans (corner labels, all caps) */
+font-family: 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+font-weight: 600;
+letter-spacing: 1.8px;
+text-transform: uppercase;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Playfair+Display:ital,wght@0,400;0,700;0,800;0,900;1,400;1,700;1,900&family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-bg: #7BA3C6;
+  --color-cream: #F5F0E6;
+  --color-blue-shadow: #5A84AA;
+
+  /* Colors -- Accent */
+  --color-cream-glow: #FAF5EB;
+  --color-blue-mid: #6E9BC0;
+  --color-ink-dark: #3D5A75;
+
+  /* Colors -- Neutral Scale (cream alpha tones) */
+  --color-cream-100: #F5F0E6;
+  --color-cream-80: rgba(245, 240, 230, 0.80);
+  --color-cream-60: rgba(245, 240, 230, 0.60);
+  --color-cream-40: rgba(245, 240, 230, 0.40);
+  --color-cream-20: rgba(245, 240, 230, 0.20);
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: #7BA3C6;
+  --color-surface-inset: rgba(90, 132, 170, 0.25);
+
+  /* Colors -- Borders */
+  --color-hairline: rgba(245, 240, 230, 0.35);
+  --color-hairline-strong: rgba(245, 240, 230, 0.55);
+
+  /* Colors -- Shadows */
+  --shadow-echo: #5A84AA;
+  --shadow-soft-blur: 0 0 24px rgba(90, 132, 170, 0.35);
+  --shadow-grain: rgba(61, 90, 117, 0.10);
+
+  /* Typography -- Families */
+  --font-script: 'Cormorant Garamond', 'Playfair Display', Georgia, serif;
+  --font-display: 'Playfair Display', Georgia, 'Times New Roman', serif;
+  --font-sans: 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-script-display: 160px;
+  --text-upright-display: 240px;
+  --text-section-heading: 88px;
+  --text-sub-heading: 56px;
+  --text-metadata-bold: 16px;
+  --text-metadata-strip: 14px;
+  --text-body: 18px;
+  --text-big-number: 120px;
+  --text-caption: 12px;
+  --text-cta: 14px;
+
+  /* Typography -- Weights */
+  --weight-script: 500;
+  --weight-display: 900;
+  --weight-metadata: 600;
+  --weight-metadata-bold: 700;
+  --weight-body: 500;
+
+  /* Typography -- Line Heights */
+  --leading-display: 0.95;
+  --leading-script: 1.00;
+  --leading-heading: 1.00;
+  --leading-metadata: 1.20;
+  --leading-body: 1.55;
+  --leading-caption: 1.30;
+
+  /* Typography -- Tracking */
+  --track-display: -6px;
+  --track-script: -2px;
+  --track-metadata: 1.8px;
+  --track-metadata-bold: 1.5px;
+  --track-cta: 2px;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-medium: 24px;
+  --space-art-gap: 32px;
+  --space-frame: 48px;
+  --space-outer-carousel: 60px;
+  --space-outer-slides: 80px;
+  --space-outer-story: 120px;
+
+  /* Effects */
+  --echo-offset: 5px 5px 0 var(--color-blue-shadow);
+  --illustration-stroke-width: 2.2px;
+  --illustration-stroke-color: var(--color-cream);
+}
+```
+
+### System Font Fallbacks
+- **Script (if Cormorant Garamond fails to load):** `'Playfair Display', Georgia, 'Times New Roman', serif`
+- **Display (if Playfair Display fails to load):** `Georgia, 'Times New Roman', serif`
+- **Sans (if DM Sans fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/_full/social-post-card.md
+++ b/skills/composites/goose-graphics/styles/_full/social-post-card.md
@@ -1,0 +1,477 @@
+# Design Style: Social Post Card
+
+## 1. Visual Theme & Atmosphere
+
+Social Post Card is the design language of the "dropped-in social proof" — a visual idiom where a simulated Instagram-style post card is the hero content, floating over a real-world photographed scene that grounds the product in an actual environment. The defining move is simultaneous: a crisp white rounded-rectangle card styled EXACTLY like a native social post (avatar, bold username, square photo, heart/comment/share/bookmark action row, caption) sits dead-center over a softly blurred photograph of the product's real habitat — a white marble kitchen counter with meal prep containers, a closet with clothing, a desk with a laptop. The background is never a gradient and never a flat color; it is always a real scene, slightly blurred, slightly brightened, to suggest depth and context without competing with the post.
+
+The typography is a single typeface throughout — Inter at weights 400/500/600/700 — because native social platforms use system sans-serif UI, and Inter is the closest open-source proxy. This is intentional: the card must read as "that's a real Instagram post" at a glance. The username is Inter 600, the caption body is Inter 400 at a natural reading size, the action icons are Unicode or inline SVG sized to match real platform chrome. The post card uses a 16px border-radius (not 12px, not 24px — 16px is the current Instagram card radius) and a soft drop shadow (`0 16px 48px rgba(0,0,0,0.12)`) that makes it look dropped-in rather than pasted. The overall feel is "social proof poster" — a testimonial or review presented in the exact format your audience scrolls past every day, rendered in a real-world context they recognise.
+
+**Uniqueness vs. Frosted Lens:** Social Post Card is NOT Frosted Lens (which uses a blurred *abstract chromatic* background with a data-forward card — this style uses a blurred *real-world photograph* with a *simulated social post* card). The signature move is specifically the **simulated social post as hero content** — the card is not an abstract design container; it is a literal reproduction of an Instagram post unit, with avatar, username, main square photo, action icon row, and caption, in that order. Nothing else in the pack does this.
+
+**Key Characteristics:**
+- Blurred real-world photograph as the full-bleed background (not gradient, not solid, not abstract pattern)
+- Background blur amount: `filter: blur(2px) brightness(0.95)` — subtle, not heavy
+- Crisp white (`#ffffff`) simulated post card, ~500×620px, centered on the scene
+- Card border-radius: 16px (matches real Instagram post card radius)
+- Soft drop shadow on card: `0 16px 48px rgba(0,0,0,0.12)` for the floating-on-real-surface effect
+- Header row inside card: 40px circular avatar + Inter 600 username + "..." menu at 24-28px card padding
+- Main square photo area inside the card: 400×400px square with 8px inner border-radius
+- Action row below the photo: heart, comment, paper plane, bookmark — Unicode or inline SVG, 22-24px
+- Caption: Inter 400, 16-17px, left-aligned, 1.45 line-height, 3-5 lines of testimonial body
+- Single typeface: Inter only (400/500/600/700) — matches native platform UI
+- Scene photography is context-specific: food product → kitchen; fashion → closet; tech → workspace
+- Near-black (`#111111`) text inside the card, mid-gray (`#8e8e8e`) for timestamps and meta
+- 1:1 square canvas as the primary format — the entire composition is photographed as if it were a printable poster
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Card White** (`#ffffff`): The simulated post card surface. Pure white to match Instagram's native post background and read as "real social card."
+- **Near-Black** (`#111111`): Primary text color inside the card — username, caption body, action icon fills.
+- **Scene Backdrop** (`#eeeae5`): A conceptual neutral warm gray that represents the dominant tone of the background photograph. Used as a fallback solid color if the photo fails to load.
+
+### Accent
+- **Instagram Red** (`#ed4956`): The heart/like icon color when active or filled. Used sparingly as a single accent spark inside the card.
+- **Link Blue** (`#00376b`): Used for "@mentions" or linked usernames inside the caption if present.
+- **Timestamp Gray** (`#8e8e8e`): Meta text — "2 HOURS AGO," like counts, small platform labels.
+
+### Neutral Scale
+- **Divider Gray** (`#efefef`): The hairline divider between caption area and any footer row.
+- **Icon Gray** (`#262626`): Default color for the unfilled action icons (heart outline, comment, share, bookmark).
+- **Secondary Text** (`#555555`): Optional supporting text under a username (e.g., "Sponsored").
+- **Tertiary Text** (`#8e8e8e`): Timestamps and metadata.
+- **Disabled** (`#c7c7c7`): Inactive or ghost elements.
+- **Shadow Hint** (`rgba(0,0,0,0.04)`): Subtle inner shadow for depth inside card.
+
+### Surface & Borders
+- **Surface Card** (`#ffffff`): The post card body.
+- **Surface Photo** (`#f2f2f2`): The inner square photo container background (before the actual image loads).
+- **Border Default** (`rgba(0,0,0,0.06)`): Near-invisible hairline that some platforms use between card sections.
+- **Border Photo** (`rgba(0,0,0,0.04)`): The inside edge of the square photo area.
+- **Divider Rule** (`#efefef`): Full-width horizontal separator.
+- **Border Accent** (`rgba(237,73,86,0.3)`): Red-tinted border for featured or highlighted action elements.
+
+### Shadow Colors
+- **Shadow Card** (`rgba(0,0,0,0.12)`): The signature drop shadow on the main post card — soft, wide, slightly diffuse.
+- **Shadow Card Deep** (`rgba(0,0,0,0.18)`): Stronger variant for extra emphasis or overlay use.
+- **Shadow Subtle** (`rgba(0,0,0,0.04)`): Ambient inner shadows for depth inside the card.
+- **Shadow Scene** (`rgba(0,0,0,0.25)`): A subtle vignette overlay used on the background scene to push the card forward.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Body**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+(Single-family system. This is intentional — native social platforms use a single sans-serif UI stack, and matching that is core to the "looks like a real post" effect.)
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Inter | 48px | 700 | 1.15 | -0.5px | Optional headline on poster above the card |
+| Section Heading | Inter | 32px | 700 | 1.20 | -0.3px | Story/secondary headlines |
+| Username | Inter | 15px | 600 | 1.20 | -0.1px | The bold username in the card header — matches IG card username weight |
+| Sub-username | Inter | 12px | 500 | 1.30 | 0px | Optional "Sponsored" / location line below username |
+| Caption Body | Inter | 16px | 400 | 1.45 | 0px | The testimonial paragraph — 3-5 lines, left-aligned |
+| Caption Bold | Inter | 16px | 600 | 1.45 | 0px | Bolded key phrases inside the caption (sparingly) |
+| Action Count | Inter | 14px | 600 | 1.20 | 0px | "1,248 likes" — if shown |
+| Timestamp | Inter | 11px | 500 | 1.00 | 0.4px | "2 HOURS AGO" uppercase meta |
+| CTA Text | Inter | 15px | 600 | 1.00 | 0px | Any "Learn more" link inside card |
+
+### Principles
+- **Single typeface, matched weights**: Inter across all elements. The card must read as native platform UI, and every native platform uses one sans-serif family.
+- **Inter 600 for usernames**: This is the exact weight Instagram, Threads, and X use for the display name in post cards. Do not use 700 (too heavy) or 500 (too light) — 600 is the right reading.
+- **Inter 400 for caption body**: Captions on social platforms are always regular weight, not medium. Keep the caption honest: weight 400, size 15-17px.
+- **Tight but not aggressive tracking**: Headings use -0.3 to -0.5px tracking. Caption body is 0px. Timestamps are 0.4px uppercase.
+- **Line height 1.45 for captions**: Natural, readable, matches platform rendering. Do not go below 1.35 or above 1.55.
+- **No italic, no decorative variants**: Platforms don't show italic in captions by default, so we don't either. Keep it plain.
+
+## 4. Component Patterns
+
+### Background Scene (CRITICAL — always present)
+
+The full-bleed container that holds a blurred real-world photograph. The scene is product-context-specific: for food, use a kitchen counter with product visible in foreground; for fashion, use a closet with garments; for tech, use a workspace with a laptop; for home goods, use a styled room. Never use a gradient or flat color — the scene photography is essential to the style.
+
+```html
+<div style="position: relative; width: 100%; height: 100%; overflow: hidden;">
+  <!-- Blurred real-world photograph as the scene backdrop -->
+  <div style="position: absolute; inset: 0; background-image: url('https://example.com/kitchen-counter-mealprep.jpg'); background-size: cover; background-position: center; filter: blur(2px) brightness(0.95);"></div>
+  <!-- Subtle vignette to push the card forward -->
+  <div style="position: absolute; inset: 0; background: radial-gradient(ellipse at center, rgba(0,0,0,0) 0%, rgba(0,0,0,0.1) 80%, rgba(0,0,0,0.2) 100%); pointer-events: none;"></div>
+  <!-- Simulated post card centered on the scene -->
+  <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+    <!-- Post card content goes here -->
+  </div>
+</div>
+```
+
+Guidance: the background should be a photographed scene relevant to the product — e.g., for food use a kitchen counter; for fashion use a closet; for tech use a workspace; for home goods use a styled room. The blur stays at 2–4px and brightness at 0.95. Never over-blur (above 5px it reads as generic glass effect, which is Frosted Lens, not this style).
+
+### Simulated Post Card (SIGNATURE component)
+
+The core element. A crisp white rounded rectangle styled to look exactly like an Instagram post, with header row, square photo, action row, and caption — in that fixed order.
+
+```html
+<div style="width: 500px; background: var(--color-card-white); border-radius: 16px; box-shadow: 0 16px 48px rgba(0,0,0,0.12); overflow: hidden; font-family: var(--font-body);">
+  <!-- Header Row: avatar + username + menu -->
+  <div style="display: flex; align-items: center; padding: 14px 16px 12px; gap: 12px;">
+    <div style="width: 40px; height: 40px; border-radius: 50%; background: #f2f2f2 url('https://example.com/avatar.jpg') center/cover; flex-shrink: 0; border: 1px solid rgba(0,0,0,0.04);"></div>
+    <div style="flex: 1; min-width: 0;">
+      <p style="font-family: var(--font-body); font-size: 15px; font-weight: 600; color: var(--color-near-black); margin: 0; line-height: 1.20; letter-spacing: -0.1px;">Stefano Reed</p>
+    </div>
+    <div style="font-size: 20px; color: var(--color-icon-gray); line-height: 1; padding: 0 4px; font-weight: 700;">&#8943;</div>
+  </div>
+  <!-- Main Square Photo -->
+  <div style="padding: 0 16px;">
+    <div style="width: 100%; aspect-ratio: 1 / 1; background: var(--color-surface-photo) url('https://example.com/mealprep-hero.jpg') center/cover; border-radius: 8px; border: 1px solid rgba(0,0,0,0.04);"></div>
+  </div>
+  <!-- Action Row: heart, comment, share, bookmark -->
+  <div style="display: flex; align-items: center; padding: 14px 16px 8px; gap: 16px;">
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--color-icon-gray)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--color-icon-gray)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--color-icon-gray)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+    <div style="flex: 1;"></div>
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="var(--color-icon-gray)" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+  </div>
+  <!-- Caption -->
+  <div style="padding: 4px 16px 20px;">
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.45; color: var(--color-near-black); margin: 0;">I've tried my fair share of meal prep kits, but this one is a total game-changer. Everything comes pre-portioned, super fresh, and packed with flavor&mdash;no more sad desk lunches!</p>
+  </div>
+</div>
+```
+
+### Avatar Circle
+
+A 40px circular avatar with a photo or initial fallback, used in the post card header row.
+
+```html
+<!-- Photo avatar -->
+<div style="width: 40px; height: 40px; border-radius: 50%; background: #f2f2f2 url('https://example.com/avatar.jpg') center/cover; border: 1px solid rgba(0,0,0,0.04);"></div>
+
+<!-- Initial fallback avatar -->
+<div style="width: 40px; height: 40px; border-radius: 50%; background: var(--color-icon-gray); display: flex; align-items: center; justify-content: center; color: #ffffff; font-family: var(--font-body); font-size: 15px; font-weight: 600;">SR</div>
+```
+
+### Action Icon Row
+
+The horizontal row of heart, comment, paper plane, and bookmark icons that makes the card read as a social post. Must be present — do not skip.
+
+```html
+<div style="display: flex; align-items: center; padding: 14px 16px 8px; gap: 16px;">
+  <!-- Heart -->
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#262626" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+  <!-- Comment -->
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#262626" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/></svg>
+  <!-- Share / Paper Plane -->
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#262626" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+  <div style="flex: 1;"></div>
+  <!-- Bookmark (far right) -->
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#262626" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>
+</div>
+```
+
+Unicode fallback: if SVG is not practical, use `♡` (heart), `💬` (comment), `✈` (share), `🔖` (bookmark) — but SVG is preferred because the icons must read as flat line art, not emoji.
+
+### Stat Display (inside card)
+
+When the post card needs to show a stat in the caption area — like counts or rating metrics — stack them like Instagram's native "X likes" row.
+
+```html
+<div style="padding: 4px 16px 6px;">
+  <p style="font-family: var(--font-body); font-size: 14px; font-weight: 600; color: var(--color-near-black); margin: 0;">1,248 likes</p>
+</div>
+```
+
+### Quote / Testimonial Caption
+
+Most common use: the caption area holds a short testimonial. Keep it to 3-5 lines of Inter 400 at 16px with 1.45 line height, left-aligned.
+
+```html
+<div style="padding: 4px 16px 20px;">
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.45; color: var(--color-near-black); margin: 0;"><span style="font-weight: 600;">stefanoreed</span> I've tried my fair share of meal prep kits, but this one is a total game-changer. Everything comes pre-portioned, super fresh, and packed with flavor&mdash;no more sad desk lunches!</p>
+  <p style="font-family: var(--font-body); font-size: 11px; font-weight: 500; line-height: 1.00; letter-spacing: 0.4px; text-transform: uppercase; color: var(--color-tertiary); margin: 8px 0 0;">2 HOURS AGO</p>
+</div>
+```
+
+### CTA Block (outside the card)
+
+Optional: if the design needs a CTA, it sits outside the post card, layered over the scene background, typically at the bottom in Inter 700 with a soft dark pill button.
+
+```html
+<div style="text-align: center; padding: 24px 0 0;">
+  <a style="display: inline-block; background: var(--color-near-black); color: #ffffff; font-family: var(--font-body); font-size: 15px; font-weight: 600; text-decoration: none; padding: 14px 32px; border-radius: 32px; box-shadow: 0 8px 24px rgba(0,0,0,0.18);">Try the kit</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap — between icon and adjacent element in the action row.
+- **8px**: Tight gap — between caption and timestamp row.
+- **12px**: Small gap — between avatar and username in the header row.
+- **14px**: Card header padding top/bottom — matches Instagram's standard header inset.
+- **16px**: Card horizontal padding — the standard left/right inset for all card content.
+- **20px**: Card bottom padding — after the caption.
+- **24px**: Base gap between card and background edge on a 1:1 square at 600px canvas.
+- **32px**: Medium gap for poster/story layouts between card and headline.
+- **48px**: Section divider — used when multiple cards stack.
+- **80px**: Maximum section padding for story and slides formats around the card.
+
+### Format Padding
+
+| Format | Outer Padding | Card Width | Card Radius |
+|--------|---------------|------------|-------------|
+| Square 1:1 (600×600 or 1080×1080) | 40–60px on all sides | 440–520px | 16px |
+| Story 1080x1920 | 120px top/bottom, 60px left/right | 500px | 16px |
+| Poster 1080x1350 | 60px left/right, 80px top/bottom | 500px | 16px |
+| Slides 1920x1080 | 80px all sides | 560px | 16px |
+| Infographic 1080×N | 60px left/right, 80px top/bottom per section | 500px | 16px |
+
+### Alignment & Grid
+- **Primary composition**: Card is always horizontally centered on the scene background. Vertical alignment is typically center, but can shift slightly upward (approx 45%) to give headline space above.
+- **Card internal alignment**: Left-aligned. Username, caption, and action icons all anchor to the left padding edge.
+- **Action row special case**: The bookmark icon is always flex-pushed to the right edge; heart/comment/share cluster left.
+- **Grid**: Single centered card per composition. For multi-card stories, stack cards vertically with 48px gap.
+- **Content gravity**: The card is the center of gravity. Any supporting text (headline, CTA) lives in the scene area above or below the card, with 32px minimum distance.
+- **Scene photography rules**: The real-world photo should have a natural horizon or surface line that the card can sit on. For food, shoot the countertop flat-on with containers in the foreground. For fashion, shoot the closet from a clean front angle. For tech, shoot the desk with subtle perspective.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow | Scene background photograph |
+| Subtle (Level 1) | `0 2px 8px rgba(0,0,0,0.04)` | Inner photo square inside the card |
+| Card (Level 2) | `0 16px 48px rgba(0,0,0,0.12)` | The signature post card drop shadow |
+| Elevated (Level 3) | `0 24px 64px rgba(0,0,0,0.18)` | Featured card with extra emphasis |
+| Overlay (Level 4) | `0 32px 80px rgba(0,0,0,0.25)` | Card over very busy background, or modal overlay |
+
+### Border Treatments
+- **Card outer border**: No border — the card is defined purely by its drop shadow. This is critical: a visible border breaks the "floating social post" illusion.
+- **Inner photo border**: `1px solid rgba(0,0,0,0.04)` with `border-radius: 8px` — a barely-visible hairline that defines the photo area without being a frame.
+- **Avatar border**: `1px solid rgba(0,0,0,0.04)` at 50% radius — keeps the circle crisp against the white card.
+- **Divider rule (inside card)**: `1px solid #efefef` for any full-width horizontal separator between sections.
+
+### Surface Hierarchy
+Depth is communicated via shadow intensity and the contrast between the scene (busy, blurred, tonal) and the card (flat white, crisp).
+1. **Scene background** — blurred, photographic, the deepest layer.
+2. **Card** (`#ffffff`) — flat white, defined by its drop shadow, floats above the scene.
+3. **Inner photo** inside the card — the second-highest information layer, visually "pressed into" the card with a barely-there border.
+4. **Action icons** — the highest-contrast line elements in the composition, anchoring the card as a social post.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use a blurred real-world photograph as the scene background — the scene photography is essential to the style.
+- Center the simulated post card on the scene with generous space around it.
+- Use Inter (400/500/600/700) for everything to match real social platform UI.
+- Use a 40px circular avatar with a real photo or initials in the card header.
+- Use Inter 600 at 15px for the username — matches native platform weight.
+- Use soft drop shadows (`0 16px 48px rgba(0,0,0,0.12)`) on the post card so it looks dropped-in.
+- Use SVG or Unicode icons for the action row — heart, comment, share, bookmark in that order with bookmark pushed right.
+- Keep the card border-radius at 16px to match current Instagram card radius.
+- Keep the caption at 3–5 lines of Inter 400 at 16px, left-aligned, line-height 1.45.
+- Use a 1:1 square canvas as the primary format — the post card looks best on a square poster.
+- Include all four action icons (heart, comment, share, bookmark) — they are what make the card read as a social post.
+- Ensure the scene background is contextually relevant to the product (kitchen for food, closet for fashion, workspace for tech).
+
+### Don't
+- Don't use solid-color backgrounds — the scene photography is essential. No flat colors, no gradients, no abstract patterns.
+- Don't over-blur the background — stay around 2–4px. Above 5px it reads as generic glassmorphism, which is Frosted Lens, not this style.
+- Don't use fonts other than Inter — a serif or display face immediately breaks the "real social post" illusion.
+- Don't skip the action icon row — it is the single most important element that makes the card read as a social post.
+- Don't use pure black (`#000000`) for text — use `#111111` or `#262626` for warmth and to match Instagram's actual text color.
+- Don't use a visible border on the main card — the card is defined by its drop shadow only.
+- Don't use emoji icons for the action row — use SVG line icons. Emoji are rendered as color glyphs and break the native-UI look.
+- Don't place the card off-center — centered is correct; off-center feels like a layout mistake.
+- Don't stack multiple post cards in a single square frame — one card per composition.
+- Don't omit the avatar circle — the header row must have avatar + username to read as a post.
+- Don't use more than 5 lines of caption — real social captions are short.
+- Don't use serif, display, or monospace fonts anywhere — Inter only.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel / Square (1080x1080px)
+- **Typography scale**: Username stays at 15px, caption at 16px — do not scale these up, they must match native platform sizing. Optional headline above card at 48px Inter 700.
+- **Padding**: 60px on all sides. Card centered at 500×620px.
+- **Cover slide**: Scene background + centered post card. Optional framework label or headline sits above the card with 32px gap.
+- **Content slides**: Each slide is a single post card with different username, photo, and caption — a testimonial carousel.
+- **Card position**: Centered horizontally. Vertically, shift to ~48% of canvas height to give slight breathing room above.
+- **Swipe indicator**: Small dots at bottom center over the scene, 6px diameter, white at 80% opacity for active, white at 30% opacity for inactive.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Card typography stays constant (Inter 15/16px). Section headlines between card groups at 32-40px Inter 700.
+- **Padding**: 60px left/right. 80px top/bottom.
+- **Vertical rhythm**: Stack post cards with 48px gap between them. Each card represents a different testimonial in a sequence.
+- **Scene strategy**: For infographic use, the scene background can shift between sections — different scene per testimonial card — or use a single continuous blurred scene behind the entire stack.
+- **Footer**: Small Inter 500 at 13px with uppercase letter-spacing for brand attribution.
+
+### Slides (1920x1080px)
+- **Typography scale**: Card content stays at native size (15/16px) — it must look like a real post. Supporting headline above or beside card can scale to 72-88px Inter 700.
+- **Padding**: 80px on all sides. Card at 560×700px, positioned left or center.
+- **Layout**: Two common patterns:
+  1. **Centered hero**: Card centered on a full-bleed blurred scene, with optional headline stacked above.
+  2. **Split layout**: Card on the left third, headline + CTA stacked on the right two thirds over the scene.
+- **Title slides**: Card centered, headline above at 72px Inter 700, optional CTA button below.
+- **CTA slides**: Card on one side, CTA headline and button on the other, all on one continuous scene background.
+
+### Poster (1080x1350px)
+- **Typography**: Card content at native size. Optional headline above card at 56-64px Inter 700.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top third for optional headline. Middle third for the post card (centered, ~500×620px). Bottom third for CTA button and small attribution.
+- **Scene strategy**: Full-bleed blurred photograph from edge to edge. Card floats dead-center. Let the scene photography carry the brand recognition.
+
+### Story (1080x1920px)
+- **Typography scale**: Card content at native size (Inter 15/16px). Optional headline above card at 56-64px Inter 700. Uppercase framework label (if used) at Inter 600 12px with 0.8px letter-spacing.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 220px bottom reserved for platform UI (profile avatar, progress bar, reply input, share sticker row). All critical content must sit inside y=160 to y=1700.
+- **Layout**: Single centered column. Card at 500×620px, centered horizontally at x=540, vertically centered around y=960. The scene background runs full-bleed edge to edge.
+- **Cover slide**: Scene background edge-to-edge. Card centered. Optional 56-64px Inter 700 headline 48px above the card (y ≈ 380). Small uppercase brand label (Inter 600 12px, letter-spacing 0.8px) 24px above the headline.
+- **Content slides**: One testimonial card per slide. For multi-testimonial stories, each slide is a different username + photo + caption but the same scene background to imply a series.
+- **CTA slide**: Card at top half with a final testimonial. Below the card (48px gap), a dark pill CTA button (`#111111`, white Inter 600 15px, 32px radius, 14px×32px padding) with a soft drop shadow. Optional small Inter 500 11px caption above the button in uppercase letter-spacing for a call to action label.
+- **Progress indicator**: Thin segments at y=40, inactive white at 30% opacity, active white at 90% opacity. Sits above the scene, does not touch the card.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Card White | `#ffffff` | Post card surface |
+| Near-Black | `#111111` | Primary text inside card |
+| Icon Gray | `#262626` | Action icon stroke color |
+| Timestamp Gray | `#8e8e8e` | Meta text, timestamps |
+| Instagram Red | `#ed4956` | Active heart/like accent |
+| Link Blue | `#00376b` | Caption mentions and links |
+| Scene Backdrop | `#eeeae5` | Fallback solid if photo fails |
+| Divider Gray | `#efefef` | Hairline separators |
+| Surface Photo | `#f2f2f2` | Inner photo area background |
+| Secondary Text | `#555555` | Sub-username, supporting text |
+| Disabled | `#c7c7c7` | Inactive elements |
+
+### Font Declarations
+
+```css
+/* Single family — Inter for everything */
+font-family: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-card-white: #ffffff;
+  --color-near-black: #111111;
+  --color-scene-backdrop: #eeeae5;
+
+  /* Colors -- Accent */
+  --color-instagram-red: #ed4956;
+  --color-link-blue: #00376b;
+  --color-timestamp: #8e8e8e;
+
+  /* Colors -- Neutral Scale */
+  --color-icon-gray: #262626;
+  --color-divider: #efefef;
+  --color-secondary: #555555;
+  --color-tertiary: #8e8e8e;
+  --color-disabled: #c7c7c7;
+  --color-shadow-hint: rgba(0, 0, 0, 0.04);
+
+  /* Colors -- Surfaces */
+  --color-surface-card: #ffffff;
+  --color-surface-photo: #f2f2f2;
+
+  /* Colors -- Borders */
+  --color-border-default: rgba(0, 0, 0, 0.06);
+  --color-border-photo: rgba(0, 0, 0, 0.04);
+  --color-border-accent: rgba(237, 73, 86, 0.3);
+  --color-divider-rule: #efefef;
+
+  /* Colors -- Shadows */
+  --shadow-subtle: rgba(0, 0, 0, 0.04);
+  --shadow-card: rgba(0, 0, 0, 0.12);
+  --shadow-card-deep: rgba(0, 0, 0, 0.18);
+  --shadow-scene: rgba(0, 0, 0, 0.25);
+
+  /* Typography -- Families */
+  --font-display: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 48px;
+  --text-section-heading: 32px;
+  --text-username: 15px;
+  --text-sub-username: 12px;
+  --text-caption: 16px;
+  --text-action-count: 14px;
+  --text-timestamp: 11px;
+  --text-cta: 15px;
+
+  /* Typography -- Weights */
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --weight-bold: 700;
+
+  /* Typography -- Line Heights */
+  --leading-display: 1.15;
+  --leading-heading: 1.20;
+  --leading-caption: 1.45;
+  --leading-tight: 1.00;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-card-header: 14px;
+  --space-card-padding: 16px;
+  --space-card-bottom: 20px;
+  --space-base: 24px;
+  --space-medium: 32px;
+  --space-section: 48px;
+  --space-max: 80px;
+
+  /* Borders */
+  --radius-card: 16px;
+  --radius-photo: 8px;
+  --radius-avatar: 50%;
+  --radius-cta: 32px;
+
+  /* Composed Shadows */
+  --shadow-card-drop: 0 16px 48px rgba(0, 0, 0, 0.12);
+  --shadow-card-deep-drop: 0 24px 64px rgba(0, 0, 0, 0.18);
+  --shadow-inner-photo: 0 2px 8px rgba(0, 0, 0, 0.04);
+  --shadow-cta-button: 0 8px 24px rgba(0, 0, 0, 0.18);
+
+  /* Scene Background */
+  --scene-blur: blur(2px) brightness(0.95);
+}
+```
+
+### System Font Fallbacks
+- **Sans-serif (if Inter fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **No serif fallback** — this style does not use serif typography. If Inter is completely unavailable, use the system sans stack above.

--- a/skills/composites/goose-graphics/styles/_full/soft-cloud.md
+++ b/skills/composites/goose-graphics/styles/_full/soft-cloud.md
@@ -1,0 +1,450 @@
+# Design Style: Soft Cloud
+
+## 1. Visual Theme & Atmosphere
+
+Soft Cloud is the visual language of modern SaaS at its most inviting -- the kind of interface design you see in a product that wants you to feel at home the moment you land on the page. The pale gradient background drifts from lavender (`#e8e0f0`) to mint (`#d8f0e8`), creating a sense of openness and calm that immediately signals approachability. This is not the sterile white of enterprise dashboards or the aggressive dark mode of developer tools -- it is a gentle, airy canvas that breathes. White cards (`#ffffff`) float above this gradient like clouds in a pastel sky, their generous rounded corners (16-20px) and soft shadows removing any sharpness or tension from the layout.
+
+The typographic identity rests entirely on Plus Jakarta Sans, a geometric sans-serif from Google Fonts that balances friendliness with professionalism. At weight 600, headlines feel confident without being aggressive. At weight 500, body text reads as warm and approachable without sacrificing clarity. The rounded terminals and open apertures of Plus Jakarta Sans complement the soft geometry of the card-based layout -- everything works together to say "modern, trustworthy, easy." There is no serif counterpoint here; the entire system speaks in one friendly voice, varying only in size and weight to establish hierarchy.
+
+Soft purple (`#8b6cc7`) serves as the primary accent colour, adding just enough chromatic energy to guide the eye without overwhelming the pastel tranquility of the canvas. It appears in buttons, active states, and key metrics -- moments where the design needs to say "look here" without shouting. Mint (`#5cb8a5`) operates as the secondary accent, used for success states, secondary actions, and supporting indicators. Together, purple and mint create a cool-toned accent vocabulary that feels fresh and contemporary. The interplay between the gradient background, white card surfaces, and these two accent colours produces a layered, dimensional aesthetic that is unmistakably modern SaaS -- think Notion's calm confidence crossed with Linear's polished softness.
+
+**Key Characteristics:**
+- Pale gradient background from lavender (`#e8e0f0`) to mint (`#d8f0e8`) -- a dreamy canvas that sets the tone instantly
+- White (`#ffffff`) card surfaces floating above the gradient with soft shadows and rounded corners (16-20px)
+- Dark charcoal (`#2d2d3d`) for all primary text -- dark enough for strong contrast, warm enough to avoid harshness
+- Plus Jakarta Sans at weight 500-600 throughout -- one font family, friendly and geometric
+- Soft purple (`#8b6cc7`) as primary accent for buttons, links, stats, and focal points
+- Mint (`#5cb8a5`) as secondary accent for success states, secondary CTAs, and supporting elements
+- Generous border-radius (16-20px) on all cards and containers -- softness is structural, not decorative
+- Soft shadows using `rgba(139,108,199,0.08)` -- purple-tinted ambient glow that stays on-palette
+- Ample white space and relaxed padding to maintain the airy, breathable feel
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Lavender** (`#e8e0f0`): Gradient start colour. The left/top anchor of the background gradient.
+- **Mint Background** (`#d8f0e8`): Gradient end colour. The right/bottom anchor of the background gradient.
+- **White** (`#ffffff`): Card and container surface. The primary content background.
+- **Dark Charcoal** (`#2d2d3d`): Primary text colour. Rich and warm without being pure black.
+- **Soft Purple** (`#8b6cc7`): Primary accent. Buttons, links, key metrics, and focal-point elements.
+
+### Accent
+- **Mint** (`#5cb8a5`): Secondary accent for success states, tags, and secondary CTAs.
+- **Deep Purple** (`#6b4fa7`): Darker purple for hover/active states on interactive elements.
+- **Light Purple** (`#a78fd4`): Lighter purple for backgrounds of badges, tags, and subtle highlights.
+- **Light Mint** (`#d0f0e4`): Background tint for success messages and positive indicators.
+
+### Neutral Scale
+- **Dark Charcoal** (`#2d2d3d`): Primary text, headings, and high-emphasis labels.
+- **Charcoal** (`#4a4a5a`): Secondary text for descriptions and supporting copy.
+- **Warm Gray** (`#6b6b7a`): Tertiary text for timestamps, metadata, and captions.
+- **Medium Gray** (`#9a9aaa`): Placeholder text, disabled labels, and de-emphasized content.
+- **Light Gray** (`#c8c8d4`): Borders, dividers, and subtle UI lines.
+- **Pale Gray** (`#f0eef4`): Subtle surface tint for hover states on white cards.
+
+### Surface & Borders
+- **Surface Primary** (`#ffffff`): Card and container background.
+- **Surface Tinted** (`#f8f5fc`): Lightly purple-tinted surface for featured or highlighted cards.
+- **Surface Gradient** (`linear-gradient(135deg, #e8e0f0, #d8f0e8)`): Page-level background.
+- **Border Default** (`rgba(45,45,61,0.1)`): Standard border for cards and containers.
+- **Border Accent** (`rgba(139,108,199,0.3)`): Purple-tinted border for active or featured elements.
+- **Border Light** (`rgba(45,45,61,0.06)`): Subtle divider for list items and table rows.
+
+### Shadow Colors
+- **Shadow Purple** (`rgba(139,108,199,0.08)`): Primary shadow -- purple-tinted ambient glow for on-palette elevation.
+- **Shadow Medium** (`rgba(139,108,199,0.12)`): Medium elevation for featured cards and hover states.
+- **Shadow Soft** (`rgba(45,45,61,0.06)`): Neutral soft shadow for subtle depth.
+- **Shadow Deep** (`rgba(45,45,61,0.15)`): Deep shadow for modals and overlays.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Plus Jakarta Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Body**: `'Plus Jakarta Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Plus Jakarta Sans | 64px | 700 | 1.10 | -1px | Hero headlines, cover statements |
+| Section Heading | Plus Jakarta Sans | 40px | 700 | 1.15 | -0.5px | Major section titles |
+| Sub-heading | Plus Jakarta Sans | 28px | 600 | 1.20 | -0.25px | Card headings, subsection titles |
+| Body Large | Plus Jakarta Sans | 20px | 500 | 1.60 | 0px | Lead paragraphs, introductions |
+| Body | Plus Jakarta Sans | 16px | 400 | 1.65 | 0px | Standard reading text |
+| Small / Caption | Plus Jakarta Sans | 13px | 500 | 1.50 | 0.2px | Metadata, timestamps, captions |
+| Big Numbers | Plus Jakarta Sans | 56px | 700 | 1.00 | -0.5px | Statistics, key metrics |
+| Label | Plus Jakarta Sans | 13px | 600 | 1.00 | 0.5px | Uppercase tag labels, category markers |
+| CTA Text | Plus Jakarta Sans | 15px | 600 | 1.00 | 0.3px | Button text |
+
+### Principles
+- **One family, many weights**: Plus Jakarta Sans handles every role. Hierarchy is created through size and weight variation, not font-family contrast.
+- **Medium weights for body**: Weight 400-500 for body text keeps the reading experience warm and approachable. Avoid weight 300 -- it feels too thin for this friendly style.
+- **Bold for display only**: Weight 700 is reserved for display headings (28px+) and big numbers. Do not use 700 for body text or small labels.
+- **Relaxed line heights**: 1.60-1.65 for body text creates an open, breathable reading rhythm that matches the airy visual theme.
+- **Uppercase sparingly**: Reserve uppercase + letter-spacing for small labels and category markers only. Headlines and body text are always mixed case.
+
+## 4. Component Patterns
+
+### Title Block (Cover / Header Section)
+
+```html
+<div style="background: linear-gradient(135deg, #e8e0f0, #d8f0e8); padding: 80px 60px; text-align: center;">
+  <div style="display: inline-block; background: rgba(139,108,199,0.12); border-radius: 24px; padding: 6px 20px; margin-bottom: 24px;">
+    <span style="font-family: var(--font-body); font-size: 13px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; color: var(--color-purple);">Introducing</span>
+  </div>
+  <h1 style="font-family: var(--font-display); font-size: 64px; font-weight: 700; line-height: 1.10; letter-spacing: -1px; color: var(--color-charcoal); margin: 0 0 20px;">Your AI Team,<br>Always On</h1>
+  <p style="font-family: var(--font-body); font-size: 20px; font-weight: 500; line-height: 1.60; color: var(--color-secondary-text); max-width: 560px; margin: 0 auto;">Deploy intelligent coworkers that handle research, drafting, and coordination while you focus on what matters.</p>
+</div>
+```
+
+### Feature Card
+
+```html
+<div style="background: var(--color-white); border-radius: 20px; padding: 40px 32px; box-shadow: 0px 4px 20px rgba(139,108,199,0.08); border: 1px solid rgba(45,45,61,0.06);">
+  <div style="width: 48px; height: 48px; border-radius: 14px; background: rgba(139,108,199,0.1); display: flex; align-items: center; justify-content: center; margin-bottom: 20px;">
+    <span style="color: var(--color-purple); font-size: 22px;">&#9672;</span>
+  </div>
+  <h3 style="font-family: var(--font-display); font-size: 28px; font-weight: 600; line-height: 1.20; letter-spacing: -0.25px; color: var(--color-charcoal); margin: 0 0 12px;">Persistent Memory</h3>
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-secondary-text); margin: 0;">Every agent maintains its own filesystem, notes, and learned preferences across sessions. Context is never lost between conversations.</p>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="background: var(--color-white); border-radius: 20px; padding: 40px 32px; text-align: center; box-shadow: 0px 4px 20px rgba(139,108,199,0.08); border: 1px solid rgba(45,45,61,0.06);">
+  <p style="font-family: var(--font-display); font-size: 56px; font-weight: 700; line-height: 1.00; letter-spacing: -0.5px; color: var(--color-purple); margin: 0 0 8px;">47%</p>
+  <p style="font-family: var(--font-body); font-size: 13px; font-weight: 600; letter-spacing: 0.5px; text-transform: uppercase; color: var(--color-charcoal); margin: 0 0 12px;">Faster Response</p>
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-secondary-text); max-width: 280px; margin: 0 auto;">Teams using AI coworkers respond to inbound leads nearly twice as fast as manual workflows.</p>
+</div>
+```
+
+### Comparison Grid
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+  <div style="background: var(--color-white); border-radius: 20px; padding: 40px 32px; box-shadow: 0px 4px 20px rgba(139,108,199,0.08); border: 1px solid rgba(45,45,61,0.06);">
+    <div style="display: inline-block; background: rgba(45,45,61,0.06); border-radius: 24px; padding: 4px 14px; margin-bottom: 16px;">
+      <span style="font-family: var(--font-body); font-size: 13px; font-weight: 500; color: var(--color-warm-gray);">Without Goose</span>
+    </div>
+    <h3 style="font-family: var(--font-display); font-size: 28px; font-weight: 600; line-height: 1.20; letter-spacing: -0.25px; color: var(--color-charcoal); margin: 0 0 12px;">Manual & Fragmented</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-secondary-text); margin: 0;">Teams juggle Slack threads, spreadsheets, and context-switching between a dozen tabs to coordinate basic workflows.</p>
+  </div>
+  <div style="background: var(--color-white); border-radius: 20px; padding: 40px 32px; box-shadow: 0px 4px 20px rgba(139,108,199,0.08); border: 2px solid rgba(139,108,199,0.3);">
+    <div style="display: inline-block; background: rgba(139,108,199,0.1); border-radius: 24px; padding: 4px 14px; margin-bottom: 16px;">
+      <span style="font-family: var(--font-body); font-size: 13px; font-weight: 600; color: var(--color-purple);">With Goose</span>
+    </div>
+    <h3 style="font-family: var(--font-display); font-size: 28px; font-weight: 600; line-height: 1.20; letter-spacing: -0.25px; color: var(--color-charcoal); margin: 0 0 12px;">Orchestrated & Autonomous</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-secondary-text); margin: 0;">AI coworkers handle research, drafting, and follow-up autonomously. Your team focuses on decisions, not busywork.</p>
+  </div>
+</div>
+```
+
+### List Item
+
+```html
+<div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0; border-bottom: 1px solid rgba(45,45,61,0.06);">
+  <div style="width: 40px; height: 40px; min-width: 40px; display: flex; align-items: center; justify-content: center; background: rgba(139,108,199,0.1); border-radius: 12px; color: var(--color-purple); font-size: 18px;">&#10003;</div>
+  <div>
+    <h4 style="font-family: var(--font-display); font-size: 20px; font-weight: 600; line-height: 1.25; color: var(--color-charcoal); margin: 0 0 6px;">Multi-Channel Access</h4>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.65; color: var(--color-secondary-text); margin: 0;">Reach your AI coworkers through Slack, Telegram, WhatsApp, or the web -- wherever your team already works.</p>
+  </div>
+</div>
+```
+
+### Quote Block
+
+```html
+<div style="background: var(--color-white); border-radius: 20px; padding: 40px 32px; border-left: 4px solid var(--color-purple); box-shadow: 0px 4px 20px rgba(139,108,199,0.08);">
+  <p style="font-family: var(--font-display); font-size: 24px; font-weight: 500; font-style: italic; line-height: 1.45; color: var(--color-charcoal); margin: 0 0 20px;">"It felt less like configuring software and more like onboarding a new team member."</p>
+  <div style="display: flex; align-items: center; gap: 12px;">
+    <div style="width: 36px; height: 36px; border-radius: 50%; background: linear-gradient(135deg, #8b6cc7, #5cb8a5);"></div>
+    <div>
+      <p style="font-family: var(--font-body); font-size: 15px; font-weight: 600; color: var(--color-charcoal); margin: 0;">Sarah Chen</p>
+      <p style="font-family: var(--font-body); font-size: 13px; font-weight: 500; color: var(--color-warm-gray); margin: 0;">VP Operations, Acme Corp</p>
+    </div>
+  </div>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="text-align: center; padding: 60px 40px; background: var(--color-white); border-radius: 24px; box-shadow: 0px 8px 32px rgba(139,108,199,0.12);">
+  <h2 style="font-family: var(--font-display); font-size: 40px; font-weight: 700; line-height: 1.15; letter-spacing: -0.5px; color: var(--color-charcoal); margin: 0 0 16px;">Ready to meet your team?</h2>
+  <p style="font-family: var(--font-body); font-size: 18px; font-weight: 500; line-height: 1.60; color: var(--color-secondary-text); max-width: 480px; margin: 0 auto 32px;">Deploy your first AI coworker in under five minutes. No setup fees, no long-term commitments.</p>
+  <a style="display: inline-block; background: var(--color-purple); color: #ffffff; font-family: var(--font-body); font-size: 15px; font-weight: 600; letter-spacing: 0.3px; text-decoration: none; padding: 14px 36px; border-radius: 12px;">Get Started</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between icon and inline label.
+- **8px**: Tight gap -- between stat number and label, between tag elements.
+- **12px**: Small gap -- between heading and body text within a card.
+- **16px**: Base gap -- between body paragraphs, between compact list items.
+- **20px**: Card gap -- between cards in a grid, between icon container and text.
+- **24px**: Medium gap -- standard list item vertical padding, between grouped elements.
+- **32px**: Card padding -- internal padding for cards and containers.
+- **40px**: Section internal -- padding inside feature cards and quote blocks.
+- **48px**: Section divider -- vertical space between major content blocks.
+- **60px**: Large section padding -- hero and CTA block top/bottom padding.
+- **80px**: Maximum section padding -- cover slides and high-impact hero areas.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 48px all sides | 984px |
+| Infographic (1080xN) | 48px left/right, 60px top/bottom | 984px |
+| Slides (1920x1080) | 60px all sides | 1800px |
+| Poster (1080x1350) | 48px left/right, 60px top/bottom | 984px |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned text for body content. Center-aligned for hero titles, stats, and CTA blocks.
+- **Grid**: Use 2-column or 3-column grids for feature cards with 20px gaps. Single-column for narrative content. 2-column for comparisons.
+- **Card spacing**: 20px gap between all cards in a grid layout. Cards should feel like they are floating independently.
+- **Rounded corners**: 16-20px for cards and containers. 12px for buttons and interactive elements. 24px for pill-shaped badges.
+- **Content gravity**: On widescreen slides (1920x1080), center content with generous margins. The gradient background should be visible as a frame around the content.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, gradient background | Page canvas, base layer |
+| Resting (Level 1) | `rgba(139,108,199,0.06) 0px 2px 12px` | Subtle lift for secondary elements |
+| Card (Level 2) | `rgba(139,108,199,0.08) 0px 4px 20px, rgba(45,45,61,0.04) 0px 1px 4px` | Standard card elevation |
+| Featured (Level 3) | `rgba(139,108,199,0.12) 0px 8px 32px, rgba(45,45,61,0.06) 0px 2px 8px` | Featured cards, hover states, CTA blocks |
+| Overlay (Level 4) | `rgba(45,45,61,0.15) 0px 16px 48px` | Modals, overlays, floating panels |
+
+### Border Treatments
+- **Standard border**: `1px solid rgba(45,45,61,0.06)` -- barely visible line that defines card edges without adding visual weight.
+- **Active border**: `2px solid rgba(139,108,199,0.3)` -- purple-tinted border for featured or active containers.
+- **Divider line**: `1px solid rgba(45,45,61,0.06)` -- subtle separator for list items within cards.
+- **No heavy borders**: This style avoids visible borders wherever possible. Shadows and background contrast handle the separation.
+
+### Surface Hierarchy
+On the gradient background, elevation is communicated through whiteness and shadow:
+1. **Background** (gradient `#e8e0f0` to `#d8f0e8`) -- the coloured canvas, always visible as a frame.
+2. **Surface** (`#ffffff`) -- white cards float above the gradient, the primary content layer.
+3. **Tinted Surface** (`#f8f5fc`) -- lightly purple-tinted cards for featured or highlighted content.
+4. **Inset** (`#f0eef4`) -- recessed areas within white cards for input fields or secondary panels.
+
+Purple-tinted shadows (`rgba(139,108,199,0.06-0.12)`) maintain the colour palette in elevation effects and prevent cards from feeling disconnected from the gradient background.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use the lavender-to-mint gradient (`#e8e0f0` to `#d8f0e8`) as the page background -- it is the signature of this style.
+- Float white cards above the gradient with soft purple-tinted shadows to create the "cloud" effect.
+- Use Plus Jakarta Sans at weight 500-600 for all text -- friendly, medium-weight type is the voice of this style.
+- Apply generous border-radius (16-20px) to all cards and containers -- softness is a core design decision.
+- Use soft purple (`#8b6cc7`) as the primary accent for buttons, links, and focal metrics.
+- Use mint (`#5cb8a5`) as a secondary accent for success states, tags, and variety in multi-element layouts.
+- Use pill-shaped badges (border-radius: 24px) for labels and category markers above headlines.
+- Maintain ample white space inside and between cards -- the layout should feel open and breathable.
+- Keep shadows subtle and purple-tinted -- elevation should feel gentle, not dramatic.
+
+### Don't
+- Don't use pure black (`#000000`) for text -- always use dark charcoal (`#2d2d3d`) to keep the tone warm.
+- Don't use sharp corners (border-radius: 0-4px) on any container -- this style is defined by its softness.
+- Don't use heavy shadows or drop-shadow effects -- elevation should be gentle and barely perceptible.
+- Don't use more than 2 accent colours per slide -- soft purple and mint only. No reds, oranges, or yellows.
+- Don't use weight 700 for body text or small labels -- it breaks the friendly, approachable feel.
+- Don't use dark backgrounds -- this is a light, airy style. Even dark sections should use tinted white (`#f8f5fc`), not dark surfaces.
+- Don't use serif fonts -- Plus Jakarta Sans is the entire typographic identity. No mixing with serif faces.
+- Don't crowd cards together -- minimum 20px gap between all card elements. Space is a feature.
+- Don't use hard borders (2px+ solid dark lines) -- borders should be nearly invisible or accent-coloured.
+- Don't use flat, unshadowed cards directly on the gradient -- every card needs at least Level 1 shadow to float.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale down**: Display Hero becomes 48px (from 64px). Section Heading becomes 32px. Sub-heading stays 28px. Body stays 16px.
+- **Padding**: 48px on all sides. Content area is 984x984px.
+- **Cover slide**: Title centered vertically and horizontally. Pill badge above the headline. Subtitle below in secondary text colour.
+- **Content slides**: White card centered on the gradient background with 32px internal padding. One concept per slide.
+- **Stat slides**: Single stat centered within a white card. Big number in purple, label below.
+- **Swipe indicator**: Small purple dots at bottom center, 8px diameter, 12px gap. Active dot filled, others 30% opacity.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Uses full-scale type hierarchy. Display Hero at 64px for the title section.
+- **Padding**: 48px left/right. 60px top/bottom margins.
+- **Section spacing**: 48px vertical gap between major sections. White cards contain each section, floating on the gradient.
+- **Vertical rhythm**: Alternate between feature cards (2-column grid) and full-width sections (stats, quotes, CTAs). Each major block is its own white card.
+- **Footer**: Secondary text, 13px Plus Jakarta Sans, centered, with a subtle purple-tinted rule above.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 72px. Section Heading becomes 48px. Body Large becomes 22px.
+- **Padding**: 60px on all sides. Content area is 1800x960px.
+- **Layout**: Centered composition. White cards are the primary content containers, floated on the gradient.
+- **Title slides**: Headline centered on frame. Pill badge above. Subtitle below.
+- **Content slides**: 2-3 feature cards in a row for comparisons. Single large card for narrative content.
+- **Stat slides**: Up to 3 stat cards in a row with 20px gaps, evenly spaced.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 56px. Section Heading at 36px. Body at 16px.
+- **Padding**: 48px left/right, 60px top/bottom.
+- **Composition**: Top third for hero headline in a white card. Middle third for feature cards (2-column grid) or stat displays. Bottom third for CTA card.
+- **Vertical flow**: Content reads top-to-bottom with clear card separation. The gradient background acts as the connecting tissue between floating card sections.
+- **CTA placement**: Always in its own white card at the bottom, with a prominent purple button centered.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Hero becomes 64px in Plus Jakarta Sans 600 (approximately 30% larger than Carousel 48px). Section Heading becomes 44px. Body Large becomes 22px in Plus Jakarta Sans 500. Big numbers for metrics become 72-80px in soft purple.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical text must sit inside y=160 to y=1760.
+- **Layout**: Single centered column. Content max-width 920px. Vertical center of gravity -- cluster hero content in y=400 to y=1500 range. The signature lavender-to-mint pastel gradient (`linear-gradient(160deg, #e8e0f0 0%, #d8f0e8 100%)`) runs the full vertical -- now a dreamy sky from soft purple morning to mint afternoon.
+- **Cover slide**: A single tall white card (`#ffffff`, 20px radius, soft purple-tinted shadow `0 16px 48px rgba(139,108,199,0.1)`) centered in the safe zone. Inside the card, Plus Jakarta Sans 600 headline at 64px in dark charcoal, weight-500 subtitle at 22px below. Generous internal padding (48px) preserves the airy feel.
+- **Content slides**: One white cloud-card per slide floating mid-frame. Inside: a purple (`#8b6cc7`) or mint (`#5cb8a5`) big number at 72-80px as the hero element, a Plus Jakarta Sans 600 sub-heading at 36-40px, and body at 22px weight 500. Mint accents for success indicators, purple for focal stats. Shadows stay soft and purple-tinted throughout.
+- **CTA slide**: Its own cloud-card at the middle of the safe zone. Plus Jakarta Sans 600 headline at 52px, short supporting body, and a prominent purple (`#8b6cc7`) pill button with generous 16px radius and white Plus Jakarta Sans 600 CTA text. Optional mint checkmark indicator nearby.
+- **Progress indicator**: Soft pill-shaped segments at the top of the safe zone, 4px tall with full radius -- inactive in `rgba(45,45,61,0.15)`, active in soft purple (`#8b6cc7`). The rounded shape matches the cloud-card vocabulary -- nothing sharp survives in this style.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Lavender | `#e8e0f0` | Gradient start (background) |
+| Mint Background | `#d8f0e8` | Gradient end (background) |
+| White | `#ffffff` | Card and container surface |
+| Dark Charcoal | `#2d2d3d` | Primary text |
+| Soft Purple | `#8b6cc7` | Accent: buttons, links, stats, focal points |
+| Mint | `#5cb8a5` | Secondary accent: success, tags, secondary CTA |
+| Deep Purple | `#6b4fa7` | Hover/active state for purple elements |
+| Light Purple | `#a78fd4` | Badge backgrounds, subtle highlights |
+| Light Mint | `#d0f0e4` | Success message backgrounds |
+| Charcoal | `#4a4a5a` | Secondary text, descriptions |
+| Warm Gray | `#6b6b7a` | Tertiary text, metadata |
+| Medium Gray | `#9a9aaa` | Placeholder, disabled text |
+| Light Gray | `#c8c8d4` | Borders, dividers |
+| Pale Gray | `#f0eef4` | Hover surface on white cards |
+| Tinted Surface | `#f8f5fc` | Featured card backgrounds |
+
+### Font Declarations
+
+```css
+font-family: 'Plus Jakarta Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-lavender: #e8e0f0;
+  --color-mint-bg: #d8f0e8;
+  --color-white: #ffffff;
+  --color-charcoal: #2d2d3d;
+  --color-purple: #8b6cc7;
+
+  /* Colors -- Accent */
+  --color-mint: #5cb8a5;
+  --color-deep-purple: #6b4fa7;
+  --color-light-purple: #a78fd4;
+  --color-light-mint: #d0f0e4;
+
+  /* Colors -- Neutral Scale */
+  --color-secondary-text: #4a4a5a;
+  --color-warm-gray: #6b6b7a;
+  --color-medium-gray: #9a9aaa;
+  --color-light-gray: #c8c8d4;
+  --color-pale-gray: #f0eef4;
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: #ffffff;
+  --color-surface-tinted: #f8f5fc;
+  --color-surface-gradient: linear-gradient(135deg, #e8e0f0, #d8f0e8);
+
+  /* Colors -- Borders */
+  --color-border-default: rgba(45, 45, 61, 0.06);
+  --color-border-accent: rgba(139, 108, 199, 0.3);
+  --color-border-light: rgba(45, 45, 61, 0.06);
+
+  /* Colors -- Shadows */
+  --shadow-purple: rgba(139, 108, 199, 0.08);
+  --shadow-purple-medium: rgba(139, 108, 199, 0.12);
+  --shadow-soft: rgba(45, 45, 61, 0.06);
+  --shadow-deep: rgba(45, 45, 61, 0.15);
+
+  /* Typography -- Families */
+  --font-display: 'Plus Jakarta Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-body: 'Plus Jakarta Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 64px;
+  --text-section-heading: 40px;
+  --text-sub-heading: 28px;
+  --text-body-large: 20px;
+  --text-body: 16px;
+  --text-small: 13px;
+  --text-big-number: 56px;
+  --text-label: 13px;
+  --text-cta: 15px;
+
+  /* Typography -- Weights */
+  --weight-display: 700;
+  --weight-heading: 600;
+  --weight-body-medium: 500;
+  --weight-body: 400;
+  --weight-label: 600;
+
+  /* Typography -- Line Heights */
+  --leading-display: 1.10;
+  --leading-heading: 1.15;
+  --leading-sub-heading: 1.20;
+  --leading-body-large: 1.60;
+  --leading-body: 1.65;
+  --leading-small: 1.50;
+  --leading-number: 1.00;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-card-gap: 20px;
+  --space-medium: 24px;
+  --space-card-padding: 32px;
+  --space-large: 40px;
+  --space-section: 48px;
+  --space-hero: 60px;
+  --space-max: 80px;
+
+  /* Borders */
+  --radius-card: 20px;
+  --radius-button: 12px;
+  --radius-pill: 24px;
+  --radius-icon: 14px;
+
+  /* Shadows -- Composed */
+  --shadow-card: rgba(139,108,199,0.08) 0px 4px 20px, rgba(45,45,61,0.04) 0px 1px 4px;
+  --shadow-featured: rgba(139,108,199,0.12) 0px 8px 32px, rgba(45,45,61,0.06) 0px 2px 8px;
+}
+```
+
+### System Font Fallbacks
+- **Sans-serif (if Plus Jakarta Sans fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/_full/split-yellow-product.md
+++ b/skills/composites/goose-graphics/styles/_full/split-yellow-product.md
@@ -1,0 +1,501 @@
+# Design Style: Split Yellow Product
+
+## 1. Visual Theme & Atmosphere
+
+Split Yellow Product is the design language of the contemporary product poster — a distilled marketing artifact inspired by modernist European furniture advertising and the confident editorial layouts found in magazines like Apartamento, Kinfolk's product reviews, and IKEA campaign posters. It is the visual equivalent of a product landing page collapsed into a single still frame: one booming headline, one crisp paragraph of voice, one clean hero shot, and nothing else. The defining move is a rigid 2/3 + 1/3 split of the canvas — the top two-thirds is a saturated mustard yellow block carrying a massive three-line headline, and the bottom third is subdivided horizontally into a warm gray body-copy panel and a darker olive-yellow panel holding the product photo.
+
+The palette is deliberately restricted: a single dominant vivid mustard yellow (`#f4d624`) drives the composition, paired with a warm pale gray (`#e8e5dd`) that cools the bottom-left quadrant just enough to give the body copy breathing room, a darker yellow-to-olive gradient (`#e5c51a` → `#b59a00`) behind the product to create depth without introducing a new hue, and a near-black (`#141414`) that carries every piece of text. There is no white anywhere in the composition — the warm gray replaces it and keeps the temperature consistently warm. Inter at weight 900 handles the headline at 88-96px, left-aligned and slightly tucked into the top-left corner, treated as architecture rather than text. Inter 500 handles the body copy in the gray panel, and Inter 700 tracked uppercase handles the small brand wordmark anchored at the bottom-left corner. A single typeface family, one dominant color, and one structural grid — that is the entire style.
+
+The mood is confident, catalog-grade, and Scandinavian-adjacent: it feels like a product ad torn from a design quarterly, a limited-edition furniture drop, or the cover of a lighting showroom's seasonal lookbook. It rejects minimalist neutrality in favor of a single assertive brand color, and it rejects maximalist collage in favor of a single architectural grid. The tension between the shouting headline on the top yellow slab and the quiet caption on the bottom gray panel is what makes it memorable — it reads like a poster that knows exactly what it wants to say.
+
+**Key Characteristics:**
+- Vivid mustard yellow (`#f4d624`) as the dominant surface — covers roughly 60% of the canvas in the top block and the bottom-right product panel
+- Warm pale gray (`#e8e5dd`) for the body-copy panel — cools the composition without introducing white
+- Near-black (`#141414`) for all text — headline and body — never pure black
+- Inter 900 for the massive headline at 88-96px with slightly negative tracking (-2px)
+- Inter 500 for body copy at 20-22px in near-black on the warm gray panel
+- Inter 700 tracked uppercase for the small bottom-left brand wordmark
+- Rigid 2/3 top + 1/3 bottom split, with the bottom subdivided roughly 45/55 into gray panel (left) + dark yellow panel (right)
+- Darkening yellow gradient (`#e5c51a` → `#b59a00`) as the backdrop for product photography — yellow fading into olive at the bottom of the panel
+- Left-aligned headline with top and left padding of 60-80px — the headline hugs the top-left corner
+- No rounded corners, no shadows, no borders — structure comes entirely from the panel split and the flat color blocks
+- Single product photo centered within the dark-yellow panel, occupying roughly 65-75% of the panel's height
+- Brand wordmark set in two stacked lines, tracked 2-3px uppercase, anchored to the bottom-left corner with 40-60px padding
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Vivid Yellow** (`#f4d624`): The dominant surface color. Fills the entire top 2/3 of the canvas and serves as the starting point of the product photo gradient. This is a saturated school-bus/mustard yellow — vivid, warm, and unapologetic.
+- **Near-Black** (`#141414`): The only text color in the composition. Used for the massive headline on the yellow block, for body copy on the gray panel, and for the brand wordmark. Never pure black — the slight warmth keeps it aligned with the palette.
+- **Warm Pale Gray** (`#e8e5dd`): The body-copy panel background. A desaturated warm gray that cools the bottom-left quadrant just enough to let the body copy sit quietly while the rest of the poster shouts. Replaces white entirely in the composition.
+
+### Accent
+- **Dark Mustard** (`#e5c51a`): Top of the product photo gradient. A slightly darker, earthier yellow that connects the primary yellow block to the olive bottom without introducing a new hue.
+- **Olive** (`#b59a00`): Bottom of the product photo gradient. A desaturated olive-yellow that grounds the product photo and gives it visual weight at the base of the composition.
+- **Yellow-Hover** (`#e8c91a`): Slightly darker mustard for hover/active states when this style is adapted to web. Keeps interactivity on-palette.
+
+### Neutral Scale
+- **Gray Panel** (`#e8e5dd`): Primary warm gray for body-copy panel.
+- **Gray Deep** (`#d9d6ce`): Slightly darker gray for subtle panel dividers or secondary surfaces.
+- **Gray Text Secondary** (`#3a3a38`): For secondary metadata or lower-priority labels on the gray panel.
+- **Gray Border** (`rgba(20, 20, 20, 0.12)`): Barely-there border for dividing adjacent panels if needed.
+- **Muted Text** (`rgba(20, 20, 20, 0.55)`): Captions, attributions, footnote text.
+- **Tracked Wordmark** (`#141414`): The bottom-left brand wordmark color — same as primary text.
+
+### Surface & Borders
+- **Surface Yellow** (`#f4d624`): Primary yellow block. Flat, no gradient.
+- **Surface Gray** (`#e8e5dd`): Body-copy panel.
+- **Surface Gradient Start** (`#e5c51a`): Top of the product photo panel.
+- **Surface Gradient End** (`#b59a00`): Bottom of the product photo panel.
+- **Border Default** (`rgba(20, 20, 20, 0.12)`): Optional hairline if two panels need a visible seam — in most compositions, panels butt directly against each other with no visible border.
+- **Panel Seam** (`rgba(20, 20, 20, 0.08)`): The subtle divider between the yellow top block and the bottom split. Usually invisible — the color contrast does the work.
+- **Divider Rule** (`rgba(20, 20, 20, 0.15)`): Thin rule for separating content within the gray panel if needed.
+
+### Shadow Colors
+- **Shadow None**: This style uses flat color blocks with no shadows. Depth comes entirely from the gradient in the product panel.
+- **Shadow Product** (`rgba(120, 100, 0, 0.35)`): If the product photo needs a subtle cast shadow at its base, use this warm olive shadow tone — never a cool gray shadow.
+- **Shadow Deep** (`rgba(40, 35, 0, 0.40)`): Deep olive shadow for the bottom of the product photo gradient, blending into the gradient.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;900&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Body**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+Single family, four weights — 400, 500, 700, 900. The entire type system is Inter.
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Inter | 92px | 900 | 0.95 | -2px | Massive headline on yellow block. Usually 3 lines. Slightly negative tracking tightens the heavy letterforms. |
+| Display Small | Inter | 72px | 900 | 0.98 | -1.5px | Shorter 2-line headlines or smaller format variants. |
+| Section Heading | Inter | 48px | 900 | 1.00 | -1px | Sub-headlines inside the gray panel or carousel slides. |
+| Sub-heading | Inter | 28px | 700 | 1.15 | -0.3px | Section titles within body content. |
+| Body Large | Inter | 22px | 500 | 1.45 | 0px | Lead paragraphs and primary body copy in the gray panel. |
+| Body | Inter | 20px | 500 | 1.50 | 0px | Standard body copy — 5-7 lines in the bottom gray panel. Inter 500 is the default voice weight. |
+| Body Bold | Inter | 20px | 700 | 1.50 | 0px | Emphasis within body paragraphs. |
+| Small / Caption | Inter | 14px | 500 | 1.45 | 0.2px | Metadata, image credits, dates. |
+| Big Numbers | Inter | 96px | 900 | 0.95 | -2.5px | Statistics, pricing, large data points. |
+| Wordmark | Inter | 14px | 700 | 1.10 | 2.5px | Uppercase, tracked, stacked 2 lines. Brand mark anchored bottom-left. |
+| CTA Text | Inter | 16px | 700 | 1.00 | 0.4px | Button text. Uppercase optional. |
+
+### Principles
+- **Single family, strict weight steps**: Inter handles everything. The distance between weight 500 and weight 900 does all the hierarchical work — there is no need for a second font family to create contrast.
+- **Massive display, quiet body**: The headline at 92px Inter 900 and the body at 20px Inter 500 are the two typographic poles of the composition. Everything else is either support for or a variant on one of these two.
+- **Negative tracking on heavy weights**: Inter 900 at display sizes needs slightly negative tracking (-1 to -2px) to prevent the heavy letterforms from looking loose. At body sizes, tracking is 0.
+- **Left-aligned everything**: Both the headline and the body copy are left-aligned. Center alignment breaks the grid. The wordmark is anchored bottom-left, not centered.
+- **Uppercase only for the wordmark**: The only uppercase element in this style is the tracked brand wordmark at the bottom-left. Headlines and body are always mixed case.
+- **Line height tightens with weight**: Display Hero runs at 0.95 line height (tight, so the three lines stack like a slab). Body runs at 1.50 (airy, so 6-7 lines in a small panel remain readable).
+
+## 4. Component Patterns
+
+### Split Block Container (Signature Layout)
+
+The structural backbone of the style. A rigid 2/3 + 1/3 grid where the top block is a single yellow slab and the bottom is subdivided into a gray body panel and a dark-yellow product panel.
+
+```html
+<div style="width: 1080px; height: 1350px; display: grid; grid-template-rows: 60% 40%; background: var(--color-yellow);">
+  <!-- TOP: Yellow headline block -->
+  <div style="background: var(--color-yellow); padding: 72px 72px 48px 72px; display: flex; align-items: flex-start;">
+    <h1 style="font-family: var(--font-display); font-size: 92px; font-weight: 900; line-height: 0.95; letter-spacing: -2px; color: var(--color-near-black); margin: 0; max-width: 940px;">Where<br>design meets<br>atmosphere.</h1>
+  </div>
+  <!-- BOTTOM: Split into gray + dark yellow -->
+  <div style="display: grid; grid-template-columns: 45% 55%; background: var(--color-gray-panel);">
+    <!-- Bottom-left: Gray body panel -->
+    <div style="background: var(--color-gray-panel); padding: 60px 40px 60px 72px; position: relative; display: flex; flex-direction: column; justify-content: space-between;">
+      <p style="font-family: var(--font-body); font-size: 20px; font-weight: 500; line-height: 1.50; color: var(--color-near-black); margin: 0;">A statement lamp designed to transform your space. Sculptural shape, warm ambient glow, timeless elegance.</p>
+      <div style="font-family: var(--font-body); font-size: 14px; font-weight: 700; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-near-black); line-height: 1.10;">FORMA<br>LIGHTS</div>
+    </div>
+    <!-- Bottom-right: Dark yellow product panel -->
+    <div style="background: linear-gradient(180deg, var(--color-gradient-start) 0%, var(--color-gradient-end) 100%); padding: 40px; display: flex; align-items: center; justify-content: center; position: relative; overflow: hidden;">
+      <img src="[product-image]" alt="Product" style="max-width: 70%; max-height: 85%; object-fit: contain;" />
+    </div>
+  </div>
+</div>
+```
+
+### Massive Yellow Headline Block
+
+The signature headline treatment. Inter 900 at 92px, left-aligned with generous top padding, sitting on the primary yellow surface. The headline is the loudest element on the page and must dominate the top 60% of the canvas.
+
+```html
+<div style="background: var(--color-yellow); padding: 72px 72px 48px 72px; min-height: 60%;">
+  <h1 style="font-family: var(--font-display); font-size: 92px; font-weight: 900; line-height: 0.95; letter-spacing: -2px; color: var(--color-near-black); margin: 0; max-width: 940px;">Where<br>design meets<br>atmosphere.</h1>
+</div>
+```
+
+### Body Panel (Gray) with Wordmark
+
+Warm pale gray body copy container with the brand wordmark anchored to the bottom-left corner. The body copy sits in the top portion of the panel and the wordmark anchors the bottom — the two elements are vertically spread using `justify-content: space-between`.
+
+```html
+<div style="background: var(--color-gray-panel); padding: 60px 40px 60px 72px; display: flex; flex-direction: column; justify-content: space-between; height: 100%;">
+  <p style="font-family: var(--font-body); font-size: 20px; font-weight: 500; line-height: 1.50; color: var(--color-near-black); margin: 0; max-width: 320px;">A statement lamp designed to transform your space. Sculptural shape, warm ambient glow, timeless elegance.</p>
+  <div style="font-family: var(--font-body); font-size: 14px; font-weight: 700; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-near-black); line-height: 1.10;">FORMA<br>LIGHTS</div>
+</div>
+```
+
+### Product Photo Panel (Dark Yellow)
+
+A darker yellow-to-olive gradient panel holding a centered product photograph. The gradient runs top-to-bottom: vivid mustard at the top blending into olive at the bottom. The product photo sits centered, occupying roughly 65-75% of the panel's vertical height.
+
+```html
+<div style="background: linear-gradient(180deg, var(--color-gradient-start) 0%, var(--color-gradient-end) 100%); display: flex; align-items: center; justify-content: center; padding: 40px; position: relative; overflow: hidden; height: 100%;">
+  <img src="[product-image]" alt="Product hero" style="max-width: 72%; max-height: 80%; object-fit: contain; display: block;" />
+</div>
+```
+
+### Numbered Item (Content Carousel Slide)
+
+For content carousel slides that need numbered framework steps — numbers set large in Inter 900 on the yellow background with headline and body below.
+
+```html
+<div style="background: var(--color-yellow); padding: 72px; display: flex; flex-direction: column; gap: 24px;">
+  <div style="font-family: var(--font-display); font-size: 120px; font-weight: 900; line-height: 0.85; letter-spacing: -3px; color: var(--color-near-black); margin: 0;">01</div>
+  <h2 style="font-family: var(--font-display); font-size: 56px; font-weight: 900; line-height: 1.00; letter-spacing: -1px; color: var(--color-near-black); margin: 0; max-width: 720px;">Design that fills the room.</h2>
+  <p style="font-family: var(--font-body); font-size: 22px; font-weight: 500; line-height: 1.45; color: var(--color-near-black); margin: 0; max-width: 620px;">Sculptural forms that define the atmosphere of a space without demanding attention.</p>
+</div>
+```
+
+### Stat Display
+
+A statistic presented in Inter 900 at display size on the yellow block, with a small supporting label below. Used for hero metrics or pricing callouts.
+
+```html
+<div style="background: var(--color-yellow); padding: 80px 72px; text-align: left;">
+  <div style="font-family: var(--font-display); font-size: 160px; font-weight: 900; line-height: 0.90; letter-spacing: -4px; color: var(--color-near-black); margin: 0 0 16px;">86%</div>
+  <p style="font-family: var(--font-body); font-size: 20px; font-weight: 500; line-height: 1.45; color: var(--color-near-black); margin: 0; max-width: 480px;">of customers say the lamp transformed how their space feels at night.</p>
+</div>
+```
+
+### Comparison Grid (2-Column)
+
+Two panels side-by-side, each with a heavy heading and body copy. Used for before/after, product variants, or feature comparison. One panel yellow, one panel gray — using the signature color split.
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; width: 100%; min-height: 520px;">
+  <div style="background: var(--color-yellow); padding: 60px 48px; display: flex; flex-direction: column; justify-content: flex-end;">
+    <h3 style="font-family: var(--font-display); font-size: 56px; font-weight: 900; line-height: 0.98; letter-spacing: -1px; color: var(--color-near-black); margin: 0 0 20px;">Warm glow</h3>
+    <p style="font-family: var(--font-body); font-size: 20px; font-weight: 500; line-height: 1.50; color: var(--color-near-black); margin: 0;">2700K amber output tuned for evening ambient lighting in living rooms and bedrooms.</p>
+  </div>
+  <div style="background: var(--color-gray-panel); padding: 60px 48px; display: flex; flex-direction: column; justify-content: flex-end;">
+    <h3 style="font-family: var(--font-display); font-size: 56px; font-weight: 900; line-height: 0.98; letter-spacing: -1px; color: var(--color-near-black); margin: 0 0 20px;">Cool focus</h3>
+    <p style="font-family: var(--font-body); font-size: 20px; font-weight: 500; line-height: 1.50; color: var(--color-near-black); margin: 0;">4000K neutral output tuned for reading, working, and task lighting in studios.</p>
+  </div>
+</div>
+```
+
+### Quote Block
+
+A pull quote set in Inter 700 at display size on the yellow block, with the attribution in tracked uppercase below. No quotation marks — the weight and size carry the emphasis.
+
+```html
+<div style="background: var(--color-yellow); padding: 80px 72px;">
+  <p style="font-family: var(--font-display); font-size: 52px; font-weight: 900; line-height: 1.05; letter-spacing: -0.8px; color: var(--color-near-black); margin: 0 0 40px; max-width: 900px;">It felt less like turning on a light and more like changing the temperature of the room.</p>
+  <div style="font-family: var(--font-body); font-size: 14px; font-weight: 700; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-near-black); line-height: 1.10;">SARAH CHEN<br>DESIGN DIRECTOR</div>
+</div>
+```
+
+### CTA Block
+
+A call-to-action using the signature split grid — headline on the yellow top, CTA button anchored in the gray bottom panel. The button is near-black with yellow text, inverting the main palette.
+
+```html
+<div style="display: grid; grid-template-rows: 65% 35%; width: 100%; height: 100%;">
+  <div style="background: var(--color-yellow); padding: 72px 72px 40px 72px;">
+    <h2 style="font-family: var(--font-display); font-size: 88px; font-weight: 900; line-height: 0.95; letter-spacing: -1.8px; color: var(--color-near-black); margin: 0;">Light your<br>space today.</h2>
+  </div>
+  <div style="background: var(--color-gray-panel); padding: 48px 72px; display: flex; align-items: center; justify-content: space-between;">
+    <p style="font-family: var(--font-body); font-size: 20px; font-weight: 500; line-height: 1.45; color: var(--color-near-black); margin: 0; max-width: 360px;">Free shipping on orders over $200. Lifetime warranty.</p>
+    <a style="display: inline-block; background: var(--color-near-black); color: var(--color-yellow); font-family: var(--font-body); font-size: 16px; font-weight: 700; letter-spacing: 0.4px; text-decoration: none; padding: 22px 48px; text-transform: uppercase;">Shop now</a>
+  </div>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap — between inline label and icon.
+- **8px**: Tight gap — between stacked wordmark lines.
+- **16px**: Base gap — between body paragraphs.
+- **24px**: Small gap — between headline and body on carousel slides.
+- **32px**: Medium gap — between section elements.
+- **40px**: Panel inner spacing — padding inside the gray or dark yellow panels (top/bottom).
+- **48px**: Block separation — vertical space between stacked content blocks.
+- **60px**: Panel padding — standard horizontal padding inside the gray body panel.
+- **72px**: Canvas padding — standard outer padding for poster and carousel formats (left/right, top).
+- **80px**: Large outer padding — slides and hero sections.
+- **120px**: Story format outer padding (top/bottom) — vertical safe zone for 1080x1920.
+
+### Format Padding
+| Format | Outer Padding | Top Block Height | Bottom Split |
+|--------|---------------|------------------|--------------|
+| Carousel (1080x1080) | 60px edges | 55% yellow | 45% (45/55 gray/dark-yellow) |
+| Infographic (1080xN) | 60px left/right, 72px top/bottom | Variable | Stacked vertical sections |
+| Slides (1920x1080) | 80px all sides | 60% yellow | 40% (45/55 gray/dark-yellow) |
+| Poster (1080x1350) | 72px left/right, 72px top / 60px bottom | 58% yellow | 42% (45/55 gray/dark-yellow) |
+| Story (1080x1920) | 120px top/bottom, 60px left/right | 55% yellow | 45% (45/55 gray/dark-yellow), hero ~30% bigger |
+
+### Alignment & Grid
+- **Primary alignment**: Everything is left-aligned. Headlines hug the top-left corner of the yellow block. Body copy sits against the left edge of the gray panel. The brand wordmark anchors the bottom-left. There is no center-aligned content in this style.
+- **Grid**: The signature 2/3 top + 1/3 bottom split with the bottom subdivided 45/55 (gray panel / dark yellow panel) is the defining layout. The top yellow block is always a single undivided slab. The bottom is always split horizontally into exactly two panels. Three panels in the split breaks the style.
+- **Headline placement**: The headline is left-aligned with top padding of ~72px and left padding of ~72px. It occupies up to 85% of the yellow block's width and hugs the top — never center-aligned vertically within the block.
+- **Body panel gravity**: Body copy sits at the top of the gray panel with 60px top padding. The brand wordmark anchors the bottom-left with 60px bottom padding. The two are vertically spread with `justify-content: space-between`.
+- **Product photo gravity**: The product photo is centered both horizontally and vertically within the dark yellow panel, occupying 65-75% of the panel's dimensions. The gradient behind it darkens from top to bottom to push the product photo toward the bottom visually.
+- **Panel seams**: Panels butt directly against each other with no visible border. The color contrast between the yellow, gray, and dark yellow panels creates the structural separation.
+- **Vertical rhythm**: The three elements of the composition — headline, body, product — each occupy their own distinct panel. Do not mix them. Do not add a fourth panel.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, flat color block | Yellow block, gray panel — all top-level surfaces |
+| Gradient (Level 1) | `linear-gradient(180deg, #e5c51a 0%, #b59a00 100%)` | Product photo panel background only |
+| Product Shadow (Level 2) | `0 20px 40px rgba(120, 100, 0, 0.35)` | Subtle cast shadow under product photo if needed |
+| Inset Deep (Level 3) | `inset 0 -80px 120px rgba(40, 35, 0, 0.30)` | Darkened bottom of the product panel for extra depth |
+| Modal Overlay (Level 4) | `0 32px 80px rgba(40, 35, 0, 0.45)` | Only for interactive overlays or expanded CTAs |
+
+### Border Treatments
+- **No standard borders**: This style does not use borders on components. Structure comes from the flat color panels.
+- **Panel seam**: When two panels butt against each other, they share a 0px seam. The color contrast provides the visible separation.
+- **Hairline divider** (`1px solid rgba(20, 20, 20, 0.12)`): Only used inside the gray panel when separating stacked content blocks within the same panel.
+- **No rounded corners**: All corners are sharp 0px. Rounded corners break the structural grid.
+
+### Surface Hierarchy
+On this style, depth is communicated through color steps and gradients rather than shadows:
+1. **Yellow Block** (`#f4d624`) — the loudest, most saturated surface. Dominates attention.
+2. **Dark Yellow Gradient** (`#e5c51a` → `#b59a00`) — a deeper, darker step in the same hue. Creates a sense of recession behind the product photo.
+3. **Gray Panel** (`#e8e5dd`) — the quietest surface. Cools the composition and provides the reading canvas for body copy.
+4. **Near-Black Text** (`#141414`) — sits above all surfaces as the consistent text color.
+5. **Near-Black Button** (`#141414` with yellow text) — the strongest anchor when used. Inverts the palette.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use vivid mustard yellow (`#f4d624`) as the dominant surface — it should cover roughly 55-65% of the total canvas area.
+- Use near-black Inter 900 for headlines at 88-96px with slightly negative tracking (-1 to -2px).
+- Use warm pale gray (`#e8e5dd`) for the body panel to cool the composition — this replaces white everywhere.
+- Use the darkening yellow gradient (`#e5c51a` → `#b59a00`) as the photo backdrop, never a flat color behind product photos.
+- Use the rigid 2/3 top + 1/3 bottom split as the structural backbone — the top is always undivided yellow, the bottom is always split into exactly two panels (gray + dark yellow).
+- Left-align everything: headline, body copy, and wordmark.
+- Anchor the brand wordmark to the bottom-left corner with 2.5px tracked uppercase in Inter 700, stacked on two lines.
+- Keep headlines to 3 lines maximum on the primary yellow block — more than 3 lines breaks the density balance.
+- Use Inter as the single font family at weights 400, 500, 700, and 900 only — no other weights.
+- Center the product photo both horizontally and vertically within the dark yellow panel at 65-75% of the panel's dimensions.
+- Use 72px as the default outer padding for poster and carousel formats, stepping up to 120px top/bottom for story format.
+
+### Don't
+- Don't use white backgrounds anywhere in the composition — the warm gray (`#e8e5dd`) replaces white entirely.
+- Don't use non-Inter fonts — this is a single-family typographic system. No serifs, no monospace, no secondary fonts.
+- Don't use more than 3 panels in the split — the 2/3 yellow + 1/3 (gray + dark yellow) structure is the signature and must not be subdivided further.
+- Don't use pure black (`#000000`) or pure white (`#ffffff`) — always near-black (`#141414`) and warm gray (`#e8e5dd`).
+- Don't use rounded corners on any panel — all panel corners are sharp 0px.
+- Don't center-align the headline or body copy — everything is left-aligned.
+- Don't use shadows on components — depth is carried by the product-panel gradient alone.
+- Don't add borders to panels — structure comes from color contrast between adjacent panels.
+- Don't use Inter weight 600 or weight 800 — only 400, 500, 700, and 900 are part of the system.
+- Don't place the headline in the center or bottom of the yellow block — it must hug the top-left with 72px padding.
+- Don't introduce a second accent color (red, blue, green) — the palette is strictly yellow family + warm gray + near-black.
+- Don't use multiple product photos in the dark yellow panel — exactly one hero product, centered.
+- Don't replace the darkening yellow gradient with a flat yellow behind product photos — the gradient-to-olive is essential for depth.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale down**: Display Hero becomes 80px (from 92px). Section Heading becomes 44px. Body stays 20px.
+- **Padding**: 60px outer on all sides.
+- **Layout**: The 2/3 + 1/3 split applies but is compressed. Top yellow block is 55% of height (594px). Bottom split is 45% (486px), subdivided 45/55 into gray body panel (~486px wide) and dark yellow product panel (~594px wide).
+- **Cover slide**: Full signature layout — massive 3-line headline on yellow, body + wordmark on gray, product photo on dark yellow.
+- **Content slides**: Numbered slides use the full yellow block with the number set at 120px Inter 900 in the top-left, headline below at 56px, body at 22px. No bottom split on content slides — keep the yellow block pure for dense numbered content.
+- **CTA slide**: Use the CTA block pattern — yellow top with headline, gray bottom with body and dark near-black button.
+- **Swipe indicator**: Small near-black dots at the bottom center of content slides only (8px diameter). Active dot in solid near-black, inactive in `rgba(20, 20, 20, 0.25)`.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Full-scale hierarchy. Display Hero at 92px for the title section.
+- **Padding**: 60px left/right. 72px top/bottom margins.
+- **Section spacing**: Alternate between full-width yellow blocks and gray panels for vertical rhythm. Each major section is a full-width panel (either yellow or gray) with a heading and 2-4 content blocks inside.
+- **Vertical flow**: Start with a signature 2/3 + 1/3 split hero at the top (55% yellow, 45% split). Below that, continue with alternating yellow and gray sections stacked vertically. End with a gray footer panel containing the wordmark.
+- **Footer**: Gray panel (`#e8e5dd`), 120px tall, with the brand wordmark centered-left at 72px from the left edge.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 108px. Section Heading becomes 64px. Body Large becomes 24px.
+- **Padding**: 80px on all sides.
+- **Layout**: The 2/3 + 1/3 split applies horizontally for 16:9 — top yellow block is 60% of height (648px), bottom split is 40% (432px), subdivided 45/55 into gray (864px wide) and dark yellow (1056px wide).
+- **Title slides**: Hero layout with massive headline on yellow block, body + wordmark on gray, product hero on dark yellow.
+- **Content slides**: Full yellow block with left-aligned headline at 88px Inter 900, body at 24px Inter 500 in a 60% width column on the left. Right 40% reserved for a large product image or number callout.
+- **CTA slides**: Split layout — yellow top with "Light your space today." at 108px, gray bottom with CTA button and supporting copy.
+
+### Poster (1080x1350px) — PRIMARY FORMAT
+- **Typography**: Display Hero at 92px (the reference value). Section Heading at 48px. Body at 20px.
+- **Padding**: 72px left/right, 72px top, 60px bottom.
+- **Composition**: The signature 2/3 + 1/3 split is the defining layout of this format.
+  - **Top 58% (~783px tall)**: Solid yellow block (`#f4d624`) with the massive 3-line headline left-aligned, hugging the top-left corner with 72px top/left padding. The headline at 92px Inter 900 with -2px tracking and 0.95 line height stacks into three tight rows that occupy 70-80% of the block's height. Remaining space below the headline is empty yellow — let it breathe.
+  - **Bottom 42% (~567px tall)**: Horizontally split into two panels with no visible border between them.
+    - **Left panel (~45%, ~486px wide)**: Warm pale gray (`#e8e5dd`). Body copy in Inter 500 at 20px, 6-7 lines, left-aligned at the top with 60px top padding and 72px left padding. Brand wordmark ("FORMA / LIGHTS") anchored to the bottom-left with 60px bottom padding, 14px Inter 700 uppercase tracked 2.5px, stacked on two lines.
+    - **Right panel (~55%, ~594px wide)**: Dark yellow gradient (`#e5c51a` → `#b59a00`) running top-to-bottom. Product photo centered both horizontally and vertically, occupying 70-75% of the panel's dimensions. No caption, no label — the product carries itself.
+- **Vertical flow**: The poster reads top-to-bottom as a single statement — headline announces the concept, body explains it, product shows it.
+- **No CTA**: The poster format does not include a button. The product photo is the CTA.
+
+### Story (1080x1920px) — EXTENDED VERTICAL
+- **Typography scale**: Display Hero at 96px Inter 900 — approximately 30% larger than the Carousel 72px equivalent to account for the taller canvas. Section Heading at 56px. Body Large at 24px Inter 500. Body at 22px Inter 500. Wordmark stays at 14px Inter 700 tracked 2.5px uppercase.
+- **Padding**: 120px top/bottom (safe zones for platform UI), 60px left/right. Safe zones: 160px top reserved for profile avatar and progress bar, 160px bottom reserved for reply input. All critical content must sit inside y=160 to y=1760.
+- **Composition**: The signature 2/3 + 1/3 split applies vertically with amplified proportions for the 9:16 canvas.
+  - **Top 55% (~1056px tall, inside safe zone ~936px)**: Solid yellow block (`#f4d624`) with the massive 3-line headline left-aligned, hugging the top-left corner with 120px top padding (inside the safe zone) and 60px left padding. The headline at 96px Inter 900 with -2px tracking and 0.95 line height stacks into three tight rows. **The hero headline is approximately 30% bigger than the poster format to compensate for the taller canvas and longer viewing distance on mobile screens.** Let the bottom half of the yellow block breathe as empty yellow.
+  - **Bottom 45% (~864px tall)**: Horizontally split into two panels with no visible border.
+    - **Left panel (~45%, ~486px wide)**: Warm pale gray (`#e8e5dd`). Body copy in Inter 500 at 24px (scaled up for readability at arm's length on mobile), 6-8 lines, left-aligned at the top with 60px top padding and 60px left padding. Brand wordmark anchored bottom-left with 120px bottom padding (inside the safe zone), 14px Inter 700 uppercase tracked 2.5px, stacked on two lines.
+    - **Right panel (~55%, ~594px wide)**: Dark yellow gradient (`#e5c51a` → `#b59a00`) running top-to-bottom. Product photo centered, ~30% larger than the poster format — occupying roughly 80% of the panel's dimensions to maximize product visibility on mobile.
+- **Progress indicator**: Thin segments at the top of the safe zone (y=60 to y=72) — inactive in `rgba(20, 20, 20, 0.25)`, active in solid near-black (`#141414`). The dark-on-yellow progress bar reads cleanly without competing with the headline below.
+- **Single slide concept**: Story format is a single slide — one concept, one headline, one product. Do not chain multiple content slides in this format.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Vivid Yellow | `#f4d624` | Primary surface, top yellow block |
+| Near-Black | `#141414` | All text, wordmark, CTA button fill |
+| Warm Pale Gray | `#e8e5dd` | Body copy panel, replaces white |
+| Dark Mustard | `#e5c51a` | Top of product photo gradient |
+| Olive | `#b59a00` | Bottom of product photo gradient |
+| Yellow Hover | `#e8c91a` | Interactive hover state |
+| Gray Deep | `#d9d6ce` | Secondary surface variant |
+| Gray Text Secondary | `#3a3a38` | Secondary metadata text |
+| Gray Border | `rgba(20, 20, 20, 0.12)` | Hairline dividers |
+| Muted Text | `rgba(20, 20, 20, 0.55)` | Captions, footnotes |
+| Shadow Product | `rgba(120, 100, 0, 0.35)` | Product cast shadow |
+| Shadow Deep | `rgba(40, 35, 0, 0.40)` | Deep gradient shadow |
+
+### Font Declarations
+
+```css
+/* Display & Body (single family) */
+font-family: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;900&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-yellow: #f4d624;
+  --color-near-black: #141414;
+  --color-gray-panel: #e8e5dd;
+
+  /* Colors -- Accent */
+  --color-gradient-start: #e5c51a;
+  --color-gradient-end: #b59a00;
+  --color-yellow-hover: #e8c91a;
+
+  /* Colors -- Neutral Scale */
+  --color-gray-deep: #d9d6ce;
+  --color-gray-text-secondary: #3a3a38;
+  --color-gray-border: rgba(20, 20, 20, 0.12);
+  --color-muted-text: rgba(20, 20, 20, 0.55);
+
+  /* Colors -- Surfaces */
+  --color-surface-yellow: #f4d624;
+  --color-surface-gray: #e8e5dd;
+  --color-surface-gradient: linear-gradient(180deg, #e5c51a 0%, #b59a00 100%);
+
+  /* Colors -- Borders */
+  --color-border-default: rgba(20, 20, 20, 0.12);
+  --color-panel-seam: rgba(20, 20, 20, 0.08);
+  --color-divider: rgba(20, 20, 20, 0.15);
+
+  /* Colors -- Shadows */
+  --shadow-product: 0 20px 40px rgba(120, 100, 0, 0.35);
+  --shadow-deep: inset 0 -80px 120px rgba(40, 35, 0, 0.30);
+  --shadow-overlay: 0 32px 80px rgba(40, 35, 0, 0.45);
+
+  /* Typography -- Families */
+  --font-display: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 92px;
+  --text-display-small: 72px;
+  --text-section-heading: 48px;
+  --text-sub-heading: 28px;
+  --text-body-large: 22px;
+  --text-body: 20px;
+  --text-small: 14px;
+  --text-big-number: 96px;
+  --text-wordmark: 14px;
+  --text-cta: 16px;
+
+  /* Typography -- Weights */
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-bold: 700;
+  --weight-heavy: 900;
+
+  /* Typography -- Line Heights */
+  --leading-display: 0.95;
+  --leading-heading: 1.00;
+  --leading-sub-heading: 1.15;
+  --leading-body-large: 1.45;
+  --leading-body: 1.50;
+  --leading-small: 1.45;
+  --leading-wordmark: 1.10;
+
+  /* Typography -- Letter Spacing */
+  --tracking-display: -2px;
+  --tracking-heading: -1px;
+  --tracking-sub-heading: -0.3px;
+  --tracking-body: 0px;
+  --tracking-wordmark: 2.5px;
+  --tracking-cta: 0.4px;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-base: 16px;
+  --space-small: 24px;
+  --space-medium: 32px;
+  --space-panel-inner: 40px;
+  --space-block: 48px;
+  --space-panel: 60px;
+  --space-canvas: 72px;
+  --space-large: 80px;
+  --space-story-safe: 120px;
+
+  /* Borders */
+  --radius-none: 0px;
+
+  /* Grid -- Signature Split */
+  --split-top: 58%;
+  --split-bottom: 42%;
+  --split-bottom-left: 45%;
+  --split-bottom-right: 55%;
+}
+```
+
+### System Font Fallbacks
+- **Sans-serif (if Inter fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **No serif fallback needed** — this style does not use serif typography.

--- a/skills/composites/goose-graphics/styles/_full/sunburst-editorial.md
+++ b/skills/composites/goose-graphics/styles/_full/sunburst-editorial.md
@@ -1,0 +1,568 @@
+# Design Style: Sunburst Editorial
+
+## 1. Visual Theme & Atmosphere
+
+Sunburst Editorial is the design language of a mid-century boutique publishing house — the visual equivalent of a refined editorial carousel built by someone who keeps a shelf of Penguin Classics and a stack of old New Yorker issues within arm's reach. The style sits at the intersection of 1950s book-cover design, slow-reading literary magazines, and the small-press stationery shop aesthetic. Every slide feels like a page torn from a well-designed paperback: a near-white cream canvas (`#FBFAF4`), generous margins, a serif headline that commands the page like a chapter title, and body copy that reads like prose rather than sales copy. The canvas is deliberately *not* pure white — it is a warm, paper-stock cream that flatters the black text and lets the decorative elements sing without ever feeling like a glaring screen surface.
+
+The dual-serif typography system — DM Serif Display for the headline and Lora for the body — creates an elegant, quiet tension between authority and readability. DM Serif Display is a high-contrast display serif with classical proportions and subtle flourishes; at 72-84px, weight 400, stacked on two lines and left-aligned, it reads like the title of a literary essay. Lora is a Bresse-sisters-style text serif designed for long-form reading; at 18-20px it delivers four to seven lines of body copy that invite the reader to actually *read*, not skim. Headlines and body are both in mixed case — there is no uppercase screaming, no tag pills, no modern startup affectation. The text is the content. The style's authority comes from restraint.
+
+The signature move — the element that transforms this from "a nice serif carousel" into the Sunburst Editorial style — is the **decorative geometric collage in the top-right corner**: a stack of overlapping shapes including a mustard-yellow rectangle (`#D8AD38`), a forest-green rectangle (`#1E4A30`), a thin-line black sunburst (radiating lines from a small central circle), and occasionally a topographic contour blob. These elements nest, overlap, and crop each other like pieces of a hand-pasted collage. A second signature element — the hand-drawn-feeling numbered circle marker in the top-left corner (a thin outlined circle with a small open gap at its top, a number in serif inside) — reinforces the artisanal, craft-paper feel. The footer carries a brand name on the left and a URL on the right, both set in small rust-orange (`#C85A1F`) serif text, like the imprint line on the spine of a clothbound book. Think *Liceria & Co. meets Reader's Digest 1962 meets a modern independent zine*.
+
+**Key Characteristics:**
+- Near-white cream background (`#FBFAF4`) — warm paper-stock, never pure white
+- Near-black serif text (`#1A1A1A`) — maximum readability without the harshness of pure black
+- DM Serif Display at weight 400 for all headlines — stacked, left-aligned, 60–84px
+- Lora at weight 400-500 for body text — 18–20px, line-height 1.65, classical reading rhythm
+- Numbered circle marker in top-left (`~78px` diameter), thin 1.5px outline with a small open gap at top (hand-drawn feel), number in serif inside
+- Signature sunburst + geometric collage in top-right corner (mustard rect + forest green rect + black sunburst radial lines + thin outlined circle)
+- Mustard yellow accent (`#D8AD38`) — geometric collage block
+- Forest green accent (`#1E4A30`) — geometric collage block
+- Rust / brick-orange accent (`#C85A1F`) — footer text, byline, page numbers, small decorative marks
+- Page numbers in rust serif, small (12-14px), bottom corners
+- Generous padding (60-80px outer) — content breathes like a printed page
+- No rounded corners on geometric shapes — the collage is deliberately hard-edged
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Cream** (`#FBFAF4`): Primary background. A warm, very light cream that reads as printed paper rather than screen white. The signature surface of the style — never substitute pure white.
+- **Near-Black** (`#1A1A1A`): Primary text and sunburst line color. Used for all headlines and body copy. Confident without the flatness of `#000`.
+- **Rust Orange** (`#C85A1F`): Primary accent. Used exclusively for footer text, byline, page numbers, and small editorial marks. This is the "imprint color" — the color of the publisher's mark on the spine.
+
+### Accent
+- **Mustard Yellow** (`#D8AD38`): Decorative block color. Used only in the sunburst collage and occasional inline decorative blocks. A warm, aged gold — never neon.
+- **Forest Green** (`#1E4A30`): Decorative block color. Used only in the sunburst collage and occasional inline decorative blocks. A deep, bottle-green — the color of old library binding.
+- **Rust Deep** (`#A54617`): Hover/active state for rust orange elements. Used on links and interactive rust text.
+
+### Neutral Scale
+- **Cream Deep** (`#F4F1E8`): Slightly deeper cream for inset panels and quiet recesses.
+- **Secondary Text** (`#3D3A36`): Warm dark gray for subtitles and supporting prose. Keeps the body in the warm family — never cool gray.
+- **Tertiary Text** (`#6B6660`): Warm mid-gray for metadata, attributions, captions.
+- **Muted Text** (`rgba(26,26,26,0.35)`): Very low-emphasis text like slide numbers when not using rust.
+- **Pencil Gray** (`rgba(26,26,26,0.65)`): Used for the thin outline of the numbered circle marker to evoke a pencil-drawn feel.
+
+### Surface & Borders
+- **Surface Primary** (`#FBFAF4`): The canvas itself — cards are rarely used; content sits directly on the background.
+- **Surface Inset** (`#F4F1E8`): Deeper cream for the occasional inset panel or pull-quote background.
+- **Border Hairline** (`rgba(26,26,26,0.15)`): Ultra-thin hairline for quiet dividers.
+- **Border Default** (`rgba(26,26,26,0.25)`): Standard thin line for the numbered circle marker and sparse dividers.
+- **Border Rust** (`rgba(200,90,31,0.4)`): Rust-tinted hairline for occasional accent rules.
+- **Divider Rule** (`rgba(26,26,26,0.12)`): Subtle section divider.
+
+### Shadow Colors
+- **Shadow Warm Subtle** (`rgba(120,80,30,0.05)`): Ambient warm shadow for a hint of paper depth.
+- **Shadow Warm Medium** (`rgba(120,80,30,0.10)`): Standard warm shadow — rarely used; this style is mostly flat.
+- **Shadow Warm Deep** (`rgba(120,80,30,0.18)`): For the rare elevated element (inset pull-quote, featured card).
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'DM Serif Display', Georgia, 'Times New Roman', serif`
+- **Body**: `'Lora', Georgia, 'Times New Roman', serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | DM Serif Display | 84px | 400 | 1.05 | -1.5px | Chapter/title headlines. Stack on 2 lines, left-aligned. |
+| Section Heading | DM Serif Display | 72px | 400 | 1.05 | -1px | Content-slide headlines. Always 2-line stack. |
+| Sub-heading | DM Serif Display | 44px | 400 | 1.15 | -0.5px | Secondary headlines, pull-quote titles. |
+| Body Large | Lora | 20px | 400 | 1.65 | 0px | Lead paragraphs and standard body copy. |
+| Body | Lora | 18px | 400 | 1.65 | 0px | Standard reading text — 4 to 7 lines per block. |
+| Body Italic | Lora (italic) | 18px | 400 | 1.65 | 0px | Gentle emphasis within body prose. |
+| Small / Caption | Lora | 13px | 500 | 1.50 | 0.2px | Metadata, attributions, captions. |
+| Big Numbers | DM Serif Display | 72px | 400 | 1.00 | -1px | Statistics and key metrics. |
+| Numbered Marker | DM Serif Display | 32px | 400 | 1.00 | 0px | Inside the numbered circle marker. |
+| Footer Brand | Lora | 14px | 500 | 1.40 | 0.3px | Footer brand mark, set in rust orange. |
+| Footer URL | Lora | 14px | 500 | 1.40 | 0.3px | Footer URL, set in rust orange. |
+| Page Number | Lora | 13px | 500 | 1.00 | 0.3px | Slide number in rust orange. |
+
+### Principles
+- **Serif everything**: Both display and body are serifs. There is no sans-serif in this style — that is the defining discipline. Mixing in a sans would shatter the literary, printed-page feel.
+- **Stacked headlines**: Headlines always break onto two lines. "Be Clear and / Concise." "Regular / Updates." The line break is deliberate — it creates the magazine-title silhouette.
+- **Display weight 400, not 700**: DM Serif Display only ships at weight 400 — resist the urge to simulate boldness. The letterforms already have high stroke contrast; they carry weight without extra.
+- **Body line-height 1.65**: Long-form reading rhythm. Tighter than 1.5 feels cramped on a serif; looser than 1.7 breaks cohesion. 1.65 is the sweet spot for Lora at 18-20px.
+- **Rust for the imprint, not the content**: Rust orange is used *only* for footer brand, URL, page numbers, and occasional editorial marks. Never for headlines, never for body text, never for large decorative fills.
+- **Left-align the text, center is forbidden**: Content text is always left-aligned. Title slides, content slides, and most CTA slides use left alignment. Only the decorative collage sits in the top-right.
+- **Mixed case always**: Never uppercase headlines. The style is a printed book — books do not shout.
+
+## 4. Component Patterns
+
+### Numbered Circle Marker (Top-Left)
+
+The hand-drawn-feeling outlined circle with a number inside. Built with inline SVG so the "open gap at top" is controllable and crisp at any size. Placed at the top-left of title and content slides.
+
+```html
+<div style="position: absolute; top: 60px; left: 60px; width: 78px; height: 78px;">
+  <svg viewBox="0 0 78 78" xmlns="http://www.w3.org/2000/svg" style="width: 100%; height: 100%;">
+    <!-- Hand-drawn feel: an arc that leaves a small gap at the top -->
+    <path d="M 42 4 A 35 35 0 1 1 36 4"
+          fill="none"
+          stroke="rgba(26,26,26,0.65)"
+          stroke-width="1.5"
+          stroke-linecap="round" />
+  </svg>
+  <div style="position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; font-family: 'DM Serif Display', Georgia, serif; font-size: 32px; font-weight: 400; color: #1A1A1A; line-height: 1;">1</div>
+</div>
+```
+
+### Sunburst Collage (Top-Right Signature Element)
+
+The signature visual — a collage of overlapping geometric shapes and a thin-line black sunburst in the top-right corner. Drop this inline SVG into any title slide and every other content slide. Dimensions are ~220×260px; scale with the `width` wrapper.
+
+```html
+<div style="position: absolute; top: 0; right: 0; width: 240px; height: 280px; pointer-events: none;">
+  <svg viewBox="0 0 240 280" xmlns="http://www.w3.org/2000/svg" style="width: 100%; height: 100%;">
+    <!-- Mustard rectangle (sits behind, top) -->
+    <rect x="150" y="0" width="90" height="130" fill="#D8AD38" />
+    <!-- Forest green rectangle (sits behind, bottom-right) -->
+    <rect x="170" y="110" width="70" height="170" fill="#1E4A30" />
+    <!-- Sunburst: 24 radiating lines from central point -->
+    <g stroke="#1A1A1A" stroke-width="1.5" stroke-linecap="round">
+      <line x1="140" y1="90" x2="140" y2="30" />
+      <line x1="140" y1="90" x2="155.5" y2="33.9" />
+      <line x1="140" y1="90" x2="170" y2="43.9" />
+      <line x1="140" y1="90" x2="182.4" y2="60" />
+      <line x1="140" y1="90" x2="190" y2="78.8" />
+      <line x1="140" y1="90" x2="195" y2="90" />
+      <line x1="140" y1="90" x2="190" y2="101.2" />
+      <line x1="140" y1="90" x2="182.4" y2="120" />
+      <line x1="140" y1="90" x2="170" y2="136.1" />
+      <line x1="140" y1="90" x2="155.5" y2="146.1" />
+      <line x1="140" y1="90" x2="140" y2="150" />
+      <line x1="140" y1="90" x2="124.5" y2="146.1" />
+      <line x1="140" y1="90" x2="110" y2="136.1" />
+      <line x1="140" y1="90" x2="97.6" y2="120" />
+      <line x1="140" y1="90" x2="90" y2="101.2" />
+      <line x1="140" y1="90" x2="85" y2="90" />
+      <line x1="140" y1="90" x2="90" y2="78.8" />
+      <line x1="140" y1="90" x2="97.6" y2="60" />
+      <line x1="140" y1="90" x2="110" y2="43.9" />
+      <line x1="140" y1="90" x2="124.5" y2="33.9" />
+    </g>
+    <!-- Thin outlined circle at the center of the sunburst -->
+    <circle cx="140" cy="90" r="13" fill="#FBFAF4" stroke="#1A1A1A" stroke-width="1.5" />
+    <!-- Tiny dot inside the circle (small sun icon) -->
+    <circle cx="140" cy="90" r="3" fill="#1A1A1A" />
+  </svg>
+</div>
+```
+
+### Title Block (Cover / Content Header)
+
+```html
+<div style="background-color: var(--color-bg); padding: 60px; position: relative; min-height: 100%;">
+  <!-- Numbered circle marker (top-left) -->
+  <div style="position: absolute; top: 60px; left: 60px; width: 78px; height: 78px;">
+    <svg viewBox="0 0 78 78" xmlns="http://www.w3.org/2000/svg" style="width: 100%; height: 100%;">
+      <path d="M 42 4 A 35 35 0 1 1 36 4" fill="none" stroke="rgba(26,26,26,0.65)" stroke-width="1.5" stroke-linecap="round" />
+    </svg>
+    <div style="position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; font-family: var(--font-display); font-size: 32px; color: var(--color-near-black); line-height: 1;">1</div>
+  </div>
+
+  <!-- Sunburst collage (top-right) goes here — see component above -->
+
+  <!-- Headline -->
+  <div style="position: absolute; left: 60px; right: 60px; top: 240px;">
+    <h1 style="font-family: var(--font-display); font-size: 84px; font-weight: 400; line-height: 1.05; letter-spacing: -1.5px; color: var(--color-near-black); margin: 0 0 40px; max-width: 70%;">Be Clear and<br>Concise</h1>
+    <p style="font-family: var(--font-body); font-size: 20px; font-weight: 400; line-height: 1.65; color: var(--color-near-black); max-width: 78%; margin: 0;">Communicate your ideas in a straightforward manner to avoid misunderstandings. Avoid jargon and overly complex sentences, as these can lead to confusion. It's also helpful to organize your thoughts logically, presenting them in a step-by-step fashion.</p>
+  </div>
+
+  <!-- Footer -->
+  <div style="position: absolute; left: 60px; right: 60px; bottom: 60px; display: flex; justify-content: space-between; align-items: baseline;">
+    <span style="font-family: var(--font-body); font-size: 14px; font-weight: 500; letter-spacing: 0.3px; color: var(--color-rust);">Liceria &amp; Co.</span>
+    <span style="font-family: var(--font-body); font-size: 14px; font-weight: 500; letter-spacing: 0.3px; color: var(--color-rust);">reallygreatsite.com</span>
+  </div>
+</div>
+```
+
+### Serif Editorial Body (Standard Body Component)
+
+Standard body component with Lora text and a drop-style opening — the first few words of the first paragraph can be set slightly larger for a literary opening flourish.
+
+```html
+<div style="max-width: 78%;">
+  <p style="font-family: var(--font-body); font-size: 18px; font-weight: 400; line-height: 1.65; color: var(--color-near-black); margin: 0 0 18px;">
+    <span style="font-family: var(--font-display); font-size: 22px; line-height: 1; color: var(--color-near-black);">Keep the team informed</span>
+    with frequent progress reports and updates. Regular communication helps ensure everyone is on the same page and can address any issues promptly.
+  </p>
+  <p style="font-family: var(--font-body); font-size: 18px; font-weight: 400; line-height: 1.65; color: var(--color-near-black); margin: 0;">
+    Additionally, consider scheduling brief but regular check-ins, either through virtual meetings or written summaries, to discuss milestones, challenges, and next steps.
+  </p>
+</div>
+```
+
+### Numbered Item (Within Body Flow)
+
+```html
+<div style="display: flex; gap: 24px; padding: 20px 0; border-top: 1px solid rgba(26,26,26,0.12);">
+  <div style="flex-shrink: 0; font-family: var(--font-display); font-size: 32px; color: var(--color-rust); line-height: 1; min-width: 44px;">01</div>
+  <div>
+    <h3 style="font-family: var(--font-display); font-size: 26px; font-weight: 400; line-height: 1.2; color: var(--color-near-black); margin: 0 0 8px;">Be Clear and Concise</h3>
+    <p style="font-family: var(--font-body); font-size: 17px; font-weight: 400; line-height: 1.6; color: var(--color-secondary); margin: 0;">Avoid jargon and overly complex sentences; prefer examples and analogies to make your points more relatable.</p>
+  </div>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="padding: 40px 0; max-width: 360px;">
+  <p style="font-family: var(--font-display); font-size: 96px; font-weight: 400; line-height: 1.0; letter-spacing: -2px; color: var(--color-near-black); margin: 0 0 12px;">47<span style="color: var(--color-rust);">%</span></p>
+  <div style="width: 48px; height: 1.5px; background: var(--color-rust); margin: 0 0 14px;"></div>
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.55; color: var(--color-secondary); margin: 0;">Teams respond to leads nearly twice as fast when editorial discipline meets modern tooling.</p>
+</div>
+```
+
+### Comparison Grid (2-Column Editorial)
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1px 1fr; gap: 40px; align-items: start;">
+  <div>
+    <p style="font-family: var(--font-body); font-size: 13px; font-weight: 500; letter-spacing: 0.5px; color: var(--color-rust); margin: 0 0 12px; text-transform: uppercase;">Before</p>
+    <h3 style="font-family: var(--font-display); font-size: 32px; font-weight: 400; line-height: 1.15; color: var(--color-near-black); margin: 0 0 14px;">Manual &amp;<br>Fragmented</h3>
+    <p style="font-family: var(--font-body); font-size: 17px; font-weight: 400; line-height: 1.6; color: var(--color-secondary); margin: 0;">Slack threads, spreadsheets, and endless context switching between a dozen tabs.</p>
+  </div>
+  <div style="background: rgba(26,26,26,0.15); align-self: stretch;"></div>
+  <div>
+    <p style="font-family: var(--font-body); font-size: 13px; font-weight: 500; letter-spacing: 0.5px; color: var(--color-rust); margin: 0 0 12px; text-transform: uppercase;">After</p>
+    <h3 style="font-family: var(--font-display); font-size: 32px; font-weight: 400; line-height: 1.15; color: var(--color-near-black); margin: 0 0 14px;">Orchestrated<br>&amp; Calm</h3>
+    <p style="font-family: var(--font-body); font-size: 17px; font-weight: 400; line-height: 1.6; color: var(--color-secondary); margin: 0;">Research, drafting, and follow-up handled quietly in the background while the team focuses on decisions.</p>
+  </div>
+</div>
+```
+
+### Pull-Quote Block
+
+```html
+<div style="padding: 44px 0 44px 32px; border-left: 2px solid var(--color-rust); max-width: 80%;">
+  <p style="font-family: var(--font-display); font-size: 34px; font-weight: 400; font-style: italic; line-height: 1.25; color: var(--color-near-black); margin: 0 0 24px;">It felt less like configuring software and more like onboarding a new colleague.</p>
+  <div style="display: flex; align-items: center; gap: 14px;">
+    <div style="width: 28px; height: 1.5px; background: var(--color-rust);"></div>
+    <p style="font-family: var(--font-body); font-size: 13px; font-weight: 500; letter-spacing: 0.3px; color: var(--color-tertiary); margin: 0;">Sarah Chen, VP Operations</p>
+  </div>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="padding: 60px; position: relative; min-height: 100%;">
+  <!-- Sunburst collage goes in top-right -->
+
+  <div style="max-width: 72%; position: absolute; left: 60px; right: 60px; top: 240px;">
+    <h2 style="font-family: var(--font-display); font-size: 84px; font-weight: 400; line-height: 1.05; letter-spacing: -1.5px; color: var(--color-near-black); margin: 0 0 32px;">Meet your<br>new coworker.</h2>
+    <p style="font-family: var(--font-body); font-size: 20px; font-weight: 400; line-height: 1.65; color: var(--color-secondary); max-width: 90%; margin: 0 0 40px;">Deploy your first AI coworker in minutes. Start free, scale when ready.</p>
+    <a style="display: inline-block; font-family: var(--font-body); font-size: 18px; font-weight: 600; color: var(--color-rust); text-decoration: none; border-bottom: 1.5px solid var(--color-rust); padding-bottom: 4px; letter-spacing: 0.2px;">Get started &rarr;</a>
+  </div>
+
+  <!-- Footer -->
+  <div style="position: absolute; left: 60px; right: 60px; bottom: 60px; display: flex; justify-content: space-between; align-items: baseline;">
+    <span style="font-family: var(--font-body); font-size: 14px; font-weight: 500; color: var(--color-rust);">Liceria &amp; Co.</span>
+    <span style="font-family: var(--font-body); font-size: 14px; font-weight: 500; color: var(--color-rust);">reallygreatsite.com</span>
+  </div>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap — within a single inline element.
+- **8px**: Tight gap — between a label and its adjacent text.
+- **14px**: Small gap — between a subtitle and the headline below it.
+- **20px**: Base gap — between body paragraphs.
+- **32px**: Section internal — gap between headline and first body paragraph.
+- **40px**: Content gap — between stacked content components within a slide.
+- **48px**: Section divider — vertical space between major content blocks.
+- **60px**: Standard outer padding — the default page margin.
+- **80px**: Wide outer padding — used on slides and posters.
+- **120px**: Story-format outer padding — used on vertical Story format only.
+
+### Format Padding
+
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 960px |
+| Story (1080x1920) | 120px left/right, 60px top/bottom | 840px |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned for *all* content — headlines, body, footers. The only exception is when a byline or credit needs to sit in the right corner of a footer row.
+- **Grid**: Content sits in a generous single column or a 2-column editorial split for comparisons. Never use more than 2 columns; this is a reading style, not a dashboard style.
+- **Corner zones**: Top-left is reserved for the numbered circle marker. Top-right is reserved for the sunburst collage (on title slides and every other content slide). Bottom-left and bottom-right are reserved for the rust footer band.
+- **Vertical rhythm**: Maintain 40-48px gaps between top-level sections. Leave generous breathing room — if in doubt, add 20px more.
+- **Content gravity**: On most slides, content settles in the middle-left zone, with the headline starting around the 35-45% vertical line and body flowing below it. Never center.
+- **Headline stack**: Always break headlines onto 2 lines manually. The line break is a design decision, not a wrapping accident.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, background `#FBFAF4` | The default — almost every element lives here |
+| Hairline (Level 1) | `1px solid rgba(26,26,26,0.12)` divider | Section separators within body flow |
+| Subtle (Level 2) | `0 2px 8px rgba(120,80,30,0.05)` | Rare — a pull-quote hovering slightly |
+| Card (Level 3) | `0 8px 24px rgba(120,80,30,0.10)` | Featured editorial card, almost never used |
+| Overlay (Level 4) | `0 16px 40px rgba(120,80,30,0.18)` | Modal or drop panel, essentially unused |
+
+### Border Treatments
+- **Hairline divider**: `1px solid rgba(26,26,26,0.12)` — the standard divider between numbered items or editorial blocks.
+- **Thin content rule**: `1.5px solid rgba(26,26,26,0.25)` — for the numbered circle marker and other sparse outlined elements.
+- **Rust accent rule**: `2px solid #C85A1F` — used as the left border of a pull-quote block, or as a short horizontal rule under a stat number.
+- **No rounded corners on shapes**: All decorative geometric blocks in the collage are hard-edged rectangles. Never use `border-radius` on the mustard or forest green blocks.
+
+### Surface Hierarchy
+On this cream canvas, depth is almost always flat. Elevation is communicated not through shadow but through **line weight, color temperature, and whitespace**:
+1. **Cream** (`#FBFAF4`) — the canvas. 95% of every slide lives here.
+2. **Near-black type** (`#1A1A1A`) — the primary foreground, commanding attention through serif mass.
+3. **Rust footer text** (`#C85A1F`) — a quiet second voice, the publisher's imprint.
+4. **Geometric collage blocks** (mustard, forest green) — the loudest surface in the style, but confined entirely to the top-right corner.
+5. **Sunburst lines** — black on cream, visually layered on top of the mustard and green blocks.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use the sunburst collage on every title slide and *every other* content slide. The rhythm is: slide 1 has it, slide 2 doesn't, slide 3 has it, slide 4 doesn't. This creates alternation without overuse.
+- Use the numbered circle marker (thin outline with a small top gap) in the top-left corner of every numbered content slide. The number inside should be in DM Serif Display at 32px.
+- Use DM Serif Display at weight 400 for all headlines. Resist the urge to apply `font-weight: 700` — it is not a supported weight and will render as faux-bold.
+- Use rust orange (`#C85A1F`) for footer brand text, footer URL, page numbers, stat accents, and pull-quote rules — the small editorial marks only.
+- Break every headline into 2 lines manually with a `<br>`. The stacked silhouette is core to the style.
+- Keep body copy in Lora at 18-20px with line-height 1.65 — the long-form reading rhythm.
+- Use the near-white cream background (`#FBFAF4`) on every slide without exception. The cream is the style.
+- Keep all decorative geometric shapes (mustard rect, forest green rect) with hard corners — no `border-radius`.
+- Left-align all content — headline, body, numbered items, pull-quotes.
+- Include the footer brand + URL line on every carousel slide. It is the imprint, and it anchors the publication feel.
+- Use italic Lora for gentle emphasis in body prose — never bold.
+- Build the sunburst with inline SVG using the provided component. Do not use a background-image or PNG.
+
+### Don't
+- Don't use the sunburst collage on every single slide — it will overwhelm. Use it on alternating slides only.
+- Don't use pure white (`#FFFFFF`) or pure black (`#000000`). The cream (`#FBFAF4`) and near-black (`#1A1A1A`) are non-negotiable.
+- Don't use modern sans-serif fonts (Inter, DM Sans, Space Grotesk) for headlines — this style is serif-only. Mixing in a sans is the single biggest way to destroy the aesthetic.
+- Don't center-align content. Editorial type reads left-aligned.
+- Don't use yellow pill tags, step labels, or any modern "carousel framework" UI elements. This is not that style.
+- Don't use mustard or forest green for text — they live only in the collage blocks.
+- Don't use rust orange for headlines or body text — it is reserved for footer marks, page numbers, and small editorial accents.
+- Don't round the corners of the geometric collage shapes. Hard edges only.
+- Don't use rounded corners larger than 4px on any element. This style is flat and editorial.
+- Don't use drop shadows on body content. The style is deliberately flat.
+- Don't add icons, emoji, or illustrations. The sunburst collage is the only decorative element.
+- Don't stack more than 2 lines in the headline, or use more than 7 lines of body copy per slide. Reading space is the luxury.
+- Don't uppercase headlines. Ever. Books do not shout.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale**: Display Hero at 72px (down from 84px). Section Heading at 64px. Body at 18px, line-height 1.65.
+- **Padding**: 60px all sides. Content area is 960x960px.
+- **Cover slide**: Numbered circle marker top-left ("1"). Sunburst collage top-right. Headline stacked on 2 lines, starting ~45% down the slide, max-width 70%. Short 3-4 line lead paragraph below. Footer brand + URL in rust at bottom.
+- **Content slides**: Numbered marker (2, 3, 4...) top-left. Sunburst collage top-right on alternating slides only. Headline starts mid-slide. Body flows below, 4-7 lines. Rust footer at bottom.
+- **CTA slide**: Same title-slide structure with the CTA link in rust-underlined text. Sunburst in top-right.
+- **Swipe indicator**: Omit — this is a style that trusts the reader to turn the page. If required, use small rust dots, 6px diameter, bottom center.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Full-scale hierarchy. Display Hero at 84px for the top section.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Section spacing**: 80px vertical gap between major sections.
+- **Top zone**: Numbered marker + sunburst collage + hero headline + lead paragraph.
+- **Middle zones**: Numbered item components stacked with hairline dividers, or editorial 2-column splits with the thin vertical rule between them.
+- **Bottom zone**: Rust footer band with brand + URL.
+- **Sunburst placement**: Only at the very top of the infographic, never in the middle sections.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero at 108px. Section Heading at 88px. Body at 22px with line-height 1.65.
+- **Padding**: 80px all sides. Content area 1760x920px.
+- **Layout**: Content occupies left ~65% of slide. Sunburst collage sits in top-right corner, scaled to ~320x380px to balance the widescreen format.
+- **Title slide**: Numbered marker top-left (scaled to 100px). Stacked headline on 2 lines with 108px serif. Lead paragraph below, max-width 1100px. Rust footer row at bottom spanning left-to-right.
+- **Content slide**: Headline on the left 55%. Body and editorial components fill left 65%. Sunburst remains top-right. Generous whitespace on the right of the content.
+- **CTA slide**: Centered headline + rust-underlined CTA link. Sunburst top-right. Footer rust band bottom.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 92px. Section Heading at 72px. Body at 19px with line-height 1.65.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top third — numbered marker top-left, sunburst collage top-right. Middle third — headline stack and lead paragraph. Bottom third — secondary body block or numbered items. Footer at the very bottom with rust brand + URL.
+- **Vertical flow**: A full editorial page — reads top to bottom like a printed poster pinned to a café wall.
+
+### Story (1080x1920px)
+- **Typography scale**: Display Hero at 108px (hero ~30% bigger than carousel for the vertical scale). Section Heading at 84px. Body at 22px with line-height 1.65.
+- **Padding**: 120px left/right, 60px top/bottom — wider horizontal margin than other formats to preserve the editorial gutters on a phone screen.
+- **Content max-width**: 840px.
+- **Cover/title layout**: Numbered marker top-left at ~100px. Sunburst collage top-right scaled to ~300x360px. Hero headline stacked on 2-3 lines starting ~40% down the canvas. Lead paragraph of 4-6 lines beneath. Footer rust band at the bottom (above any Story UI safe zone).
+- **Content slide layout**: Same corner zones. Headline occupies the upper-middle third. Body flows down to the lower third. Generous whitespace above the headline is the key to the Story format's cinematic feel.
+- **Safe zones**: Keep critical text 180px from the top and 280px from the bottom to avoid Story UI chrome (username, reply bar). The outer 120px horizontal padding handles the left/right safe zones.
+- **Sunburst rhythm**: On Story decks of 3+ slides, the sunburst appears on the first, third, fifth slides — alternating as with carousels.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Cream | `#FBFAF4` | Primary background (all slides, all formats) |
+| Near-Black | `#1A1A1A` | Primary text, sunburst lines, numbered marker text |
+| Rust Orange | `#C85A1F` | Footer brand, URL, page numbers, stat accents, pull-quote rules |
+| Mustard Yellow | `#D8AD38` | Sunburst collage block only |
+| Forest Green | `#1E4A30` | Sunburst collage block only |
+| Rust Deep | `#A54617` | Hover/active state for rust elements |
+| Cream Deep | `#F4F1E8` | Inset panels, rare recessed areas |
+| Secondary Text | `#3D3A36` | Subtitles, supporting prose |
+| Tertiary Text | `#6B6660` | Metadata, captions, attributions |
+| Pencil Gray | `rgba(26,26,26,0.65)` | Thin outline of numbered circle marker |
+| Border Hairline | `rgba(26,26,26,0.12)` | Section dividers |
+
+### Font Declarations
+
+```css
+/* Display — headlines, big numbers, numbered marker */
+font-family: 'DM Serif Display', Georgia, 'Times New Roman', serif;
+
+/* Body — everything else */
+font-family: 'Lora', Georgia, 'Times New Roman', serif;
+```
+
+### Google Fonts Link
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors — Primary */
+  --color-bg: #FBFAF4;
+  --color-near-black: #1A1A1A;
+  --color-rust: #C85A1F;
+
+  /* Colors — Decorative Accents (collage only) */
+  --color-mustard: #D8AD38;
+  --color-forest: #1E4A30;
+  --color-rust-deep: #A54617;
+
+  /* Colors — Neutral Scale */
+  --color-cream-deep: #F4F1E8;
+  --color-secondary: #3D3A36;
+  --color-tertiary: #6B6660;
+  --color-muted: rgba(26, 26, 26, 0.35);
+  --color-pencil: rgba(26, 26, 26, 0.65);
+
+  /* Colors — Surfaces */
+  --color-surface-primary: #FBFAF4;
+  --color-surface-inset: #F4F1E8;
+
+  /* Colors — Borders */
+  --color-border-hairline: rgba(26, 26, 26, 0.12);
+  --color-border-default: rgba(26, 26, 26, 0.25);
+  --color-border-rust: rgba(200, 90, 31, 0.4);
+  --color-divider: rgba(26, 26, 26, 0.12);
+
+  /* Colors — Shadows */
+  --shadow-subtle: rgba(120, 80, 30, 0.05);
+  --shadow-medium: rgba(120, 80, 30, 0.10);
+  --shadow-deep: rgba(120, 80, 30, 0.18);
+
+  /* Typography — Families */
+  --font-display: 'DM Serif Display', Georgia, 'Times New Roman', serif;
+  --font-body: 'Lora', Georgia, 'Times New Roman', serif;
+
+  /* Typography — Sizes */
+  --text-display-hero: 84px;
+  --text-section-heading: 72px;
+  --text-sub-heading: 44px;
+  --text-body-large: 20px;
+  --text-body: 18px;
+  --text-small: 13px;
+  --text-big-number: 72px;
+  --text-marker: 32px;
+  --text-footer: 14px;
+
+  /* Typography — Weights */
+  --weight-display: 400;
+  --weight-body: 400;
+  --weight-body-medium: 500;
+  --weight-body-bold: 600;
+
+  /* Typography — Line Heights */
+  --leading-display: 1.05;
+  --leading-heading: 1.15;
+  --leading-sub-heading: 1.20;
+  --leading-body: 1.65;
+  --leading-small: 1.50;
+  --leading-number: 1.00;
+
+  /* Typography — Letter Spacing */
+  --tracking-display: -1.5px;
+  --tracking-heading: -1px;
+  --tracking-body: 0px;
+  --tracking-footer: 0.3px;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 14px;
+  --space-base: 20px;
+  --space-medium: 32px;
+  --space-gap: 40px;
+  --space-section: 48px;
+  --space-outer: 60px;
+  --space-wide: 80px;
+  --space-story: 120px;
+
+  /* Borders */
+  --radius-none: 0;
+  --radius-hair: 2px;
+  --border-thin: 1px solid rgba(26, 26, 26, 0.12);
+  --border-thick: 1.5px solid rgba(26, 26, 26, 0.25);
+  --border-rust: 2px solid #C85A1F;
+
+  /* Numbered Marker */
+  --marker-size: 78px;
+  --marker-stroke: 1.5px;
+  --marker-color: rgba(26, 26, 26, 0.65);
+
+  /* Sunburst Collage */
+  --collage-width: 240px;
+  --collage-height: 280px;
+}
+```
+
+### System Font Fallbacks
+- **Display (if DM Serif Display fails to load):** `Georgia, 'Times New Roman', serif`
+- **Body (if Lora fails to load):** `Georgia, 'Times New Roman', serif`
+
+### Quick-Reference Checklist for Agents
+Before finalizing any Sunburst Editorial slide, confirm:
+1. Background is `#FBFAF4` (not pure white).
+2. All text is serif — no sans-serif anywhere.
+3. Headline is stacked on 2 lines, left-aligned, in DM Serif Display weight 400.
+4. Body is in Lora at 18-20px with line-height 1.65.
+5. Numbered circle marker (with top gap) is in the top-left of every numbered slide.
+6. Sunburst collage is in the top-right of title slides and every other content slide.
+7. Footer has brand name + URL in rust orange (`#C85A1F`), small serif.
+8. No rounded corners on the decorative geometric blocks.
+9. No yellow pill tags, step labels, or modern carousel UI elements.
+10. Content is left-aligned — never centered.

--- a/skills/composites/goose-graphics/styles/_full/terminal.md
+++ b/skills/composites/goose-graphics/styles/_full/terminal.md
@@ -1,0 +1,462 @@
+# Design Style: Terminal
+
+## 1. Visual Theme & Atmosphere
+
+Terminal is the visual language of the command line made tangible -- the aesthetic of a developer who lives in the terminal, who finds beauty in monospaced type, blinking cursors, and the soft glow of phosphor green on a dark screen. The dark charcoal background (`#1a1a2e`) is not just dark mode; it is the colour of a terminal emulator at 2am, slightly blue-shifted from pure black, carrying the subtle warmth of a CRT display. Every element on this canvas is informed by the grammar of command-line interfaces: monospaced type, grid-aligned layouts, uppercase labels with wide letter-spacing, and the disciplined economy of a system that wastes nothing.
+
+JetBrains Mono is the sole typeface, used for everything -- headers, body text, labels, statistics, buttons. There is no typographic contrast between serif and sans-serif here; hierarchy is established purely through size, weight, and colour. This is a deliberate constraint that reinforces the terminal metaphor: in a CLI, everything is monospaced, and that uniformity is the source of its visual integrity. At large display sizes (48px+), JetBrains Mono has a distinctive character -- its generous x-height and distinctive letterforms (the slashed zero, the curved lowercase `l`) make it surprisingly effective for headlines. Uppercase labels with 2-4px letter-spacing evoke the cadence of system status messages and log output.
+
+Matrix green (`#00ff41`) is the primary text and accent colour -- the unmistakable hue of green-screen terminals and Hollywood hacker sequences. It is used for primary text, active states, key metrics, and any element that should feel "live" or "active." Amber (`#ffb000`) serves as the secondary accent, evoking the amber phosphor of early IBM terminals and providing a warm counterpoint to the cool green. Amber is used for warnings, highlights, important labels, and elements that need to stand apart from the green without breaking the retro-tech vocabulary. Dim gray (`#4a4a5a`) handles borders, inactive elements, and the subtle grid patterns that create the architectural framework of the layout.
+
+A subtle scanline overlay effect using `repeating-linear-gradient` adds the final layer of atmosphere -- thin, semi-transparent horizontal lines that evoke CRT monitors without degrading readability. This is applied at low opacity (0.03-0.05) as a background texture, never over text directly.
+
+**Key Characteristics:**
+- Dark charcoal background (`#1a1a2e`) with slight blue undertone -- the colour of a terminal window, not generic dark mode
+- Matrix green (`#00ff41`) as primary text and accent -- the signature colour of this entire system
+- Amber (`#ffb000`) as secondary accent for warnings, highlights, and warm focal points
+- JetBrains Mono for ALL text -- headers, body, labels, buttons. No sans-serif, no serif. Monospace only.
+- Uppercase labels with wide letter-spacing (2-4px) for system-style category markers and status labels
+- Scanline overlay effect via `repeating-linear-gradient(0deg, rgba(0,255,65,0.03) 0px, transparent 1px, transparent 2px)` for CRT texture
+- Grid background patterns using subtle dotted or lined grids in dim gray (`#4a4a5a`) at low opacity
+- Blinking cursor animations (`@keyframes blink`) appended to headings and active elements
+- Code-block aesthetics: content presented in bordered containers that evoke terminal windows
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Terminal Dark** (`#1a1a2e`): Primary background. Dark charcoal with a blue undertone evoking late-night coding sessions.
+- **Matrix Green** (`#00ff41`): Primary text and accent. The signature terminal green for headings, body text, and active elements.
+- **Amber** (`#ffb000`): Secondary accent. Used for warnings, highlights, key labels, and warm focal points.
+
+### Accent
+- **Bright Green** (`#33ff66`): Hover state for green elements. Slightly lighter and warmer.
+- **Dark Amber** (`#cc8e00`): Hover/active state for amber elements.
+- **Dim Green** (`#00cc33`): Muted green for secondary text and less prominent body copy.
+- **Cyan** (`#00d4ff`): Tertiary accent for links, info states, and occasional emphasis. Used sparingly.
+
+### Neutral Scale
+- **Dim Gray** (`#4a4a5a`): Borders, grid lines, and inactive UI elements.
+- **Dark Surface** (`#12122a`): Inset panels, code blocks, and recessed areas.
+- **Mid Dark** (`#222240`): Elevated surface for cards and containers.
+- **Faint Gray** (`#3a3a4e`): Secondary borders, subtle dividers.
+- **Ghost Gray** (`#2a2a3e`): Tertiary surface, nested containers.
+- **Muted Green** (`#00802a`): Disabled green text, low-emphasis indicators.
+
+### Surface & Borders
+- **Surface Primary** (`#222240`): Card and container background -- one step lighter than the canvas.
+- **Surface Inset** (`#12122a`): Recessed panels, terminal output areas, code blocks.
+- **Surface Canvas** (`#1a1a2e`): The base background layer.
+- **Border Default** (`rgba(0,255,65,0.15)`): Green-tinted border for standard containers.
+- **Border Accent** (`rgba(255,176,0,0.3)`): Amber-tinted border for highlighted or warning containers.
+- **Border Dim** (`rgba(74,74,90,0.5)`): Subtle gray border for inactive or background elements.
+- **Divider Rule** (`#00ff41`): Solid green for horizontal accent rules.
+
+### Shadow Colors
+- **Shadow Green** (`rgba(0,255,65,0.06)`): Green-tinted ambient glow for on-palette elevation.
+- **Shadow Deep** (`rgba(0,0,0,0.5)`): Deep shadow for high-elevation elements.
+- **Shadow Soft** (`rgba(0,0,0,0.3)`): Standard shadow for cards.
+- **Shadow Glow** (`rgba(0,255,65,0.1)`): Green glow effect for featured/active elements.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'JetBrains Mono', 'Fira Code', 'Courier New', monospace`
+- **Body**: `'JetBrains Mono', 'Fira Code', 'Courier New', monospace`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | JetBrains Mono | 56px | 700 | 1.10 | -0.5px | Hero headlines, primary statement |
+| Section Heading | JetBrains Mono | 36px | 700 | 1.15 | 0px | Major section titles |
+| Sub-heading | JetBrains Mono | 24px | 600 | 1.20 | 0px | Card titles, subsection headers |
+| Body Large | JetBrains Mono | 18px | 400 | 1.70 | 0px | Lead paragraphs, introductions |
+| Body | JetBrains Mono | 15px | 400 | 1.75 | 0.2px | Standard reading text |
+| Small / Caption | JetBrains Mono | 12px | 400 | 1.50 | 0.5px | Metadata, timestamps, path labels |
+| Big Numbers | JetBrains Mono | 56px | 700 | 1.00 | 0px | Statistics, key metrics |
+| System Label | JetBrains Mono | 12px | 600 | 1.00 | 3px | Uppercase system labels ("STATUS: ACTIVE") |
+| CTA Text | JetBrains Mono | 14px | 600 | 1.00 | 2px | Button text, uppercase |
+| Prompt Prefix | JetBrains Mono | 15px | 500 | 1.00 | 0px | Command prompt characters ($ > //) |
+
+### Principles
+- **Monospace only**: JetBrains Mono handles every typographic role. No sans-serif, no serif. The constraint is the identity.
+- **Wide tracking for labels**: System labels and category markers use 2-4px letter-spacing in uppercase to evoke log output and status messages.
+- **Generous line height for body**: 1.70-1.75 for body text compensates for the inherently denser texture of monospaced type.
+- **Size does the heavy lifting**: Without font-family contrast, hierarchy depends on size jumps. Display at 56px, section at 36px, sub at 24px -- clear, stepped reductions.
+- **Green for live, amber for highlight**: Primary text in green, highlighted or warning text in amber. Gray for inactive or de-emphasized content.
+- **Blinking cursor**: Append a blinking block cursor (`_`) to hero headings using CSS `@keyframes blink { 0%, 100% { opacity: 1; } 50% { opacity: 0; } }` with `animation: blink 1s step-end infinite`.
+
+## 4. Component Patterns
+
+### Title Block (Cover / Header Section)
+
+```html
+<div style="background-color: #1a1a2e; padding: 80px 60px; text-align: left; position: relative; background-image: repeating-linear-gradient(0deg, rgba(0,255,65,0.03) 0px, transparent 1px, transparent 2px);">
+  <p style="font-family: 'JetBrains Mono', monospace; font-size: 12px; font-weight: 600; letter-spacing: 3px; text-transform: uppercase; color: #ffb000; margin: 0 0 24px;">// SYSTEM BRIEFING</p>
+  <h1 style="font-family: 'JetBrains Mono', monospace; font-size: 56px; font-weight: 700; line-height: 1.10; letter-spacing: -0.5px; color: #00ff41; margin: 0 0 8px;">The Future of<br>Autonomous Work<span style="animation: blink 1s step-end infinite; display: inline-block;">_</span></h1>
+  <div style="width: 60px; height: 2px; background: #00ff41; margin: 24px 0;"></div>
+  <p style="font-family: 'JetBrains Mono', monospace; font-size: 18px; font-weight: 400; line-height: 1.70; color: #00cc33; max-width: 600px;">How AI coworkers are reshaping the way teams operate, collaborate, and deliver results.</p>
+</div>
+```
+
+### Terminal Card
+
+```html
+<div style="background: #222240; border: 1px solid rgba(0,255,65,0.15); border-radius: 4px; overflow: hidden;">
+  <div style="display: flex; align-items: center; gap: 8px; padding: 12px 16px; background: #12122a; border-bottom: 1px solid rgba(0,255,65,0.15);">
+    <span style="width: 10px; height: 10px; border-radius: 50%; background: #ff5f57;"></span>
+    <span style="width: 10px; height: 10px; border-radius: 50%; background: #ffbd2e;"></span>
+    <span style="width: 10px; height: 10px; border-radius: 50%; background: #28c840;"></span>
+    <span style="font-family: 'JetBrains Mono', monospace; font-size: 12px; font-weight: 400; letter-spacing: 0.5px; color: #4a4a5a; margin-left: 8px;">~/goose/agents</span>
+  </div>
+  <div style="padding: 32px 24px;">
+    <p style="font-family: 'JetBrains Mono', monospace; font-size: 12px; font-weight: 600; letter-spacing: 3px; text-transform: uppercase; color: #ffb000; margin: 0 0 12px;">FEATURE_01</p>
+    <h3 style="font-family: 'JetBrains Mono', monospace; font-size: 24px; font-weight: 600; line-height: 1.20; color: #00ff41; margin: 0 0 12px;">Persistent Memory</h3>
+    <p style="font-family: 'JetBrains Mono', monospace; font-size: 15px; font-weight: 400; line-height: 1.75; letter-spacing: 0.2px; color: #00cc33; margin: 0;">Every agent maintains its own filesystem, notes, and learned preferences across sessions. Context is never lost.</p>
+  </div>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="background: #222240; border: 1px solid rgba(0,255,65,0.15); border-radius: 4px; padding: 40px 24px; text-align: center;">
+  <p style="font-family: 'JetBrains Mono', monospace; font-size: 56px; font-weight: 700; line-height: 1.00; color: #00ff41; margin: 0 0 8px; text-shadow: 0 0 20px rgba(0,255,65,0.3);">47%</p>
+  <p style="font-family: 'JetBrains Mono', monospace; font-size: 12px; font-weight: 600; letter-spacing: 3px; text-transform: uppercase; color: #ffb000; margin: 0 0 12px;">FASTER RESPONSE</p>
+  <p style="font-family: 'JetBrains Mono', monospace; font-size: 15px; font-weight: 400; line-height: 1.75; letter-spacing: 0.2px; color: #00cc33; max-width: 280px; margin: 0 auto;">Teams using AI coworkers respond to inbound leads nearly twice as fast.</p>
+</div>
+```
+
+### Comparison Grid
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2px; background: rgba(0,255,65,0.15); border-radius: 4px; overflow: hidden;">
+  <div style="background: #222240; padding: 40px 24px;">
+    <p style="font-family: 'JetBrains Mono', monospace; font-size: 12px; font-weight: 600; letter-spacing: 3px; text-transform: uppercase; color: #4a4a5a; margin: 0 0 16px;">// BEFORE</p>
+    <h3 style="font-family: 'JetBrains Mono', monospace; font-size: 24px; font-weight: 600; line-height: 1.20; color: #00ff41; margin: 0 0 12px;">Manual & Fragmented</h3>
+    <p style="font-family: 'JetBrains Mono', monospace; font-size: 15px; font-weight: 400; line-height: 1.75; letter-spacing: 0.2px; color: #00cc33; margin: 0;">Teams juggle Slack threads, spreadsheets, and context-switching between tabs.</p>
+  </div>
+  <div style="background: #222240; padding: 40px 24px; border-left: 2px solid #ffb000;">
+    <p style="font-family: 'JetBrains Mono', monospace; font-size: 12px; font-weight: 600; letter-spacing: 3px; text-transform: uppercase; color: #ffb000; margin: 0 0 16px;">// AFTER</p>
+    <h3 style="font-family: 'JetBrains Mono', monospace; font-size: 24px; font-weight: 600; line-height: 1.20; color: #00ff41; margin: 0 0 12px;">Orchestrated & Autonomous</h3>
+    <p style="font-family: 'JetBrains Mono', monospace; font-size: 15px; font-weight: 400; line-height: 1.75; letter-spacing: 0.2px; color: #00cc33; margin: 0;">AI coworkers handle research, drafting, and follow-up. Your team focuses on decisions.</p>
+  </div>
+</div>
+```
+
+### List Item
+
+```html
+<div style="display: flex; gap: 16px; align-items: flex-start; padding: 20px 0; border-bottom: 1px solid rgba(74,74,90,0.5);">
+  <span style="font-family: 'JetBrains Mono', monospace; font-size: 15px; font-weight: 500; color: #ffb000; min-width: 24px;">$</span>
+  <div>
+    <h4 style="font-family: 'JetBrains Mono', monospace; font-size: 18px; font-weight: 600; line-height: 1.25; color: #00ff41; margin: 0 0 6px;">multi-channel --access</h4>
+    <p style="font-family: 'JetBrains Mono', monospace; font-size: 15px; font-weight: 400; line-height: 1.75; letter-spacing: 0.2px; color: #00cc33; margin: 0;">Reach your AI coworkers through Slack, Telegram, WhatsApp, or the web -- wherever your team already works.</p>
+  </div>
+</div>
+```
+
+### Quote Block
+
+```html
+<div style="background: #12122a; padding: 40px 32px; border-left: 2px solid #ffb000; border-radius: 4px;">
+  <p style="font-family: 'JetBrains Mono', monospace; font-size: 12px; font-weight: 600; letter-spacing: 3px; text-transform: uppercase; color: #4a4a5a; margin: 0 0 16px;">// TESTIMONIAL</p>
+  <p style="font-family: 'JetBrains Mono', monospace; font-size: 20px; font-weight: 400; line-height: 1.55; color: #00ff41; margin: 0 0 20px;">"It felt less like configuring software and more like onboarding a new team member."</p>
+  <p style="font-family: 'JetBrains Mono', monospace; font-size: 12px; font-weight: 600; letter-spacing: 3px; text-transform: uppercase; color: #ffb000; margin: 0;">-- SARAH CHEN // VP OPERATIONS</p>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="text-align: center; padding: 60px 40px; background: #222240; border: 1px solid rgba(0,255,65,0.15); border-radius: 4px; position: relative; background-image: repeating-linear-gradient(0deg, rgba(0,255,65,0.02) 0px, transparent 1px, transparent 2px);">
+  <p style="font-family: 'JetBrains Mono', monospace; font-size: 12px; font-weight: 600; letter-spacing: 3px; text-transform: uppercase; color: #ffb000; margin: 0 0 20px;">// READY?</p>
+  <h2 style="font-family: 'JetBrains Mono', monospace; font-size: 36px; font-weight: 700; line-height: 1.15; color: #00ff41; margin: 0 0 16px;">Deploy your first agent<span style="animation: blink 1s step-end infinite; display: inline-block;">_</span></h2>
+  <p style="font-family: 'JetBrains Mono', monospace; font-size: 15px; font-weight: 400; line-height: 1.75; color: #00cc33; max-width: 480px; margin: 0 auto 32px;">Up and running in under five minutes. No setup fees, no long-term commitments.</p>
+  <a style="display: inline-block; background: transparent; color: #00ff41; font-family: 'JetBrains Mono', monospace; font-size: 14px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; text-decoration: none; padding: 14px 36px; border: 2px solid #00ff41; border-radius: 4px;">$ get-started</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between inline elements and tight icon/label pairs.
+- **8px**: Tight gap -- between terminal window dots, between stat number and label.
+- **12px**: Small gap -- between heading and body text within a terminal card.
+- **16px**: Base gap -- between body paragraphs, between list items, terminal card title bar padding.
+- **20px**: List padding -- vertical padding for list items.
+- **24px**: Medium gap -- internal padding for terminal card content areas.
+- **32px**: Card padding -- primary content padding inside containers.
+- **40px**: Section internal -- padding for quote blocks and stat displays.
+- **48px**: Section divider -- vertical space between major content blocks.
+- **60px**: Large section padding -- hero and CTA block top/bottom padding.
+- **80px**: Maximum section padding -- cover slides and high-impact displays.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 48px all sides | 984px |
+| Infographic (1080xN) | 48px left/right, 60px top/bottom | 984px |
+| Slides (1920x1080) | 60px all sides | 1800px |
+| Poster (1080x1350) | 48px left/right, 60px top/bottom | 984px |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned text for body and heading content. Center-aligned only for stat numbers and CTA blocks.
+- **Grid**: Use 2-column grids for comparisons with 2px gap (the gap becomes a visible green border). 3-column for stat grids on widescreen. Single-column for narrative.
+- **Terminal window chrome**: Cards include a title bar with traffic-light dots (red, amber, green circles) and a path label, mimicking a terminal window.
+- **Scanline overlay**: Apply `repeating-linear-gradient(0deg, rgba(0,255,65,0.03) 0px, transparent 1px, transparent 2px)` as a background-image on hero sections and cover slides.
+- **Grid background**: For large canvases, use a subtle dot-grid pattern: `radial-gradient(circle, rgba(74,74,90,0.3) 1px, transparent 1px)` with `background-size: 24px 24px`.
+- **Content gravity**: Left-aligned. On widescreen slides, content hugs the left side with generous right margin for breathing room.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, background `#1a1a2e` | Page canvas, base layer |
+| Subtle (Level 1) | `rgba(0,0,0,0.3) 0px 2px 8px` | Slight lift for secondary containers |
+| Card (Level 2) | `rgba(0,0,0,0.4) 0px 4px 16px, rgba(0,255,65,0.04) 0px 0px 12px` | Standard terminal card elevation |
+| Featured (Level 3) | `rgba(0,0,0,0.5) 0px 8px 32px, rgba(0,255,65,0.08) 0px 0px 24px` | Featured elements, active terminal windows |
+| Glow (Level 4) | `rgba(0,0,0,0.6) 0px 16px 48px, rgba(0,255,65,0.12) 0px 0px 40px` | Hero elements, high-priority overlays with green glow |
+
+### Border Treatments
+- **Standard border**: `1px solid rgba(0,255,65,0.15)` -- green-tinted line that evokes terminal window borders.
+- **Accent border**: `2px solid #ffb000` -- solid amber for left-border accents on quotes and highlighted containers.
+- **Active border**: `1px solid rgba(0,255,65,0.4)` -- brighter green for active/selected containers.
+- **Grid gap border**: `2px` gap filled with surface or green-tinted background for comparison grids.
+- **Divider line**: `1px solid rgba(74,74,90,0.5)` -- dim gray for list separators.
+
+### Surface Hierarchy
+On the dark canvas, elevation uses slight lightness shifts and green-tinted glow:
+1. **Canvas** (`#1a1a2e`) -- the darkest layer, the terminal background.
+2. **Surface** (`#222240`) -- cards and terminal windows step up by becoming slightly lighter with a purple undertone.
+3. **Inset** (`#12122a`) -- recessed areas (code output, inner panels) sit darker than the canvas.
+4. **Ghost** (`#2a2a3e`) -- nested containers within cards.
+
+Green-tinted glow effects (`rgba(0,255,65,0.04-0.12)`) on elevated elements create the characteristic "lit terminal" feel, as if the green text is casting light onto its container.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use JetBrains Mono for ALL text -- headers, body, labels, buttons, everything. The monospace constraint is the entire identity.
+- Use uppercase + wide letter-spacing (2-4px) for system labels, category markers, and status indicators.
+- Apply the scanline overlay (`repeating-linear-gradient`) on hero sections and cover backgrounds for CRT atmosphere.
+- Use matrix green (`#00ff41`) as the primary text colour on dark backgrounds -- it is the signature of this style.
+- Use amber (`#ffb000`) for highlights, warnings, and secondary emphasis that needs to stand apart from green.
+- Include terminal window chrome (traffic-light dots + path label) on card components for authenticity.
+- Add blinking cursor animations to hero headlines and active input fields.
+- Use `text-shadow: 0 0 20px rgba(0,255,65,0.3)` on big numbers and hero stats for a subtle phosphor glow.
+- Keep border-radius at 4px maximum -- terminals are sharp, not rounded.
+- Use `//` prefix comments in labels and headings to evoke code comments.
+
+### Don't
+- Don't use sans-serif or serif fonts anywhere -- JetBrains Mono is the ONLY typeface. No Inter, no Playfair, no system sans-serif.
+- Don't use rounded corners above 4px -- this is a sharp, technical aesthetic. No soft corners.
+- Don't use gradients for surfaces or buttons -- backgrounds are flat, solid colours. Gradients are reserved for scanline overlays only.
+- Don't use matrix green for backgrounds or large filled areas -- it is a text and accent colour, not a surface colour.
+- Don't use white (`#ffffff`) for text -- it breaks the terminal illusion. Use green or amber only.
+- Don't use more than 3 colours per slide -- green, amber, and dim gray. No blues, purples, or reds (except traffic-light dots in chrome).
+- Don't increase body text size above 18px -- monospaced type at large sizes creates uncomfortably wide text blocks.
+- Don't use drop caps or decorative typography -- this style is disciplined and mechanical, not literary.
+- Don't center-align body text -- left-alignment is the grammar of terminal output. Center only stats and CTAs.
+- Don't use soft shadows or ambient glow without the green tint -- all elevation effects must feel like phosphor light.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale down**: Display Hero becomes 44px (from 56px). Section Heading becomes 28px. Sub-heading stays 24px. Body stays 15px.
+- **Padding**: 48px on all sides. Content area is 984x984px.
+- **Cover slide**: Left-aligned title with blinking cursor. Amber system label above. Scanline overlay on background. Green horizontal rule below title.
+- **Content slides**: Terminal card with window chrome. One concept per slide with system label and description.
+- **Stat slides**: Single stat centered. Big number in green with text-shadow glow. Amber label below.
+- **Swipe indicator**: Small green squares at bottom-left (not circles), 6px, 12px gap. Active square filled, others outline only.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Uses full-scale type hierarchy. Display Hero at 56px for the title section.
+- **Padding**: 48px left/right. 60px top/bottom margins.
+- **Section spacing**: 48px vertical gap between major sections. Green horizontal rules (60px wide) between sections.
+- **Vertical rhythm**: Alternate between terminal cards and full-width sections. Use `//` comment labels to introduce each section. Numbered items use green monospaced numbers with amber labels.
+- **Footer**: Dim gray text, 12px JetBrains Mono, with a final green rule above and a `> exit` prompt.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 64px. Section Heading becomes 44px. Body Large becomes 20px.
+- **Padding**: 60px on all sides. Content area is 1800x960px.
+- **Layout**: Left-heavy composition. Title and body occupy the left 55%. Right side can contain a terminal card or stat display.
+- **Title slides**: Left-aligned headline with blinking cursor. Amber label above. Green rule below. Scanline overlay on full background.
+- **Content slides**: 2-column terminal cards for comparisons. Single terminal card for narrative.
+- **Stat slides**: Up to 3 stats in a row, each in its own terminal card with window chrome.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 48px. Section Heading at 32px. Body at 15px.
+- **Padding**: 48px left/right, 60px top/bottom.
+- **Composition**: Top third for hero headline with scanline overlay. Middle third for terminal cards (content or stats). Bottom third for CTA in a terminal card.
+- **Vertical flow**: Green horizontal rules separate the three zones. Each zone is introduced by an amber `//` label.
+- **Background**: Apply subtle dot-grid pattern across the full poster for depth.
+- **CTA placement**: Terminal-styled button with green border at the bottom, centered within a card.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Hero becomes 56px in JetBrains Mono (approximately 30% larger than Carousel 44px). Section Heading becomes 36px. Body Large becomes 20px. Labels stay at 14-16px uppercase with 2-4px letter-spacing. Everything monospaced -- no exceptions.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical text must sit inside y=160 to y=1760.
+- **Layout**: Single centered column. Content max-width 920px. Vertical center of gravity -- cluster hero content in y=400 to y=1500 range. Dark charcoal background (`#1a1a2e`) runs edge-to-edge with the signature scanline overlay (`repeating-linear-gradient(0deg, rgba(0,255,65,0.03) 0px, transparent 1px, transparent 2px)`) applied across the full canvas. Optional dim-gray dot-grid beneath the scanlines for architectural depth.
+- **Cover slide**: Amber (`#ffb000`) `//` comment-style label at the top inside the safe zone in uppercase with wide tracking. Matrix green (`#00ff41`) JetBrains Mono headline at 56px below, framed as if it were a terminal output. A blinking green cursor (`@keyframes blink`) trails the last character of the headline. Short green body text below.
+- **Content slides**: One bordered "terminal window" card per slide, 1px dim-gray border with a subtle dark-mid surface. Inside: amber `//` label at the top, matrix green heading at 36px, and green/dim body content. Stats rendered in matrix green at 72px with blinking cursors feel genuinely "live." Grid-aligned to the monospace rhythm throughout.
+- **CTA slide**: Terminal card centered in the middle zone. Amber `//` label, matrix green JetBrains Mono headline at 44px, green body line, and a terminal-styled button -- 1px solid matrix green border, transparent fill, green uppercase text with wide tracking. A blinking cursor sits inside the button to signal "input required."
+- **Progress indicator**: ASCII-style progress bar at the top of the safe zone rendered in monospace: matrix green filled blocks (`█`) for complete, dim gray (`░`) for incomplete, wrapped in square brackets (`[███░░░░]`). Scanlines preserved across it. The progress indicator IS the aesthetic.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Terminal Dark | `#1a1a2e` | Primary background (canvas) |
+| Matrix Green | `#00ff41` | Primary text, accent, rules, active states |
+| Amber | `#ffb000` | Secondary accent: labels, warnings, highlights |
+| Bright Green | `#33ff66` | Hover state for green elements |
+| Dark Amber | `#cc8e00` | Hover state for amber elements |
+| Dim Green | `#00cc33` | Secondary text, body copy |
+| Cyan | `#00d4ff` | Tertiary accent, links (used sparingly) |
+| Dim Gray | `#4a4a5a` | Borders, grid lines, inactive elements |
+| Dark Surface | `#12122a` | Inset panels, code blocks |
+| Mid Dark | `#222240` | Card/container surface |
+| Faint Gray | `#3a3a4e` | Secondary borders |
+| Ghost Gray | `#2a2a3e` | Nested containers |
+| Muted Green | `#00802a` | Disabled text |
+
+### Font Declarations
+
+```css
+font-family: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-terminal-dark: #1a1a2e;
+  --color-matrix-green: #00ff41;
+  --color-amber: #ffb000;
+
+  /* Colors -- Accent */
+  --color-bright-green: #33ff66;
+  --color-dark-amber: #cc8e00;
+  --color-dim-green: #00cc33;
+  --color-cyan: #00d4ff;
+
+  /* Colors -- Neutral Scale */
+  --color-dim-gray: #4a4a5a;
+  --color-dark-surface: #12122a;
+  --color-mid-dark: #222240;
+  --color-faint-gray: #3a3a4e;
+  --color-ghost-gray: #2a2a3e;
+  --color-muted-green: #00802a;
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: #222240;
+  --color-surface-inset: #12122a;
+  --color-surface-canvas: #1a1a2e;
+
+  /* Colors -- Borders */
+  --color-border-default: rgba(0, 255, 65, 0.15);
+  --color-border-accent: rgba(255, 176, 0, 0.3);
+  --color-border-active: rgba(0, 255, 65, 0.4);
+  --color-border-dim: rgba(74, 74, 90, 0.5);
+  --color-divider-rule: #00ff41;
+
+  /* Colors -- Shadows */
+  --shadow-green: rgba(0, 255, 65, 0.06);
+  --shadow-deep: rgba(0, 0, 0, 0.5);
+  --shadow-soft: rgba(0, 0, 0, 0.3);
+  --shadow-glow: rgba(0, 255, 65, 0.1);
+
+  /* Typography -- Families */
+  --font-display: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+  --font-body: 'JetBrains Mono', 'Fira Code', 'Courier New', monospace;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 56px;
+  --text-section-heading: 36px;
+  --text-sub-heading: 24px;
+  --text-body-large: 18px;
+  --text-body: 15px;
+  --text-small: 12px;
+  --text-big-number: 56px;
+  --text-label: 12px;
+  --text-cta: 14px;
+
+  /* Typography -- Weights */
+  --weight-display: 700;
+  --weight-heading: 600;
+  --weight-body: 400;
+  --weight-label: 600;
+  --weight-prompt: 500;
+
+  /* Typography -- Line Heights */
+  --leading-display: 1.10;
+  --leading-heading: 1.15;
+  --leading-sub-heading: 1.20;
+  --leading-body-large: 1.70;
+  --leading-body: 1.75;
+  --leading-small: 1.50;
+  --leading-number: 1.00;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-list: 20px;
+  --space-medium: 24px;
+  --space-card-padding: 32px;
+  --space-large: 40px;
+  --space-section: 48px;
+  --space-hero: 60px;
+  --space-max: 80px;
+
+  /* Borders */
+  --radius-standard: 4px;
+
+  /* Shadows -- Composed */
+  --shadow-card: rgba(0,0,0,0.4) 0px 4px 16px, rgba(0,255,65,0.04) 0px 0px 12px;
+  --shadow-featured: rgba(0,0,0,0.5) 0px 8px 32px, rgba(0,255,65,0.08) 0px 0px 24px;
+
+  /* Effects */
+  --scanline-overlay: repeating-linear-gradient(0deg, rgba(0,255,65,0.03) 0px, transparent 1px, transparent 2px);
+  --dot-grid: radial-gradient(circle, rgba(74,74,90,0.3) 1px, transparent 1px);
+  --dot-grid-size: 24px 24px;
+  --text-glow-green: 0 0 20px rgba(0,255,65,0.3);
+}
+
+/* Animation */
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}
+```
+
+### System Font Fallbacks
+- **Monospace (if JetBrains Mono fails to load):** `'Fira Code', 'Courier New', monospace`

--- a/skills/composites/goose-graphics/styles/_full/venn-infographic.md
+++ b/skills/composites/goose-graphics/styles/_full/venn-infographic.md
@@ -1,0 +1,523 @@
+# Design Style: Venn Infographic
+
+## 1. Visual Theme & Atmosphere
+
+Venn Infographic is the design language of the friendly modern business explainer — the visual vocabulary shared by Harvard Business Review explainers, Notion blog post hero illustrations, and McKinsey-style productivity carousels. It is clean but never cold, editorial but never stiff. The entire composition sits on a warm off-white canvas (`#F6F5F2`) that reads as premium paper stock under soft studio light. Against this canvas, a single Inter typeface does all the work — a near-black (`#1A1A1A`) 700-weight headline at the top left, a quiet mid-gray subtitle underneath, and the rest of the composition falls to a signature illustrative device: a three-circle Venn diagram rendered in pastel sage, coral, and soft blue at ~70% opacity so the overlaps mix into muted tertiary zones.
+
+The Venn diagram is the identity. Three big translucent circles (~260px each, overlapping by a third) create a classical framework diagram that feels both academic and approachable. The colors — sage green `#B8D4A8`, coral `#E8A89E`, and soft blue `#A8C4D8` — are deliberately desaturated. They are the colors of a grade-school science textbook reimagined for a 2026 productivity blog: playful enough to invite, muted enough to stay credible in a C-suite context. Floating white info cards with barely-there drop shadows (`0 4px 16px rgba(0,0,0,0.06)`) anchor to each circle, each containing an outlined circular icon, a small number label (`01`, `02`, `03` in near-black), a bold short heading, and two lines of gray body text. The cards feel like they were plucked from a Notion document and pinned to the diagram — which is precisely the mood.
+
+The result is a style that solves a specific problem: explaining a 3-part framework without looking like a PowerPoint deck. It shines brightest when the content has a natural trinity (three skills, three pillars, three overlapping forces), but the system is flexible enough to carry single-topic infographics, stat displays, and quote blocks through the same visual grammar. Think of it as the design equivalent of an HBR 1-minute explainer — clear, warm, and unmistakably editorial.
+
+**Key Characteristics:**
+- Warm off-white background (`#F6F5F2`) — not pure white, not gray, a slightly beige paper tone
+- Near-black (`#1A1A1A`) Inter 700 headlines at 36–44px with tight `-0.3px` tracking, left-aligned
+- Mid-gray (`#6B6B6B`) Inter 400 subtitles at 16–18px, generous 1.55 line height
+- Signature Venn diagram: three 260px circles in sage `#B8D4A8`, coral `#E8A89E`, blue `#A8C4D8` at 70% opacity
+- Circle overlap creates visible tertiary mix zones — never use `mix-blend-mode: normal`
+- Floating white cards with 12px border-radius and subtle shadow `0 4px 16px rgba(0,0,0,0.06)`
+- Outlined circular icons (1.5px stroke, 44px diameter, near-black stroke on white fill)
+- Numbered labels (`01`, `02`, `03`) in Inter 700 at 20–24px placed inside each colored circle
+- Card internal layout: icon top, number, bold heading, 2-line gray body — strict rhythm
+- Single Inter font family across display and body, weights 400/600/700 only
+- Never any hard borders on cards — elevation comes from shadow, not line
+- Friendly-editorial mood — warm, clean, modern corporate, never cold or techy
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Paper** (`#F6F5F2`): Primary background. A warm off-white that reads as premium matte paper stock. Never swap for pure white.
+- **Near-Black** (`#1A1A1A`): Primary text, headlines, numbered labels, icon strokes. Deep enough to command, soft enough to avoid harshness.
+- **Sage Green** (`#B8D4A8`): First Venn circle fill. A dusty, desaturated green — never saturated, never bright.
+
+### Accent (Venn Trio)
+- **Coral** (`#E8A89E`): Second Venn circle fill. Warm salmon-pink, medium saturation.
+- **Soft Blue** (`#A8C4D8`): Third Venn circle fill. Dusty powder blue with a hint of gray.
+- **All three are always rendered at `opacity: 0.7`** so overlapping regions produce muted tertiary mixes (sage+coral → warm olive; sage+blue → teal-gray; coral+blue → mauve).
+
+### Neutral Scale
+- **Card White** (`#FFFFFF`): Floating info card background — this is the one place pure white is allowed, because the warm paper canvas behind it creates visible contrast.
+- **Secondary Text** (`#6B6B6B`): Subtitles, card body text, descriptions, captions.
+- **Tertiary Text** (`#9A9A9A`): Metadata, small labels, low-priority supporting copy.
+- **Muted Divider** (`#E8E6E0`): Subtle dividers, hairlines, input borders when needed.
+- **Icon Stroke Soft** (`#2A2A2A`): Outlined icon strokes — slightly softer than headline near-black for visual weight balance.
+
+### Surface & Borders
+- **Surface Primary** (`#FFFFFF`): Card and container backgrounds. Cards rely on shadow, not borders, for definition.
+- **Surface Inset** (`#F0EEE8`): Slightly darker paper tone for recessed panels, code blocks, or subtle section differentiation.
+- **Border Hairline** (`rgba(0,0,0,0.06)`): Only used when a card needs a whisper of edge definition in light-on-light scenarios.
+- **Divider Rule** (`#E8E6E0`): Horizontal rules between sections.
+- **No accent borders.** Elevation is communicated exclusively through shadow.
+
+### Shadow Colors
+- **Shadow Card** (`rgba(0, 0, 0, 0.06)`): Standard floating card shadow. Soft and barely perceptible.
+- **Shadow Elevated** (`rgba(0, 0, 0, 0.10)`): Featured card or modal shadow.
+- **Shadow Deep** (`rgba(0, 0, 0, 0.14)`): Overlay and dropdown shadows.
+- **Shadow Ambient** (`rgba(0, 0, 0, 0.03)`): Sublimnal depth for the page canvas on infographics.
+
+### Palette Temperature
+Overall **warm-neutral**. The paper background carries the warmth; the Venn trio supplies just enough color variety to read as illustrated without breaking the editorial calm. Never introduce cool grays or pure whites outside of the card surface.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Body**: `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+This is a **single-family** style. Inter handles every text role through weight and size differentiation. No serif, no display face, no decorative type. The restraint is the point.
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Inter | 44px | 700 | 1.15 | -0.3px | Top-level headline. Always left-aligned. Often 2 lines. |
+| Section Heading | Inter | 36px | 700 | 1.20 | -0.3px | Section titles on infographics. |
+| Sub-heading | Inter | 22px | 700 | 1.25 | -0.2px | Card headings, category titles. |
+| Body Large | Inter | 18px | 400 | 1.55 | 0px | Subtitles, lead paragraphs — `#6B6B6B`. |
+| Body | Inter | 16px | 400 | 1.55 | 0px | Card body text, descriptions — `#6B6B6B`. |
+| Body Bold | Inter | 16px | 600 | 1.55 | 0px | Emphasis within body copy. |
+| Small / Caption | Inter | 13px | 500 | 1.50 | 0.1px | Metadata, footer attributions. |
+| Big Number (Card) | Inter | 20px | 700 | 1.00 | 0px | The `01` / `02` / `03` label on cards. |
+| Big Number (Venn) | Inter | 24px | 700 | 1.00 | -0.2px | The number placed inside each Venn circle. |
+| Numbered Label Small | Inter | 13px | 600 | 1.00 | 0.5px | Uppercase "STEP 01" or similar tags. |
+| CTA Text | Inter | 15px | 600 | 1.00 | 0.2px | Button text. |
+
+### Principles
+- **Single family, weight differentiation.** Hierarchy is driven entirely by Inter at 400, 600, and 700. Never mix in a serif or display face — the restraint is the identity.
+- **Tight tracking on headlines.** Display and section headings always use `-0.3px` letter-spacing. This makes 700-weight Inter read as confident rather than chunky.
+- **Left-aligned is default.** Headlines, subtitles, and card content all align left. Centered text is reserved for the numbered labels inside Venn circles.
+- **Generous body line-height.** Body copy uses 1.55 leading to breathe — this is a friendly-editorial style, not a dense technical one.
+- **Secondary text never below 13px.** Keep all supporting copy legible; this style favors clarity over density.
+- **Mixed case always.** Only small framework labels (e.g., "STEP 01", "FRAMEWORK") use uppercase, with `0.5px` positive tracking.
+
+## 4. Component Patterns
+
+### Title Block (Hero / Header Section)
+
+```html
+<div style="background-color: var(--color-paper); padding: 80px 80px 40px; text-align: left;">
+  <h1 style="font-family: var(--font-body); font-size: 44px; font-weight: 700; line-height: 1.15; letter-spacing: -0.3px; color: var(--color-near-black); margin: 0 0 20px; max-width: 720px;">Decision-Making Skills<br>Under Intense Pressure</h1>
+  <p style="font-family: var(--font-body); font-size: 18px; font-weight: 400; line-height: 1.55; color: var(--color-secondary); margin: 0; max-width: 520px;">Stay calm, assess clearly, and act decisively when it matters most.</p>
+</div>
+```
+
+### Venn Diagram — Signature Component
+
+The Venn diagram is the identity of this style. Use it whenever the content naturally groups into three overlapping concepts. It is built from three absolutely-positioned div circles with `opacity: 0.7` so overlaps mix visibly.
+
+```html
+<div style="position: relative; width: 560px; height: 520px; margin: 0 auto;">
+  <!-- Circle 1: Sage Green (top) -->
+  <div style="position: absolute; top: 0; left: 50%; transform: translateX(-50%); width: 280px; height: 280px; border-radius: 50%; background-color: #B8D4A8; opacity: 0.7;"></div>
+
+  <!-- Circle 2: Coral (bottom-left) -->
+  <div style="position: absolute; bottom: 40px; left: 60px; width: 280px; height: 280px; border-radius: 50%; background-color: #E8A89E; opacity: 0.7;"></div>
+
+  <!-- Circle 3: Soft Blue (bottom-right) -->
+  <div style="position: absolute; bottom: 40px; right: 60px; width: 280px; height: 280px; border-radius: 50%; background-color: #A8C4D8; opacity: 0.7;"></div>
+
+  <!-- Number label inside Sage circle -->
+  <div style="position: absolute; top: 120px; left: 50%; transform: translateX(-50%); font-family: 'Inter', sans-serif; font-size: 24px; font-weight: 700; color: #1A1A1A; letter-spacing: -0.2px;">01</div>
+
+  <!-- Number label inside Coral circle -->
+  <div style="position: absolute; bottom: 160px; left: 140px; font-family: 'Inter', sans-serif; font-size: 24px; font-weight: 700; color: #1A1A1A; letter-spacing: -0.2px;">03</div>
+
+  <!-- Number label inside Blue circle -->
+  <div style="position: absolute; bottom: 160px; right: 140px; font-family: 'Inter', sans-serif; font-size: 24px; font-weight: 700; color: #1A1A1A; letter-spacing: -0.2px;">02</div>
+</div>
+```
+
+**Notes on the Venn:**
+- Each circle is `280px × 280px` with `border-radius: 50%`. On Story format, scale up to `360px × 360px`.
+- Overlap math: the top circle is centered horizontally; the two bottom circles are inset by `60px` from each side. This creates the classical 1/3 overlap geometry.
+- `opacity: 0.7` is non-negotiable. The tertiary mix zones where circles overlap are a key visual signal.
+- Alternative: use `mix-blend-mode: multiply` if you want slightly richer overlap colors against the warm paper background. Both work; `opacity` is more predictable across renderers.
+- Place the numbered label (`01`, `02`, `03`) inside each circle's unique non-overlapping region, centered, using Inter 700 at 24px.
+
+### Info Card — Main Content Unit
+
+The floating info card is the second critical component. It pairs with the Venn diagram (one card per circle) but also works standalone in infographic vertical layouts.
+
+```html
+<div style="background-color: #FFFFFF; border-radius: 12px; padding: 24px 22px; box-shadow: 0 4px 16px rgba(0,0,0,0.06); width: 220px; font-family: 'Inter', sans-serif;">
+  <!-- Outlined circular icon -->
+  <div style="width: 44px; height: 44px; border-radius: 50%; border: 1.5px solid #1A1A1A; display: flex; align-items: center; justify-content: center; margin: 0 0 14px;">
+    <!-- Inline SVG icon goes here, stroke: #1A1A1A, stroke-width: 1.5 -->
+    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="#1A1A1A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="9"/>
+      <path d="M12 7v5l3 2"/>
+    </svg>
+  </div>
+  <!-- Bold short heading -->
+  <h3 style="font-size: 17px; font-weight: 700; line-height: 1.25; letter-spacing: -0.2px; color: #1A1A1A; margin: 0 0 8px;">Pause and Breathe</h3>
+  <!-- 2-line gray body -->
+  <p style="font-size: 14px; font-weight: 400; line-height: 1.55; color: #6B6B6B; margin: 0;">Take a deep breath and respond with calm clarity.</p>
+</div>
+```
+
+**Card rules:**
+- Background always pure white `#FFFFFF` (only place in the style where pure white is allowed).
+- Border-radius always `12px` — no exceptions.
+- Shadow always `0 4px 16px rgba(0,0,0,0.06)`. Subtle. Never heavy.
+- Internal padding `24px 22px`.
+- Icon diameter `44px`, stroke width `1.5px`, color near-black.
+- Fixed vertical rhythm: icon → 14px gap → heading → 8px gap → body.
+- Cards never have visible borders. Shadow alone defines them.
+- Card width on carousels/slides: ~220–240px. On Story format: 260–280px.
+
+### Venn + Cards Composite Layout
+
+When combining the Venn diagram with its info cards, position the cards around the diagram anchored to each circle. This is the signature hero composition.
+
+```html
+<div style="position: relative; padding: 60px; max-width: 960px; margin: 0 auto;">
+  <!-- Venn diagram goes here (see above) -->
+
+  <!-- Card anchored to top-right of sage circle -->
+  <div style="position: absolute; top: 40px; right: 80px; /* info card styles from above */">…</div>
+
+  <!-- Card anchored to bottom-left of coral circle -->
+  <div style="position: absolute; bottom: 60px; left: 40px;">…</div>
+
+  <!-- Card anchored to bottom-right of blue circle -->
+  <div style="position: absolute; bottom: 60px; right: 40px;">…</div>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="background-color: #FFFFFF; border-radius: 12px; padding: 32px 28px; box-shadow: 0 4px 16px rgba(0,0,0,0.06); text-align: left; max-width: 280px;">
+  <p style="font-family: 'Inter', sans-serif; font-size: 48px; font-weight: 700; line-height: 1.0; letter-spacing: -1px; color: #1A1A1A; margin: 0 0 8px;">73%</p>
+  <p style="font-family: 'Inter', sans-serif; font-size: 14px; font-weight: 400; line-height: 1.55; color: #6B6B6B; margin: 0;">of leaders say calm decision-making is the most valuable skill under pressure.</p>
+</div>
+```
+
+### Comparison Grid (2-column)
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
+  <div style="background-color: #FFFFFF; border-radius: 12px; padding: 28px 24px; box-shadow: 0 4px 16px rgba(0,0,0,0.06);">
+    <p style="font-family: 'Inter', sans-serif; font-size: 13px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: #9A9A9A; margin: 0 0 12px;">BEFORE</p>
+    <h3 style="font-family: 'Inter', sans-serif; font-size: 20px; font-weight: 700; line-height: 1.25; letter-spacing: -0.2px; color: #1A1A1A; margin: 0 0 10px;">Reactive Decisions</h3>
+    <p style="font-family: 'Inter', sans-serif; font-size: 14px; font-weight: 400; line-height: 1.55; color: #6B6B6B; margin: 0;">Stress drives impulsive choices and costly mistakes.</p>
+  </div>
+  <div style="background-color: #FFFFFF; border-radius: 12px; padding: 28px 24px; box-shadow: 0 4px 16px rgba(0,0,0,0.06);">
+    <p style="font-family: 'Inter', sans-serif; font-size: 13px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; color: #9A9A9A; margin: 0 0 12px;">AFTER</p>
+    <h3 style="font-family: 'Inter', sans-serif; font-size: 20px; font-weight: 700; line-height: 1.25; letter-spacing: -0.2px; color: #1A1A1A; margin: 0 0 10px;">Calm Clarity</h3>
+    <p style="font-family: 'Inter', sans-serif; font-size: 14px; font-weight: 400; line-height: 1.55; color: #6B6B6B; margin: 0;">Grounded leaders respond with intention and purpose.</p>
+  </div>
+</div>
+```
+
+### List Item
+
+```html
+<div style="display: flex; align-items: flex-start; gap: 16px; padding: 16px 0;">
+  <div style="flex-shrink: 0; width: 32px; height: 32px; border-radius: 50%; background-color: #B8D4A8; opacity: 0.85; display: flex; align-items: center; justify-content: center; font-family: 'Inter', sans-serif; font-size: 14px; font-weight: 700; color: #1A1A1A;">1</div>
+  <div>
+    <h4 style="font-family: 'Inter', sans-serif; font-size: 17px; font-weight: 700; line-height: 1.3; letter-spacing: -0.2px; color: #1A1A1A; margin: 0 0 4px;">Pause before reacting</h4>
+    <p style="font-family: 'Inter', sans-serif; font-size: 15px; font-weight: 400; line-height: 1.55; color: #6B6B6B; margin: 0;">Take a deep breath and let the first impulse pass.</p>
+  </div>
+</div>
+```
+
+### Quote Block
+
+```html
+<div style="background-color: #FFFFFF; border-radius: 12px; padding: 36px 32px; box-shadow: 0 4px 16px rgba(0,0,0,0.06); max-width: 560px;">
+  <p style="font-family: 'Inter', sans-serif; font-size: 22px; font-weight: 600; line-height: 1.4; letter-spacing: -0.2px; color: #1A1A1A; margin: 0 0 20px;">"The best decisions are the ones made with a quiet mind, not a loud one."</p>
+  <div style="display: flex; align-items: center; gap: 12px;">
+    <div style="width: 32px; height: 32px; border-radius: 50%; background-color: #A8C4D8; opacity: 0.7;"></div>
+    <p style="font-family: 'Inter', sans-serif; font-size: 13px; font-weight: 600; color: #6B6B6B; margin: 0;">Ana Rivera<span style="color: #9A9A9A; font-weight: 400;"> · VP Operations</span></p>
+  </div>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="text-align: center; padding: 60px 40px;">
+  <h2 style="font-family: 'Inter', sans-serif; font-size: 36px; font-weight: 700; line-height: 1.20; letter-spacing: -0.3px; color: #1A1A1A; margin: 0 0 16px;">Ready to lead with calm clarity?</h2>
+  <p style="font-family: 'Inter', sans-serif; font-size: 17px; font-weight: 400; line-height: 1.55; color: #6B6B6B; max-width: 480px; margin: 0 auto 32px;">Start practicing the three-part framework that grounds high-stakes decisions.</p>
+  <a style="display: inline-block; background-color: #1A1A1A; color: #FFFFFF; font-family: 'Inter', sans-serif; font-size: 15px; font-weight: 600; letter-spacing: 0.2px; text-decoration: none; padding: 16px 36px; border-radius: 999px;">Get the Framework</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap — between icon and its inner content.
+- **8px**: Tight gap — between card heading and body text.
+- **12px**: Small gap — between number label and adjacent heading.
+- **14px**: Card rhythm gap — between icon and heading inside info cards.
+- **16px**: Base gap — between body paragraphs.
+- **20px**: Medium gap — between cards in a grid.
+- **24px**: Card internal padding — standard inside info cards.
+- **32px**: Component gap — between major components within a section.
+- **48px**: Section gap — between sections on an infographic.
+- **60px**: Outer padding — default canvas padding on carousels, slides, posters.
+- **80px**: Hero padding — top/bottom of hero sections on infographics.
+- **120px**: Story padding — vertical padding on Story format.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 960px |
+| **Story (1080x1920)** | **60px left/right, 120px top/bottom** | **960px** |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned for headlines, subtitles, card content. Center-aligned only for the Venn diagram itself and CTA blocks.
+- **Hero composition**: Title and subtitle top-left, Venn + cards composite filling the center and lower portion of the canvas.
+- **Card grid**: Info cards can also stack in vertical 3-column grids (no Venn) or be arranged asymmetrically around the Venn diagram.
+- **Vertical rhythm**: 48px between infographic sections, 32px between components within a section, 20px between cards in a row.
+- **Visual gravity**: The Venn diagram is the heaviest element. Position it in the visual center-lower third. The headline anchors the top-left.
+- **No hard rules or dividers**. Sections separate via whitespace only.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, background `#F6F5F2` | Page canvas, hero backgrounds |
+| Ambient (Level 1) | `0 1px 3px rgba(0,0,0,0.03)` | Subtle hover states, quiet surfaces |
+| Card (Level 2) | `0 4px 16px rgba(0,0,0,0.06)` | **Standard info card shadow — the signature** |
+| Elevated (Level 3) | `0 8px 24px rgba(0,0,0,0.10)` | Featured cards, hover states on standard cards |
+| Overlay (Level 4) | `0 20px 40px rgba(0,0,0,0.14)` | Modals, dropdowns, tooltips |
+
+### Border Treatments
+- **Cards**: No border. Ever. Elevation from `0 4px 16px rgba(0,0,0,0.06)` shadow only.
+- **Icon circles**: `1.5px solid #1A1A1A` with `border-radius: 50%`. Stroke is the defining feature.
+- **Divider rules**: `1px solid #E8E6E0` — only used when absolutely necessary between sections in long infographics. Prefer whitespace.
+- **Venn circles**: No border. Fill only, at `opacity: 0.7`.
+
+### Surface Hierarchy
+On the warm paper canvas, elevation is communicated almost entirely through shadow intensity:
+1. **Background** (`#F6F5F2`) — the warm canvas.
+2. **Venn circles** (sage/coral/blue at 0.7 opacity) — sit directly on the canvas with no shadow, creating a painted-on effect.
+3. **Cards** (`#FFFFFF` + subtle shadow) — float above the canvas, defined by shadow alone.
+4. **CTA buttons** (`#1A1A1A`) — the strongest visual anchor, dark against light for maximum contrast.
+
+## 7. Do's and Don'ts
+
+### Do
+- **Use the pastel Venn trio exactly as specified.** `#B8D4A8` sage, `#E8A89E` coral, `#A8C4D8` blue at `opacity: 0.7`. This muted palette is the identity — substituting bright saturated versions destroys the warm editorial feel.
+- Keep Venn circles translucent. Always `opacity: 0.7` (or `mix-blend-mode: multiply`). The visible overlap mixing is the whole point.
+- Use Inter at weights 400, 600, and 700 only. Never introduce a serif or second family.
+- Apply `-0.3px` letter-spacing to all headlines at 36px+. This tightens 700-weight Inter to a confident, editorial feel.
+- Use `0 4px 16px rgba(0,0,0,0.06)` for the standard card shadow. Subtle is non-negotiable.
+- Round all cards to exactly `12px`. Round the Venn circles to `50%` (full circle). Round CTA buttons to `999px` (pill).
+- Place numbered labels (`01`, `02`, `03`) inside each colored Venn circle using Inter 700 at 24px, centered in the circle's unique region.
+- Use outlined circular icons at `44px` diameter with `1.5px` near-black stroke on white fill — never solid filled icons.
+- Left-align headlines and subtitles. Reserve centering for the Venn diagram and CTA blocks.
+- Use `#F6F5F2` as the background. The warm off-white is half the mood — never swap for pure white.
+- Keep info cards sparse: icon, heading, 2-line body. Three elements max. Never overflow.
+- Pair every card with its number label matching the Venn circle it anchors to — this creates the legend without needing one.
+
+### Don't
+- Don't use saturated or bright versions of the Venn colors. Sage is not kelly green. Coral is not red. Blue is not royal. If the pastel looks too quiet, you're doing it right.
+- Don't add borders to info cards. Shadow alone — always.
+- Don't use pure white (`#FFFFFF`) for the background. That pure-white look is cold and wrong for this style. Paper tone only.
+- Don't introduce a second typeface. No Playfair, no Georgia, no serif accents. Single family only.
+- Don't use heavy shadows. Maximum is `rgba(0,0,0,0.14)` for overlays. Card shadow stays at `0.06` alpha.
+- Don't make Venn circles opaque. Without translucent overlap, the diagram reads as stacked shapes instead of a Venn.
+- Don't use dot grids, gradients, or background textures. The warm paper canvas must stay clean.
+- Don't use emoji or illustrated icons. Outlined line icons only, 1.5px stroke, monochrome near-black.
+- Don't center-align body paragraphs. Only headlines in CTA blocks and numbered labels inside Venn circles are centered.
+- Don't use more than one Venn diagram per composition. It's the signature element — repeating it dilutes the hero.
+- Don't crowd the Venn with more than three info cards. One card per circle. If you have more than three concepts, use a vertical card list elsewhere on the page.
+- Don't use uppercase for headlines. Only small 13px labels ("STEP 01", "FRAMEWORK") get uppercase + `0.5px` tracking.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale**: Display Hero at 40px (from 44px). Section Heading at 32px. Body Large at 17px. Body at 15px.
+- **Padding**: 60px on all sides. Content area 960x960px.
+- **Cover slide**: Headline top-left, subtitle below, Venn + 3 cards composite filling bottom two-thirds.
+- **Content slides**: Left-aligned headline at top, one of: (a) single Venn + cards, (b) vertical list of 3 info cards, (c) stat display + supporting cards.
+- **Card slides**: 3 info cards in a vertical stack with 20px gaps, or single featured card centered.
+- **Swipe indicator**: Small gray dots at bottom center (6px diameter, `#9A9A9A`, active dot in `#1A1A1A`).
+
+### Infographic (1080px wide, variable height) — **Primary Format**
+- **This style shines brightest as infographics.** The Venn + card pattern can repeat vertically with different 3-concept groupings, creating a long-scroll editorial flow.
+- **Typography**: Full-scale hierarchy. Display Hero at 44px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Section rhythm**: 48px vertical gap between sections. Each section is a self-contained "chapter" with a section heading (36px Inter 700), optional supporting text, and its signature component (Venn + cards, stat grid, comparison, or quote block).
+- **Vertical composition pattern**: Hero (headline + Venn) → Section 1 (3 info cards vertical) → Section 2 (stat display) → Section 3 (second Venn, different trio of concepts) → Section 4 (comparison grid) → CTA footer.
+- **Footer**: Small metadata in Inter 500 at 13px, `#9A9A9A`. Optional mini logo or URL.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero at 56px. Section Heading at 44px. Body Large at 20px. Card headings at 22px.
+- **Padding**: 80px all sides. Content area 1760x920px.
+- **Layout**: Title slides use a left-half/right-half split — headline + subtitle left, Venn + cards right. Content slides left-align headline with ~60% width, Venn + cards composite right.
+- **Title slides**: Headline top-left, subtitle below (`#6B6B6B`, 20px), Venn diagram positioned in the right half with info cards anchored asymmetrically.
+- **Content slides**: Section heading (44px Inter 700), optional intro line, then either a Venn + cards composite or a 3-column card grid.
+- **CTA slides**: Centered layout. Headline, subtitle, dark pill button.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 48px. Section Heading at 36px. Body at 16px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top third for headline + subtitle (left-aligned). Middle half for the Venn diagram + cards composite (the hero element). Bottom zone for a closing statement and CTA.
+- **Vertical flow**: Headline → Venn hero → closing bold statement → CTA pill.
+- **Card placement**: Cards sit asymmetrically around the Venn — one top-right, two at bottom corners — to create visual balance.
+
+### Story (1080x1920px) — **NEW**
+- **Typography scale**: Display Hero at 52px. Section Heading at 40px. Body Large at 19px. Card headings at 19px.
+- **Padding**: **60px left/right, 120px top/bottom** — the extra vertical padding frames the tall canvas.
+- **Venn scales up ~30% bigger**: Circles at `360px × 360px` (instead of 280px). Overall Venn container ~720x680px. The larger diagram dominates the vertical format.
+- **Composition**: Top third — headline + subtitle, left-aligned. Middle half — oversized Venn + cards composite, center-aligned. Bottom zone — CTA pill or closing line, centered.
+- **Card sizing**: Info cards scale to 260–280px width, with slightly larger padding (`28px 26px`) to match the enlarged diagram.
+- **Asymmetric card anchoring**: On Story format, arrange cards vertically along the sides — one top-right adjacent to the sage circle, one bottom-left adjacent to coral, one bottom-right adjacent to blue. This creates a flowing visual rhythm suited to the tall canvas.
+- **Safe zones**: Keep critical content inside the inner 1080x1680 zone to account for Story UI overlays on Instagram/TikTok.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Paper | `#F6F5F2` | Primary background (warm off-white) |
+| Near-Black | `#1A1A1A` | Primary text, headlines, icon strokes |
+| Sage Green | `#B8D4A8` | Venn circle 1 (at 0.7 opacity) |
+| Coral | `#E8A89E` | Venn circle 2 (at 0.7 opacity) |
+| Soft Blue | `#A8C4D8` | Venn circle 3 (at 0.7 opacity) |
+| Card White | `#FFFFFF` | Info card backgrounds (only place pure white is used) |
+| Secondary Text | `#6B6B6B` | Subtitles, body text, descriptions |
+| Tertiary Text | `#9A9A9A` | Metadata, small labels |
+| Surface Inset | `#F0EEE8` | Recessed panels, subtle backgrounds |
+| Divider | `#E8E6E0` | Hairlines, section dividers |
+| Shadow Card | `rgba(0,0,0,0.06)` | Standard card shadow alpha |
+
+### Font Declarations
+
+```css
+/* Single family — Inter handles everything */
+font-family: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors — Primary */
+  --color-paper: #F6F5F2;
+  --color-near-black: #1A1A1A;
+  --color-sage: #B8D4A8;
+
+  /* Colors — Venn Accent Trio */
+  --color-coral: #E8A89E;
+  --color-soft-blue: #A8C4D8;
+  --venn-opacity: 0.7;
+
+  /* Colors — Neutral Scale */
+  --color-card-white: #FFFFFF;
+  --color-secondary: #6B6B6B;
+  --color-tertiary: #9A9A9A;
+  --color-muted-divider: #E8E6E0;
+  --color-icon-stroke: #2A2A2A;
+
+  /* Colors — Surfaces */
+  --color-surface-primary: #FFFFFF;
+  --color-surface-inset: #F0EEE8;
+  --color-divider: #E8E6E0;
+  --color-border-hairline: rgba(0, 0, 0, 0.06);
+
+  /* Colors — Shadows */
+  --shadow-ambient: 0 1px 3px rgba(0, 0, 0, 0.03);
+  --shadow-card: 0 4px 16px rgba(0, 0, 0, 0.06);
+  --shadow-elevated: 0 8px 24px rgba(0, 0, 0, 0.10);
+  --shadow-overlay: 0 20px 40px rgba(0, 0, 0, 0.14);
+
+  /* Typography — Families */
+  --font-display: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography — Sizes */
+  --text-display-hero: 44px;
+  --text-section-heading: 36px;
+  --text-sub-heading: 22px;
+  --text-body-large: 18px;
+  --text-body: 16px;
+  --text-small: 13px;
+  --text-big-number-card: 20px;
+  --text-big-number-venn: 24px;
+  --text-cta: 15px;
+
+  /* Typography — Weights */
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --weight-bold: 700;
+
+  /* Typography — Line Heights */
+  --leading-display: 1.15;
+  --leading-heading: 1.20;
+  --leading-sub-heading: 1.25;
+  --leading-body: 1.55;
+  --leading-small: 1.50;
+  --leading-number: 1.00;
+
+  /* Typography — Letter Spacing */
+  --tracking-display: -0.3px;
+  --tracking-heading: -0.3px;
+  --tracking-sub: -0.2px;
+  --tracking-body: 0px;
+  --tracking-label: 0.5px;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-card-rhythm: 14px;
+  --space-base: 16px;
+  --space-medium: 20px;
+  --space-card-padding: 24px;
+  --space-component: 32px;
+  --space-section: 48px;
+  --space-outer: 60px;
+  --space-hero: 80px;
+  --space-story: 120px;
+
+  /* Borders */
+  --radius-card: 12px;
+  --radius-circle: 50%;
+  --radius-pill: 999px;
+  --stroke-icon: 1.5px;
+
+  /* Venn Diagram Dimensions */
+  --venn-circle-standard: 280px;
+  --venn-circle-story: 360px;
+  --venn-container-standard: 560px;
+  --venn-container-story: 720px;
+}
+```
+
+### System Font Fallbacks
+- **Sans-serif (if Inter fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+Inter is the only typeface. No fallback serif. If Inter unavailable, the system sans stack carries the full hierarchy through weight differentiation.

--- a/skills/composites/goose-graphics/styles/_full/vintage-duotone-poster.md
+++ b/skills/composites/goose-graphics/styles/_full/vintage-duotone-poster.md
@@ -1,0 +1,528 @@
+# Design Style: Vintage Duotone Poster
+
+## 1. Visual Theme & Atmosphere
+
+Vintage Duotone Poster is a mid-century letterpress aesthetic pulled straight from a 1950s drive-in marquee. It is the visual language of a printed event flyer stapled to a telephone pole outside a small-town cinema -- two-color halftone reproduction, chunky brush-script display type, and a heavy condensed poster sans that hits like a hammer. The canvas is a deep forest green (`#2D4D3A`) that reads less like a digital background and more like the ink-saturated fiber of pulp board stock. Against that green, a single dusty salmon pink (`#EDB5A7`) does all the work -- it is the only accent, used for type, photography tint, halftone dots, and the thin corner rules. The restraint is the point. When every mark on the canvas is one of two colors, the composition feels authored, printed, and deliberate.
+
+The signature move is a **duotone halftone photograph** -- a black-and-white portrait re-inked into green shadows and pink highlights, printed through a dot screen so the image breathes with visible texture. In CSS this is achieved with a stacked filter chain (`grayscale(100%) contrast(120%) sepia(100%) hue-rotate(...)` plus a pink-tinted `mix-blend-mode: screen` overlay), or more reliably by pre-processing the image in Photoshop/Figma as a true duotone and dropping it in as a static asset. Either way, the photograph is not decoration -- it is the hero. It occupies the lower two-thirds of the composition, bleeds to the edges, and carries all the human warmth while the typography handles authority and impact.
+
+The typography pairs a **chunky 1950s brush script** for the emotional word with a **heavy condensed poster sans in ALL CAPS** for the impact word. The script word floats with personal handwriting energy -- rounded, slightly slanted, dropping below baseline. The condensed sans word below it is set enormous, nearly edge-to-edge, so tight the tracking almost collapses. This stacking -- casual script over commanding sans -- is how 1950s movie posters shouted their titles from a block away. Event metadata (`@reallygreatsite`, `08/09 10 PM`, `FREE ENTRY`) is set small in uppercase sans and pushed into the left and right margins beside the photograph, creating a symmetric frame that reads like a ticket stub. The whole thing feels like a Saul Bass rough, a Hatch Show Print run, or a Criterion Collection sleeve for a forgotten B-movie.
+
+**Key Characteristics:**
+- Deep forest green background (`#2D4D3A`) -- the ink-saturated canvas, never lighter, never a gradient
+- Dusty salmon pink (`#EDB5A7`) as the **sole** accent -- for type, photo tint, rules, halftone dots, and every mark
+- Duotone halftone photography occupying the lower two-thirds -- green shadows, pink highlights, visible grain
+- Chunky brush-script display font for the emotional word (Alfa Slab One as the fallback, Rubik Puddles for true brush feel)
+- Heavy condensed poster sans (Oswald / Bebas Neue) for the impact word, set in ALL CAPS at ~200-280px
+- Stacked two-word headline: script on top (~30% of headline height), condensed sans below (~70%)
+- Metadata in small uppercase sans (14-18px, weight 600, letter-spacing 2px) pushed to left/right margins
+- Subtle film grain / halftone dot texture overlay at 6-10% opacity -- never flat
+- Thin 1-2px pink rules for dividers and corner accents -- never rounded
+- High contrast between type and ground -- 4.8:1 ratio minimum for all pink-on-green text
+- Zero use of rounded corners, gradients, or drop shadows -- this is a printed artifact
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Forest Green** (`#2D4D3A`): Primary background. A deep, slightly desaturated forest green that reads as printed ink on pulp board. The dominant surface across every format.
+- **Dusty Pink** (`#EDB5A7`): Primary accent and primary text. The sole content color -- headlines, body, metadata, rules, halftone highlights, photograph tint. Its dustiness is load-bearing; a brighter coral would look digital.
+- **Deep Green** (`#1F3528`): A darker forest green used for photograph shadows, subtle recessed panels, and the deep end of the duotone gradient.
+
+### Accent
+- **Pink Highlight** (`#F5CFC6`): A slightly paler pink for halftone highlights, photograph catch-lights, and hover states. Used sparingly -- never as a second accent color, only as a lightness variant of the primary pink.
+- **Pink Shadow** (`#D9948A`): A slightly deeper pink for the darker end of pink type on ambiguous ground, or for drop-cap emphasis. The lower bound of the pink range.
+
+### Neutral Scale
+- **Green Canvas** (`#2D4D3A`): The base green.
+- **Green Inset** (`#264030`): A recessed green for inset panels -- ~10% darker than the canvas.
+- **Green Deep** (`#1F3528`): The deepest end of any duotone gradient.
+- **Pink Text Primary** (`#EDB5A7`): All primary type.
+- **Pink Text Muted** (`rgba(237, 181, 167, 0.65)`): Secondary text, metadata lines, slide numbers.
+- **Pink Text Faint** (`rgba(237, 181, 167, 0.35)`): Borders, dividers, watermarks.
+
+### Surface & Borders
+- **Surface Primary** (`#2D4D3A`): The canvas itself. Cards and containers do not use a different fill -- they are defined by borders and rules only.
+- **Surface Inset** (`#264030`): Rare recessed panel color -- 10% darker than the canvas.
+- **Border Default** (`rgba(237, 181, 167, 0.35)`): Standard 1px pink rule for dividers and thin corner accents.
+- **Border Strong** (`rgba(237, 181, 167, 0.65)`): 2px pink rule for featured borders and framing devices.
+- **Border Accent** (`#EDB5A7`): Full-opacity pink border for the rare emphasized container.
+- **Divider Rule** (`rgba(237, 181, 167, 0.25)`): Faint hairline for internal section separators.
+
+### Shadow Colors
+- **Shadow None** (`transparent`): The default. This style uses no drop shadows.
+- **Shadow Ink** (`rgba(31, 53, 40, 0.5)`): A deep green "ink bleed" used only on duotone photograph edges where a soft vignette is needed.
+- **Grain Overlay** (`rgba(237, 181, 167, 0.06)`): The pink film-grain texture applied as a full-canvas overlay at very low opacity.
+
+### Texture
+- **Halftone Dots**: `radial-gradient(circle, rgba(237, 181, 167, 0.12) 1px, transparent 1.5px)` at `4px 4px` spacing. Applied as a subtle overlay on photograph areas to simulate print-screen reproduction.
+- **Film Grain**: `radial-gradient(circle, rgba(237, 181, 167, 0.08) 0.5px, transparent 1px)` at `3px 3px` spacing. Applied across the entire canvas at low opacity for paper-stock feel.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Alfa+Slab+One&family=Oswald:wght@400;500;600;700&family=Bebas+Neue&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Script Display** (`Alfa Slab One`, fallback `Georgia, serif`): Used exclusively for the "emotional word" in a stacked headline -- the equivalent of "Movie" in the reference. Chunky, slab-like, with a hand-drawn vintage presence. Alfa Slab One is the closest Google Font to the reference's brush-script feel while remaining legible and impactful.
+- **Impact Display** (`Oswald`, fallback `Impact, sans-serif`): Used for the "impact word" -- the equivalent of "NIGHT". Heavy condensed sans at weight 700, set in ALL CAPS at poster-scale sizes.
+- **Metadata** (`Oswald`, weight 600): Small uppercase sans for event metadata, handles, dates, and CTA labels. Same family as the impact word for compositional unity.
+- **Body** (`Inter`, fallback `-apple-system, Helvetica, Arial, sans-serif`): Reserved for rare body-text overflow cases. This style is display-heavy -- most compositions contain very little body text.
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Script | Alfa Slab One | 140px | 400 | 0.95 | -2px | The emotional word. Slightly tilted via `transform: rotate(-3deg)`. Positioned to overlap the impact word slightly. |
+| Display Impact | Oswald | 240px | 700 | 0.85 | -4px | The impact word. ALL CAPS. Set nearly edge-to-edge. Tight tracking. |
+| Section Heading | Oswald | 72px | 700 | 0.95 | -1px | Section dividers. ALL CAPS. |
+| Sub-heading | Oswald | 48px | 600 | 1.05 | 0px | Card headings. ALL CAPS. |
+| Body Large | Inter | 22px | 500 | 1.55 | 0.3px | Body overflow, rare. |
+| Body | Inter | 18px | 500 | 1.55 | 0.3px | Standard body text when needed. |
+| Metadata Large | Oswald | 32px | 600 | 1.10 | 2px | "08/09 10 PM" -- corner metadata at poster scale. ALL CAPS. |
+| Metadata | Oswald | 18px | 600 | 1.20 | 2px | Standard metadata, handles, tags. ALL CAPS. |
+| Metadata Small | Oswald | 14px | 600 | 1.20 | 2.5px | Fine print, slide numbers, credits. ALL CAPS. |
+| Big Numbers | Oswald | 180px | 700 | 0.90 | -3px | Stat displays. ALL CAPS. |
+| CTA Label | Oswald | 24px | 700 | 1.00 | 3px | Button text. ALL CAPS. |
+
+### Principles
+- **Two fonts do everything.** Alfa Slab One for the single emotional word. Oswald for everything else. This is a binary type system -- the restraint is the style.
+- **Stack the headline.** Display headlines are always two words, stacked vertically: script on top, condensed sans below. The script word is ~30% of the total headline height, the impact word is ~70%. They overlap slightly (negative margin, -20px to -40px) to feel hand-composed.
+- **ALL CAPS is the default.** Oswald is used almost exclusively in uppercase. Mixed case is reserved for the rare body-text overflow. The only lowercase letters in the reference are in the `@reallygreatsite` handle.
+- **Tight tracking on display, wide tracking on metadata.** Display Impact runs at -4px letter-spacing for edge-to-edge impact. Metadata runs at +2px to +2.5px for that "etched plate" feel.
+- **Line height collapses at display scale.** The impact word sits at 0.85 line height so stacked words almost touch. Metadata sits at 1.10-1.20 for breathing room.
+- **Never italicize.** This style has no italic variants. The script font provides the "soft" energy; nothing else needs to lean.
+- **Slight rotation on the script word.** Apply `transform: rotate(-3deg)` or `rotate(-2deg)` to the script word for hand-set-on-press energy. Never rotate anything else.
+
+## 4. Component Patterns
+
+### Title Block (Stacked Script + Impact Headline)
+
+```html
+<div style="background-color: var(--color-green); padding: 80px 60px; text-align: center; position: relative; overflow: hidden;">
+  <!-- Film grain overlay -->
+  <div style="position: absolute; inset: 0; background-image: radial-gradient(circle, rgba(237,181,167,0.08) 0.5px, transparent 1px); background-size: 3px 3px; pointer-events: none;"></div>
+  <div style="position: relative; z-index: 1;">
+    <h1 style="margin: 0; line-height: 0.85;">
+      <span style="display: block; font-family: var(--font-script); font-size: 140px; font-weight: 400; color: var(--color-pink); line-height: 0.95; letter-spacing: -2px; transform: rotate(-3deg); margin: 0 0 -30px;">Movie</span>
+      <span style="display: block; font-family: var(--font-impact); font-size: 240px; font-weight: 700; color: var(--color-pink); line-height: 0.85; letter-spacing: -4px; text-transform: uppercase;">NIGHT</span>
+    </h1>
+  </div>
+</div>
+```
+
+### Event Metadata Strip (Signature Component)
+
+```html
+<div style="display: flex; justify-content: space-between; align-items: flex-start; padding: 0 60px; gap: 40px;">
+  <!-- Left metadata block -->
+  <div style="text-align: left;">
+    <p style="font-family: var(--font-impact); font-size: 18px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: var(--color-pink); margin: 0 0 16px;">@reallygreatsite</p>
+    <p style="font-family: var(--font-impact); font-size: 32px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: var(--color-pink); line-height: 1.10; margin: 0;">08/09<br>10 PM</p>
+  </div>
+  <!-- Right metadata block -->
+  <div style="text-align: right;">
+    <p style="font-family: var(--font-impact); font-size: 18px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: var(--color-pink); margin: 0 0 16px;">@reallygreatsite</p>
+    <p style="font-family: var(--font-impact); font-size: 32px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: var(--color-pink); line-height: 1.10; margin: 0;">FREE<br>ENTRY</p>
+  </div>
+</div>
+```
+
+### Duotone Halftone Photograph
+
+```html
+<!-- Approach A: Pre-processed duotone image (RECOMMENDED) -->
+<div style="position: relative; overflow: hidden; background-color: var(--color-green);">
+  <img src="path/to/duotone-image.png" alt="" style="display: block; width: 100%; height: auto; mix-blend-mode: screen; opacity: 0.95;">
+  <!-- Halftone dot overlay -->
+  <div style="position: absolute; inset: 0; background-image: radial-gradient(circle, rgba(237,181,167,0.12) 1px, transparent 1.5px); background-size: 4px 4px; pointer-events: none;"></div>
+</div>
+
+<!-- Approach B: CSS-only duotone from a grayscale source image -->
+<div style="position: relative; overflow: hidden; background-color: var(--color-green);">
+  <img src="path/to/bw-photo.jpg" alt="" style="display: block; width: 100%; height: auto; filter: grayscale(100%) contrast(120%) brightness(0.9); mix-blend-mode: screen;">
+  <!-- Pink tint layer -->
+  <div style="position: absolute; inset: 0; background-color: #EDB5A7; mix-blend-mode: multiply; pointer-events: none;"></div>
+  <!-- Halftone dot overlay -->
+  <div style="position: absolute; inset: 0; background-image: radial-gradient(circle, rgba(45,77,58,0.3) 1px, transparent 1.5px); background-size: 4px 4px; pointer-events: none;"></div>
+</div>
+```
+
+### Numbered Item (Poster Bullet)
+
+```html
+<div style="padding: 32px 0; display: flex; align-items: flex-start; gap: 32px;">
+  <span style="font-family: var(--font-impact); font-size: 72px; font-weight: 700; color: var(--color-pink); line-height: 0.85; letter-spacing: -2px;">01</span>
+  <div style="flex: 1; padding-top: 12px;">
+    <p style="font-family: var(--font-impact); font-size: 32px; font-weight: 700; letter-spacing: -0.5px; text-transform: uppercase; color: var(--color-pink); line-height: 1.10; margin: 0 0 8px;">FIND YOUR SEAT</p>
+    <p style="font-family: var(--font-impact); font-size: 16px; font-weight: 500; letter-spacing: 1.5px; text-transform: uppercase; color: rgba(237,181,167,0.65); line-height: 1.40; margin: 0;">Doors open thirty minutes before showtime.</p>
+  </div>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="text-align: center; padding: 40px 24px; border-top: 2px solid rgba(237,181,167,0.65); border-bottom: 2px solid rgba(237,181,167,0.65);">
+  <p style="font-family: var(--font-impact); font-size: 180px; font-weight: 700; line-height: 0.85; letter-spacing: -4px; color: var(--color-pink); margin: 0 0 12px;">1957</p>
+  <p style="font-family: var(--font-impact); font-size: 18px; font-weight: 600; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-pink); margin: 0;">YEAR IT ALL BEGAN</p>
+</div>
+```
+
+### Comparison Grid
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1px 1fr; gap: 0; align-items: stretch;">
+  <div style="padding: 40px 32px; text-align: center;">
+    <p style="font-family: var(--font-impact); font-size: 14px; font-weight: 600; letter-spacing: 2.5px; text-transform: uppercase; color: rgba(237,181,167,0.65); margin: 0 0 16px;">BEFORE</p>
+    <p style="font-family: var(--font-impact); font-size: 56px; font-weight: 700; line-height: 0.95; letter-spacing: -1px; text-transform: uppercase; color: var(--color-pink); margin: 0 0 12px;">SILENT</p>
+    <p style="font-family: var(--font-impact); font-size: 16px; font-weight: 500; letter-spacing: 1.5px; text-transform: uppercase; color: rgba(237,181,167,0.65); line-height: 1.40; margin: 0;">Piano accompaniment only.</p>
+  </div>
+  <div style="background: rgba(237,181,167,0.35);"></div>
+  <div style="padding: 40px 32px; text-align: center;">
+    <p style="font-family: var(--font-impact); font-size: 14px; font-weight: 600; letter-spacing: 2.5px; text-transform: uppercase; color: rgba(237,181,167,0.65); margin: 0 0 16px;">AFTER</p>
+    <p style="font-family: var(--font-impact); font-size: 56px; font-weight: 700; line-height: 0.95; letter-spacing: -1px; text-transform: uppercase; color: var(--color-pink); margin: 0 0 12px;">TALKIES</p>
+    <p style="font-family: var(--font-impact); font-size: 16px; font-weight: 500; letter-spacing: 1.5px; text-transform: uppercase; color: rgba(237,181,167,0.65); line-height: 1.40; margin: 0;">Sound changed everything.</p>
+  </div>
+</div>
+```
+
+### List Item
+
+```html
+<div style="padding: 20px 0; border-bottom: 1px solid rgba(237,181,167,0.35); display: flex; align-items: baseline; gap: 24px;">
+  <span style="font-family: var(--font-impact); font-size: 18px; font-weight: 600; letter-spacing: 2px; text-transform: uppercase; color: rgba(237,181,167,0.65); min-width: 40px;">01</span>
+  <p style="flex: 1; font-family: var(--font-impact); font-size: 28px; font-weight: 700; letter-spacing: -0.5px; text-transform: uppercase; color: var(--color-pink); line-height: 1.10; margin: 0;">DOUBLE FEATURE</p>
+  <span style="font-family: var(--font-impact); font-size: 14px; font-weight: 600; letter-spacing: 2.5px; text-transform: uppercase; color: rgba(237,181,167,0.65);">08/09</span>
+</div>
+```
+
+### Quote Block
+
+```html
+<div style="padding: 60px 40px; text-align: center; border-top: 2px solid rgba(237,181,167,0.65); border-bottom: 2px solid rgba(237,181,167,0.65);">
+  <p style="font-family: var(--font-script); font-size: 64px; font-weight: 400; line-height: 1.05; letter-spacing: -1px; color: var(--color-pink); margin: 0 0 32px; transform: rotate(-1deg);">"the show<br>must go on"</p>
+  <div style="display: inline-flex; align-items: center; gap: 16px;">
+    <div style="width: 40px; height: 2px; background: var(--color-pink);"></div>
+    <p style="font-family: var(--font-impact); font-size: 14px; font-weight: 600; letter-spacing: 2.5px; text-transform: uppercase; color: var(--color-pink); margin: 0;">CURTAIN CALL, 1952</p>
+  </div>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="text-align: center; padding: 80px 40px; position: relative;">
+  <!-- Film grain overlay -->
+  <div style="position: absolute; inset: 0; background-image: radial-gradient(circle, rgba(237,181,167,0.08) 0.5px, transparent 1px); background-size: 3px 3px; pointer-events: none;"></div>
+  <div style="position: relative; z-index: 1;">
+    <p style="font-family: var(--font-impact); font-size: 18px; font-weight: 600; letter-spacing: 3px; text-transform: uppercase; color: rgba(237,181,167,0.65); margin: 0 0 24px;">ONE NIGHT ONLY</p>
+    <h2 style="margin: 0 0 48px; line-height: 0.85;">
+      <span style="display: block; font-family: var(--font-script); font-size: 96px; font-weight: 400; color: var(--color-pink); line-height: 0.95; letter-spacing: -1.5px; transform: rotate(-3deg); margin: 0 0 -20px;">Get Your</span>
+      <span style="display: block; font-family: var(--font-impact); font-size: 160px; font-weight: 700; color: var(--color-pink); line-height: 0.85; letter-spacing: -3px; text-transform: uppercase;">TICKETS</span>
+    </h2>
+    <a style="display: inline-block; border: 2px solid var(--color-pink); color: var(--color-pink); font-family: var(--font-impact); font-size: 24px; font-weight: 700; letter-spacing: 3px; text-transform: uppercase; text-decoration: none; padding: 20px 48px;">RSVP NOW</a>
+  </div>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between stacked headline words when they overlap.
+- **8px**: Tight gap -- between metadata lines, between icon and label.
+- **12px**: Small gap -- between stat number and its caption.
+- **16px**: Base gap -- between metadata rows, between body paragraphs.
+- **24px**: Medium gap -- between tag and adjacent content.
+- **32px**: Standard section internal -- between heading and first content block.
+- **40px**: Content gap -- between list items, between major elements.
+- **60px**: Large gap -- side padding for most formats.
+- **80px**: Section padding -- top/bottom padding for title and CTA blocks.
+- **120px**: Hero padding -- top/bottom for Story format hero sections.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 960px |
+| **Story (1080x1920)** | **60px left/right, 120px top/bottom** | **960px** |
+
+### Alignment & Grid
+- **Primary alignment**: Center-aligned for title blocks and CTA blocks. Left-aligned for list content. The reference's signature layout is a centered headline stack with metadata pushed to both margins.
+- **Grid**: The poster grid is effectively a two-column metadata frame (left + right) wrapping a central photo + headline column. Carousels use a single-column stack.
+- **Headline stacking**: Stacked script + impact headlines are always center-aligned with slight overlap (-20px to -40px negative margin between the two words).
+- **Metadata placement**: Event metadata always sits in the left and right margins beside the photograph, never over it. On narrower formats, metadata collapses into a centered single-column strip.
+- **Photograph placement**: Duotone photo occupies the lower 50-66% of the canvas, bleeding to the left and right edges. Never let the photograph cross into the headline zone.
+- **Vertical rhythm**: 48px between top-level sections, 32px between components within a section, 16px between metadata lines.
+- **Content gravity**: Everything reads top-to-bottom with the photograph anchoring the bottom and the headline anchoring the top -- a printed-poster hierarchy.
+- **Halftone texture**: Applied as a full-canvas overlay at 6-10% opacity. Never applied to type itself.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, background `#2D4D3A` | Page canvas, base layer |
+| Rule (Level 1) | `1px solid rgba(237, 181, 167, 0.35)` | Standard divider rule between list items |
+| Frame (Level 2) | `2px solid rgba(237, 181, 167, 0.65)` top + bottom | Emphasized section frame for stats and quotes |
+| Outline (Level 3) | `2px solid #EDB5A7` full border | CTA buttons and rare emphasized containers |
+| Photograph (Level 4) | Duotone image with optional `inset 0 -40px 80px rgba(31, 53, 40, 0.5)` vignette | Full-bleed photograph with soft ink-bleed edge |
+
+### Border Treatments
+- **Standard rule**: `1px solid rgba(237, 181, 167, 0.35)` with `border-radius: 0`. Used for list item dividers and internal section separators. Thin, pink, always sharp-cornered.
+- **Featured frame**: `2px solid rgba(237, 181, 167, 0.65)` top and bottom only. Used to emphasize stat blocks and quote blocks. Never a full border, only top+bottom rules.
+- **CTA outline**: `2px solid #EDB5A7` on all four sides, sharp corners (`border-radius: 0`). The only component that uses a full four-sided border.
+- **Divider hairline**: `1px solid rgba(237, 181, 167, 0.25)` -- the faintest visible rule, used to separate metadata lines within a block.
+
+### Surface Hierarchy
+On a deep green canvas, depth comes from **type weight**, **rule thickness**, and **photograph placement** -- never from shadows or background tints:
+1. **Background** (`#2D4D3A`) -- the single canvas color. Never tinted or gradient.
+2. **Type** (`#EDB5A7`) -- all content sits one level above the canvas via pink ink.
+3. **Rules** (`rgba(237, 181, 167, 0.35)` to `#EDB5A7`) -- horizontal lines define regions without adding fills.
+4. **Photograph** -- the duotone image is the highest-impact element, occupying the largest surface area and carrying the most visual weight.
+5. **Impact headline** -- set at 200px+, it competes with the photograph for primacy and wins by scale alone.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use forest green (`#2D4D3A`) as the **only** background color. Never tint it, never gradient it, never swap it for black.
+- Use dusty pink (`#EDB5A7`) as the **sole** accent for every mark on the canvas -- type, rules, photograph tint, halftone dots.
+- Stack headlines in two words: script on top (Alfa Slab One), impact below (Oswald ALL CAPS). The stacking is the style.
+- Set the impact word at 200-280px with letter-spacing -4px so it runs nearly edge-to-edge.
+- Rotate the script word -3deg for hand-set-on-press energy. Never rotate anything else.
+- Use duotone halftone photography with visible dot texture -- it is the heart of the aesthetic.
+- Push event metadata into the left and right margins beside the photograph to create a symmetric ticket-stub frame.
+- Use ALL CAPS for Oswald everywhere -- section headings, metadata, list items, stats, CTAs.
+- Set metadata at letter-spacing +2px to +2.5px for that etched-plate feel.
+- Apply a faint film-grain overlay (6-8% opacity) across the entire canvas for paper-stock texture.
+- Use sharp corners (`border-radius: 0`) on every container and button. This is a letterpress aesthetic, not a modern app.
+- Keep body text extremely minimal -- this style is display-driven, not reading-driven.
+
+### Don't
+- Don't use pure black (`#000000`) anywhere. The darkest tone is `#1F3528`.
+- Don't use pure white (`#ffffff`) anywhere. The lightest tone is pink highlight `#F5CFC6`.
+- Don't introduce a third color. Two colors plus their tonal variants is the entire palette.
+- Don't use drop shadows, glows, or gradients. This style is flat two-color print reproduction.
+- Don't use rounded corners on any element -- containers, buttons, tags, or photographs.
+- Don't use mixed case for Oswald. It is ALL CAPS everywhere except the rare body overflow.
+- Don't italicize anything. The script font provides all the soft energy; no italic variants exist in this style.
+- Don't place photographs in the headline zone -- the top third is for type only.
+- Don't use thin type weights (300-400) for the impact word. Oswald runs at 700 minimum.
+- Don't track the display impact word loose. It must be -4px letter-spacing to feel like a poster.
+- Don't use icons, emoji, or illustrations. The only imagery is duotone halftone photography.
+- Don't center-align list items or body text -- only headlines and CTAs are centered.
+- Don't add secondary background tints or card fills -- cards are defined by rules alone.
+- Don't skip the halftone / grain overlay -- a perfectly smooth green canvas reads as digital, not printed.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale**: Display Script 120px. Display Impact 200px. Section Heading 64px. Metadata Large 28px. Body 18px.
+- **Padding**: 60px on all sides. Content area is 960x960px.
+- **Cover slide**: Stacked script + impact headline centered. Duotone photograph below (lower 50% of canvas). Metadata strips in left/right margins beside the photo.
+- **Content slides**: Single-column stack. Section heading in Oswald ALL CAPS at 64px. List items or numbered sequence below with sharp pink rule dividers.
+- **Card slides**: Quote blocks and stat blocks framed by 2px pink rules top and bottom.
+- **Swipe indicator**: Small pink squares at bottom center, 6px x 6px, active dot in full pink, inactive in 35% pink. Never circles -- this style rejects roundness.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Full-scale hierarchy. Display Impact at 240px for the title. Numbered items at 72px.
+- **Padding**: 60px left/right. 80px top/bottom.
+- **Section spacing**: 64px vertical gap between sections. Use 2px pink rules between major sections.
+- **Vertical rhythm**: Alternate between full-bleed duotone photographs and pure-type sections. Use numbered list items (01, 02, 03) for sequential content.
+- **Footer**: Small metadata in Oswald at 14px, letter-spacing +2.5px, 65% pink. Above the footer, a 1px hairline rule.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Script 180px. Display Impact 320px. Section Heading 96px. Metadata Large 40px.
+- **Padding**: 80px on all sides. Content area is 1760x920px.
+- **Layout**: Title/CTA slides are centered with the stacked script + impact headline. Content slides use a left-aligned two-column layout: type on the left, duotone photograph on the right (or vice versa).
+- **Title slides**: Script word + impact word stacked center. Metadata strips on left and right margins. Duotone photograph bleeds from one edge.
+- **Content slides**: Section heading in Oswald ALL CAPS at 96px, left-aligned. Numbered list below. Optional duotone photograph in the right third.
+- **CTA slides**: Stacked headline center. 2px pink-outlined button below.
+
+### Poster (1080x1350px)
+- **Typography**: Display Script 140px. Display Impact 240px. Metadata Large 32px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: **This is the reference layout.** Top third: stacked script + impact headline. Middle to bottom: full-bleed duotone photograph. Left and right margins beside the photograph: event metadata strips with handle at top, details below.
+- **Vertical flow**: Headline anchors the top, photograph anchors the bottom, metadata frames the middle.
+- **CTA placement**: Integrated into the photograph margins as a metadata block ("FREE ENTRY", "RSVP NOW"). No separate button -- the metadata itself is the call to action.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Script 180px. Display Impact 320px (~33% larger than carousel). Section Heading 88px. Metadata Large 40px.
+- **Padding**: **120px top/bottom** + **60px left/right**. The extra vertical padding is critical -- Story format needs breathing room above and below to feel composed rather than cramped.
+- **Composition**: Full vertical hierarchy. Top 30%: stacked script + impact headline centered with 120px top padding. Middle 50-60%: full-bleed duotone photograph with metadata strips in left/right margins at the photo's midline. Bottom 15-20%: CTA outlined button centered with 120px bottom padding.
+- **Safe zones**: Keep all critical content within 60px of the left/right edges and 120px of the top/bottom edges to avoid Instagram/TikTok UI overlap (profile, actions, caption).
+- **Hero emphasis**: Hero type in Story format is **~30% larger** than carousel equivalent -- Display Impact at 320px vs 200px -- because the vertical canvas demands scale to feel anchored.
+- **Motion hint**: Story posts support optional subtle entrance animation -- a 200ms fade on the script word, 300ms delayed on the impact word -- but the base design must read perfectly as a static frame.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Forest Green | `#2D4D3A` | Primary background, the only canvas color |
+| Dusty Pink | `#EDB5A7` | Primary text, all accents, photo tint |
+| Deep Green | `#1F3528` | Photo shadows, duotone deep end |
+| Pink Highlight | `#F5CFC6` | Photo highlights, rare hover states |
+| Pink Shadow | `#D9948A` | Deep pink variant, rare emphasis |
+| Pink Text Muted | `rgba(237, 181, 167, 0.65)` | Secondary text, metadata |
+| Pink Text Faint | `rgba(237, 181, 167, 0.35)` | Borders, divider rules |
+| Green Inset | `#264030` | Recessed panels (rare) |
+
+### Font Declarations
+
+```css
+/* Script Display (emotional word only) */
+font-family: 'Alfa Slab One', Georgia, 'Times New Roman', serif;
+
+/* Impact Display + Metadata (everything else) */
+font-family: 'Oswald', Impact, 'Arial Narrow', sans-serif;
+
+/* Body (rare overflow only) */
+font-family: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Alfa+Slab+One&family=Oswald:wght@400;500;600;700&family=Bebas+Neue&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-green: #2D4D3A;
+  --color-pink: #EDB5A7;
+  --color-green-deep: #1F3528;
+
+  /* Colors -- Accent */
+  --color-pink-highlight: #F5CFC6;
+  --color-pink-shadow: #D9948A;
+
+  /* Colors -- Neutral Scale */
+  --color-green-canvas: #2D4D3A;
+  --color-green-inset: #264030;
+  --color-pink-text-primary: #EDB5A7;
+  --color-pink-text-muted: rgba(237, 181, 167, 0.65);
+  --color-pink-text-faint: rgba(237, 181, 167, 0.35);
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: #2D4D3A;
+  --color-surface-inset: #264030;
+
+  /* Colors -- Borders */
+  --color-border-default: rgba(237, 181, 167, 0.35);
+  --color-border-strong: rgba(237, 181, 167, 0.65);
+  --color-border-accent: #EDB5A7;
+  --color-divider: rgba(237, 181, 167, 0.25);
+
+  /* Colors -- Shadows (rarely used) */
+  --shadow-none: transparent;
+  --shadow-ink: rgba(31, 53, 40, 0.5);
+  --grain-overlay: rgba(237, 181, 167, 0.06);
+
+  /* Typography -- Families */
+  --font-script: 'Alfa Slab One', Georgia, 'Times New Roman', serif;
+  --font-impact: 'Oswald', Impact, 'Arial Narrow', sans-serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-script: 140px;
+  --text-display-impact: 240px;
+  --text-section-heading: 72px;
+  --text-sub-heading: 48px;
+  --text-metadata-large: 32px;
+  --text-metadata: 18px;
+  --text-metadata-small: 14px;
+  --text-body-large: 22px;
+  --text-body: 18px;
+  --text-big-number: 180px;
+  --text-cta: 24px;
+
+  /* Typography -- Weights */
+  --weight-script: 400;
+  --weight-impact: 700;
+  --weight-heading: 700;
+  --weight-metadata: 600;
+  --weight-body: 500;
+
+  /* Typography -- Line Heights */
+  --leading-display-script: 0.95;
+  --leading-display-impact: 0.85;
+  --leading-heading: 0.95;
+  --leading-metadata: 1.10;
+  --leading-body: 1.55;
+
+  /* Typography -- Letter Spacing */
+  --tracking-display-script: -2px;
+  --tracking-display-impact: -4px;
+  --tracking-heading: -1px;
+  --tracking-metadata: 2px;
+  --tracking-metadata-tight: 2.5px;
+  --tracking-cta: 3px;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-medium: 24px;
+  --space-large: 32px;
+  --space-gap: 40px;
+  --space-section: 48px;
+  --space-outer: 60px;
+  --space-max: 80px;
+  --space-hero: 120px;
+
+  /* Borders */
+  --radius-none: 0;
+  --border-rule: 1px solid rgba(237, 181, 167, 0.35);
+  --border-frame: 2px solid rgba(237, 181, 167, 0.65);
+  --border-outline: 2px solid #EDB5A7;
+  --border-divider: 1px solid rgba(237, 181, 167, 0.25);
+
+  /* Texture */
+  --halftone-dots: radial-gradient(circle, rgba(237, 181, 167, 0.12) 1px, transparent 1.5px);
+  --halftone-size: 4px 4px;
+  --film-grain: radial-gradient(circle, rgba(237, 181, 167, 0.08) 0.5px, transparent 1px);
+  --film-grain-size: 3px 3px;
+
+  /* Transforms */
+  --rotate-script: rotate(-3deg);
+  --rotate-script-subtle: rotate(-1deg);
+}
+```
+
+### System Font Fallbacks
+- **Script (if Alfa Slab One fails to load):** `Georgia, 'Times New Roman', serif` -- a heavy serif that approximates the chunky display feel.
+- **Impact (if Oswald fails to load):** `Impact, 'Arial Narrow', 'Helvetica Condensed', sans-serif` -- the closest system-level condensed heavy sans.
+- **Body (if Inter fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`.
+
+### Duotone Photograph Recipe
+
+**Recommended (Pre-processed):** Process the source image in Photoshop or Figma as a true duotone using `#2D4D3A` (shadows) and `#EDB5A7` (highlights), export as PNG with transparent background, then drop it in as a standard `<img>` element. This gives the cleanest print-quality result.
+
+**CSS-only fallback:** Stack the following on a grayscale source image:
+1. Container with `background-color: #2D4D3A`
+2. `<img>` with `filter: grayscale(100%) contrast(120%) brightness(0.9); mix-blend-mode: screen`
+3. Pink tint layer (`background: #EDB5A7; mix-blend-mode: multiply`)
+4. Halftone dot overlay (`background-image: radial-gradient(circle, rgba(45,77,58,0.3) 1px, transparent 1.5px); background-size: 4px 4px`)
+
+The CSS-only approach is approximate -- true duotone requires per-pixel remapping that only image editors can deliver. When fidelity matters, pre-process.

--- a/skills/composites/goose-graphics/styles/_full/warm-earth.md
+++ b/skills/composites/goose-graphics/styles/_full/warm-earth.md
@@ -1,0 +1,437 @@
+# Design Style: Warm Earth
+
+## 1. Visual Theme & Atmosphere
+
+Warm Earth is the design language of handmade quality and Mediterranean warmth -- the visual equivalent of a sun-bleached terracotta courtyard, a handwritten recipe on cream paper, a linen-wrapped journal from a coastal bookshop. The warm cream canvas (`#faf3eb`) is not merely a background; it is the colour of parchment, of unbleached cotton, of morning light on plaster walls. Every element placed upon it inherits that warmth, creating compositions that feel tactile, inviting, and deeply human.
+
+The typeface choice -- Nunito for both display and body -- reinforces this philosophy of approachable craft. Nunito is a rounded sans-serif whose soft terminals and generous letter spacing create a friendly, open voice without ever becoming childish or casual. At display sizes (48px+), its rounded forms at weight 700-800 produce headlines that feel welcoming and substantial, like hand-painted shop signage. At body sizes, lighter weights (300-400) maintain excellent readability while preserving the rounded warmth. The single-family approach keeps the visual identity cohesive: hierarchy comes from size and weight, while the consistent rounded character ensures every piece of text feels like it belongs to the same story.
+
+Terracotta (`#c67a4a`) is the accent that gives this system its soul. It is the colour of clay pots, of desert sunsets, of aged brick -- a warm orange-brown that feels both ancient and alive. Used for accent lines, numbering, CTAs, and focal points, it carries an organic energy that synthetic colours cannot replicate. Sage green (`#7a9e7e`) serves as the secondary accent, bringing the natural complement to the warm palette -- the colour of olive leaves, of herb gardens, of aged copper patina. Together, terracotta and sage create a palette rooted in the natural world: earth and plant, clay and leaf, warmth and shade. Soft rounded corners (12-16px) on containers echo Nunito's rounded terminals, creating a visual consistency between type and layout. Warm shadows with brown undertones (`rgba(61,43,31,0.08)`) keep elevation effects on-palette, ensuring that even depth feels organic.
+
+**Key Characteristics:**
+- Warm cream background (`#faf3eb`) as the dominant surface -- the warmth of unbleached paper, not the sterility of white
+- Dark brown (`#3d2b1f`) for all primary text -- a rich, readable brown warmer than black
+- Nunito for all typography -- rounded sans-serif, friendly and approachable at every weight
+- Terracotta (`#c67a4a`) as the primary accent for numbering, rules, CTAs, and focal elements
+- Sage green (`#7a9e7e`) as the secondary accent for supporting elements, tags, and natural contrast
+- Soft rounded corners (12-16px) on all containers -- echoing the rounded terminals of Nunito
+- Warm brown-tinted shadows using `rgba(61,43,31,0.08)` -- elevation that stays earthy and organic
+- Natural, flowing spacing -- generous but not stark, comfortable but not cramped
+- Textural warmth -- every element should feel like it could exist on handmade paper
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Cream** (`#faf3eb`): Primary background. A warm off-white with yellow-pink undertone, like sun-warmed parchment.
+- **Dark Brown** (`#3d2b1f`): Primary text colour. A rich brown-black with warm undertones -- the colour of dark roasted coffee or aged walnut.
+- **Terracotta** (`#c67a4a`): Primary accent. Used for numbering, horizontal rules, CTA buttons, and focal-point elements. The earthy signature colour.
+
+### Accent
+- **Sage Green** (`#7a9e7e`): Secondary accent for tags, supporting highlights, success states, and natural contrast against terracotta.
+- **Deep Sage** (`#5c8060`): Darker sage for hover/active states on green interactive elements.
+- **Warm Tan** (`#d4a574`): Lighter terracotta variant for borders, decorative elements, and secondary emphasis.
+- **Deep Terracotta** (`#a85e30`): Darker terracotta for hover/active states on primary interactive elements.
+
+### Neutral Scale
+- **Linen** (`#f5ece0`): Elevated surface -- cards, containers, and content panels sitting above the cream background.
+- **Sand** (`#ebe0d0`): Secondary surface for nested containers, input fields, and inset areas.
+- **Tan Border** (`#d9cbb8`): Visible border for inputs, dividers, and structural lines.
+- **Warm Medium** (`#a89a8a`): Disabled text, placeholder content, and subtle dividers.
+- **Clay Gray** (`#8a7b6b`): Tertiary text for timestamps, metadata, and low-priority labels.
+- **Earth Gray** (`#6b5d4f`): Secondary body text and descriptions.
+
+### Surface & Borders
+- **Surface Primary** (`#f5ece0`): Card and container background.
+- **Surface Inset** (`#f0e6d8`): Recessed areas, code blocks, and inset panels.
+- **Border Default** (`rgba(61,43,31,0.12)`): Standard warm border for cards and dividers.
+- **Border Accent** (`rgba(198,122,74,0.3)`): Terracotta-tinted border for active or featured elements.
+- **Border Strong** (`rgba(61,43,31,0.2)`): Higher-contrast border for prominent containers.
+- **Divider Rule** (`#c67a4a`): Solid terracotta for horizontal accent rules (typically 2px height).
+
+### Shadow Colors
+- **Shadow Warm** (`rgba(61,43,31,0.08)`): Primary shadow -- brown-tinted ambient for on-palette elevation.
+- **Shadow Deep** (`rgba(61,43,31,0.16)`): Deep shadow for high-elevation elements like modals.
+- **Shadow Soft** (`rgba(61,43,31,0.05)`): Standard shadow layer for cards and containers.
+- **Shadow Ambient** (`rgba(198,122,74,0.04)`): Subtle terracotta ambient for barely-there warmth.
+
+## 3. Typography Rules
+
+### Font Families
+
+**Google Fonts CDN:**
+```html
+<link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,400;1,700&display=swap" rel="stylesheet">
+```
+
+- **Display**: `'Nunito', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Body**: `'Nunito', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | Nunito | 72px | 800 | 1.10 | -1px | Cover headlines, single impactful statement |
+| Section Heading | Nunito | 48px | 700 | 1.15 | -0.5px | Major section titles |
+| Sub-heading | Nunito | 32px | 700 | 1.20 | -0.25px | Subsection titles, card headings |
+| Body Large | Nunito | 20px | 300 | 1.70 | 0px | Lead paragraphs, introductions |
+| Body | Nunito | 16px | 400 | 1.70 | 0.1px | Standard reading text |
+| Small / Caption | Nunito | 13px | 400 | 1.50 | 0.3px | Metadata, attributions, timestamps |
+| Big Numbers | Nunito | 64px | 800 | 1.00 | -0.5px | Statistics, key metrics, hero data |
+| Numbered Label | Nunito | 14px | 600 | 1.00 | 1.5px | Uppercase step labels ("01 -- HARVEST") |
+| CTA Text | Nunito | 15px | 700 | 1.00 | 0.5px | Button and call-to-action text |
+
+### Principles
+- **Rounded warmth at every size**: Nunito's soft, rounded terminals are the typographic expression of this style's personality. The rounded forms should be visible even at display sizes -- never use a tight tracking that obscures them.
+- **Heavier display weights**: Unlike sharp geometric fonts that look best at 700, Nunito benefits from 800 weight at hero sizes. The extra weight gives the rounded forms substance and presence.
+- **Generous line height for body**: 1.70 for body text (slightly more than typical) creates a relaxed, unhurried reading pace that matches the organic theme.
+- **Minimal negative tracking**: Because Nunito's letterforms are already round and open, aggressive negative tracking works against the design. Limit tracking to -1px at the largest sizes.
+- **Moderate letter-spacing at small sizes**: Captions and labels use 0.3px-1.5px tracking for legibility, consistent with the open, breathable feel.
+- **Uppercase sparingly**: Reserve uppercase + wide tracking for numbered labels and CTA buttons. Headlines are always mixed case to preserve the friendly, conversational tone.
+
+## 4. Component Patterns
+
+### Title Block (Cover / Header Section)
+
+```html
+<div style="background-color: var(--color-cream); padding: 80px 60px; text-align: center;">
+  <div style="width: 60px; height: 3px; background: var(--color-terracotta); margin: 0 auto 32px; border-radius: 2px;"></div>
+  <h1 style="font-family: var(--font-display); font-size: 72px; font-weight: 800; line-height: 1.10; letter-spacing: -1px; color: var(--color-dark-brown); margin: 0 0 24px;">The Future of<br>Autonomous Work</h1>
+  <p style="font-family: var(--font-body); font-size: 20px; font-weight: 300; line-height: 1.70; color: var(--color-earth-gray); max-width: 600px; margin: 0 auto;">How AI coworkers are reshaping the way teams operate, collaborate, and deliver results.</p>
+  <div style="width: 60px; height: 3px; background: var(--color-terracotta); margin: 40px auto 0; border-radius: 2px;"></div>
+</div>
+```
+
+### Numbered Item
+
+```html
+<div style="display: flex; gap: 24px; align-items: flex-start; padding: 32px 0; border-bottom: 1px solid rgba(61,43,31,0.12);">
+  <span style="font-family: var(--font-display); font-size: 48px; font-weight: 800; line-height: 1.00; color: var(--color-terracotta); min-width: 72px;">01</span>
+  <div>
+    <p style="font-family: var(--font-body); font-size: 14px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-sage); margin: 0 0 8px;">SIGNAL-BASED OUTBOUND</p>
+    <h3 style="font-family: var(--font-display); font-size: 32px; font-weight: 700; line-height: 1.20; letter-spacing: -0.25px; color: var(--color-dark-brown); margin: 0 0 12px;">Find buyers before they find you</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.70; color: var(--color-earth-gray); margin: 0;">Monitor hiring signals, funding events, and tech stack changes to identify high-intent prospects the moment they enter the market.</p>
+  </div>
+</div>
+```
+
+### Stat Display
+
+```html
+<div style="text-align: center; padding: 40px 24px; background: var(--color-linen); border: 1px solid rgba(61,43,31,0.12); border-radius: 16px;">
+  <p style="font-family: var(--font-display); font-size: 64px; font-weight: 800; line-height: 1.00; letter-spacing: -0.5px; color: var(--color-terracotta); margin: 0 0 8px;">47%</p>
+  <p style="font-family: var(--font-body); font-size: 14px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-dark-brown); margin: 0 0 12px;">FASTER RESPONSE</p>
+  <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.70; color: var(--color-earth-gray); max-width: 280px; margin: 0 auto;">Teams using AI coworkers respond to inbound leads nearly twice as fast as manual workflows.</p>
+</div>
+```
+
+### Comparison Grid
+
+```html
+<div style="display: grid; grid-template-columns: 1fr 1fr; gap: 2px; background: rgba(61,43,31,0.12); border-radius: 16px; overflow: hidden;">
+  <div style="background: var(--color-linen); padding: 40px 32px;">
+    <p style="font-family: var(--font-body); font-size: 13px; font-weight: 400; letter-spacing: 0.3px; color: var(--color-clay-gray); margin: 0 0 16px;">Without Goose</p>
+    <h3 style="font-family: var(--font-display); font-size: 32px; font-weight: 700; line-height: 1.20; letter-spacing: -0.25px; color: var(--color-dark-brown); margin: 0 0 16px;">Manual & Fragmented</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.70; color: var(--color-earth-gray); margin: 0;">Teams juggle Slack threads, spreadsheets, and context-switching between a dozen tabs to coordinate basic workflows.</p>
+  </div>
+  <div style="background: var(--color-linen); padding: 40px 32px; border-left: 3px solid var(--color-terracotta);">
+    <p style="font-family: var(--font-body); font-size: 13px; font-weight: 400; letter-spacing: 0.3px; color: var(--color-terracotta); margin: 0 0 16px;">With Goose</p>
+    <h3 style="font-family: var(--font-display); font-size: 32px; font-weight: 700; line-height: 1.20; letter-spacing: -0.25px; color: var(--color-dark-brown); margin: 0 0 16px;">Orchestrated & Autonomous</h3>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.70; color: var(--color-earth-gray); margin: 0;">AI coworkers handle research, drafting, and follow-up autonomously. Your team focuses on decisions, not busywork.</p>
+  </div>
+</div>
+```
+
+### List Item
+
+```html
+<div style="display: flex; gap: 20px; align-items: flex-start; padding: 24px 0; border-bottom: 1px solid rgba(61,43,31,0.12);">
+  <div style="width: 40px; height: 40px; min-width: 40px; display: flex; align-items: center; justify-content: center; background: rgba(122,158,126,0.15); border-radius: 12px; color: var(--color-sage); font-size: 18px;">&#9679;</div>
+  <div>
+    <h4 style="font-family: var(--font-display); font-size: 22px; font-weight: 700; line-height: 1.25; color: var(--color-dark-brown); margin: 0 0 8px;">Persistent Memory</h4>
+    <p style="font-family: var(--font-body); font-size: 16px; font-weight: 400; line-height: 1.70; color: var(--color-earth-gray); margin: 0;">Every agent maintains its own filesystem, notes, and learned preferences across sessions. Context is never lost.</p>
+  </div>
+</div>
+```
+
+### Quote Block
+
+```html
+<div style="padding: 48px 40px; border-left: 3px solid var(--color-terracotta); background: var(--color-surface-inset); border-radius: 0 16px 16px 0;">
+  <p style="font-family: var(--font-display); font-size: 32px; font-weight: 400; font-style: italic; line-height: 1.35; letter-spacing: -0.25px; color: var(--color-dark-brown); margin: 0 0 24px;">"It felt less like configuring software and more like onboarding a new team member."</p>
+  <div style="display: flex; align-items: center; gap: 12px;">
+    <div style="width: 32px; height: 3px; background: var(--color-terracotta); border-radius: 2px;"></div>
+    <p style="font-family: var(--font-body); font-size: 14px; font-weight: 600; letter-spacing: 1.5px; text-transform: uppercase; color: var(--color-clay-gray); margin: 0;">SARAH CHEN, VP OPERATIONS</p>
+  </div>
+</div>
+```
+
+### CTA Block
+
+```html
+<div style="text-align: center; padding: 60px 40px; background: var(--color-linen); border: 1px solid rgba(198,122,74,0.3); border-radius: 16px;">
+  <h2 style="font-family: var(--font-display); font-size: 40px; font-weight: 700; line-height: 1.15; letter-spacing: -0.5px; color: var(--color-dark-brown); margin: 0 0 16px;">Ready to meet your team?</h2>
+  <p style="font-family: var(--font-body); font-size: 18px; font-weight: 300; line-height: 1.70; color: var(--color-earth-gray); max-width: 480px; margin: 0 auto 32px;">Deploy your first AI coworker in under five minutes. No setup fees, no long-term commitments.</p>
+  <a style="display: inline-block; background: var(--color-terracotta); color: var(--color-cream); font-family: var(--font-body); font-size: 15px; font-weight: 700; letter-spacing: 0.5px; text-decoration: none; padding: 16px 40px; border-radius: 12px;">Get Started</a>
+</div>
+```
+
+## 5. Layout Principles
+
+### Spacing Scale
+- **4px**: Micro gap -- between icon and inline label.
+- **8px**: Tight gap -- between sub-label and heading, between stat number and label.
+- **12px**: Small gap -- between heading and body text within a component.
+- **16px**: Base gap -- between body paragraphs, between list items in compact mode.
+- **24px**: Medium gap -- between components within a section, standard list item padding.
+- **32px**: Section internal -- padding inside cards and containers, gap between grouped items.
+- **48px**: Section divider -- vertical space between major content blocks.
+- **60px**: Large section padding -- top/bottom padding for hero and CTA blocks.
+- **80px**: Maximum section padding -- cover slides and high-impact hero areas.
+
+### Format Padding
+| Format | Outer Padding | Content Max-Width |
+|--------|---------------|-------------------|
+| Carousel (1080x1080) | 60px all sides | 960px |
+| Infographic (1080xN) | 60px left/right, 80px top/bottom | 960px |
+| Slides (1920x1080) | 80px all sides | 1760px |
+| Poster (1080x1350) | 60px left/right, 80px top/bottom | 960px |
+
+### Alignment & Grid
+- **Primary alignment**: Left-aligned text for body content. Center-aligned for hero titles, stats, and CTA blocks.
+- **Grid**: Use a simple 2-column grid for comparison layouts. Single-column for narrative and list content. 3-column for stat grids on widescreen slides.
+- **Horizontal rules**: 3px tall with rounded ends (border-radius: 2px), terracotta (`#c67a4a`), 60px wide, centered -- used as section dividers and decorative accents. The rounded rule ends reinforce the soft, organic feel.
+- **Vertical rhythm**: Maintain consistent 48px gaps between top-level sections. Use 24px gaps between items within a section.
+- **Content gravity**: On widescreen slides (1920x1080), anchor content to the left two-thirds of the frame. Leave the right third as breathing room or for supporting imagery.
+- **Organic flow**: Avoid rigid grids where possible. Let content breathe with generous but not mechanical spacing. The overall feel should be comfortable, like a well-set table.
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, background `#faf3eb` | Page canvas, base layer |
+| Subtle (Level 1) | `rgba(61,43,31,0.05) 0px 2px 8px` | Slight lift for list items on hover |
+| Card (Level 2) | `rgba(61,43,31,0.08) 0px 8px 24px, rgba(198,122,74,0.04) 0px 0px 12px` | Standard card and container elevation |
+| Featured (Level 3) | `rgba(61,43,31,0.12) 0px 16px 40px, rgba(198,122,74,0.06) 0px 0px 20px` | Featured cards, quote blocks, hero elements |
+| Overlay (Level 4) | `rgba(61,43,31,0.2) 0px 24px 60px` | Modals, overlays, high-priority popups |
+
+### Border Treatments
+- **Standard border**: `1px solid rgba(61,43,31,0.12)` -- warm, barely visible brown line that defines edges while maintaining the organic feel.
+- **Active border**: `1px solid rgba(198,122,74,0.3)` -- terracotta-tinted border for featured or active containers.
+- **Accent rule**: `3px solid #c67a4a` with `border-radius: 2px` -- rounded terracotta line used as a left-border accent on quote blocks and featured items, or as horizontal dividers.
+- **Divider line**: `1px solid rgba(61,43,31,0.08)` -- nearly invisible separator for dense list content.
+
+### Surface Hierarchy
+On warm cream backgrounds, elevation is communicated through subtle warmth shifts:
+1. **Background** (`#faf3eb`) -- the warmest, brightest layer, the canvas.
+2. **Surface** (`#f5ece0`) -- cards and containers step up by becoming slightly more saturated.
+3. **Inset** (`#f0e6d8`) -- recessed areas are a touch deeper and warmer than the card surface.
+4. **Elevated** (`#ebe0d0`) -- the highest non-overlay surface, noticeably warmer for nested content inside cards.
+
+Brown-tinted shadows (`rgba(61,43,31,0.05-0.12)`) and terracotta ambient glows (`rgba(198,122,74,0.04-0.06)`) ensure that depth effects feel like natural shadow cast by warm light, not cold digital drops.
+
+## 7. Do's and Don'ts
+
+### Do
+- Use terracotta (`#c67a4a`) as the primary accent and sage green (`#7a9e7e`) as the secondary -- they are the earth-and-plant pairing that defines this style.
+- Use Nunito at weight 800 for hero headlines and big numbers -- the extra-bold rounded forms have real visual impact.
+- Keep body text in Nunito at weight 300-400 -- lightness keeps the reading experience relaxed and natural.
+- Use rounded corners (12-16px) on all containers and cards -- consistency between rounded type and rounded layout is essential.
+- Maintain generous line height (1.70) for body text -- the warm palette invites a leisurely reading pace.
+- Use rounded terracotta rules (3px, 60px wide, border-radius: 2px) as section dividers -- they are the visual punctuation of this style.
+- Add brown-tinted shadows (`rgba(61,43,31,...)`) to elevation effects to stay on-palette.
+- Use `border-left: 3px solid #c67a4a` with rounded ends on quote blocks and comparison "preferred" sides.
+- Allow sage green backgrounds (`rgba(122,158,126,0.15)`) for icon containers and tag fills.
+
+### Don't
+- Don't use sharp corners (0-4px radius) -- everything in this style has rounded edges that match the type.
+- Don't use saturated or synthetic colours (neon, electric blue, hot pink) -- every colour should feel like it exists in nature.
+- Don't use Nunito below weight 300 -- the rounded terminals lose definition at thin weights.
+- Don't use pure white (`#ffffff`) for backgrounds -- always use cream (`#faf3eb`) or warmer to preserve the earthy tone.
+- Don't use pure black (`#000000`) for text -- always use dark brown (`#3d2b1f`) for warm contrast.
+- Don't apply weight 800 to body text -- reserve extra-bold for display sizes (48px+) only.
+- Don't use more than 2 accent colours per slide -- terracotta and sage only. No blues, purples, or bright reds.
+- Don't center-align body paragraphs -- only headlines, stats, and CTAs should be centered.
+- Don't use cold-toned shadows (pure `rgba(0,0,0,...)`) -- always tint shadows with brown to maintain palette warmth.
+- Don't place more than 3 stat numbers in a single row -- each number needs space to feel organic, not crammed.
+
+## 8. Responsive Behavior
+
+This is a fixed-dimension graphics system — it responds across **format dimensions**, not device breakpoints. The same visual language adapts from a 1080x1080 square to a 1920x1080 widescreen to a 1080x1920 vertical story by scaling type, padding, and composition to fit the frame. The detailed per-format adaptations live in §9 Format Adaptation Notes; this section captures the principles that govern all of them.
+
+- **Type ramps with frame size.** Headlines scale up on Slides (1920x1080) and Story (1080x1920), scale down on Carousel (1080x1080). Body copy holds a readable floor (~16-22px) across every format; never drop below 14px or the render stops being legible at native social resolution.
+- **Padding scales with the narrow edge.** Use ~60px padding on 1080-wide frames, ~80px on 1920-wide frames. Story (1080x1920) adds extra top/bottom padding (~120px) to reserve safe zones for platform UI chrome.
+- **Safe zones are non-negotiable on Story.** Reserve the top 160px (profile/progress bar) and bottom 160px (reply input) — no load-bearing text or focal elements there.
+- **One idea per frame.** Content density does not grow with frame size. Bigger frames earn more breathing room, not more content. A Slides deck shows the same one idea per slide as the Carousel, just larger.
+- **Signature components stay constant.** The style's signature move (accent colour, hero component, tag/badge treatment) keeps the same visual weight across formats — the composition around it adapts, the move itself does not.
+- **Aspect-ratio aware composition.** Square frames → centred or two-column grid. Vertical → single centred column with vertical rhythm. Widescreen → left-heavy 60/40 split (content left, breathing room or supporting visuals right). Portrait poster → three vertical zones (headline / content / CTA).
+- **Raster export.** Everything is rendered to PNG at the target pixel dimensions via Playwright — no CSS media queries, no fluid layouts. Each format is its own fixed canvas.
+
+## 9. Format Adaptation Notes
+
+### Carousel (1080x1080px)
+- **Typography scale down**: Display Hero becomes 56px (from 72px). Section Heading becomes 40px. Sub-heading stays 32px. Body stays 16px.
+- **Padding**: 60px on all sides. Content area is 960x960px.
+- **Cover slide**: Title centered vertically and horizontally. Terracotta rule above and below (60px wide, 3px tall, rounded). Subtitle in earth gray.
+- **Content slides**: Left-aligned text. One concept per slide. Number in terracotta (48px Nunito weight 800) at top-left; content below.
+- **Stat slides**: Single stat centered. Big number at 64px. Label and description below.
+- **Swipe indicator**: Small sage green dots at bottom center, 8px diameter, 12px gap. Active dot in terracotta.
+
+### Infographic (1080px wide, variable height)
+- **Typography**: Uses full-scale type hierarchy. Display Hero at 72px for the title section.
+- **Padding**: 60px left/right. 80px top/bottom margins.
+- **Section spacing**: 64px vertical gap between major sections. Rounded terracotta rules (60px wide, centered) between sections.
+- **Vertical rhythm**: Alternate between full-width sections and 2-column grids. Use numbered items for sequential content, stat displays for key metrics, and quote blocks for testimonials.
+- **Footer**: Clay gray text, 13px Nunito, with a final terracotta rule above.
+
+### Slides (1920x1080px)
+- **Typography scale up**: Display Hero becomes 80px. Section Heading becomes 56px. Body Large becomes 22px.
+- **Padding**: 80px on all sides. Content area is 1760x920px.
+- **Layout**: Left-heavy composition. Title and body text occupy the left 60% of the frame. Right 40% is breathing room or supporting content (stats, organic illustrations).
+- **Title slides**: Headline centered on frame. Terracotta rule centered. Subtitle below.
+- **Content slides**: 2-column max for comparisons. Single column for narrative.
+- **Stat slides**: Up to 3 stats in a row, evenly spaced across the full width, each in a rounded container.
+
+### Poster (1080x1350px)
+- **Typography**: Display Hero at 64px. Section Heading at 40px. Body at 16px.
+- **Padding**: 60px left/right, 80px top/bottom.
+- **Composition**: Top third for headline with terracotta rule. Middle third for key content (stats, list, or comparison). Bottom third for CTA or closing statement.
+- **Vertical flow**: Content reads top-to-bottom with clear sections. Terracotta rules separate the three zones with organic rhythm.
+- **CTA placement**: Always in the bottom zone, centered, with generous padding above. Terracotta button with rounded corners.
+
+### Story (1080x1920px)
+- **Typography scale up**: Display Hero becomes 72px in Nunito 700-800 (approximately 30% larger than Carousel 56px). Section Heading becomes 52px. Body Large becomes 22px in Nunito 400. Numbering labels stay in Nunito 600 uppercase.
+- **Padding**: 120px top/bottom + 60px left/right. Safe zones: 160px top and 160px bottom reserved for platform UI (profile avatar, progress bar, reply input). All critical text must sit inside y=160 to y=1760.
+- **Layout**: Single centered column. Content max-width 920px. Vertical center of gravity -- cluster hero content in y=400 to y=1500 range. Warm cream background (`#faf3eb`) runs edge-to-edge -- sun-warmed parchment carrying through the whole vertical frame.
+- **Cover slide**: Short terracotta (`#c67a4a`) rule 2px tall, 80px wide, with rounded caps, centered above the headline. Nunito 700-800 headline at 72px in dark brown (`#3d2b1f`), stacked in 2-3 lines with the rounded terminals feeling handmade. Nunito 400 subtitle below at 22px in warm medium brown. A second terracotta rule closes the composition. Every curve and radius echoes the rounded sans-serif terminals.
+- **Content slides**: One idea per slide, framed in a soft-cornered card (12-16px radius) with warm brown-tinted shadow (`rgba(61,43,31,0.08)`). Terracotta number or rule anchors the top, Nunito 700 sub-heading at 44px in dark brown, Nunito 400 body at 22px. Sage green (`#7a9e7e`) accents for success indicators or tags.
+- **CTA slide**: Headline at 56px in Nunito 800 dark brown. Short Nunito 400 subtitle. Terracotta pill button with 16px border-radius and cream Nunito 700 CTA text. Everything tactile, inviting, like it could exist on handmade paper.
+- **Progress indicator**: Soft rounded pill segments at the top of the safe zone (4px tall, fully rounded) -- inactive in `rgba(61,43,31,0.15)`, active in terracotta (`#c67a4a`). Rounded segments match Nunito's rounded terminals -- visual consistency between type and chrome.
+
+## 10. Agent Prompt Guide
+
+### Quick Color Reference
+
+| Name | Hex | Usage |
+|------|-----|-------|
+| Cream | `#faf3eb` | Primary background |
+| Dark Brown | `#3d2b1f` | Primary text |
+| Terracotta | `#c67a4a` | Accent: numbers, rules, CTAs, focal points |
+| Sage Green | `#7a9e7e` | Secondary accent: tags, icons, natural contrast |
+| Deep Sage | `#5c8060` | Hover/active state for sage elements |
+| Warm Tan | `#d4a574` | Lighter terracotta variant, decorative borders |
+| Deep Terracotta | `#a85e30` | Hover/active state for terracotta elements |
+| Linen | `#f5ece0` | Card/container surface |
+| Surface Inset | `#f0e6d8` | Recessed panels, code blocks |
+| Sand | `#ebe0d0` | Nested containers, elevated surfaces |
+| Tan Border | `#d9cbb8` | Structural borders, input fields |
+| Warm Medium | `#a89a8a` | Disabled text, subtle dividers |
+| Clay Gray | `#8a7b6b` | Tertiary text, descriptions |
+| Earth Gray | `#6b5d4f` | Secondary text, body descriptions |
+
+### Font Declarations
+
+```css
+font-family: 'Nunito', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+```
+
+### Google Fonts Link
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,400;1,700&display=swap" rel="stylesheet">
+```
+
+### CSS Root Variables
+
+```css
+:root {
+  /* Colors -- Primary */
+  --color-cream: #faf3eb;
+  --color-dark-brown: #3d2b1f;
+  --color-terracotta: #c67a4a;
+
+  /* Colors -- Accent */
+  --color-sage: #7a9e7e;
+  --color-deep-sage: #5c8060;
+  --color-warm-tan: #d4a574;
+  --color-deep-terracotta: #a85e30;
+
+  /* Colors -- Neutral Scale */
+  --color-linen: #f5ece0;
+  --color-sand: #ebe0d0;
+  --color-tan-border: #d9cbb8;
+  --color-warm-medium: #a89a8a;
+  --color-clay-gray: #8a7b6b;
+  --color-earth-gray: #6b5d4f;
+
+  /* Colors -- Surfaces */
+  --color-surface-primary: #f5ece0;
+  --color-surface-inset: #f0e6d8;
+
+  /* Colors -- Borders */
+  --color-border-default: rgba(61, 43, 31, 0.12);
+  --color-border-accent: rgba(198, 122, 74, 0.3);
+  --color-border-strong: rgba(61, 43, 31, 0.2);
+  --color-divider-rule: #c67a4a;
+
+  /* Colors -- Shadows */
+  --shadow-warm: rgba(61, 43, 31, 0.08);
+  --shadow-deep: rgba(61, 43, 31, 0.16);
+  --shadow-soft: rgba(61, 43, 31, 0.05);
+  --shadow-ambient: rgba(198, 122, 74, 0.04);
+
+  /* Typography -- Families */
+  --font-display: 'Nunito', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-body: 'Nunito', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  /* Typography -- Sizes */
+  --text-display-hero: 72px;
+  --text-section-heading: 48px;
+  --text-sub-heading: 32px;
+  --text-body-large: 20px;
+  --text-body: 16px;
+  --text-small: 13px;
+  --text-big-number: 64px;
+  --text-label: 14px;
+  --text-cta: 15px;
+
+  /* Typography -- Weights */
+  --weight-display: 800;
+  --weight-heading: 700;
+  --weight-body-light: 300;
+  --weight-body: 400;
+  --weight-label: 600;
+  --weight-cta: 700;
+
+  /* Typography -- Line Heights */
+  --leading-display: 1.10;
+  --leading-heading: 1.15;
+  --leading-sub-heading: 1.20;
+  --leading-body-large: 1.70;
+  --leading-body: 1.70;
+  --leading-small: 1.50;
+  --leading-number: 1.00;
+
+  /* Spacing */
+  --space-micro: 4px;
+  --space-tight: 8px;
+  --space-small: 12px;
+  --space-base: 16px;
+  --space-medium: 24px;
+  --space-large: 32px;
+  --space-section: 48px;
+  --space-hero: 60px;
+  --space-max: 80px;
+
+  /* Borders */
+  --radius-standard: 16px;
+  --radius-small: 12px;
+  --radius-rule: 2px;
+
+  /* Shadows -- Composed */
+  --shadow-card: rgba(61,43,31,0.08) 0px 8px 24px, rgba(198,122,74,0.04) 0px 0px 12px;
+  --shadow-featured: rgba(61,43,31,0.12) 0px 16px 40px, rgba(198,122,74,0.06) 0px 0px 20px;
+}
+```
+
+### System Font Fallbacks
+- **Sans-serif (if Nunito fails to load):** `-apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`

--- a/skills/composites/goose-graphics/styles/archive-fashion.md
+++ b/skills/composites/goose-graphics/styles/archive-fashion.md
@@ -1,0 +1,129 @@
+# Archive Fashion
+
+Luxury catalog frame with a tilted handwritten sticker as the singular decorative moment. Stone beige outer frame, taupe-brown inset photo container, small italic Cormorant Garamond wordmark at top center, an Inter 700 catalog headline stacked on 2 lines, and a hot-pink sticker (tilted -8°) with handwritten Caveat copy pinned to the bottom-left corner. Feels like a high-end fashion lookbook with a personal promo note.
+
+> Full prose reference: `styles/_full/archive-fashion.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#E6DCC8` | Stone beige — outer frame background |
+| `#1A1410` | Near-black — primary text, CTA button fill |
+| `#4A352A` | Taupe brown — inset photo container background |
+| `#F4B8D4` | Candy pink — sticker fill (one use only) |
+| `#8B3A5C` | Deep pink ink — sticker inner border, accent text |
+| `#D8C9B0` | Stone deeper — subtle borders, secondary surfaces |
+| `#EFE6D6` | Stone lighter — content card highlights |
+| `#6B4C3B` | Warm brown — secondary text on photo environments |
+| `#7A6B5D` | Muted text — metadata inside stone frame |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;1,500&family=Inter:wght@500;600;700&family=Caveat:wght@500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Wordmark:** `'Cormorant Garamond', Garamond, serif` (italic 500)
+- **Display / Body:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+- **Handwritten (sticker only):** `'Caveat', 'Marker Felt', cursive`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Wordmark | Cormorant Garamond Italic | 28px | 500 | 1.0 | 0.5px |
+| Display Hero | Inter | 72px | 700 | 1.05 | -1.5px |
+| Display (1:1) | Inter | 56px | 700 | 1.05 | -1px |
+| Tracked Caps Date | Cormorant Garamond | 14px | 500 | 1.2 | 2.5px UPPER |
+| Section Heading | Inter | 32px | 600 | 1.15 | -0.5px |
+| Body Large | Inter | 20px | 500 | 1.55 | 0 |
+| Body | Inter | 17px | 500 | 1.55 | 0 |
+| Caption | Inter | 13px | 500 | 1.45 | 0.3px |
+| Sticker Headline | Caveat | 32px | 700 | 1.1 | 0 |
+| Sticker Body | Caveat | 20px | 500 | 1.25 | 0 |
+| Sticker Foot | Caveat | 16px | 600 | 1.2 | 0.5px |
+
+**Principles**
+
+- Caveat belongs ONLY on the sticker. Italic Cormorant belongs ONLY on the wordmark. Inter everywhere else.
+- Catalog headline stacked on 2 lines, centered, Inter 700.
+- Tracked-caps dates in Cormorant Garamond with 2.5px letter-spacing.
+
+## Layout
+
+- Outer frame: stone beige `#E6DCC8` with ~50px margin around the photo inset.
+- Inset photo container: taupe brown `#4A352A`, flat corners, fills center 80% of composition.
+- Wordmark "Galerie" centered at top (Cormorant italic 28px).
+- Catalog headline centered beneath wordmark or over photo depending on composition.
+- Sticker: candy pink `#F4B8D4` bubble with asymmetric border-radius, tilted -5° to -10°, pinned to bottom-left. Drop shadow `0 8px 24px rgba(139,58,92,0.18)`.
+- Only one sticker per composition.
+
+## Do / Don't
+
+**Do**
+
+- Use stone beige outer frame with ~50px margin around the photo inset on every composition.
+- Use ONE pink sticker tilted -5° to -10° in the bottom-left as the scroll-stopper.
+- Use asymmetric border-radius on the sticker to suggest a hand-cut speech bubble.
+- Use Caveat handwritten script for sticker copy only.
+- Add pink-tinted drop shadow beneath the sticker for physical-object feel.
+- Keep photo environment warm and dark (taupe brown).
+
+**Don't**
+
+- Don't center photos edge-to-edge — always inset from the stone frame.
+- Don't use more than 1 sticker.
+- Don't straighten the sticker — the tilt IS the personality.
+- Don't use Caveat anywhere except the sticker.
+- Don't use pure white or pure black — stone + warm near-black only.
+- Don't use rounded corners on content frames — only on the sticker.
+- Don't use Inter italic — italic belongs to Cormorant (heritage) and Caveat (handwritten).
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-stone: #E6DCC8;
+  --color-stone-deeper: #D8C9B0;
+  --color-stone-lighter: #EFE6D6;
+  --color-ink: #1A1410;
+  --color-taupe: #4A352A;
+  --color-pink: #F4B8D4;
+  --color-pink-ink: #8B3A5C;
+  --color-warm-brown: #6B4C3B;
+
+  --font-wordmark: 'Cormorant Garamond', Garamond, serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+  --font-hand: 'Caveat', 'Marker Felt', cursive;
+}
+```
+
+### Catalog composition
+
+```html
+<div style="background:#E6DCC8; padding:50px; min-height:960px; position:relative;">
+  <p style="font-family:'Cormorant Garamond',serif; font-style:italic; font-size:28px; font-weight:500; letter-spacing:0.5px; color:#1A1410; text-align:center; margin:0 0 16px;">Galerie</p>
+  <p style="font-family:'Cormorant Garamond',serif; font-size:14px; font-weight:500; letter-spacing:2.5px; text-transform:uppercase; color:#6B4C3B; text-align:center; margin:0 0 32px;">FEBRUARY 13 — 16</p>
+
+  <div style="background:#4A352A; padding:48px 32px; min-height:640px; position:relative;">
+    <img src="model.jpg" style="width:100%; height:auto; object-fit:cover;" alt="Archive">
+  </div>
+
+  <h1 style="font-family:'Inter',sans-serif; font-size:72px; font-weight:700; line-height:1.05; letter-spacing:-1.5px; color:#1A1410; text-align:center; margin:40px 0 0;">The Spring<br>Archive.</h1>
+
+  <div style="position:absolute; bottom:60px; left:60px; transform:rotate(-8deg); background:#F4B8D4; padding:20px 24px; border-radius:24px 16px 28px 12px; box-shadow:0 8px 24px rgba(139,58,92,0.18); max-width:260px;">
+    <p style="font-family:'Caveat',cursive; font-size:32px; font-weight:700; line-height:1.1; color:#8B3A5C; margin:0 0 6px;">SPECIAL OFFER!</p>
+    <p style="font-family:'Caveat',cursive; font-size:20px; font-weight:500; line-height:1.25; color:#8B3A5C; margin:0 0 8px;">20% off with code SPRING20</p>
+    <p style="font-family:'Caveat',cursive; font-size:16px; font-weight:600; letter-spacing:0.5px; color:#8B3A5C; margin:0;">Ends June 10th, 12pm EST</p>
+  </div>
+</div>
+```
+
+### Black CTA block
+
+```html
+<a style="display:inline-block; background:#1A1410; color:#E6DCC8; font-family:'Inter',sans-serif; font-size:15px; font-weight:600; letter-spacing:0.5px; text-decoration:none; padding:14px 32px;">SHOP THE ARCHIVE</a>
+```

--- a/skills/composites/goose-graphics/styles/aurora-app-launch.md
+++ b/skills/composites/goose-graphics/styles/aurora-app-launch.md
@@ -1,0 +1,136 @@
+# Aurora App Launch
+
+Wellness-app launch reveal. Soft rainbow mesh gradient (sky blue → peach coral → dusty pink → lavender) as a full-bleed background, a centered phone mockup at the hero, and a frosted-glass footer card holding the launch headline. Navy Fraunces brand mark lives inside the phone; everything else is Inter. The mood is an App Store splash for a meditation or mood-tracking app.
+
+> Full prose reference: `styles/_full/aurora-app-launch.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#A8C4E8` | Sky blue — gradient origin (top-left) |
+| `#F2A87C` | Peach coral — gradient center (warm bloom) |
+| `#D4A8C4` | Dusty pink — gradient terminus (right) |
+| `#C8B8E0` | Soft lavender — fourth blob (bottom-right) |
+| `#F5E6D8` | Warm cream — highlight bloom accent |
+| `#2A3551` | Deep navy — Fraunces brand mark inside phone |
+| `rgba(255,255,255,0.95)` | Near-white — primary text on gradient |
+| `rgba(255,255,255,0.80)` | Soft white — secondary text |
+| `rgba(255,255,255,0.60)` | Muted white — captions |
+| `rgba(255,255,255,0.20)` | Frosted surface — footer glass card |
+| `rgba(255,255,255,0.12)` | Frosted inset — nested glass |
+| `rgba(255,255,255,0.30)` | Glass border |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,600&family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+```
+
+- **App Brand:** `'Fraunces', Georgia, 'Times New Roman', serif` (inside phone only)
+- **Display / Body:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| App Brand Mark | Fraunces | 64px | 600 | 1.00 | -1px |
+| Display Headline | Inter | 60px | 700 | 1.05 | -1.5px |
+| Display Hero XL | Inter | 72px | 700 | 1.05 | -2px |
+| Section Heading | Inter | 40px | 700 | 1.15 | -0.8px |
+| Small Caps Label | Inter | 16px | 500 | 1.00 | 0.3px (mixed case) |
+| Body Large | Inter | 22px | 500 | 1.55 | 0 |
+| Body | Inter | 18px | 500 | 1.55 | 0 |
+| App UI Title | Inter | 22px | 700 | 1.20 | -0.3px |
+| App UI Subtitle | Inter | 16px | 500 | 1.30 | 0 |
+| App UI Time | Inter | 12px | 500 | 1.00 | 0.2px |
+| Caption | Inter | 14px | 400 | 1.50 | 0.2px |
+| CTA | Inter | 16px | 700 | 1.00 | 0.3px |
+
+**Principles**
+
+- Fraunces only inside the phone (as the app brand mark).
+- Inter handles the outer composition (launch headline, label, CTAs).
+- Labels use mixed case with small positive tracking — never all-caps.
+
+## Layout
+
+- Mesh gradient background: 4-blob radial-gradient composition covering the full canvas.
+- Phone mockup centered or slightly offset — primary hero element.
+- Frosted-glass footer card at bottom: `backdrop-filter: blur(20px)`, `background: rgba(255,255,255,0.20)`, 24-32px radius.
+- Footer card holds: small-caps label ("Download the app"), 60px Inter 700 headline, CTA buttons.
+- Navy Fraunces brand mark appears only on the phone screen.
+
+## Do / Don't
+
+**Do**
+
+- Build the background as a 4-blob mesh gradient (sky blue + peach coral + dusty pink + soft lavender).
+- Use frosted-glass `backdrop-filter: blur(20px)` for the footer card.
+- Keep text colors white with varying opacity (95/80/60) — never hex.
+- Use Fraunces only for the app brand mark inside the phone.
+- Use the phone mockup as the primary visual anchor, centered.
+
+**Don't**
+
+- Don't use flat color backgrounds — the mesh is the identity.
+- Don't use saturated primary colors (pure blue, pure red) — everything is soft pastel.
+- Don't use Fraunces outside the phone.
+- Don't use dark text on the gradient — only white with opacity.
+- Don't over-decorate the phone — keep the app UI calm and typographic.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --c-sky: #A8C4E8;
+  --c-peach: #F2A87C;
+  --c-pink: #D4A8C4;
+  --c-lavender: #C8B8E0;
+  --c-cream: #F5E6D8;
+  --c-navy: #2A3551;
+  --c-white-95: rgba(255, 255, 255, 0.95);
+  --c-white-80: rgba(255, 255, 255, 0.80);
+  --c-white-60: rgba(255, 255, 255, 0.60);
+  --c-glass: rgba(255, 255, 255, 0.20);
+  --c-glass-inset: rgba(255, 255, 255, 0.12);
+  --c-glass-border: rgba(255, 255, 255, 0.30);
+
+  --font-app-brand: 'Fraunces', Georgia, 'Times New Roman', serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+}
+```
+
+### Mesh gradient background
+
+```css
+.aurora-bg {
+  background:
+    radial-gradient(ellipse 60% 60% at 15% 20%, rgba(168,196,232,1), transparent 70%),
+    radial-gradient(ellipse 70% 60% at 70% 40%, rgba(242,168,124,0.9), transparent 65%),
+    radial-gradient(ellipse 60% 70% at 85% 75%, rgba(212,168,196,0.9), transparent 70%),
+    radial-gradient(ellipse 60% 60% at 30% 85%, rgba(200,184,224,0.9), transparent 70%),
+    #B8C4E0;
+}
+```
+
+### Full composition
+
+```html
+<div style="position:relative; min-height:1920px; background:radial-gradient(ellipse 60% 60% at 15% 20%,#A8C4E8,transparent 70%),radial-gradient(ellipse 70% 60% at 70% 40%,rgba(242,168,124,0.9),transparent 65%),radial-gradient(ellipse 60% 70% at 85% 75%,rgba(212,168,196,0.9),transparent 70%),radial-gradient(ellipse 60% 60% at 30% 85%,rgba(200,184,224,0.9),transparent 70%),#B8C4E0; overflow:hidden;">
+
+  <div style="position:absolute; top:240px; left:50%; transform:translateX(-50%); width:320px; height:640px; background:#F5E6D8; border-radius:48px; box-shadow:0 24px 80px rgba(0,0,0,0.2); padding:40px 32px;">
+    <p style="font-family:'Fraunces',serif; font-size:64px; font-weight:600; line-height:1.00; letter-spacing:-1px; color:#2A3551; margin:0 0 40px;">still</p>
+    <p style="font-family:'Inter',sans-serif; font-size:22px; font-weight:700; letter-spacing:-0.3px; color:#2A3551; margin:0 0 4px;">Evening Meditation</p>
+    <p style="font-family:'Inter',sans-serif; font-size:16px; font-weight:500; color:rgba(42,53,81,0.7); margin:0;">Stress relief · 12 min</p>
+  </div>
+
+  <div style="position:absolute; bottom:60px; left:60px; right:60px; background:rgba(255,255,255,0.20); backdrop-filter:blur(20px); -webkit-backdrop-filter:blur(20px); border:1px solid rgba(255,255,255,0.30); border-radius:32px; padding:40px;">
+    <p style="font-family:'Inter',sans-serif; font-size:16px; font-weight:500; letter-spacing:0.3px; color:rgba(255,255,255,0.80); margin:0 0 16px;">Download the app</p>
+    <h1 style="font-family:'Inter',sans-serif; font-size:60px; font-weight:700; line-height:1.05; letter-spacing:-1.5px; color:rgba(255,255,255,0.95); margin:0 0 32px;">Still minds ship better work.</h1>
+    <a style="display:inline-block; background:rgba(255,255,255,0.95); color:#2A3551; font-family:'Inter',sans-serif; font-size:16px; font-weight:700; letter-spacing:0.3px; text-decoration:none; padding:16px 32px; border-radius:24px;">Get it on the App Store</a>
+  </div>
+</div>
+```

--- a/skills/composites/goose-graphics/styles/blueprint-sticky.md
+++ b/skills/composites/goose-graphics/styles/blueprint-sticky.md
@@ -1,0 +1,144 @@
+# Blueprint Sticky
+
+Saturated cobalt-blue canvas with a blueprint grid overlay, tilted pink and yellow sticky notes pinned at various angles, massive Inter 900 white headline at bottom-left, and a stacked date label in a corner. Inter 900 for every headline. Scrapbook energy meets startup pitch deck.
+
+> Full prose reference: `styles/_full/blueprint-sticky.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#2450F5` | Cobalt blue — primary background |
+| `#1F4AF0` | Cobalt deep — alternate for depth |
+| `#4870F8` | Cobalt grid line — blueprint overlay (30% opacity) |
+| `#FFFFFF` | Blueprint white — headlines, corner dates, URL |
+| `#F4B8D4` | Sticky pink — pink sticky fill |
+| `#F4E34A` | Sticky yellow — yellow sticky fill + curved underline |
+| `#1A1A1A` | Sticky text — body copy on sticky notes |
+| `#E89FBF` | Hover pink — pressed state |
+| `#E5D23A` | Hover yellow — pressed state |
+| `rgba(255,255,255,0.70)` | Muted white — URLs |
+| `rgba(255,255,255,0.40)` | Faint white — metadata |
+| `#EBDDD0` | Sticky edge warm — torn-edge highlight |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
+```
+
+- **Display / Body:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Inter | 96px | 900 | 0.95 | -3px |
+| Section Heading | Inter | 64px | 900 | 1.00 | -2px |
+| Sub-heading | Inter | 36px | 800 | 1.10 | -1px |
+| Date Label Big | Inter | 48px | 600 | 1.00 | -1px |
+| Date Label Small | Inter | 20px | 600 | 1.10 | 0.3px |
+| Sticky Body Large | Inter | 22px | 500 | 1.45 | 0 |
+| Sticky Body | Inter | 18px | 400 | 1.50 | 0 |
+| Sticky Bold | Inter | 18px | 600 | 1.45 | 0 |
+| URL Label | Inter | 16px | 500 | 1.20 | 0.5px |
+| Caption | Inter | 13px | 500 | 1.45 | 0.4px |
+| Big Number | Inter | 140px | 900 | 0.90 | -4px |
+| CTA | Inter | 18px | 700 | 1.00 | 0.3px |
+
+**Principles**
+
+- Inter 900 for all display — the voice is massive.
+- Sticky-note copy stays Inter 400-600 mixed case on near-black, reads like handwriting but crisp.
+- White text on cobalt; near-black text on stickies.
+
+## Layout
+
+- Full-bleed cobalt `#2450F5` background.
+- Blueprint grid overlay: CSS `linear-gradient` pair for vertical + horizontal 1px lines in `#4870F8` at 48-60px spacing, 30% opacity.
+- Sticky notes: pink `#F4B8D4` or yellow `#F4E34A` rectangles, 240-320px wide, 2-4° random tilt, offset shadow `4px 8px 0 rgba(0,0,0,0.15)`.
+- Corner date label: big number (48px) + month name (20px) stacked.
+- Massive white headline anchored bottom-left (96px, 3-4 lines).
+- Curved yellow underline (SVG) under emphasis words.
+
+## Do / Don't
+
+**Do**
+
+- Overlay a blueprint grid on the cobalt canvas.
+- Tilt every sticky note 2-4° randomly — axis-aligned stickies look dead.
+- Use pink AND yellow sticky notes together — the pair is the identity.
+- Anchor the display headline bottom-left with white Inter 900.
+- Add a curved yellow SVG underline under emphasis words inside stickies.
+
+**Don't**
+
+- Don't use cobalt without the grid overlay.
+- Don't use sticky-note colors other than the defined pink + yellow.
+- Don't center-align display type — bottom-left is the rule.
+- Don't use Inter weights below 800 for headlines.
+- Don't use axis-aligned stickies.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --c-cobalt: #2450F5;
+  --c-cobalt-deep: #1F4AF0;
+  --c-grid: #4870F8;
+  --c-white: #FFFFFF;
+  --c-pink: #F4B8D4;
+  --c-yellow: #F4E34A;
+  --c-sticky-text: #1A1A1A;
+
+  --font: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --grid-overlay:
+    linear-gradient(to right, rgba(72,112,248,0.3) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(72,112,248,0.3) 1px, transparent 1px);
+}
+```
+
+### Full composition
+
+```html
+<div style="background:#2450F5; background-image:linear-gradient(to right,rgba(72,112,248,0.3) 1px,transparent 1px),linear-gradient(to bottom,rgba(72,112,248,0.3) 1px,transparent 1px); background-size:60px 60px; padding:60px; min-height:960px; position:relative;">
+
+  <div style="position:absolute; top:60px; left:60px;">
+    <p style="font-family:'Inter',sans-serif; font-size:48px; font-weight:600; line-height:1.00; letter-spacing:-1px; color:#fff; margin:0;">16</p>
+    <p style="font-family:'Inter',sans-serif; font-size:20px; font-weight:600; line-height:1.10; letter-spacing:0.3px; color:#fff; margin:4px 0 0;">February</p>
+  </div>
+
+  <div style="position:absolute; top:180px; right:100px; transform:rotate(3deg); background:#F4B8D4; padding:24px; width:260px; box-shadow:4px 8px 0 rgba(0,0,0,0.15);">
+    <p style="font-family:'Inter',sans-serif; font-size:22px; font-weight:500; line-height:1.45; color:#1A1A1A; margin:0;">Zen Time meditation — we shipped the first version in <b>48 hours</b>.</p>
+  </div>
+
+  <div style="position:absolute; top:420px; right:180px; transform:rotate(-4deg); background:#F4E34A; padding:20px; width:240px; box-shadow:4px 8px 0 rgba(0,0,0,0.15);">
+    <p style="font-family:'Inter',sans-serif; font-size:18px; font-weight:400; line-height:1.50; color:#1A1A1A; margin:0;">Users stay for an average of <span style="background:none; position:relative;">11.2 minutes<svg width="120" height="8" style="position:absolute; left:0; bottom:-6px;"><path d="M0 4 Q30 0 60 4 T120 4" stroke="#1A1A1A" stroke-width="2" fill="none"/></svg></span>.</p>
+  </div>
+
+  <h1 style="position:absolute; bottom:80px; left:60px; font-family:'Inter',sans-serif; font-size:96px; font-weight:900; line-height:0.95; letter-spacing:-3px; color:#fff; margin:0; max-width:720px;">Build the habit. Ship the rest.</h1>
+
+  <p style="position:absolute; bottom:40px; right:60px; font-family:'Inter',sans-serif; font-size:16px; font-weight:500; letter-spacing:0.5px; color:rgba(255,255,255,0.70); margin:0;">www.zentime.com</p>
+</div>
+```
+
+### Sticky note helper
+
+```css
+.sticky {
+  display: inline-block;
+  padding: 20px 24px;
+  max-width: 280px;
+  transform: rotate(var(--tilt, -2deg));
+  box-shadow: 4px 8px 0 rgba(0, 0, 0, 0.15);
+  font-family: 'Inter', sans-serif;
+  font-size: 18px;
+  color: #1A1A1A;
+  line-height: 1.50;
+}
+.sticky.pink { background: #F4B8D4; }
+.sticky.yellow { background: #F4E34A; }
+```

--- a/skills/composites/goose-graphics/styles/brutalist.md
+++ b/skills/composites/goose-graphics/styles/brutalist.md
@@ -1,0 +1,132 @@
+# Brutalist
+
+Raw, structural, unapologetic. Massive uppercase Arial Black headlines that crowd container edges, hard 2-4px black borders, visible grid lines, no decoration, no shadows, no rounded corners. System fonts only — Arial + Courier New. Red (`#ff0000`) is the only color outside grayscale.
+
+> Full prose reference: `styles/_full/brutalist.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#ffffff` | Pure white background |
+| `#000000` | Pure black — primary text, all borders |
+| `#ff0000` | Pure red — accent (numbers, active borders, CTAs) |
+| `#f0f0f0` | Light gray — alternate surface, inset |
+| `#cccccc` | Medium gray — exposed grid lines |
+| `#333333` | Dark gray — secondary body text |
+
+## Typography
+
+System fonts — no webfont load.
+
+- **Display:** `Arial, Helvetica, sans-serif`
+- **Monospace:** `'Courier New', Courier, monospace`
+
+| Role | Font | Size | Weight | Line-height | Tracking | Transform |
+|------|------|------|--------|-------------|----------|-----------|
+| Display Hero | Arial | 120px | 900 | 0.90 | -2px | UPPERCASE |
+| Section Heading | Arial | 80px | 900 | 0.95 | -1px | UPPERCASE |
+| Sub-heading | Arial | 48px | 800 | 1.00 | -0.5px | UPPERCASE |
+| Body Large | Arial | 20px | 400 | 1.55 | 0 | none |
+| Body | Arial | 16px | 400 | 1.60 | 0 | none |
+| Caption | Courier New | 12px | 400 | 1.40 | 1px | UPPERCASE |
+| Big Number | Arial | 100px | 900 | 1.00 | -2px | none |
+| Structural Label | Courier New | 14px | 400 | 1.00 | 3px | UPPERCASE |
+| CTA | Arial | 18px | 800 | 1.00 | 2px | UPPERCASE |
+
+**Principles**
+
+- Display type is massive (80-120px) and crowds the container — deliberate overflow is fine.
+- Arial Black 900 for display, Arial 400 for body, Courier New for all labels/captions.
+- UPPERCASE everything that's structural; body stays mixed case for reading.
+
+## Layout
+
+- Format padding: carousel 40-60px · infographic 40/60 · slides 60-80px · poster 40/60.
+- Thick black borders: 2px, 3px, or 4px solid `#000`.
+- Exposed grid lines: 1px `#cccccc` as background CSS grid.
+- Zero border-radius anywhere. Sharp corners only.
+- Red (`#ff0000`) used for: active/current state borders, big stat numbers, CTA fills.
+- No shadows. No gradients. No decoration. Content fills the frame.
+
+## Do / Don't
+
+**Do**
+
+- Let display type crowd the frame (leading < 1.0, negative tracking, 120px+).
+- Use 2-4px solid black borders as the primary structural device.
+- Use Courier New UPPERCASE with 1-3px tracking for every label and caption.
+- Use `#ff0000` sparingly — 1-2 red elements per section.
+- Expose grid lines as part of the composition, not as mistakes.
+
+**Don't**
+
+- Don't use rounded corners, ever.
+- Don't use drop shadows or gradients.
+- Don't use decorative icons, emojis, or illustrations.
+- Don't use colors outside the palette — only black/white/red/gray.
+- Don't soften contrast — pure `#000` on pure `#fff` is the mandate.
+- Don't use thin borders (< 2px) — brutalism is heavy.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-bg: #ffffff;
+  --color-ink: #000000;
+  --color-red: #ff0000;
+  --color-alt: #f0f0f0;
+  --color-grid: #cccccc;
+  --color-dark-gray: #333333;
+
+  --font-display: Arial, Helvetica, sans-serif;
+  --font-mono: 'Courier New', Courier, monospace;
+
+  --border-thick: 3px solid #000;
+  --border-red: 3px solid #ff0000;
+}
+```
+
+### Title block (display type crowds the frame)
+
+```html
+<div style="background:#fff; padding:60px 40px; border:3px solid #000;">
+  <p style="font-family:'Courier New',monospace; font-size:14px; font-weight:400; letter-spacing:3px; text-transform:uppercase; color:#000; margin:0 0 24px;">01 — STRATEGY</p>
+  <h1 style="font-family:Arial,sans-serif; font-size:120px; font-weight:900; line-height:0.90; letter-spacing:-2px; text-transform:uppercase; color:#000; margin:0;">THE FUTURE<br>OF WORK.</h1>
+  <div style="width:100%; height:3px; background:#000; margin:32px 0;"></div>
+  <p style="font-family:Arial,sans-serif; font-size:20px; font-weight:400; line-height:1.55; color:#000; margin:0; max-width:640px;">How AI coworkers are reshaping how teams operate, collaborate, and deliver results.</p>
+</div>
+```
+
+### Numbered item (big red stat on black border)
+
+```html
+<div style="display:flex; gap:0; border:3px solid #000;">
+  <div style="min-width:180px; padding:24px; background:#ff0000; display:flex; align-items:center; justify-content:center;">
+    <span style="font-family:Arial,sans-serif; font-size:100px; font-weight:900; line-height:1.00; letter-spacing:-2px; color:#000;">47</span>
+  </div>
+  <div style="padding:24px; border-left:3px solid #000;">
+    <p style="font-family:'Courier New',monospace; font-size:14px; font-weight:400; letter-spacing:3px; text-transform:uppercase; color:#000; margin:0 0 8px;">FASTER RESPONSE</p>
+    <p style="font-family:Arial,sans-serif; font-size:16px; font-weight:400; line-height:1.60; color:#333; margin:0;">Teams respond to leads nearly twice as fast with AI-powered workflows.</p>
+  </div>
+</div>
+```
+
+### CTA (black fill, red hover)
+
+```html
+<a style="display:inline-block; background:#000; color:#fff; font-family:Arial,sans-serif; font-size:18px; font-weight:800; letter-spacing:2px; text-transform:uppercase; text-decoration:none; padding:16px 32px; border:3px solid #000;">GET STARTED →</a>
+```
+
+### Exposed grid background
+
+```css
+.brutalist-grid {
+  background-image:
+    linear-gradient(to right, #cccccc 1px, transparent 1px),
+    linear-gradient(to bottom, #cccccc 1px, transparent 1px);
+  background-size: 40px 40px;
+}
+```

--- a/skills/composites/goose-graphics/styles/bw-editorial-drop.md
+++ b/skills/composites/goose-graphics/styles/bw-editorial-drop.md
@@ -1,0 +1,120 @@
+# BW Editorial Drop
+
+Fashion-poster editorial. Top 55-60% of the frame holds a desaturated grayscale photograph; bottom 40-45% is a solid drop-black panel containing a massive Anton display headline in highlighter yellow. White uppercase tracked metadata pins the corners. Silent, cinematic, looks like Acne Studios season campaign meets Balenciaga lookbook.
+
+> Full prose reference: `styles/_full/bw-editorial-drop.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#0A0A0A` | Drop black — bottom panel fill, primary canvas |
+| `#F4ED2B` | Highlighter yellow — display headline only |
+| `#FFFFFF` | Signal white — corner metadata labels |
+| `#F8F34A` | Yellow hover (rare) |
+| `#D4CD1F` | Yellow shadow — optional 1-2px text shadow over bright photo |
+| `#0F0F0F` | Sub panel — Story format recessed strip |
+| `rgba(255,255,255,0.6)` | Metadata muted — slide counters |
+| `rgba(255,255,255,0.12)` | Hairline border |
+| `rgba(0,0,0,0.35)` | Photo vignette |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Anton&family=Inter:wght@500;600&display=swap" rel="stylesheet">
+```
+
+- **Display:** `'Anton', Impact, 'Arial Narrow', sans-serif`
+- **Metadata:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Anton | 120px | 400 | 0.92 | -0.03em UPPER |
+| Display Large | Anton | 108px | 400 | 0.92 | -0.03em UPPER |
+| Display Medium | Anton | 92px | 400 | 0.94 | -0.025em UPPER |
+| Display Small | Anton | 72px | 400 | 0.94 | -0.02em UPPER |
+| Metadata Label | Inter | 12px | 600 | 1.30 | 0.12em UPPER |
+| Metadata Small | Inter | 11px | 500 | 1.30 | 0.14em UPPER |
+| Body Cap (rare) | Inter | 14px | 500 | 1.45 | 0.08em UPPER |
+| Credit / Slug | Inter | 11px | 500 | 1.30 | 0.16em UPPER |
+| CTA Label | Inter | 12px | 600 | 1.30 | 0.14em UPPER |
+
+**Principles**
+
+- Anton is one weight (400 native heavy) but reads as 900.
+- Two-line yellow ALL-CAPS headline inside the drop panel.
+- All metadata is uppercase tracked Inter 500-600 in white.
+
+## Layout
+
+- Top 55-60% of frame: grayscale photograph (desaturated + slight contrast lift). Apply `filter: grayscale(1) contrast(1.1)`.
+- Optional bottom-edge vignette: `linear-gradient(180deg, transparent, rgba(0,0,0,0.35))`.
+- Bottom 40-45%: solid `#0A0A0A` drop panel holding the two-line yellow Anton headline.
+- Corner metadata: white uppercase Inter labels — brand/issue top-left, date top-right, page number bottom-right.
+- CTA micro-copy bottom-right of drop panel ("SHOP NOW TO ELEVATE YOUR LOOK" or similar).
+
+## Do / Don't
+
+**Do**
+
+- Desaturate the photograph fully (`filter: grayscale(1)`).
+- Use Anton 400 for the headline — yellow on drop-black, 2 lines max.
+- Use Inter uppercase tracked white for every metadata corner.
+- Add a faint bottom-edge vignette to the photo.
+- Keep the drop panel clean — headline + 1-2 micro-copy labels only.
+
+**Don't**
+
+- Don't color the photograph — grayscale is mandatory.
+- Don't use colors in the drop panel besides yellow and white.
+- Don't center-align the headline — always left-aligned inside the drop.
+- Don't exceed 2 lines on the display headline.
+- Don't use lowercase on metadata.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --c-drop: #0A0A0A;
+  --c-yellow: #F4ED2B;
+  --c-white: #FFFFFF;
+  --c-sub-panel: #0F0F0F;
+  --c-metadata-muted: rgba(255, 255, 255, 0.6);
+  --c-border: rgba(255, 255, 255, 0.12);
+
+  --font-display: 'Anton', Impact, 'Arial Narrow', sans-serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+}
+```
+
+### Full composition
+
+```html
+<div style="min-height:1350px; background:#0A0A0A; position:relative;">
+  <div style="height:60%; background-image:url('model.jpg'); background-size:cover; background-position:center; filter:grayscale(1) contrast(1.1); position:relative;">
+    <div style="position:absolute; bottom:0; left:0; right:0; height:25%; background:linear-gradient(180deg,transparent,rgba(0,0,0,0.35));"></div>
+    <p style="position:absolute; top:40px; left:40px; font-family:'Inter',sans-serif; font-size:12px; font-weight:600; letter-spacing:0.12em; text-transform:uppercase; color:#FFFFFF; margin:0;">STUDIO WILSON · VOL 04</p>
+    <p style="position:absolute; top:40px; right:40px; font-family:'Inter',sans-serif; font-size:12px; font-weight:600; letter-spacing:0.12em; text-transform:uppercase; color:#FFFFFF; margin:0;">AUTUMN 2026</p>
+  </div>
+
+  <div style="height:40%; background:#0A0A0A; padding:40px 40px 40px; display:flex; flex-direction:column; justify-content:space-between;">
+    <h1 style="font-family:'Anton',sans-serif; font-size:120px; font-weight:400; line-height:0.92; letter-spacing:-0.03em; text-transform:uppercase; color:#F4ED2B; margin:0;">THE<br>DROP.</h1>
+    <div style="display:flex; justify-content:space-between; align-items:center;">
+      <p style="font-family:'Inter',sans-serif; font-size:11px; font-weight:500; letter-spacing:0.16em; text-transform:uppercase; color:rgba(255,255,255,0.6); margin:0;">01 / 12</p>
+      <p style="font-family:'Inter',sans-serif; font-size:12px; font-weight:600; letter-spacing:0.14em; text-transform:uppercase; color:#FFFFFF; margin:0;">SHOP NOW TO ELEVATE YOUR LOOK →</p>
+    </div>
+  </div>
+</div>
+```
+
+### Story sub-panel variant
+
+```html
+<div style="background:#0F0F0F; padding:16px 40px; border-top:1px solid rgba(255,255,255,0.12);">
+  <p style="font-family:'Inter',sans-serif; font-size:14px; font-weight:500; letter-spacing:0.08em; text-transform:uppercase; color:#FFFFFF; margin:0;">Look 03 · Camel Topcoat · From $1,240</p>
+</div>
+```

--- a/skills/composites/goose-graphics/styles/card-toss.md
+++ b/skills/composites/goose-graphics/styles/card-toss.md
@@ -1,0 +1,130 @@
+# Card Toss
+
+Scattered tilted cards on a pure-black void. Sunshine yellow, cornflower blue, and coral orange cards rotated at random small angles (-8° to +8°) like polaroids tossed on a table. Each card carries a testimonial, award, or rating. DM Serif Display for oversized headline type; DM Sans for body. The mood is "press kit wall meets editorial pinboard."
+
+> Full prose reference: `styles/_full/card-toss.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#000000` | Void black — primary background |
+| `#1A1A1A` | Card text (on colored cards) |
+| `#FFD60A` | Sunshine yellow — testimonial cards, stars |
+| `#4A9FE5` | Cornflower blue — award/accolade cards, CTAs |
+| `#F47B5E` | Coral orange — brand logos, quote cards |
+| `#F5F0E0` | Off-white — decorative circles, soft accents |
+| `#D4B000` | Dark yellow hover |
+| `#3A7FBF` | Dark blue hover |
+| `#D4664D` | Dark coral hover |
+| `#E8E8E8` | Light gray — rare secondary text on dark |
+| `#999999` | Medium gray — metadata |
+| `#2A2A2A` | Charcoal — subtle dark surface |
+| `#111111` | Near black — elevated dark surface |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display&family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display:** `'DM Serif Display', Georgia, 'Times New Roman', serif`
+- **Body:** `'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | DM Serif Display | 64px | 400 | 1.05 | -0.5px |
+| Section Heading | DM Serif Display | 44px | 400 | 1.10 | -0.3px |
+| Sub-heading | DM Serif Display | 32px | 400 | 1.15 | 0 |
+| Body Large | DM Sans | 20px | 400 | 1.55 | 0 |
+| Body | DM Sans | 16px | 400 | 1.60 | 0 |
+| Caption | DM Sans | 13px | 500 | 1.45 | 0.3px |
+| Big Number | DM Serif Display | 120px | 400 | 0.90 | -2px |
+| Reviewer Name | DM Sans | 16px | 600 | 1.20 | 0 |
+| CTA | DM Sans | 16px | 700 | 1.00 | 1px UPPER |
+| Star Rating | System | 20px | 400 | 1.00 | 2px |
+
+**Principles**
+
+- DM Serif Display is used at one weight (400) — size drives impact.
+- Oversized serif (120px big numbers) is the signature.
+- Body is DM Sans — clean, small, supportive.
+
+## Layout
+
+- Background: pure `#000000` void. No texture, no gradient.
+- Cards: 16-24px radius, colored fills, no borders, soft shadow `0 12px 32px rgba(0,0,0,0.4)`.
+- Each card rotated with random angle `transform: rotate(-6deg)` through `rotate(6deg)`.
+- Cards overlap slightly at edges. Stacking order matters — featured content on top.
+- Decorative off-white `#F5F0E0` circles (80-160px) scattered behind cards as visual punctuation.
+
+## Do / Don't
+
+**Do**
+
+- Rotate each card a small random amount (-8° to +8°).
+- Use yellow for testimonials + star ratings, blue for awards + CTAs, coral for logos + quote cards.
+- Overlap cards at edges to create a "tossed" stack.
+- Use black star characters on yellow cards for ratings.
+- Add decorative off-white circles behind cards as compositional anchors.
+
+**Don't**
+
+- Don't keep cards axis-aligned — flatness kills the style.
+- Don't use more than 3 card colors (yellow + blue + coral).
+- Don't use anything other than pure black for background.
+- Don't use sans-serif for display type — DM Serif Display is mandatory.
+- Don't use heavy text shadows — cards only.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-void: #000000;
+  --color-card-text: #1A1A1A;
+  --color-yellow: #FFD60A;
+  --color-blue: #4A9FE5;
+  --color-coral: #F47B5E;
+  --color-off-white: #F5F0E0;
+
+  --font-display: 'DM Serif Display', Georgia, 'Times New Roman', serif;
+  --font-body: 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --shadow-card: 0 12px 32px rgba(0, 0, 0, 0.4);
+}
+```
+
+### Tossed-card composition
+
+```html
+<div style="position:relative; background:#000; min-height:100vh; padding:80px 60px; overflow:hidden;">
+  <div style="position:absolute; top:120px; right:80px; width:140px; height:140px; border-radius:50%; background:#F5F0E0; opacity:0.2;"></div>
+  <div style="position:absolute; bottom:100px; left:100px; width:100px; height:100px; border-radius:50%; background:#F5F0E0; opacity:0.15;"></div>
+
+  <div style="position:absolute; top:140px; left:180px; transform:rotate(-4deg); background:#FFD60A; border-radius:20px; padding:32px; width:360px; box-shadow:0 12px 32px rgba(0,0,0,0.4);">
+    <p style="letter-spacing:2px; font-size:20px; color:#1A1A1A; margin:0 0 12px;">★★★★★</p>
+    <p style="font-family:'DM Serif Display',serif; font-size:28px; font-weight:400; line-height:1.25; color:#1A1A1A; margin:0 0 16px;">"Goose saved our team six hours a week — week one."</p>
+    <p style="font-family:'DM Sans',sans-serif; font-size:16px; font-weight:600; color:#1A1A1A; margin:0;">Sarah Chen, VP Ops</p>
+  </div>
+
+  <div style="position:absolute; top:340px; left:380px; transform:rotate(3deg); background:#4A9FE5; border-radius:20px; padding:32px; width:320px; box-shadow:0 12px 32px rgba(0,0,0,0.4);">
+    <p style="font-family:'DM Sans',sans-serif; font-size:13px; font-weight:500; letter-spacing:2px; text-transform:uppercase; color:#1A1A1A; margin:0 0 12px;">BEST IN CLASS 2025</p>
+    <p style="font-family:'DM Serif Display',serif; font-size:120px; font-weight:400; line-height:0.90; letter-spacing:-2px; color:#1A1A1A; margin:0;">#1</p>
+  </div>
+
+  <div style="position:absolute; top:520px; left:140px; transform:rotate(-6deg); background:#F47B5E; border-radius:20px; padding:32px; width:280px; box-shadow:0 12px 32px rgba(0,0,0,0.4);">
+    <p style="font-family:'DM Serif Display',serif; font-size:44px; font-weight:400; line-height:1.10; letter-spacing:-0.3px; color:#1A1A1A; margin:0;">"A category-defining product."</p>
+    <p style="font-family:'DM Sans',sans-serif; font-size:13px; font-weight:500; letter-spacing:0.3px; color:#1A1A1A; margin:16px 0 0;">— TechCrunch</p>
+  </div>
+</div>
+```
+
+### Blue CTA card (tilted)
+
+```html
+<a style="display:inline-block; transform:rotate(-2deg); background:#4A9FE5; color:#1A1A1A; font-family:'DM Sans',sans-serif; font-size:16px; font-weight:700; letter-spacing:1px; text-transform:uppercase; text-decoration:none; padding:18px 36px; border-radius:16px; box-shadow:0 12px 32px rgba(0,0,0,0.4);">READ THE REVIEWS</a>
+```

--- a/skills/composites/goose-graphics/styles/cinematic-romance.md
+++ b/skills/composites/goose-graphics/styles/cinematic-romance.md
@@ -1,0 +1,136 @@
+# Cinematic Romance
+
+Streaming-service key-art. A portrait photograph color-graded into teal (shadows) and rose (highlights), with a massive hot-pink Allura script headline covering the frame. Inter uppercase metadata frames the composition. Think Netflix limited-series poster meets editorial romance cover.
+
+> Full prose reference: `styles/_full/cinematic-romance.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#3a5f6b` | Teal graded — primary canvas tone, photo grade target |
+| `#E8449A` | Hot pink — all type, all elements |
+| `#C1297A` | Pink deep — hover, gradient stop |
+| `#FF5FAE` | Pink hot — highlight glow |
+| `#1f3942` | Teal deep — gradient corners, dark base |
+| `#4b7583` | Teal mid — content-slide bg |
+| `#78a2ad` | Teal highlight — rim light |
+| `#f2e6ec` | Off-white dim — CTA inversions |
+| `#0d1a1f` | Ink — pause chrome, UI darks |
+| `#b88e87` | Graded skin — skin-tone family under grade |
+| `rgba(232,68,154,0.72)` | Caption pink dim |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Allura&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display Script:** `'Allura', 'Lucida Handwriting', cursive`
+- **Body:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Script | Allura | 220px | 400 | 0.90 | 0 |
+| Presents Line | Inter | 14px | 600 | 1.00 | 3.5px UPPER |
+| Logline | Inter | 18px | 600 | 1.45 | 1.2px UPPER |
+| Episode Label | Inter | 12px | 700 | 1.00 | 4px UPPER |
+| Body Large | Inter | 22px | 500 | 1.55 | 0.3px |
+| Body | Inter | 18px | 500 | 1.60 | 0.2px |
+| Caption | Inter | 13px | 500 | 1.40 | 1px UPPER |
+| Big Number | Allura | 180px | 400 | 0.90 | 0 |
+| Stat Label | Inter | 13px | 600 | 1.00 | 3px UPPER |
+| UI Element | Inter | 11px | 600 | 1.00 | 2px UPPER |
+
+**Principles**
+
+- Allura script at 180-220px is the entire hero — everything else supports it.
+- All type is hot pink (`#E8449A`). No exceptions for metadata, CTAs, body.
+- Uppercase tracked Inter for structural/metadata language.
+- Script is mixed case; everything else is UPPER with wide tracking.
+
+## Layout
+
+- Background: full-bleed portrait photograph duotone-graded into the teal family with pink rim lights and graded skin tones.
+- Apply `filter: contrast(1.1) saturate(0.6)` and composite with `background-blend-mode: multiply` onto teal base.
+- The hot-pink script sits ACROSS the photo at 60-80% frame width, slightly off-center.
+- Inter uppercase metadata pins the corners: "PRESENTS" top-left, "EPISODE ONE" top-right, scene caption bottom, pause-chrome UI elements.
+- Rose gradient glow `radial-gradient(circle at center, rgba(232,68,154,0.25), transparent 70%)` behind script for luminance.
+
+## Do / Don't
+
+**Do**
+
+- Color-grade the photo into the teal/rose family — never use ungraded RGB.
+- Use Allura script at 180-220px as the visual anchor.
+- Paint every typographic element in hot pink `#E8449A`.
+- Pin uppercase tracked Inter metadata in corners for the "streaming UI" frame.
+- Add scene-label UI chrome: `⏸ SCENE 03 · 02:47` bottom-left.
+
+**Don't**
+
+- Don't use any color outside the teal/pink family (no whites except `#f2e6ec` for CTA inversion, no true black).
+- Don't use sans-serif for the script — Allura is mandatory for hero type.
+- Don't split the script across the canvas; keep it as a single flowing phrase.
+- Don't brighten the photo — keep it graded and slightly muted.
+- Don't use emojis or icons other than pause/play UI chrome.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-teal: #3a5f6b;
+  --color-teal-deep: #1f3942;
+  --color-teal-mid: #4b7583;
+  --color-teal-hi: #78a2ad;
+  --color-pink: #E8449A;
+  --color-pink-deep: #C1297A;
+  --color-pink-hot: #FF5FAE;
+  --color-ink: #0d1a1f;
+  --color-off-white: #f2e6ec;
+
+  --font-script: 'Allura', 'Lucida Handwriting', cursive;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+}
+```
+
+### Cinematic hero with graded photo
+
+```html
+<div style="position:relative; min-height:100vh; background:#3a5f6b; overflow:hidden;">
+  <div style="position:absolute; inset:0; background-image:url('portrait.jpg'); background-size:cover; background-position:center; filter:contrast(1.1) saturate(0.6); mix-blend-mode:multiply;"></div>
+  <div style="position:absolute; inset:0; background:radial-gradient(circle at 50% 60%, rgba(232,68,154,0.25), transparent 70%);"></div>
+
+  <div style="position:relative; z-index:2; padding:60px;">
+    <div style="display:flex; justify-content:space-between; align-items:flex-start;">
+      <p style="font-family:'Inter',sans-serif; font-size:14px; font-weight:600; letter-spacing:3.5px; text-transform:uppercase; color:#E8449A; margin:0;">BORCELLE STUDIO PRESENTS</p>
+      <p style="font-family:'Inter',sans-serif; font-size:12px; font-weight:700; letter-spacing:4px; text-transform:uppercase; color:#E8449A; margin:0;">EPISODE ONE</p>
+    </div>
+    <h1 style="font-family:'Allura',cursive; font-size:220px; font-weight:400; line-height:0.90; color:#E8449A; text-align:center; margin:80px 0 40px;">After the<br>Long Wait</h1>
+    <p style="font-family:'Inter',sans-serif; font-size:18px; font-weight:600; letter-spacing:1.2px; text-transform:uppercase; color:#E8449A; text-align:center; max-width:640px; margin:0 auto;">A QUIET STORY ABOUT THE TEAM THAT SHIPPED IT ANYWAY.</p>
+  </div>
+
+  <div style="position:absolute; bottom:60px; left:60px; display:flex; gap:16px; align-items:center; z-index:2;">
+    <span style="font-family:'Inter',sans-serif; font-size:11px; font-weight:600; letter-spacing:2px; text-transform:uppercase; color:#E8449A;">⏸ SCENE 03 · 02:47</span>
+  </div>
+</div>
+```
+
+### Stat with script numeral
+
+```html
+<div style="text-align:center; padding:40px; background:#3a5f6b;">
+  <p style="font-family:'Allura',cursive; font-size:180px; font-weight:400; line-height:0.90; color:#E8449A; margin:0;">47</p>
+  <p style="font-family:'Inter',sans-serif; font-size:13px; font-weight:600; letter-spacing:3px; text-transform:uppercase; color:#E8449A; margin:8px 0 0;">FASTER RESPONSE</p>
+</div>
+```
+
+### CTA (pink-on-offwhite inversion)
+
+```html
+<a style="display:inline-block; background:#f2e6ec; color:#E8449A; font-family:'Inter',sans-serif; font-size:13px; font-weight:600; letter-spacing:3px; text-transform:uppercase; text-decoration:none; padding:14px 32px;">WATCH THE TRAILER</a>
+```

--- a/skills/composites/goose-graphics/styles/clean-slate.md
+++ b/skills/composites/goose-graphics/styles/clean-slate.md
@@ -1,0 +1,145 @@
+# Clean Slate
+
+Ultra-minimal pure white with aggressive negative tracking on a single-family Space Grotesk. One blue accent (`#0066ff`) for every interactive surface. Everything else is grayscale discipline — no decoration, no ornament, no emoji.
+
+> Full prose reference: `styles/_full/clean-slate.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#ffffff` | White background (primary canvas) |
+| `#171717` | Near-black — primary text |
+| `#0066ff` | Blue — single accent (CTAs, numbers, focal) |
+| `#e6f0ff` | Light blue — tag fills, subtle emphasis |
+| `#0052cc` | Dark blue — hover/active |
+| `#f5f5f5` | Snow — card surface |
+| `#fafafa` | Surface inset |
+| `#ebebeb` | Light border |
+| `#d4d4d4` | Mid gray — disabled |
+| `#9ca3af` | Cool gray — tertiary text |
+| `#6b7280` | Warm gray — secondary text |
+| `#4b5563` | Slate — secondary headings |
+| `#374151` | Charcoal — high-emphasis body |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display / Body:** `'Space Grotesk', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Space Grotesk | 72px | 700 | 1.05 | -2px |
+| Section Heading | Space Grotesk | 48px | 700 | 1.10 | -1.5px |
+| Sub-heading | Space Grotesk | 32px | 600 | 1.15 | -0.75px |
+| Body Large | Space Grotesk | 20px | 300 | 1.65 | 0 |
+| Body | Space Grotesk | 16px | 400 | 1.65 | 0 |
+| Caption | Space Grotesk | 13px | 400 | 1.50 | 0.2px |
+| Big Number | Space Grotesk | 64px | 700 | 1.00 | -1.5px |
+| Numbered Label | Space Grotesk | 14px | 500 | 1.00 | 1.5px UPPER |
+| CTA | Space Grotesk | 15px | 600 | 1.00 | 0.5px |
+
+**Principles**
+
+- One family, total discipline. Hierarchy only through size/weight/tracking.
+- Aggressive negative tracking at display sizes (-2px at 72px) for precise engineered feel.
+- Light body weight (300-400) for airy reading on white.
+
+## Layout
+
+- Format padding: carousel 60px · infographic 60/80 · slides 80px · poster 60/80.
+- Hairline `1px solid #ebebeb` borders.
+- Rules: 1px `#171717` or `#0066ff`, typically 48-60px wide.
+- Cards: `#f5f5f5` bg, 2-4px radius. Precise, not rounded.
+- Whitespace is the material. Content respects margins; nothing fills to edges.
+- Left-align body; center-align hero titles, big numbers, CTAs.
+
+## Do / Don't
+
+**Do**
+
+- Use `#0066ff` as the single accent — every CTA, every number, every focal point is this blue.
+- Use aggressive negative tracking on display type for a precise, engineered headline feel.
+- Keep hairline borders (1px) for all structural definition.
+- Use `#e6f0ff` as tag/pill fill paired with `#0066ff` text.
+- Treat whitespace as a first-class layout element.
+
+**Don't**
+
+- Don't use more than one accent color — blue only, grayscale otherwise.
+- Don't use decorative elements (icons, emojis, illustrations, gradients).
+- Don't use radius above 4px — Swiss-modernist precision, not friendly.
+- Don't use heavy shadow — elevation through border + whitespace only.
+- Don't use warm grays. Cool grays only (`#9ca3af`, `#6b7280`, `#374151`).
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-bg: #ffffff;
+  --color-text: #171717;
+  --color-blue: #0066ff;
+  --color-blue-bg: #e6f0ff;
+  --color-blue-dark: #0052cc;
+  --color-snow: #f5f5f5;
+  --color-border: #ebebeb;
+  --color-cool-gray: #9ca3af;
+  --color-warm-gray: #6b7280;
+  --color-charcoal: #374151;
+
+  --font: 'Space Grotesk', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --radius-card: 4px;
+}
+```
+
+### Hero title
+
+```html
+<div style="background:#fff; padding:80px 60px; text-align:center;">
+  <div style="width:60px; height:1px; background:#171717; margin:0 auto 40px;"></div>
+  <h1 style="font-family:'Space Grotesk',sans-serif; font-size:72px; font-weight:700; line-height:1.05; letter-spacing:-2px; color:#171717; margin:0 0 24px;">The Future of<br>Autonomous Work</h1>
+  <p style="font-family:'Space Grotesk',sans-serif; font-size:20px; font-weight:300; line-height:1.65; color:#6b7280; max-width:560px; margin:0 auto;">How AI coworkers are reshaping how teams operate.</p>
+</div>
+```
+
+### Numbered item (blue numeral)
+
+```html
+<div style="display:flex; gap:24px; align-items:flex-start; padding:32px 0; border-bottom:1px solid #ebebeb;">
+  <span style="font-family:'Space Grotesk',sans-serif; font-size:48px; font-weight:700; line-height:1.00; letter-spacing:-1.5px; color:#0066ff; min-width:72px;">01</span>
+  <div>
+    <p style="font-family:'Space Grotesk',sans-serif; font-size:14px; font-weight:500; letter-spacing:1.5px; text-transform:uppercase; color:#6b7280; margin:0 0 8px;">SIGNAL-BASED OUTBOUND</p>
+    <h3 style="font-family:'Space Grotesk',sans-serif; font-size:32px; font-weight:600; line-height:1.15; letter-spacing:-0.75px; color:#171717; margin:0 0 12px;">Find buyers before they find you</h3>
+    <p style="font-family:'Space Grotesk',sans-serif; font-size:16px; font-weight:400; line-height:1.65; color:#6b7280; margin:0;">Monitor hiring signals, funding events, tech-stack changes.</p>
+  </div>
+</div>
+```
+
+### Tag pill (light-blue fill)
+
+```html
+<span style="display:inline-block; background:#e6f0ff; color:#0066ff; font-family:'Space Grotesk',sans-serif; font-size:13px; font-weight:500; letter-spacing:0.5px; padding:6px 14px; border-radius:4px;">New</span>
+```
+
+### CTA (solid blue pill)
+
+```html
+<a style="display:inline-block; background:#0066ff; color:#fff; font-family:'Space Grotesk',sans-serif; font-size:15px; font-weight:600; letter-spacing:0.5px; text-decoration:none; padding:16px 40px; border-radius:4px;">Get Started</a>
+```
+
+### Stat
+
+```html
+<div style="text-align:center; padding:40px 24px; background:#f5f5f5; border:1px solid #ebebeb; border-radius:4px;">
+  <p style="font-family:'Space Grotesk',sans-serif; font-size:64px; font-weight:700; line-height:1.00; letter-spacing:-1.5px; color:#0066ff; margin:0 0 8px;">47%</p>
+  <p style="font-family:'Space Grotesk',sans-serif; font-size:14px; font-weight:500; letter-spacing:1.5px; text-transform:uppercase; color:#6b7280; margin:0;">FASTER RESPONSE</p>
+</div>
+```

--- a/skills/composites/goose-graphics/styles/deep-ocean.md
+++ b/skills/composites/goose-graphics/styles/deep-ocean.md
@@ -1,0 +1,146 @@
+# Deep Ocean
+
+Bioluminescent calm. Deep blue-black canvas with cyan-teal glow accents that emit light rather than just show color. Single-family Satoshi throughout. The mood is underwater immersion — quiet authority lit by scattered points of luminous data.
+
+> Full prose reference: `styles/_full/deep-ocean.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#0a1628` | Deep ocean background |
+| `#c8d6e5` | Luminous gray — primary text |
+| `#00d4aa` | Cyan glow — accent (numbers, rules, CTAs) |
+| `#3d6b99` | Muted blue — secondary accent, structural |
+| `#33e8c0` | Bright cyan — hover/high-emphasis |
+| `#009b7d` | Deep teal hover/active |
+| `#0e1f3a` | Navy surface (cards) |
+| `#091320` | Surface inset (recessed panels) |
+| `#132847` | Navy mid — nested containers |
+| `#5a7a9e` | Ocean gray — tertiary text |
+| `#8aa0b8` | Silver sea — captions |
+| `rgba(61,107,153,0.25)` | Default border |
+| `rgba(0,212,170,0.3)` | Accent border + glow shadow |
+
+## Typography
+
+**Fontshare**
+
+```html
+<link href="https://api.fontshare.com/v2/css?f[]=satoshi@400,500,700&display=swap" rel="stylesheet">
+```
+
+- **Display / Body:** `'Satoshi', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Satoshi | 72px | 700 | 1.05 | -1px |
+| Section Heading | Satoshi | 48px | 700 | 1.10 | -0.5px |
+| Sub-heading | Satoshi | 32px | 700 | 1.15 | -0.3px |
+| Body Large | Satoshi | 20px | 400 | 1.65 | 0 |
+| Body | Satoshi | 16px | 400 | 1.70 | 0.1px |
+| Caption | Satoshi | 13px | 400 | 1.50 | 0.3px |
+| Big Number | Satoshi | 64px | 700 | 1.00 | -1px |
+| Label | Satoshi | 14px | 500 | 1.00 | 2px UPPER |
+| CTA | Satoshi | 15px | 700 | 1.00 | 1px UPPER |
+
+**Principles**
+
+- Single-family immersion — never switch fonts. Hierarchy via weight (700 vs 400) and size.
+- Generous body line-height (1.65-1.70) for dark-surface legibility.
+- Negative tracking on display, positive tracking (2px) on uppercase labels.
+
+## Layout
+
+- Format padding: carousel 60px · infographic 60/80 · slides 80px · poster 60/80.
+- Gradient backgrounds: `linear-gradient(180deg, #0a1628 0%, #0e1f3a 100%)` for depth.
+- Cyan rules: 2px tall × 60px wide, with `box-shadow: 0 0 12px rgba(0,212,170,0.3)`.
+- Cards: `#0e1f3a` bg, 8px radius, muted-blue border.
+- Big serif numerals (`01`, `02`) in cyan at 48px with `text-shadow: 0 0 20px rgba(0,212,170,0.3)`.
+- Limit glow effects to 1-2 elements per section.
+
+## Do / Don't
+
+**Do**
+
+- Apply glow effects via `box-shadow` / `text-shadow` on cyan accent elements.
+- Use muted blue (`#3d6b99`) for secondary labels, metadata, structural borders.
+- Use subtle gradient backgrounds to create depth between sections.
+- Use horizontal cyan rules (2px × 60px, with glow) as section dividers.
+- Center-align hero titles, stats, and CTAs. Left-align body.
+
+**Don't**
+
+- Don't use pure white for text — always `#c8d6e5` to keep the underwater tone.
+- Don't use pure black for backgrounds — always `#0a1628`.
+- Don't use warm accent colors (orange, red, yellow). Cyan + muted blue only.
+- Don't use border-radius above 8px — technical, not bubbly.
+- Don't over-glow — more than 2 glowing elements per section breaks the calm.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-deep-ocean: #0a1628;
+  --color-luminous-gray: #c8d6e5;
+  --color-cyan-glow: #00d4aa;
+  --color-muted-blue: #3d6b99;
+  --color-bright-cyan: #33e8c0;
+  --color-navy-surface: #0e1f3a;
+  --color-navy-mid: #132847;
+  --color-surface-inset: #091320;
+  --color-ocean-gray: #5a7a9e;
+  --color-silver-sea: #8aa0b8;
+
+  --color-border-default: rgba(61, 107, 153, 0.25);
+  --color-border-accent: rgba(0, 212, 170, 0.3);
+
+  --shadow-glow: 0 0 20px rgba(0, 212, 170, 0.3);
+  --shadow-glow-soft: 0 0 12px rgba(0, 212, 170, 0.3);
+
+  --font: 'Satoshi', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --radius-card: 8px;
+}
+```
+
+### Title block (gradient + glowing rules)
+
+```html
+<div style="background:linear-gradient(180deg,#0a1628 0%,#0e1f3a 100%); padding:80px 60px; text-align:center;">
+  <div style="width:60px; height:2px; background:#00d4aa; margin:0 auto 32px; box-shadow:0 0 12px rgba(0,212,170,0.3);"></div>
+  <h1 style="font-family:'Satoshi',sans-serif; font-size:72px; font-weight:700; line-height:1.05; letter-spacing:-1px; color:#c8d6e5; margin:0 0 24px;">The Future of<br>Autonomous Work</h1>
+  <p style="font-family:'Satoshi',sans-serif; font-size:20px; font-weight:400; line-height:1.65; color:#5a7a9e; max-width:600px; margin:0 auto;">How AI coworkers are reshaping the way teams operate.</p>
+  <div style="width:60px; height:2px; background:#00d4aa; margin:40px auto 0; box-shadow:0 0 12px rgba(0,212,170,0.3);"></div>
+</div>
+```
+
+### Numbered item with glowing numeral
+
+```html
+<div style="display:flex; gap:24px; align-items:flex-start; padding:32px 0; border-bottom:1px solid rgba(61,107,153,0.25);">
+  <span style="font-family:'Satoshi',sans-serif; font-size:48px; font-weight:700; line-height:1.00; color:#00d4aa; min-width:72px; text-shadow:0 0 20px rgba(0,212,170,0.3);">01</span>
+  <div>
+    <p style="font-family:'Satoshi',sans-serif; font-size:14px; font-weight:500; letter-spacing:2px; text-transform:uppercase; color:#3d6b99; margin:0 0 8px;">SIGNAL-BASED OUTBOUND</p>
+    <h3 style="font-family:'Satoshi',sans-serif; font-size:32px; font-weight:700; line-height:1.15; letter-spacing:-0.3px; color:#c8d6e5; margin:0 0 12px;">Find buyers before they find you</h3>
+    <p style="font-family:'Satoshi',sans-serif; font-size:16px; font-weight:400; line-height:1.70; color:#5a7a9e; margin:0;">Monitor hiring signals, funding events, and tech-stack changes to identify high-intent prospects.</p>
+  </div>
+</div>
+```
+
+### Glowing stat
+
+```html
+<div style="text-align:center; padding:40px 24px; background:#0e1f3a; border:1px solid rgba(61,107,153,0.25); border-radius:8px;">
+  <p style="font-family:'Satoshi',sans-serif; font-size:64px; font-weight:700; line-height:1.00; letter-spacing:-1px; color:#00d4aa; margin:0 0 8px; text-shadow:0 0 24px rgba(0,212,170,0.3);">47%</p>
+  <p style="font-family:'Satoshi',sans-serif; font-size:14px; font-weight:500; letter-spacing:2px; text-transform:uppercase; color:#c8d6e5; margin:0;">FASTER RESPONSE</p>
+</div>
+```
+
+### CTA (glowing pill button)
+
+```html
+<a style="display:inline-block; background:#00d4aa; color:#0a1628; font-family:'Satoshi',sans-serif; font-size:15px; font-weight:700; letter-spacing:1px; text-transform:uppercase; text-decoration:none; padding:16px 40px; border-radius:8px; box-shadow:0 0 24px rgba(0,212,170,0.3);">Get Started</a>
+```

--- a/skills/composites/goose-graphics/styles/electric-burst.md
+++ b/skills/composites/goose-graphics/styles/electric-burst.md
@@ -1,0 +1,134 @@
+# Electric Burst
+
+Maximum-impact neon. Near-black canvas with fluorescent neon yellow and hot pink, Archivo Black displays at 80-200px that hit like a stadium floodlight. Layered text-shadow + box-shadow glows create actual luminous energy. This is concert-poster loud — unapologetic, confrontational, designed to stop the scroll.
+
+> Full prose reference: `styles/_full/electric-burst.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#0a0a0a` | Void — primary background |
+| `#ffffff` | Pure white — primary text |
+| `#e6ff00` | Neon yellow — primary accent (numbers, CTAs, glows) |
+| `#ff2d6f` | Hot pink — secondary accent (tags, secondary highlights) |
+| `#b8cc00` | Dark yellow hover |
+| `#cc2459` | Dark pink hover |
+| `#141414` | Dark surface (cards) |
+| `#111111` | Surface inset |
+| `#1e1e1e` | Charcoal — nested containers |
+| `#2a2a2a` | Graphite |
+| `#555555` | Steel — disabled |
+| `#888888` | Ash — tertiary text |
+| `#aaaaaa` | Silver — secondary text |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+```
+
+- **Display:** `'Archivo Black', Impact, 'Arial Black', sans-serif`
+- **Body:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Archivo Black | 80px | 400 | 1.00 | -1px |
+| Section Heading | Archivo Black | 56px | 400 | 1.05 | -0.5px |
+| Sub-heading | Archivo Black | 36px | 400 | 1.10 | 0 |
+| Body Large | Inter | 20px | 400 | 1.60 | 0 |
+| Body | Inter | 16px | 400 | 1.65 | 0 |
+| Caption | Inter | 13px | 500 | 1.50 | 0.5px |
+| Big Number | Archivo Black | 200px | 400 | 0.85 | -4px |
+| Numbered Label | Inter | 14px | 700 | 1.00 | 3px UPPER |
+| CTA | Inter | 16px | 700 | 1.00 | 1.5px UPPER |
+
+**Principles**
+
+- Archivo Black ships one weight only — size = impact.
+- "Spectacle numbers" at 200px with negative tracking are the signature.
+- Hot pink + neon yellow are hostile-bright; use on black only.
+
+## Layout
+
+- Format padding: carousel 60px · infographic 60/80 · slides 80px · poster 60/80.
+- Glow effects: `text-shadow: 0 0 30px rgba(230,255,0,0.6), 0 0 60px rgba(230,255,0,0.3)`.
+- Box glow on accent containers: `box-shadow: 0 0 40px rgba(230,255,0,0.25)`.
+- Cards: `#141414` bg, 4-6px radius, optional neon border `2px solid #e6ff00`.
+- One spectacle number per slide maximum.
+
+## Do / Don't
+
+**Do**
+
+- Use Archivo Black at 80-200px to create "felt" impact before words are read.
+- Layer text-shadow + box-shadow glows using neon yellow or hot pink.
+- Use hot pink for tags and contrast highlights; neon yellow for primary focal.
+- Fill CTA buttons with neon yellow on black text for maximum pop.
+- Let big numbers bleed off the container edge.
+
+**Don't**
+
+- Don't use subtle colors — everything is loud or nothing is.
+- Don't use dark mode grays for text — pure `#ffffff` primary.
+- Don't use serif fonts anywhere.
+- Don't use more than 2 glow colors per section.
+- Don't use radius above 8px — hard edges amplify the energy.
+- Don't use pale or pastel accents — fluorescent only.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-void: #0a0a0a;
+  --color-white: #ffffff;
+  --color-neon: #e6ff00;
+  --color-pink: #ff2d6f;
+  --color-pink-dark: #cc2459;
+  --color-surface: #141414;
+  --color-surface-inset: #111111;
+  --color-silver: #aaaaaa;
+
+  --font-display: 'Archivo Black', Impact, 'Arial Black', sans-serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --glow-neon: 0 0 30px rgba(230, 255, 0, 0.6), 0 0 60px rgba(230, 255, 0, 0.3);
+  --glow-pink: 0 0 30px rgba(255, 45, 111, 0.6), 0 0 60px rgba(255, 45, 111, 0.3);
+}
+```
+
+### Spectacle number
+
+```html
+<div style="background:#0a0a0a; padding:80px 60px; text-align:center;">
+  <p style="font-family:'Inter',sans-serif; font-size:14px; font-weight:700; letter-spacing:3px; text-transform:uppercase; color:#ff2d6f; margin:0 0 16px;">01 · THE CLAIM</p>
+  <p style="font-family:'Archivo Black',sans-serif; font-size:200px; font-weight:400; line-height:0.85; letter-spacing:-4px; color:#e6ff00; margin:0; text-shadow:0 0 30px rgba(230,255,0,0.6), 0 0 60px rgba(230,255,0,0.3);">10X</p>
+  <h2 style="font-family:'Archivo Black',sans-serif; font-size:56px; font-weight:400; line-height:1.05; letter-spacing:-0.5px; text-transform:uppercase; color:#fff; margin:16px 0 0;">FASTER THAN THE COMPETITION</h2>
+</div>
+```
+
+### Card with neon border
+
+```html
+<div style="background:#141414; border:2px solid #e6ff00; padding:24px; border-radius:6px; box-shadow:0 0 40px rgba(230,255,0,0.25);">
+  <p style="font-family:'Inter',sans-serif; font-size:14px; font-weight:700; letter-spacing:3px; text-transform:uppercase; color:#e6ff00; margin:0 0 12px;">01 — ATTACK</p>
+  <h3 style="font-family:'Archivo Black',sans-serif; font-size:36px; font-weight:400; color:#fff; margin:0 0 12px;">Own the scroll</h3>
+  <p style="font-family:'Inter',sans-serif; font-size:16px; font-weight:400; line-height:1.65; color:#aaaaaa; margin:0;">Visual volume wins attention. Anything else is furniture.</p>
+</div>
+```
+
+### Pink tag pill
+
+```html
+<span style="display:inline-block; background:#ff2d6f; color:#0a0a0a; font-family:'Inter',sans-serif; font-size:14px; font-weight:700; letter-spacing:3px; text-transform:uppercase; padding:6px 14px; border-radius:4px;">NEW</span>
+```
+
+### Neon CTA
+
+```html
+<a style="display:inline-block; background:#e6ff00; color:#0a0a0a; font-family:'Inter',sans-serif; font-size:16px; font-weight:700; letter-spacing:1.5px; text-transform:uppercase; text-decoration:none; padding:18px 44px; border-radius:4px; box-shadow:0 0 40px rgba(230,255,0,0.35);">GET STARTED →</a>
+```

--- a/skills/composites/goose-graphics/styles/extract-style.md
+++ b/skills/composites/goose-graphics/styles/extract-style.md
@@ -1,0 +1,265 @@
+# Skill: Extract Style from Reference Image
+
+Extract the visual design language from a reference image and produce a reusable DESIGN.md style definition file.
+
+---
+
+## When to Use
+
+The user provides a reference image -- a screenshot, design mockup, mood board, website capture, or any visual reference -- and wants to capture its design language as a reusable style preset. The output is a complete 9-section DESIGN.md file that can be used by other graphic design skills to produce on-brand content.
+
+---
+
+## Phase 1: Receive & Analyze the Image
+
+### Step 1 -- Get the image
+
+Ask the user to provide the reference image. Accept any of:
+- A file path to an image on disk (PNG, JPG, WebP, etc.)
+- A screenshot pasted into the conversation
+- A URL to a publicly accessible image (use WebFetch to download it first, then read the downloaded file)
+
+### Step 2 -- View the image
+
+Read the image using the Read tool. The Read tool supports image files natively -- it will display the image contents visually for analysis.
+
+If the image is unclear, low resolution, or only shows a partial design, ask the user if they have a better reference or if they want to proceed with what is available.
+
+### Step 3 -- Systematic visual analysis
+
+Examine the image carefully and work through every item in this checklist. Write your analysis out explicitly before moving to Phase 2 -- do not skip ahead.
+
+**Colors:**
+- Identify the 3-5 dominant colors in the design.
+- For each color, estimate a clean hex value that matches the observed color family. Agent vision cannot extract exact hex codes, so pick well-balanced values within the right family (e.g., if you see a warm red, choose something like `#c94a4a` rather than guessing at the last digit).
+- Classify each color by its role:
+  - **Background** -- the dominant surface color
+  - **Primary text** -- the main reading color
+  - **Accent** -- the color used for emphasis, CTAs, highlights, interactive elements
+  - **Secondary accent** -- a quieter supporting color if present
+  - **Neutral/surface** -- any additional grays, tints, or surface colors for cards and containers
+- Note whether the palette is warm, cool, or neutral in overall temperature.
+
+**Typography:**
+- Is the heading typeface serif, sans-serif, slab-serif, or monospace?
+- Is the body typeface the same family or a different one?
+- Estimate weight range: light (100-300), regular (400), medium (500), semibold (600), bold (700), heavy (800-900)?
+- Is letter-spacing tight (negative tracking), normal, or wide (positive tracking)?
+- Is line height compact or generous?
+- Classify the overall type feel: geometric, humanist, elegant, technical, rounded, condensed, modern-clean.
+
+**Layout:**
+- Dense or spacious? How much whitespace surrounds elements?
+- Grid-based or free-form? How many columns?
+- Primary alignment: left-aligned, centered, or mixed?
+- Card-based or flat sections? Do elements live in containers with visible borders/backgrounds?
+- What is the overall content density -- minimal (few elements, lots of space) or information-rich?
+
+**Mood:**
+- Dark or light theme?
+- Professional, playful, elegant, technical, warm, cold, editorial, brutalist, organic, corporate?
+- What kind of brand or publication does this feel like? Name 2-3 analogies.
+
+**Depth & Elevation:**
+- Flat design with no shadows?
+- Subtle shadows for slight lift?
+- Heavy drop shadows or elevation?
+- Borders: visible borders on containers, or borderless?
+- If shadows exist, are they cool (gray/black) or warm-tinted?
+
+**Special Elements:**
+- Any gradients? Linear, radial, or mesh?
+- Background patterns or textures?
+- Glow effects, blur, or glassmorphism?
+- Decorative elements: lines, shapes, icons, illustrations?
+- Any distinctive UI patterns: pills, tags, badges, numbered items, progress indicators?
+
+Write the full analysis as a structured list before continuing.
+
+---
+
+## Phase 2: Map to Available Fonts
+
+The reference image likely uses fonts that may be proprietary or unavailable. Map the observed typography to the nearest freely available alternatives.
+
+### Step 1 -- Classify the observed fonts
+
+Based on your analysis, classify the heading and body fonts into one of these categories:
+
+| Category | Characteristics |
+|----------|----------------|
+| Geometric sans | Clean, circular letterforms, even stroke width (e.g., Futura, Proxima Nova) |
+| Humanist sans | Slightly organic, calligraphic influence, warm (e.g., Gill Sans, Frutiger) |
+| Elegant serif | High stroke contrast, refined details, display-oriented (e.g., Didot, Bodoni) |
+| Body serif | Moderate contrast, designed for reading at text sizes (e.g., Charter, Cambria) |
+| Monospace | Fixed-width, technical feel (e.g., Courier, SF Mono) |
+| Rounded | Rounded terminals and corners, friendly feel (e.g., VAG Rounded) |
+| Condensed/heavy | Narrow letterforms or high weight, impactful (e.g., Impact, Anton) |
+| Modern clean | Contemporary geometric sans with subtle personality (e.g., Satoshi, General Sans) |
+| Slab serif | Thick, block-like serifs, sturdy feel (e.g., Rockwell, Clarendon) |
+
+### Step 2 -- Select replacement fonts
+
+Use this lookup table to pick the best available match from Google Fonts or Fontshare:
+
+| Category | Recommended Options |
+|----------|-------------------|
+| Geometric sans | Space Grotesk, Inter, DM Sans, Plus Jakarta Sans |
+| Humanist sans | Nunito, Source Sans Pro, Open Sans |
+| Elegant serif | Playfair Display, Cormorant Garamond, EB Garamond |
+| Body serif | Lora, Merriweather, Source Serif Pro |
+| Monospace | JetBrains Mono, Fira Code, IBM Plex Mono |
+| Rounded | Nunito, Varela Round, Comfortaa |
+| Condensed/heavy | Archivo Black, Oswald, Bebas Neue |
+| Modern clean | Satoshi (Fontshare), General Sans (Fontshare) |
+| Slab serif | Roboto Slab, Zilla Slab, Arvo |
+
+**Selection rules:**
+- Pick one font for display/headings and one for body text. They can be the same family if the reference uses a single typeface.
+- If the reference clearly uses a well-known free font (e.g., Inter, Roboto, Playfair Display), use it directly.
+- Prefer Google Fonts over Fontshare for wider availability.
+- Always include system font fallbacks in the font stack.
+
+### Step 3 -- Build the Google Fonts link
+
+Construct the `<link>` tag with the selected fonts and the specific weights needed:
+- Display font: include weights 400, 700, and optionally 900. Include italic variants if the reference uses italic headings.
+- Body font: include weights 300, 400, 500, and optionally 600.
+
+---
+
+## Phase 3: Generate the DESIGN.md
+
+Produce a complete file with all 9 sections, following the exact structure and depth of the existing style presets (e.g., midnight-editorial.md). Every section must be substantive -- not placeholder text.
+
+### Section 1: Visual Theme & Atmosphere
+
+Write a 2-3 paragraph narrative description of the extracted style. This is prose, not a list. Cover:
+- What tradition or design school this style draws from
+- How the color palette creates its specific mood
+- How the typography pairing works and why
+- What the accent color does for the composition
+- 2-3 real-world analogies (e.g., "the design language of a Scandinavian furniture catalog," "the feel of a fintech dashboard")
+
+End with a **Key Characteristics** bullet list (8-12 items) summarizing the most important rules, each with specific values (hex codes, pixel sizes, weights).
+
+### Section 2: Color Palette & Roles
+
+Organize colors into these groups with the same structure as the reference:
+
+- **Primary** (3 colors): Background, primary text, primary accent -- with hex codes and usage descriptions.
+- **Accent** (2-3 colors): Secondary accent, hover states, tertiary tones.
+- **Neutral Scale** (4-6 colors): Surface variations from darkest to lightest (for dark themes) or lightest to darkest (for light themes). Include disabled text, placeholder, and metadata colors.
+- **Surface & Borders**: Surface primary, surface inset, border default (with alpha), border accent, border strong, divider rule.
+- **Shadow Colors**: 3-4 shadow definitions using RGBA values that stay on-palette.
+
+**Color quality rules:**
+- Never use pure black (`#000000`) or pure white (`#ffffff`) unless the reference clearly does.
+- Text-on-background contrast must meet WCAG AA (4.5:1 ratio minimum). Mentally verify this.
+- Keep the total palette to 12-16 named colors. More than that creates inconsistency.
+- Shadow colors should use tinted RGBA from the accent color for warm palettes, or neutral RGBA for cool palettes.
+
+### Section 3: Typography Rules
+
+Include:
+- **Font Families** block with the Google Fonts CDN link and CSS font-family declarations with full fallback stacks.
+- **Hierarchy table** with columns: Role | Font | Size | Weight | Line Height | Letter Spacing | Notes. Include at minimum: Display Hero, Section Heading, Sub-heading, Body Large, Body, Small/Caption, Big Numbers, Numbered Label, CTA Text.
+- **Principles** (5-6 bullet points) explaining the typographic logic: why these pairings, how tracking changes across sizes, when to use uppercase, line height rationale.
+
+### Section 4: Component Patterns
+
+Provide 6-8 HTML/CSS component snippets using CSS custom properties (`var(--color-*)`, `var(--font-*)`). Each should be a self-contained, inline-styled HTML block. Include at minimum:
+- Title Block (hero/header section)
+- Numbered Item
+- Stat Display
+- Comparison Grid (2-column)
+- List Item
+- Quote Block
+- CTA Block
+
+Adapt each component's structure to match the reference's design language. For example, if the reference is light and airy, components should have generous padding and minimal borders. If the reference is dense and technical, components should be compact with visible structure.
+
+### Section 5: Layout Principles
+
+Include:
+- **Spacing Scale** (8-10 values from micro to max) with pixel values and usage descriptions.
+- **Format Padding** table for 4 formats: Carousel (1080x1080), Infographic (1080xN), Slides (1920x1080), Poster (1080x1350).
+- **Alignment & Grid** rules: primary alignment, grid column guidance, rule/divider conventions, vertical rhythm, content gravity.
+
+### Section 6: Depth & Elevation
+
+Include:
+- **Elevation table** with 5 levels (Flat, Subtle, Card, Featured, Overlay) showing CSS shadow values and use cases.
+- **Border Treatments** (4 types): standard, active, accent rule, divider line -- with exact CSS values.
+- **Surface Hierarchy** explanation of how depth is communicated (lightness steps for dark themes, shadow intensity for light themes).
+
+### Section 7: Do's and Don'ts
+
+Write 8-12 **Do** rules and 8-12 **Don't** rules. Each must be specific and actionable, referencing exact values (hex codes, pixel sizes, font names, weights). These should encode the guardrails that prevent someone from drifting off-style. Base them on what you observed in the reference -- if the reference never uses rounded corners, that is a Don't. If the reference uses a specific spacing rhythm, that is a Do.
+
+### Section 8: Format Adaptation Notes
+
+For each of the 4 formats (Carousel, Infographic, Slides, Poster), provide:
+- Typography scale adjustments (which sizes change and to what values)
+- Padding values
+- Layout notes (single column vs. multi-column, content placement)
+- Format-specific conventions (e.g., swipe indicators for carousels, vertical rhythm for infographics)
+
+### Section 9: Agent Prompt Guide
+
+Include:
+- **Quick Color Reference** table: Name | Hex | Usage
+- **Font Declarations** as CSS code block
+- **Google Fonts Link** as HTML code block
+- **CSS Root Variables** -- a complete `:root` block defining every variable: colors (primary, accent, neutral, surfaces, borders, shadows), typography (families, sizes, weights, line heights), spacing, borders, and composed shadows.
+- **System Font Fallbacks**
+
+---
+
+## Phase 4: Save & Confirm
+
+### Step 1 -- Ask for a name
+
+Ask the user what they want to name this style. Suggest a descriptive name based on the mood and palette (e.g., "arctic-minimal", "warm-startup", "dark-technical", "sunset-editorial"). The name should be lowercase-kebab-case.
+
+### Step 2 -- Determine save location
+
+The default save path is the same directory as the other style presets. If you can detect the goose-graphics styles directory from context, use it. Otherwise, ask the user where to save.
+
+Default path pattern:
+```
+[project-root]/goose-graphics/styles/[name].md
+```
+
+### Step 3 -- Save the file
+
+Write the complete DESIGN.md file using the Write tool.
+
+### Step 4 -- Confirm
+
+Tell the user:
+- The file was saved and its full path
+- A 3-4 line summary of the extracted style: theme (dark/light), primary palette (background + text + accent), font pairing, and overall mood
+- That the style is now ready for use with other graphic design skills
+
+---
+
+## Important Notes
+
+### On Color Accuracy
+
+Agent vision identifies color families, not exact hex values. The goal is to produce a **coherent, well-balanced palette** that captures the spirit of the reference, not to pixel-match it. When estimating hex values:
+
+- Identify the color family first (warm red, cool blue, muted green, near-black, warm gray, etc.)
+- Pick a clean, well-balanced hex within that family
+- Verify contrast: primary text on background must be at least 4.5:1 (WCAG AA). For dark themes, light text on dark backgrounds. For light themes, dark text on light backgrounds.
+- Use 3-5 primary colors max. Most well-designed references use very few colors -- adding more dilutes the identity.
+- When in doubt, desaturate slightly. Oversaturated colors extracted from compressed images tend to look garish in production.
+
+### On Font Matching
+
+The goal is **typographic equivalence**, not exact matching. A geometric sans is a geometric sans -- whether it is Circular, Proxima Nova, or Inter. Match the category, weight range, and tracking behavior. The resulting designs will feel right even if the exact typeface differs.
+
+### On Completeness
+
+Every section of the output DESIGN.md must be filled with substantive, specific content. Do not leave any section with placeholder text like "TBD" or "adjust as needed." The file should be immediately usable by another agent or skill without further editing.

--- a/skills/composites/goose-graphics/styles/frosted-lens.md
+++ b/skills/composites/goose-graphics/styles/frosted-lens.md
@@ -1,0 +1,148 @@
+# Frosted Lens
+
+Vibrant motion-blur chromatic backdrop with a large floating white card. The card is the "lens" — calm, data-forward, Swiss-precise. Outside: pink/teal/blue/amber streaks in motion. Inside: DM Sans, near-black text, sage-mint data bars, dusty-rose comparison data. Stripe-demo meets Figma-conference meets Series-B-announcement energy.
+
+> Full prose reference: `styles/_full/frosted-lens.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#ffffff` | White — primary card surface |
+| `#1A1A1A` | Near-black — primary text |
+| `#7CB68E` | Sage mint — primary data, CTAs, growth |
+| `#5A9A6E` | Dark sage — hover |
+| `#D4A0A0` | Dusty rose — secondary data |
+| `#F5F5F5` | Snow — nested card surfaces |
+| `#F8F8F8` | Surface inset |
+| `#E8E8E8` | Light border |
+| `#D1D5DB` | Mid gray — disabled |
+| `#9CA3AF` | Cool gray — tertiary, axis labels |
+| `#6B7280` | Warm gray — secondary text |
+| `#4B5563` | Slate — secondary headings |
+| `#374151` | Charcoal — high-emphasis body |
+| `#E8457A` | BG Pink streak |
+| `#3CBCB4` | BG Teal streak |
+| `#2E5C9A` | BG Blue streak |
+| `#D4943C` | BG Amber streak |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display / Body:** `'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | DM Sans | 64px | 700 | 1.08 | -1.5px |
+| Section Heading | DM Sans | 42px | 700 | 1.12 | -1px |
+| Sub-heading | DM Sans | 28px | 600 | 1.20 | -0.5px |
+| Body Large | DM Sans | 20px | 400 | 1.60 | 0 |
+| Body | DM Sans | 16px | 400 | 1.60 | 0 |
+| Caption | DM Sans | 13px | 400 | 1.45 | 0.15px |
+| Big Number | DM Sans | 56px | 700 | 1.00 | -1px |
+| Brand Label | DM Sans | 12px | 500 | 1.00 | 2.5px UPPER |
+| Data Label | DM Sans | 18px | 600 | 1.00 | -0.25px |
+| CTA | DM Sans | 15px | 600 | 1.00 | 0.3px |
+
+**Principles**
+
+- Negative tracking on display (-1 to -1.5px) for modern confidence.
+- Wide tracking (2.5px) on uppercase brand labels for the "INFRENCECORE" spaced feel.
+- Inside the card, restrained palette — all energy is in the backdrop.
+
+## Layout
+
+- Backdrop: motion-blur chromatic streaks using radial + linear gradients or a pre-rendered image. Colors: pink, teal, blue, amber.
+- Card: `#ffffff`, 20-24px radius, medium shadow `0 16px 48px rgba(0,0,0,0.12)`.
+- Card internal padding: 40-48px. Generous breathing room.
+- Data bars: sage-mint primary at full opacity, dusty-rose secondary at reduced scale.
+- One card per composition — the card is the lens.
+
+## Do / Don't
+
+**Do**
+
+- Use motion-blur streaks for the backdrop, not flat color.
+- Center a single white card with 20-24px radius — the card is the entire hero.
+- Use sage-mint (`#7CB68E`) for hero/primary metrics; dusty rose (`#D4A0A0`) for comparisons.
+- Use spaced uppercase brand labels (2.5px tracking, 12px).
+- Use medium-depth warm-tinted shadow for card elevation.
+
+**Don't**
+
+- Don't use flat color backgrounds — the chromatic blur is mandatory.
+- Don't use bright saturated data colors — sage/rose restraint is the rule.
+- Don't crowd the card — one chart, one headline, one statement per card.
+- Don't use heavy black text — always `#1A1A1A` warm near-black.
+- Don't use more than 2 data colors (sage + rose).
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-card: #ffffff;
+  --color-text: #1A1A1A;
+  --color-sage: #7CB68E;
+  --color-sage-dark: #5A9A6E;
+  --color-rose: #D4A0A0;
+  --color-snow: #F5F5F5;
+  --color-border: #E8E8E8;
+  --color-warm-gray: #6B7280;
+  --color-slate: #4B5563;
+
+  --bg-pink: #E8457A;
+  --bg-teal: #3CBCB4;
+  --bg-blue: #2E5C9A;
+  --bg-amber: #D4943C;
+
+  --font: 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --radius-card: 24px;
+  --shadow-card: 0 16px 48px rgba(0, 0, 0, 0.12);
+}
+```
+
+### Chromatic streak backdrop
+
+```css
+.backdrop {
+  background:
+    radial-gradient(ellipse 80% 60% at 10% 20%, rgba(232,69,122,0.8), transparent 60%),
+    radial-gradient(ellipse 60% 80% at 90% 40%, rgba(60,188,180,0.7), transparent 60%),
+    radial-gradient(ellipse 70% 50% at 50% 90%, rgba(46,92,154,0.6), transparent 60%),
+    radial-gradient(ellipse 50% 50% at 80% 10%, rgba(212,148,60,0.5), transparent 60%),
+    #2a2a40;
+  filter: blur(40px);
+}
+```
+
+### Hero card with data chart
+
+```html
+<div style="position:relative; min-height:100vh; display:flex; align-items:center; justify-content:center; overflow:hidden;">
+  <div style="position:absolute; inset:-40px; background:radial-gradient(ellipse 80% 60% at 10% 20%,rgba(232,69,122,0.8),transparent 60%),radial-gradient(ellipse 60% 80% at 90% 40%,rgba(60,188,180,0.7),transparent 60%),radial-gradient(ellipse 70% 50% at 50% 90%,rgba(46,92,154,0.6),transparent 60%),#2a2a40; filter:blur(40px); z-index:0;"></div>
+  <div style="position:relative; z-index:1; background:#fff; border-radius:24px; padding:48px; max-width:680px; box-shadow:0 16px 48px rgba(0,0,0,0.12);">
+    <p style="font-family:'DM Sans',sans-serif; font-size:12px; font-weight:500; letter-spacing:2.5px; text-transform:uppercase; color:#6B7280; margin:0 0 24px;">INFRENCECORE</p>
+    <h2 style="font-family:'DM Sans',sans-serif; font-size:42px; font-weight:700; line-height:1.12; letter-spacing:-1px; color:#1A1A1A; margin:0 0 32px;">Workflows that keep growing.</h2>
+    <div style="display:flex; align-items:flex-end; gap:24px; margin-bottom:24px;">
+      <div style="flex:1; height:120px; background:#7CB68E; border-radius:8px;"></div>
+      <div style="flex:1; height:180px; background:#7CB68E; border-radius:8px;"></div>
+      <div style="flex:1; height:240px; background:#7CB68E; border-radius:8px;"></div>
+    </div>
+    <p style="font-family:'DM Sans',sans-serif; font-size:20px; font-weight:400; line-height:1.60; color:#4B5563; margin:0;">Teams 2.3× their output in the first 90 days.</p>
+  </div>
+</div>
+```
+
+### Sage CTA
+
+```html
+<a style="display:inline-block; background:#7CB68E; color:#fff; font-family:'DM Sans',sans-serif; font-size:15px; font-weight:600; letter-spacing:0.3px; text-decoration:none; padding:14px 32px; border-radius:12px;">See the report</a>
+```

--- a/skills/composites/goose-graphics/styles/garden-blur.md
+++ b/skills/composites/goose-graphics/styles/garden-blur.md
@@ -1,0 +1,141 @@
+# Garden Blur
+
+Blurred natural greenery backdrop with white cards floating above. Heavy Gaussian blur (30-50px) on a warm olive / sage photograph turns a specific image into a universal mood: warmth, growth, presence. Inside the cards: clean Inter, restrained palette, dusty rose for interactive accents. Kinfolk meets iOS notifications.
+
+> Full prose reference: `styles/_full/garden-blur.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#ffffff` | White — card surface |
+| `#1c1c1e` | Near-black charcoal — primary text |
+| `#a3867a` | Dusty rose — interactive accent (heart, active) |
+| `#b89e8e` | Warm taupe — hover/light accent |
+| `#8a6e62` | Deep rose — pressed/active |
+| `#d4dcc8` | Sage tint — tag backgrounds |
+| `#3a3a3c` | Dark gray — secondary text |
+| `#636366` | Medium gray — tertiary |
+| `#8e8e93` | Warm gray — handles, icons, metadata |
+| `#c7c7cc` | Light gray — borders |
+| `#f2f2f7` | Pale gray — hover/inset |
+| `#faf8f6` | Tinted surface — featured card bg |
+| `#6b7a52` | Backdrop olive (solid fallback) |
+| `#8a9668` | Backdrop sage |
+| `#7a6b52` | Backdrop warm brown |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+```
+
+- **Display / Body:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Inter | 56px | 700 | 1.12 | -0.8px |
+| Section Heading | Inter | 36px | 700 | 1.18 | -0.4px |
+| Sub-heading | Inter | 24px | 600 | 1.25 | -0.2px |
+| Body Large | Inter | 20px | 400 | 1.55 | -0.1px |
+| Body | Inter | 16px | 400 | 1.60 | 0 |
+| Display Name | Inter | 17px | 700 | 1.25 | 0 |
+| Caption | Inter | 14px | 400 | 1.45 | 0 |
+| Big Number | Inter | 52px | 700 | 1.00 | -0.5px |
+| Label | Inter | 12px | 500 | 1.00 | 0.3px UPPER |
+| CTA | Inter | 15px | 600 | 1.00 | 0.2px |
+
+**Principles**
+
+- One family, weight-driven hierarchy.
+- Regular (400) for body keeps cards clean and iOS-like.
+- Bold (700) for display names and hero — the only strong anchors.
+
+## Layout
+
+- Background: 30-50px Gaussian-blurred photograph of greenery. Use `backdrop-filter: blur(40px)` or pre-rendered JPG with `filter: blur(40px); transform: scale(1.1)` to prevent edge artifacts.
+- Cards: white `#ffffff`, 24px radius, no visible border, minimal shadow (`0 4px 16px rgba(0,0,0,0.08)`).
+- Card internal padding: 20-28px. Stack compactly like iOS notifications.
+- Dusty rose `#a3867a` for heart icons, interactive accents, active states.
+- Sage tint `#d4dcc8` for small tag pill backgrounds.
+
+## Do / Don't
+
+**Do**
+
+- Use an actual photograph of greenery (olive/sage/warm-brown tones) as background, heavily blurred.
+- Keep cards white and clean — the blurred backdrop does all the atmospheric work.
+- Use large 24px card radius — the soft shape reads as a modern iOS component.
+- Use dusty rose (`#a3867a`) as the single interactive accent (heart, like, save).
+- Use warm medium gray (`#8e8e93`) for handles, icons, metadata.
+
+**Don't**
+
+- Don't use flat color backgrounds — the blur is the identity.
+- Don't add heavy shadows — the depth of field does the elevation.
+- Don't use colored card backgrounds — white only.
+- Don't use serif fonts.
+- Don't use more than 2 colors inside cards (charcoal + rose + 1-2 grays).
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-card: #ffffff;
+  --color-text: #1c1c1e;
+  --color-rose: #a3867a;
+  --color-rose-deep: #8a6e62;
+  --color-sage-tint: #d4dcc8;
+  --color-dark-gray: #3a3a3c;
+  --color-medium-gray: #636366;
+  --color-warm-gray: #8e8e93;
+  --color-light-gray: #c7c7cc;
+  --color-pale-gray: #f2f2f7;
+  --color-backdrop-olive: #6b7a52;
+  --color-backdrop-sage: #8a9668;
+
+  --font: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --radius-card: 24px;
+  --shadow-card: 0 4px 16px rgba(0, 0, 0, 0.08);
+}
+```
+
+### Blurred backdrop + card stack
+
+```html
+<div style="position:relative; min-height:100vh; overflow:hidden;">
+  <div style="position:absolute; inset:-40px; background-image:url('greenery.jpg'); background-size:cover; filter:blur(40px); transform:scale(1.1); z-index:0;"></div>
+  <div style="position:relative; z-index:1; padding:60px 40px; display:flex; flex-direction:column; gap:16px; max-width:520px; margin:0 auto;">
+    <div style="background:#fff; border-radius:24px; padding:24px; box-shadow:0 4px 16px rgba(0,0,0,0.08);">
+      <div style="display:flex; justify-content:space-between; align-items:flex-start; margin-bottom:12px;">
+        <div>
+          <p style="font-family:'Inter',sans-serif; font-size:17px; font-weight:700; color:#1c1c1e; margin:0;">Sarah Chen</p>
+          <p style="font-family:'Inter',sans-serif; font-size:14px; font-weight:400; color:#8e8e93; margin:0;">@sarahchen · 2h</p>
+        </div>
+        <span style="color:#a3867a; font-size:18px;">&#9825;</span>
+      </div>
+      <p style="font-family:'Inter',sans-serif; font-size:16px; font-weight:400; line-height:1.60; color:#1c1c1e; margin:0;">Spent the morning rewiring our onboarding. Three customers, three completely different paths — finally something that feels like a walk instead of a funnel.</p>
+    </div>
+  </div>
+</div>
+```
+
+### Sage-tint tag
+
+```html
+<span style="display:inline-block; background:#d4dcc8; color:#3a3a3c; font-family:'Inter',sans-serif; font-size:12px; font-weight:500; letter-spacing:0.3px; text-transform:uppercase; padding:4px 10px; border-radius:12px;">INSIGHT</span>
+```
+
+### Featured card (tinted surface)
+
+```html
+<div style="background:#faf8f6; border-radius:24px; padding:28px; box-shadow:0 4px 16px rgba(0,0,0,0.08);">
+  <h3 style="font-family:'Inter',sans-serif; font-size:24px; font-weight:600; line-height:1.25; letter-spacing:-0.2px; color:#1c1c1e; margin:0 0 12px;">The quiet path forward</h3>
+  <p style="font-family:'Inter',sans-serif; font-size:16px; font-weight:400; line-height:1.60; color:#3a3a3c; margin:0;">Some weeks you ship features. Other weeks you rearrange the furniture.</p>
+</div>
+```

--- a/skills/composites/goose-graphics/styles/golden-dusk.md
+++ b/skills/composites/goose-graphics/styles/golden-dusk.md
@@ -1,0 +1,143 @@
+# Golden Dusk
+
+Warm luxury on deep navy. Gold acts as the spice (accent only, never surface), DM Sans carries all type with open tracking for a premium, considered feel. Hairline borders and fading-light gradient rules are the signature ornaments. Think boutique hotel brand book meets annual-report polish.
+
+> Full prose reference: `styles/_full/golden-dusk.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#0f1629` | Deep navy background |
+| `#f5f2ed` | Warm white — primary text |
+| `#d4a853` | Gold — accent (numbers, rules, CTAs) |
+| `#b87333` | Copper — secondary accent, labels |
+| `#e8c877` | Light gold — hover/high-emphasis |
+| `#b8923d` | Deep gold — hover/active |
+| `#162040` | Navy surface (cards) |
+| `#111b33` | Surface inset |
+| `#1c2a50` | Navy light — nested containers |
+| `#3d4a6b` | Slate — subtle dividers |
+| `#6b7a9e` | Muted blue — tertiary text |
+| `#8a96b5` | Silver blue — captions |
+| `rgba(212,168,83,0.15)` | Hairline border |
+| `rgba(212,168,83,0.3)` | Accent border |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,300;1,9..40,400&display=swap" rel="stylesheet">
+```
+
+- **Display / Body:** `'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | DM Sans | 72px | 600 | 1.05 | +0.5px |
+| Section Heading | DM Sans | 48px | 600 | 1.10 | +0.5px |
+| Sub-heading | DM Sans | 32px | 500 | 1.20 | 0 |
+| Body Large | DM Sans | 20px | 300 | 1.65 | 0 |
+| Body | DM Sans | 16px | 400 | 1.70 | 0.1px |
+| Caption | DM Sans | 13px | 400 | 1.50 | 0.5px |
+| Big Number | DM Sans | 64px | 700 | 1.00 | -0.5px |
+| Label | DM Sans | 13px | 500 | 1.00 | 2.5px UPPER |
+| CTA | DM Sans | 15px | 600 | 1.00 | 1.5px UPPER |
+
+**Principles**
+
+- Light body (300) creates airy luxury; display at 500-600 — never 700+.
+- Positive tracking on display (+0.5px) for open, premium feel.
+- Hierarchy via tracking and subtle weight differences, not heavy contrast.
+
+## Layout
+
+- Format padding: carousel 60px · infographic 60/80 · slides 80px · poster 60/80.
+- Hairline `1px solid rgba(212,168,83,0.15)` borders — never 2px+.
+- Signature divider: `linear-gradient(90deg, transparent, #d4a853, transparent)` 80px × 1px.
+- Cards: `#162040` bg, 4px radius only. Precise and architectural.
+- One focal stat or headline per section — restraint is the hallmark.
+- Left-align body; center-align titles, stats, CTAs.
+
+## Do / Don't
+
+**Do**
+
+- Use gold sparingly — single focal points, numbers, CTA fills, thin accent bars.
+- Use DM Sans 300 for body — the lightness signals confidence.
+- Use gradient rules as the signature section divider (fading in and out).
+- Use copper (`#b87333`) for secondary labels and metadata — gold's quieter companion.
+- Keep CTA buttons understated — subtle gradient, moderate padding.
+
+**Don't**
+
+- Don't fill large surfaces with gold — it's an accent, not a background.
+- Don't use display weights above 600 — heavy type breaks the refined feel.
+- Don't use pure white/black; always warm white + deep navy.
+- Don't use saturated competing colors (blue, green, orange).
+- Don't use radius above 4px.
+- Don't use borders thicker than 1px — hairline is the rule.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-navy: #0f1629;
+  --color-warm-white: #f5f2ed;
+  --color-gold: #d4a853;
+  --color-copper: #b87333;
+  --color-light-gold: #e8c877;
+  --color-navy-surface: #162040;
+  --color-surface-inset: #111b33;
+  --color-muted-blue: #6b7a9e;
+  --color-border-default: rgba(212, 168, 83, 0.15);
+  --color-border-accent: rgba(212, 168, 83, 0.3);
+
+  --font: 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --gold-rule: linear-gradient(90deg, transparent, #d4a853, transparent);
+  --radius-card: 4px;
+}
+```
+
+### Title block (with fading gold rules)
+
+```html
+<div style="background:#0f1629; padding:80px 60px; text-align:center;">
+  <div style="width:80px; height:1px; background:linear-gradient(90deg,transparent,#d4a853,transparent); margin:0 auto 40px;"></div>
+  <h1 style="font-family:'DM Sans',sans-serif; font-size:72px; font-weight:600; line-height:1.05; letter-spacing:0.5px; color:#f5f2ed; margin:0 0 24px;">The Future of<br>Autonomous Work</h1>
+  <p style="font-family:'DM Sans',sans-serif; font-size:20px; font-weight:300; line-height:1.65; color:#b87333; max-width:560px; margin:0 auto;">How AI coworkers are reshaping how teams operate.</p>
+  <div style="width:80px; height:1px; background:linear-gradient(90deg,transparent,#d4a853,transparent); margin:40px auto 0;"></div>
+</div>
+```
+
+### Numbered item (big gold numeral)
+
+```html
+<div style="display:flex; gap:24px; align-items:flex-start; padding:32px 0; border-bottom:1px solid rgba(212,168,83,0.15);">
+  <span style="font-family:'DM Sans',sans-serif; font-size:48px; font-weight:700; line-height:1.00; color:#d4a853; min-width:72px;">01</span>
+  <div>
+    <p style="font-family:'DM Sans',sans-serif; font-size:13px; font-weight:500; letter-spacing:2.5px; text-transform:uppercase; color:#b87333; margin:0 0 8px;">SIGNAL-BASED OUTBOUND</p>
+    <h3 style="font-family:'DM Sans',sans-serif; font-size:32px; font-weight:500; line-height:1.20; color:#f5f2ed; margin:0 0 12px;">Find buyers before they find you</h3>
+    <p style="font-family:'DM Sans',sans-serif; font-size:16px; font-weight:400; line-height:1.70; color:#6b7a9e; margin:0;">Monitor hiring signals, funding events, and tech-stack changes.</p>
+  </div>
+</div>
+```
+
+### Stat
+
+```html
+<div style="text-align:center; padding:40px 24px; background:#162040; border:1px solid rgba(212,168,83,0.15); border-radius:4px;">
+  <p style="font-family:'DM Sans',sans-serif; font-size:64px; font-weight:700; line-height:1.00; letter-spacing:-0.5px; color:#d4a853; margin:0 0 8px;">47%</p>
+  <p style="font-family:'DM Sans',sans-serif; font-size:13px; font-weight:500; letter-spacing:2.5px; text-transform:uppercase; color:#f5f2ed; margin:0;">FASTER RESPONSE</p>
+</div>
+```
+
+### CTA
+
+```html
+<a style="display:inline-block; background:linear-gradient(180deg,#d4a853,#b8923d); color:#0f1629; font-family:'DM Sans',sans-serif; font-size:15px; font-weight:600; letter-spacing:1.5px; text-transform:uppercase; text-decoration:none; padding:16px 40px; border-radius:4px;">Get Started</a>
+```

--- a/skills/composites/goose-graphics/styles/grid-quote-editorial.md
+++ b/skills/composites/goose-graphics/styles/grid-quote-editorial.md
@@ -1,0 +1,124 @@
+# Grid Quote Editorial
+
+Royal-purple widescreen quote card with a pink 4-column grid overlay and a massive mint-green Figtree 800 pull quote at center. A large pink opening-quote glyph anchors the top-left grid cell. Attribution in uppercase pink sits bottom-left. Built for the 1920×1080 widescreen slide that delivers a single knockout quote.
+
+> Full prose reference: `styles/_full/grid-quote-editorial.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#2D1A5E` | Royal purple — primary background, entire canvas |
+| `#C9E8B5` | Mint green — pull quote display |
+| `#F2C9C4` | Peach pink — grid lines, opening-quote glyph, attribution |
+| `#1F0F47` | Deep purple — inset/depth |
+| `#D4ECB8` | Soft mint — secondary accents |
+| `#E5B8B3` | Dusty pink — hover/secondary |
+| `rgba(242,201,196,0.55)` | Pink dim — inactive |
+| `rgba(242,201,196,0.25)` | Pink faint — tertiary dividers |
+| `#F2C9C4` | Grid line (1px) |
+| `#251353` | Purple inset — subtle depth stepping |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Figtree:wght@500;600;700;800;900&display=swap" rel="stylesheet">
+```
+
+- **Display / Body:** `'Figtree', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Pull Quote Hero (Slides) | Figtree | 120px | 800 | 1.10 | -1px |
+| Pull Quote Hero (Carousel) | Figtree | 88px | 800 | 1.10 | -0.5px |
+| Pull Quote Hero (Story) | Figtree | 116px | 800 | 1.08 | -0.5px |
+| Pull Quote Hero (Poster) | Figtree | 96px | 800 | 1.10 | -0.5px |
+| Section Heading | Figtree | 56px | 800 | 1.15 | -0.5px |
+| Sub-heading | Figtree | 36px | 700 | 1.20 | 0 |
+| Body Large | Figtree | 22px | 500 | 1.55 | 0 |
+| Body | Figtree | 18px | 500 | 1.55 | 0 |
+| Caption | Figtree | 14px | 600 | 1.50 | 0.3px |
+| Attribution Caps | Figtree | 16px | 600 | 1.00 | 2px UPPER |
+| Opening Quote Glyph | Figtree | 120px | 900 | 1.00 | 0 |
+| Slide Number | Figtree | 14px | 500 | 1.00 | 1.5px |
+
+**Principles**
+
+- Figtree 800 in mint green is the pull quote voice — large, confident, single quote per slide.
+- Pink opening `"` glyph sits in the top-left cell of the 4-column grid.
+- Pink attribution uppercase tracked 2px in bottom-left.
+
+## Layout
+
+- Full-bleed royal purple `#2D1A5E`.
+- 4-column grid overlay using 1px peach-pink (`#F2C9C4`) vertical lines at 25%, 50%, 75% — always visible.
+- Pull quote lives at center spanning columns 2-3 (middle two of four), left-aligned within its cell.
+- Opening pink quote glyph `"` at top-left cell.
+- Slide number pink top-right.
+- Attribution bottom-left in uppercase pink.
+
+## Do / Don't
+
+**Do**
+
+- Keep the 4-column pink grid visible on every slide — it's the editorial structure.
+- Use mint green `#C9E8B5` for the pull quote only.
+- Use peach pink for grid lines, opening-quote glyph, and attribution.
+- Set the opening `"` glyph at 120px Figtree 900 in the top-left grid cell.
+- Left-align the quote within its grid span.
+
+**Don't**
+
+- Don't center the pull quote horizontally — left-aligned inside grid cell.
+- Don't hide the grid lines — they're the identity.
+- Don't use more than one quote per slide.
+- Don't add images or decorative objects beyond the grid + glyph + quote.
+- Don't use colors outside the purple + mint + pink system.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --c-purple: #2D1A5E;
+  --c-purple-deep: #1F0F47;
+  --c-purple-inset: #251353;
+  --c-mint: #C9E8B5;
+  --c-mint-soft: #D4ECB8;
+  --c-pink: #F2C9C4;
+  --c-pink-dim: rgba(242, 201, 196, 0.55);
+  --c-pink-faint: rgba(242, 201, 196, 0.25);
+
+  --font: 'Figtree', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+}
+```
+
+### Grid + quote composition
+
+```html
+<div style="background:#2D1A5E; min-height:1080px; position:relative; padding:60px; background-image:linear-gradient(to right,transparent 24.5%,#F2C9C4 24.5%,#F2C9C4 25%,transparent 25%,transparent 49.5%,#F2C9C4 49.5%,#F2C9C4 50%,transparent 50%,transparent 74.5%,#F2C9C4 74.5%,#F2C9C4 75%,transparent 75%); background-size:100% 100%;">
+
+  <p style="position:absolute; top:40px; left:40px; font-family:'Figtree',sans-serif; font-size:120px; font-weight:900; line-height:1.00; color:#F2C9C4; margin:0;">"</p>
+
+  <p style="position:absolute; top:60px; right:60px; font-family:'Figtree',sans-serif; font-size:14px; font-weight:500; letter-spacing:1.5px; color:#F2C9C4; margin:0;">03 / 12</p>
+
+  <div style="position:absolute; top:50%; left:25%; width:50%; transform:translateY(-50%);">
+    <p style="font-family:'Figtree',sans-serif; font-size:120px; font-weight:800; line-height:1.10; letter-spacing:-1px; color:#C9E8B5; margin:0;">The best teams write less, ship more, and argue louder about what matters.</p>
+  </div>
+
+  <p style="position:absolute; bottom:60px; left:60px; font-family:'Figtree',sans-serif; font-size:16px; font-weight:600; letter-spacing:2px; text-transform:uppercase; color:#F2C9C4; margin:0;">— MAYA KIM, HEAD OF PRODUCT @ DRIFT</p>
+</div>
+```
+
+### Poster variant
+
+```html
+<div style="background:#2D1A5E; padding:60px; min-height:1350px; position:relative; background-image:linear-gradient(to right,transparent calc(33.3% - 0.5px),#F2C9C4 33.3%,#F2C9C4 calc(33.3% + 0.5px),transparent calc(33.3% + 0.5px),transparent calc(66.6% - 0.5px),#F2C9C4 66.6%,#F2C9C4 calc(66.6% + 0.5px),transparent calc(66.6% + 0.5px));">
+  <p style="font-family:'Figtree',sans-serif; font-size:120px; font-weight:900; line-height:1.00; color:#F2C9C4; margin:0;">"</p>
+  <h1 style="font-family:'Figtree',sans-serif; font-size:96px; font-weight:800; line-height:1.10; letter-spacing:-0.5px; color:#C9E8B5; margin:120px 0 0; max-width:720px;">The first version is a question. The second version is the answer.</h1>
+  <p style="position:absolute; bottom:60px; left:60px; font-family:'Figtree',sans-serif; font-size:16px; font-weight:600; letter-spacing:2px; text-transform:uppercase; color:#F2C9C4; margin:0;">— OLIVIA WILSON, FOUNDER</p>
+</div>
+```

--- a/skills/composites/goose-graphics/styles/heatwave-orange.md
+++ b/skills/composites/goose-graphics/styles/heatwave-orange.md
@@ -1,0 +1,144 @@
+# Heatwave Orange
+
+Three-variant carousel system — orange, black, and near-white slides interleaved. Inter 900 stacked headlines 3-4 lines tall. Signature: hand-drawn peach/gold line-wave decorations + small lavender round arrow button. Pinterest-style corner metadata strip. The rhythm of alternating backgrounds is the identity.
+
+> Full prose reference: `styles/_full/heatwave-orange.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#E06A2C` | Heat orange — orange variant bg, primary accent |
+| `#E37230` | Heat orange light — hover |
+| `#F0EFEA` | Near-white — white variant bg (cream) |
+| `#0D0D0D` | Near-black — black variant bg, primary text on white |
+| `#FFFFFF` | Pure white — primary text on orange + black |
+| `#F2A36A` | Peach highlight — signature block on white slides |
+| `#E0896B` | Peach deep — line-wave on white slides |
+| `#D0C8E8` | Lavender button — round arrow fill |
+| `#C8BFE0` | Lavender deep — arrow hover |
+| `#C9A46B` | Gold tan — line-wave on black slides |
+| `#2B2B2B` | Charcoal — secondary text on white |
+| `#6A6A6A` | Tertiary gray — muted metadata on white |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@500;600;800;900&display=swap" rel="stylesheet">
+```
+
+- **Display / Body:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Inter | 88px | 900 | 1.05 | -2px |
+| Display Stack | Inter | 76px | 900 | 1.05 | -1.5px |
+| Section Heading | Inter | 56px | 900 | 1.08 | -1px |
+| Sub-heading | Inter | 32px | 800 | 1.15 | -0.5px |
+| Body Large | Inter | 22px | 600 | 1.45 | 0 |
+| Body | Inter | 18px | 600 | 1.50 | 0 |
+| Caption | Inter | 14px | 500 | 1.45 | 0.2px |
+| Big Number | Inter | 120px | 900 | 1.00 | -3px |
+| Tag Label | Inter | 16px | 800 | 1.00 | 0.3px |
+| CTA | Inter | 18px | 800 | 1.00 | 0.3px |
+
+**Principles**
+
+- Inter 900 black for stacked headlines (3-4 lines).
+- Heavy weights only (800-900) — this style doesn't do light.
+- Body is rare; when used, 600 weight minimum.
+
+## Layout
+
+- Three-variant carousel: slides alternate orange → white → black → orange → white → black...
+- Each variant has its own line-wave accent color (peach on white, gold tan on black, none on orange).
+- Line-wave decoration: hand-drawn sine wave SVG, 2-3px stroke, 40-60px tall, placed behind or above headline.
+- Small lavender round arrow button in one corner (swipe-to-next affordance).
+- Stack headlines 3-4 lines — each line stands alone, left-aligned, bold block-like.
+- Metadata strip (category · author · handle) in uppercase Inter 500 14px top or bottom.
+
+## Do / Don't
+
+**Do**
+
+- Alternate orange / white / black variants slide-to-slide.
+- Stack each headline on 3-4 lines, left-aligned, Inter 900.
+- Use peach line-wave on white slides, gold-tan on black slides, no wave on orange.
+- Add the small lavender round arrow button as the "swipe" affordance.
+- Include a metadata strip with category · author · handle.
+
+**Don't**
+
+- Don't use the same background for consecutive slides.
+- Don't use body text longer than 2 lines — stacked headlines are the identity.
+- Don't use color accents outside the defined palette.
+- Don't smooth the line-wave into a mathematical sine — keep it hand-drawn.
+- Don't use light font weights.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --c-orange: #E06A2C;
+  --c-orange-light: #E37230;
+  --c-white: #F0EFEA;
+  --c-black: #0D0D0D;
+  --c-peach: #F2A36A;
+  --c-peach-deep: #E0896B;
+  --c-lavender: #D0C8E8;
+  --c-gold-tan: #C9A46B;
+  --c-charcoal: #2B2B2B;
+  --c-gray: #6A6A6A;
+
+  --font: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+}
+```
+
+### Orange variant hero
+
+```html
+<div style="background:#E06A2C; padding:60px 40px; min-height:960px; position:relative;">
+  <p style="font-family:'Inter',sans-serif; font-size:14px; font-weight:500; letter-spacing:0.2px; text-transform:uppercase; color:#FFFFFF; margin:0 0 48px;">ESSAY · OLIVIA WILSON · @oliviaw</p>
+  <h1 style="font-family:'Inter',sans-serif; font-size:88px; font-weight:900; line-height:1.05; letter-spacing:-2px; color:#FFFFFF; margin:0;">
+    Heat<br>rearranges<br>everything<br>in August.
+  </h1>
+</div>
+```
+
+### White variant with peach line-wave
+
+```html
+<div style="background:#F0EFEA; padding:60px 40px; min-height:960px; position:relative;">
+  <svg viewBox="0 0 400 60" width="300" height="45" style="position:absolute; top:80px; right:40px;">
+    <path d="M0 30 Q50 0 100 30 T200 30 T300 30 T400 30" stroke="#E0896B" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </svg>
+  <h2 style="font-family:'Inter',sans-serif; font-size:76px; font-weight:900; line-height:1.05; letter-spacing:-1.5px; color:#0D0D0D; margin:120px 0 0;">
+    But it also<br>slows every<br>conversation<br>down.
+  </h2>
+  <div style="position:absolute; bottom:40px; right:40px; width:64px; height:64px; border-radius:50%; background:#D0C8E8; display:flex; align-items:center; justify-content:center;">
+    <span style="font-size:24px; color:#0D0D0D;">→</span>
+  </div>
+</div>
+```
+
+### Black variant with gold-tan wave + stat
+
+```html
+<div style="background:#0D0D0D; padding:60px 40px; min-height:960px; position:relative;">
+  <svg viewBox="0 0 400 60" width="300" height="45" style="margin-bottom:32px;">
+    <path d="M0 30 Q50 0 100 30 T200 30 T300 30 T400 30" stroke="#C9A46B" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </svg>
+  <p style="font-family:'Inter',sans-serif; font-size:120px; font-weight:900; line-height:1.00; letter-spacing:-3px; color:#E06A2C; margin:0;">47%</p>
+  <p style="font-family:'Inter',sans-serif; font-size:32px; font-weight:800; letter-spacing:-0.5px; color:#FFFFFF; margin:16px 0 0; max-width:640px;">of decisions I made at 97°F I rewrote two weeks later in a cool kitchen.</p>
+</div>
+```
+
+### Peach tag label
+
+```html
+<span style="display:inline-block; background:#F2A36A; color:#0D0D0D; font-family:'Inter',sans-serif; font-size:16px; font-weight:800; letter-spacing:0.3px; padding:6px 14px; border-radius:4px;">Example</span>
+```

--- a/skills/composites/goose-graphics/styles/highlighter-yellow.md
+++ b/skills/composites/goose-graphics/styles/highlighter-yellow.md
@@ -1,0 +1,124 @@
+# Highlighter Yellow
+
+Saturated yellow canvas, heavy Inter 900 black type, and a white-rectangle italic emphasis word as the signature move. A URL pill search-bar lives at the bottom. The mood is "Google search result made into a poster" — loud, punchy, extremely legible at thumbnail size.
+
+> Full prose reference: `styles/_full/highlighter-yellow.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#F4DC2E` | Highlighter yellow — primary background (every slide) |
+| `#F6E038` | Bright yellow — alternate variation |
+| `#F4D41E` | Deep yellow — darker variant |
+| `#1A1A1A` | Near-black — all primary text, dividers, dots, icons |
+| `#FFFFFF` | Pure white — white-rect emphasis, URL pill |
+| `#3A3A3A` | Secondary text — rare secondary copy |
+| `rgba(26,26,26,0.6)` | Tertiary text — URL domain |
+| `rgba(26,26,26,0.12)` | Dot grid — background texture |
+| `rgba(26,26,26,0.4)` | Muted — slide numbers, watermarks |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,500;0,700;0,900;1,500;1,900&display=swap" rel="stylesheet">
+```
+
+- **Display / Body:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Inter | 72px | 900 | 1.08 | -1.5px |
+| Headline Large | Inter | 64px | 900 | 1.08 | -1px |
+| Headline | Inter | 56px | 900 | 1.08 | -1px |
+| Emphasis Italic | Inter | matches headline | 900 italic | matches | -1px |
+| Sub-heading | Inter | 32px | 900 | 1.15 | -0.5px |
+| Body Large | Inter | 22px | 500 | 1.55 | 0 |
+| Body | Inter | 18px | 500 | 1.55 | 0 |
+| Caption | Inter | 14px | 500 | 1.50 | 0.2px |
+| URL Pill Text | Inter | 16px | 500 | 1.00 | 0 |
+| Icon Label | Inter | 12px | 700 | 1.00 | 1px UPPER |
+
+**Principles**
+
+- Inter 900 black weight for all headlines. No 700. No 500 in headline role.
+- The "white rectangle with italic word inside" is THE move — appears on every slide.
+- Body is rare. This style is headline-driven.
+
+## Layout
+
+- Full-bleed `#F4DC2E`.
+- White rectangle emphasis: inline `<span>` with `background: #fff; padding: 4px 12px; font-style: italic`. Sits on one word inside a larger black headline.
+- URL pill at bottom: white rounded-rectangle holding a search-bar lookalike with a small icon and the domain text.
+- Optional dot-grid background texture: `radial-gradient(circle, rgba(26,26,26,0.12) 1px, transparent 1px)` at 24px spacing.
+- Left-align headline; anchor URL pill bottom-left or bottom-center.
+
+## Do / Don't
+
+**Do**
+
+- Use Inter 900 black for every headline — hierarchy through size, not weight.
+- Apply the white-rect italic emphasis to one word per headline.
+- Build a bottom URL pill as the signature "search bar" CTA.
+- Use dot-grid background texture on hero slides for subtle depth.
+- Keep text all near-black `#1A1A1A`, not pure black.
+
+**Don't**
+
+- Don't use Inter weights below 900 for headlines.
+- Don't use more than one white-rect emphasis per slide.
+- Don't use colors beyond yellow, near-black, white.
+- Don't use curved or serif type.
+- Don't fill the canvas with body — this is a headline format.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-yellow: #F4DC2E;
+  --color-yellow-deep: #F4D41E;
+  --color-ink: #1A1A1A;
+  --color-white: #FFFFFF;
+  --color-url-domain: rgba(26, 26, 26, 0.6);
+  --color-dot: rgba(26, 26, 26, 0.12);
+
+  --font: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --dot-grid: radial-gradient(circle, rgba(26,26,26,0.12) 1px, transparent 1px);
+}
+```
+
+### Hero with white-rect emphasis
+
+```html
+<div style="background:#F4DC2E; padding:60px 40px; min-height:960px; position:relative; background-image:radial-gradient(circle,rgba(26,26,26,0.12) 1px,transparent 1px); background-size:24px 24px;">
+  <h1 style="font-family:'Inter',sans-serif; font-size:72px; font-weight:900; line-height:1.08; letter-spacing:-1.5px; color:#1A1A1A; margin:0; max-width:720px;">
+    How do I <span style="background:#fff; font-style:italic; padding:4px 14px; box-shadow:2px 2px 0 rgba(26,26,26,0.1);">actually</span> get my first 100 customers?
+  </h1>
+
+  <div style="position:absolute; bottom:60px; left:40px; display:flex; align-items:center; gap:12px; background:#fff; padding:12px 20px; border-radius:40px; box-shadow:0 4px 12px rgba(26,26,26,0.1);">
+    <span style="font-size:16px;">🔍</span>
+    <span style="font-family:'Inter',sans-serif; font-size:16px; font-weight:500; color:rgba(26,26,26,0.6);">— growth.guide/first-100</span>
+  </div>
+</div>
+```
+
+### Content slide (sub-headline + divider)
+
+```html
+<div style="background:#F4DC2E; padding:60px 40px; min-height:960px;">
+  <h2 style="font-family:'Inter',sans-serif; font-size:56px; font-weight:900; line-height:1.08; letter-spacing:-1px; color:#1A1A1A; margin:0 0 40px; max-width:800px;">The answer isn't a funnel — it's <span style="background:#fff; font-style:italic; padding:4px 12px;">ten conversations</span>.</h2>
+  <div style="width:60px; height:3px; background:#1A1A1A; margin-bottom:32px;"></div>
+  <p style="font-family:'Inter',sans-serif; font-size:32px; font-weight:900; line-height:1.15; letter-spacing:-0.5px; color:#1A1A1A; margin:0; max-width:720px;">Talk to ten humans this week. Write down what they said. Ship the next version.</p>
+</div>
+```
+
+### Slide number / watermark
+
+```html
+<p style="position:absolute; bottom:20px; right:20px; font-family:'Inter',sans-serif; font-size:14px; font-weight:500; color:rgba(26,26,26,0.4); margin:0;">03 / 07</p>
+```

--- a/skills/composites/goose-graphics/styles/index.json
+++ b/skills/composites/goose-graphics/styles/index.json
@@ -1,0 +1,77 @@
+{
+  "version": 1,
+  "count": 36,
+  "groups": [
+    {
+      "name": "Dark & Moody",
+      "styles": [
+        { "slug": "midnight-editorial", "name": "Midnight Editorial", "tagline": "Dark, elegant magazine aesthetic with copper accents." },
+        { "slug": "deep-ocean", "name": "Deep Ocean", "tagline": "Calm cyan glow on deep blue-black." },
+        { "slug": "golden-dusk", "name": "Golden Dusk", "tagline": "Warm gold highlights on dark navy." },
+        { "slug": "terminal", "name": "Terminal", "tagline": "Green-on-dark monospace hacker aesthetic." },
+        { "slug": "bw-editorial-drop", "name": "BW Editorial Drop", "tagline": "Grayscale photo top + yellow Anton display on black drop panel." },
+        { "slug": "masked-object-editorial", "name": "Masked Object Editorial", "tagline": "Navy + photo clipped into an object silhouette + italic Playfair." },
+        { "slug": "grid-quote-editorial", "name": "Grid Quote Editorial", "tagline": "Royal purple widescreen quote card + pink grid overlay + mint Figtree." }
+      ]
+    },
+    {
+      "name": "Light & Editorial",
+      "styles": [
+        { "slug": "clean-slate", "name": "Clean Slate", "tagline": "Ultra-minimal white canvas with a single blue accent." },
+        { "slug": "paper-and-ink", "name": "Paper & Ink", "tagline": "Classic serif editorial with red accent on cream." },
+        { "slug": "matt-gray", "name": "Matt Gray", "tagline": "Playfair italic green + yellow pill tags on light gray." },
+        { "slug": "magazine-red", "name": "Magazine Red", "tagline": "Massive tomato-red condensed headlines on cream paper." },
+        { "slug": "sunburst-editorial", "name": "Sunburst Editorial", "tagline": "Mid-century book cover feel with serif + collage accents." },
+        { "slug": "product-minimal", "name": "Product Minimal", "tagline": "Apple-style white canvas, hero product photo, underlined URL." },
+        { "slug": "archive-fashion", "name": "Archive Fashion", "tagline": "Stone beige catalog frame + brown photo inset + pink sticker." }
+      ]
+    },
+    {
+      "name": "Organic & Warm",
+      "styles": [
+        { "slug": "warm-earth", "name": "Warm Earth", "tagline": "Organic terracotta and sage on cream." },
+        { "slug": "garden-blur", "name": "Garden Blur", "tagline": "Soft botanical backgrounds with translucent card overlays." },
+        { "slug": "soft-cloud", "name": "Soft Cloud", "tagline": "Airy pastel gradients with white cards." },
+        { "slug": "peach-pop", "name": "Peach Pop", "tagline": "DTC beauty: monospace testimonials on peach + blue blocks." },
+        { "slug": "pastel-organic-shapes", "name": "Pastel Organic Shapes", "tagline": "Cream canvas with one pistachio circle half off-frame." },
+        { "slug": "aurora-app-launch", "name": "Aurora App Launch", "tagline": "Rainbow mesh gradient + phone mockup + frosted-glass footer." }
+      ]
+    },
+    {
+      "name": "Bold & Energetic",
+      "styles": [
+        { "slug": "electric-burst", "name": "Electric Burst", "tagline": "Bold neon yellow and hot pink on black." },
+        { "slug": "highlighter-yellow", "name": "Highlighter Yellow", "tagline": "Saturated yellow + heavy black sans + white-rect italic emphasis." },
+        { "slug": "heatwave-orange", "name": "Heatwave Orange", "tagline": "Three-variant white/orange/black system + line-wave accents." },
+        { "slug": "split-yellow-product", "name": "Split Yellow Product", "tagline": "Vivid mustard 2/3 headline slab + gray body panel + yellow photo." },
+        { "slug": "blueprint-sticky", "name": "Blueprint Sticky", "tagline": "Cobalt blueprint grid + tilted pink/yellow sticky notes." }
+      ]
+    },
+    {
+      "name": "Retro & Cinematic",
+      "styles": [
+        { "slug": "cinematic-romance", "name": "Cinematic Romance", "tagline": "Portrait photo canvas + hot pink chancery script headlines." },
+        { "slug": "vintage-duotone-poster", "name": "Vintage Duotone Poster", "tagline": "Forest green + dusty pink halftone, 1950s letterpress." },
+        { "slug": "retro-line-art", "name": "Retro Line Art", "tagline": "Powder blue + cream hand-drawn cocktail-poster line art." },
+        { "slug": "iridescent-y2k", "name": "Iridescent Y2K", "tagline": "Brutalist grid + chrome iridescent blob hero, Y2K club poster." },
+        { "slug": "ink-doodle-event", "name": "Ink Doodle Event", "tagline": "Kraft paper + loose hand-drawn ink character + Yellowtail script." }
+      ]
+    },
+    {
+      "name": "Structural & Technical",
+      "styles": [
+        { "slug": "brutalist", "name": "Brutalist", "tagline": "Raw heavy borders, system fonts, no decoration." },
+        { "slug": "frosted-lens", "name": "Frosted Lens", "tagline": "Glassmorphism + blurred photography backgrounds." },
+        { "slug": "card-toss", "name": "Card Toss", "tagline": "Scattered tilted cards with sticky-note energy." },
+        { "slug": "venn-infographic", "name": "Venn Infographic", "tagline": "Translucent three-circle Venn diagrams + floating info cards." },
+        { "slug": "social-post-card", "name": "Social Post Card", "tagline": "Blurred real scene + simulated Instagram post card as hero." }
+      ]
+    },
+    {
+      "name": "Friendly Corporate",
+      "styles": [
+        { "slug": "mint-pixel-corporate", "name": "Mint Pixel Corporate", "tagline": "Pale mint + lime pixel-staircase corner decorations." }
+      ]
+    }
+  ]
+}

--- a/skills/composites/goose-graphics/styles/ink-doodle-event.md
+++ b/skills/composites/goose-graphics/styles/ink-doodle-event.md
@@ -1,0 +1,147 @@
+# Ink Doodle Event
+
+Skate-zine event flyer. Kraft paper wheat canvas, loose hand-drawn ink character or illustration at center, a massive single-word Yellowtail calligraphic headline that sings, and italic Fraunces words flanking the illustration. Top corners hold DM Mono metadata. Everything in black ink on warm wheat paper.
+
+> Full prose reference: `styles/_full/ink-doodle-event.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#EAD9AE` | Wheat paper — primary background, edge-to-edge |
+| `#0E0E0E` | Ink black — all type, illustration strokes, halftone dots |
+| `#F0E1BA` | Wheat highlight — rare paper-grain highlight |
+| `#DCCA9C` | Wheat shadow — rare paper-edge vignette |
+| `rgba(14,14,14,0.80)` | Ink 80 — rare secondary |
+| `rgba(14,14,14,0.60)` | Ink 60 — rare tertiary |
+| `rgba(14,14,14,0.40)` | Ink 40 — whisper accents |
+| `rgba(14,14,14,0.20)` | Ink 20 — halftone zones |
+| `rgba(14,14,14,0.35)` | Hairline ink |
+| `rgba(14,14,14,0.06)` | Paper grain texture overlay |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Yellowtail&family=Fraunces:ital,wght@0,400;0,500;1,400;1,500&family=DM+Mono:wght@400&display=swap" rel="stylesheet">
+```
+
+- **Script:** `'Yellowtail', 'Lucida Handwriting', cursive`
+- **Body Italic / Serif:** `'Fraunces', Georgia, 'Times New Roman', serif`
+- **Monospace:** `'DM Mono', 'Courier New', Courier, monospace`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Script Hero | Yellowtail | 160px | 400 | 0.95 | -2px |
+| Script Secondary | Yellowtail | 96px | 400 | 1.00 | -1px |
+| Flanking Italic | Fraunces Italic | 24px | 400 | 1.20 | 0.2px |
+| Body Italic | Fraunces Italic | 20px | 400 | 1.50 | 0.2px |
+| Body Roman | Fraunces | 18px | 400 | 1.55 | 0.2px |
+| Top Metadata | DM Mono | 22px | 400 | 1.20 | 0.5px |
+| Address Footer | Fraunces | 20px | 400 | 1.40 | 0.2px |
+| Small Caption | DM Mono | 14px | 400 | 1.30 | 0.5px |
+| Framework Tag | Fraunces Italic | 16px | 500 | 1.20 | 0.5px |
+
+**Principles**
+
+- Yellowtail for the ONE calligraphic word; Fraunces italic for the flanking secondary words.
+- DM Mono exclusively for metadata corners (time, date, slide numbers).
+- Script requires extra vertical padding (40px top, 60px bottom) for ascenders and descenders.
+
+## Layout
+
+- Wheat paper background edge-to-edge; optional subtle paper-grain overlay.
+- Central hand-drawn illustration (cocktail glass, skater, sun, etc.) in black ink, 2-3px stroke weight.
+- Script word positioned ABOVE the illustration, angled slightly.
+- Two italic Fraunces "flanking words" LEFT + RIGHT of illustration, mixed case.
+- DM Mono metadata in top-left and top-right corners (date + time).
+- Two-line Fraunces address footer at the very bottom.
+- Halftone dot zones for decorative shading.
+
+## Do / Don't
+
+**Do**
+
+- Use one Yellowtail script word as the hero — it's the whole mood.
+- Hand-draw the central illustration with consistent 2-3px ink strokes — no flat vectors.
+- Add italic Fraunces flanking words for "club" / "skate" / "after hours" callouts.
+- Use DM Mono 0.5px tracked for corner metadata.
+- Include halftone dot zones (scattered `rgba(14,14,14,0.2)` dots) for tonal variation.
+
+**Don't**
+
+- Don't use Yellowtail for more than one word per composition.
+- Don't uppercase flanking italic words — mixed case only.
+- Don't add color — ink black on wheat paper is the identity.
+- Don't smooth the illustration — keep it loose and hand-drawn.
+- Don't use sans-serif for body — Fraunces or DM Mono only.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --c-wheat: #EAD9AE;
+  --c-ink: #0E0E0E;
+  --c-wheat-hi: #F0E1BA;
+  --c-wheat-shadow: #DCCA9C;
+  --c-ink-60: rgba(14, 14, 14, 0.60);
+  --c-ink-20: rgba(14, 14, 14, 0.20);
+
+  --font-script: 'Yellowtail', 'Lucida Handwriting', cursive;
+  --font-body: 'Fraunces', Georgia, 'Times New Roman', serif;
+  --font-mono: 'DM Mono', 'Courier New', Courier, monospace;
+}
+```
+
+### Paper-grain texture
+
+```css
+.paper {
+  background-color: #EAD9AE;
+  background-image:
+    radial-gradient(circle, rgba(14,14,14,0.06) 1px, transparent 1px),
+    radial-gradient(circle, rgba(14,14,14,0.04) 1px, transparent 1px);
+  background-size: 4px 4px, 7px 7px;
+  background-position: 0 0, 2px 3px;
+}
+```
+
+### Event flyer hero
+
+```html
+<div style="background:#EAD9AE; padding:60px; min-height:960px; position:relative;">
+  <div style="display:flex; justify-content:space-between;">
+    <p style="font-family:'DM Mono',monospace; font-size:22px; font-weight:400; letter-spacing:0.5px; color:#0E0E0E; margin:0;">Sun 10/20</p>
+    <p style="font-family:'DM Mono',monospace; font-size:22px; font-weight:400; letter-spacing:0.5px; color:#0E0E0E; margin:0;">8:00 PM — late</p>
+  </div>
+
+  <div style="text-align:center; margin-top:80px; padding-top:40px; padding-bottom:60px;">
+    <h1 style="font-family:'Yellowtail',cursive; font-size:160px; font-weight:400; line-height:0.95; letter-spacing:-2px; color:#0E0E0E; margin:0; transform:rotate(-2deg);">Sunday</h1>
+  </div>
+
+  <div style="display:flex; justify-content:space-between; align-items:center; margin-top:40px;">
+    <p style="font-family:'Fraunces',serif; font-style:italic; font-size:24px; font-weight:400; letter-spacing:0.2px; color:#0E0E0E; margin:0;">skate</p>
+    <svg width="200" height="200" viewBox="0 0 200 200">
+      <path d="M60 140 Q100 40 140 140 Q120 160 100 160 Q80 160 60 140 Z" stroke="#0E0E0E" stroke-width="3" fill="none" stroke-linecap="round"/>
+      <circle cx="100" cy="90" r="4" fill="#0E0E0E"/>
+    </svg>
+    <p style="font-family:'Fraunces',serif; font-style:italic; font-size:24px; font-weight:400; letter-spacing:0.2px; color:#0E0E0E; margin:0;">club</p>
+  </div>
+
+  <div style="text-align:center; margin-top:80px;">
+    <p style="font-family:'Fraunces',serif; font-size:20px; font-weight:400; line-height:1.40; letter-spacing:0.2px; color:#0E0E0E; margin:0;">The Old Warehouse · 108 Ruin Street<br>Free entry before 9 · $8 after</p>
+  </div>
+</div>
+```
+
+### Halftone dot zone
+
+```css
+.halftone {
+  background-image: radial-gradient(circle, rgba(14,14,14,0.2) 1.5px, transparent 1.5px);
+  background-size: 8px 8px;
+}
+```

--- a/skills/composites/goose-graphics/styles/iridescent-y2k.md
+++ b/skills/composites/goose-graphics/styles/iridescent-y2k.md
@@ -1,0 +1,162 @@
+# Iridescent Y2K
+
+Stone beige canvas with a single chromatic iridescent blob (cyan → lavender → pink) as the hero visual. Brutalist editorial grid: `01`, `02`, `03` index columns, `|` rule separators, metadata tables. Archivo Black stacked-headline display type at 140px. Space Mono 500 for all metadata. Y2K club-flyer meets rigid editorial.
+
+> Full prose reference: `styles/_full/iridescent-y2k.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#ECE8DD` | Stone beige — primary background |
+| `#111111` | Near-black ink — primary text, rules, borders |
+| `#2B2B2B` | Ink secondary — softened small metadata |
+| `#555555` | Ink tertiary — quieter metadata |
+| `#D8D2C3` | Stone darker — rare recessed surface |
+| `#F2EEE4` | Stone lighter — rare lifted surface |
+| `#FF6EC7` | Hot pink — iridescent peak (warm) |
+| `#8DEBFF` | Cyan shimmer — iridescent peak (cool) |
+| `#C79DFF` | Lavender midtone — iridescent bridge |
+| `#FFE8F0` | Pearl pink — highlight rim |
+| `#F6F3FA` | Pearl lilac — soft blend |
+| `rgba(255,110,199,0.25)` | Blob glow (pink halo) |
+| `rgba(199,157,255,0.20)` | Blob glow deep (lavender halo) |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Space+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+```
+
+- **Display:** `'Archivo Black', Impact, 'Arial Black', sans-serif`
+- **Body / Monospace:** `'Space Mono', 'Courier New', Courier, monospace`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Archivo Black | 140px | 400 | 0.88 | -2px |
+| Display Medium | Archivo Black | 104px | 400 | 0.90 | -1.5px |
+| Display Small | Archivo Black | 72px | 400 | 0.92 | -1px |
+| Subtitle | Space Mono | 18px | 500 | 1.45 | 0.4px |
+| Body | Space Mono | 14px | 500 | 1.55 | 0.3px |
+| Body Bold | Space Mono | 14px | 700 | 1.55 | 0.3px |
+| Metadata Label | Space Mono | 13px | 500 | 1.35 | 0.6px |
+| Metadata Value | Space Mono | 16px | 700 | 1.30 | 0.2px |
+| Big Number | Archivo Black | 96px | 400 | 0.90 | -1.5px |
+| Footer Text | Space Mono | 12px | 500 | 1.40 | 1.5px UPPER |
+| CTA | Space Mono | 14px | 700 | 1.00 | 1.2px UPPER |
+
+**Principles**
+
+- Archivo Black stacked 1-3 words per line, left-aligned.
+- Every metadata cell uses Space Mono — the brutalist grid is monospaced.
+- Subtitles in sentence case; everything structural is UPPER with tracking.
+
+## Layout
+
+- Full-bleed stone beige `#ECE8DD` background.
+- Central iridescent blob: CSS conic or radial gradient cycling pink → lavender → cyan → pearl.
+- 12-column grid with visible `|` rules between columns (`border-right: 1px solid #111`).
+- Metadata tables: rows of Space Mono label (uppercase tracked) + value pairs separated by `|`.
+- Numerical indices `01 / 02 / 03` in top-left corner, Space Mono 700.
+
+## Do / Don't
+
+**Do**
+
+- Render the iridescent blob as a large central focal, 40-60% frame size.
+- Use the blob gradient: `conic-gradient(from 180deg, #FF6EC7, #C79DFF, #8DEBFF, #FFE8F0, #FF6EC7)` with 40-60px blur.
+- Structure the layout as a rigid 12-column grid with vertical rules.
+- Use Space Mono for every metadata role.
+- Stack Archivo Black headlines left-aligned, 1-3 words per line.
+
+**Don't**
+
+- Don't use more than one blob per composition — it is the visual anchor.
+- Don't use sans-serif body — Space Mono is mandatory.
+- Don't use gradient backgrounds (other than the blob itself).
+- Don't use color outside stone beige + iridescent palette.
+- Don't soften the grid — visible rules are the editorial identity.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-stone: #ECE8DD;
+  --color-ink: #111111;
+  --color-ink-2: #2B2B2B;
+  --color-ink-3: #555555;
+  --color-pink: #FF6EC7;
+  --color-cyan: #8DEBFF;
+  --color-lavender: #C79DFF;
+  --color-pearl: #FFE8F0;
+  --color-pearl-lilac: #F6F3FA;
+
+  --font-display: 'Archivo Black', Impact, 'Arial Black', sans-serif;
+  --font-mono: 'Space Mono', 'Courier New', Courier, monospace;
+}
+```
+
+### Iridescent blob
+
+```html
+<div style="position:relative; width:480px; height:480px; margin:0 auto;">
+  <div style="position:absolute; inset:-40px; background:conic-gradient(from 180deg at 50% 50%, #FF6EC7, #C79DFF, #8DEBFF, #FFE8F0, #FF6EC7); border-radius:50%; filter:blur(40px); opacity:0.9;"></div>
+  <div style="position:absolute; inset:0; background:conic-gradient(from 180deg at 50% 50%, #FF6EC7, #C79DFF, #8DEBFF, #FFE8F0, #FF6EC7); border-radius:50%;"></div>
+</div>
+```
+
+### Hero layout (grid + blob + stacked display)
+
+```html
+<div style="background:#ECE8DD; padding:40px; min-height:100vh;">
+  <div style="display:grid; grid-template-columns:repeat(12, 1fr); gap:16px; padding-bottom:16px; border-bottom:1px solid #111;">
+    <p style="grid-column:span 2; font-family:'Space Mono',monospace; font-size:13px; font-weight:700; letter-spacing:0.6px; color:#111; margin:0;">01 / 03</p>
+    <p style="grid-column:span 4; font-family:'Space Mono',monospace; font-size:13px; font-weight:500; letter-spacing:0.6px; color:#2B2B2B; margin:0;">VOL. IV · SUMMER ISSUE</p>
+    <p style="grid-column:span 6; text-align:right; font-family:'Space Mono',monospace; font-size:13px; font-weight:500; letter-spacing:0.6px; color:#555; margin:0;">12.04.2026</p>
+  </div>
+
+  <div style="display:grid; grid-template-columns:1fr 1fr; gap:40px; padding-top:60px;">
+    <div>
+      <h1 style="font-family:'Archivo Black',sans-serif; font-size:140px; font-weight:400; line-height:0.88; letter-spacing:-2px; color:#111; margin:0;">FUTURE<br>LIVES<br>HERE.</h1>
+      <p style="font-family:'Space Mono',monospace; font-size:18px; font-weight:500; line-height:1.45; color:#2B2B2B; margin:32px 0 0;">A brutalist-iridescent issue on the teams quietly building what's next.</p>
+    </div>
+    <div style="position:relative; width:100%; aspect-ratio:1;">
+      <div style="position:absolute; inset:-20px; background:conic-gradient(from 180deg, #FF6EC7, #C79DFF, #8DEBFF, #FFE8F0, #FF6EC7); border-radius:50%; filter:blur(40px); opacity:0.85;"></div>
+      <div style="position:absolute; inset:0; background:conic-gradient(from 180deg, #FF6EC7, #C79DFF, #8DEBFF, #FFE8F0, #FF6EC7); border-radius:50%;"></div>
+    </div>
+  </div>
+</div>
+```
+
+### Metadata table
+
+```html
+<div style="display:grid; grid-template-columns:repeat(4, 1fr); border-top:1px solid #111; border-bottom:1px solid #111;">
+  <div style="padding:16px; border-right:1px solid #111;">
+    <p style="font-family:'Space Mono',monospace; font-size:13px; font-weight:500; letter-spacing:0.6px; text-transform:uppercase; color:#555; margin:0 0 4px;">VENUE</p>
+    <p style="font-family:'Space Mono',monospace; font-size:16px; font-weight:700; color:#111; margin:0;">Palace Hall</p>
+  </div>
+  <div style="padding:16px; border-right:1px solid #111;">
+    <p style="font-family:'Space Mono',monospace; font-size:13px; font-weight:500; letter-spacing:0.6px; text-transform:uppercase; color:#555; margin:0 0 4px;">DATE</p>
+    <p style="font-family:'Space Mono',monospace; font-size:16px; font-weight:700; color:#111; margin:0;">20.10.2026</p>
+  </div>
+  <div style="padding:16px; border-right:1px solid #111;">
+    <p style="font-family:'Space Mono',monospace; font-size:13px; font-weight:500; letter-spacing:0.6px; text-transform:uppercase; color:#555; margin:0 0 4px;">TIME</p>
+    <p style="font-family:'Space Mono',monospace; font-size:16px; font-weight:700; color:#111; margin:0;">20:00 — 02:00</p>
+  </div>
+  <div style="padding:16px;">
+    <p style="font-family:'Space Mono',monospace; font-size:13px; font-weight:500; letter-spacing:0.6px; text-transform:uppercase; color:#555; margin:0 0 4px;">ADMISSION</p>
+    <p style="font-family:'Space Mono',monospace; font-size:16px; font-weight:700; color:#111; margin:0;">$12 / DOOR</p>
+  </div>
+</div>
+```
+
+### CTA
+
+```html
+<a style="display:inline-block; background:#111; color:#ECE8DD; font-family:'Space Mono',monospace; font-size:14px; font-weight:700; letter-spacing:1.2px; text-transform:uppercase; text-decoration:none; padding:14px 24px;">RSVP →</a>
+```

--- a/skills/composites/goose-graphics/styles/magazine-red.md
+++ b/skills/composites/goose-graphics/styles/magazine-red.md
@@ -1,0 +1,147 @@
+# Magazine Red
+
+Startup pitch-deck energy in magazine clothing. Massive tomato-red Anton condensed headlines at 180-240px on warm cream paper, with espresso-black Inter body handling all secondary roles. Bracketed red pagination `[1]` `(05)` and hairline rules carry the editorial grammar. Think early-2000s Wired cover meets a Series A announcement.
+
+> Full prose reference: `styles/_full/magazine-red.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#F2EEE2` | Cream paper — primary background |
+| `#C33A1F` | Tomato red — display headlines, bracketed numbers |
+| `#2B2119` | Espresso black — primary body text |
+| `#4A3E33` | Ink medium — secondary text |
+| `#7A6B5C` | Ink light — tertiary, photo credits |
+| `#A82E17` | Brick red — hover/active |
+| `#B83327` | Rust red — alternative display red |
+| `#ECE6D6` | Cream deep — subtle inset |
+| `#E4DCC8` | Paper fold — photo frame bg |
+| `rgba(43,33,25,0.15)` | Border hairline |
+| `rgba(43,33,25,0.45)` | Ink mute — page numbers, watermarks |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Anton&family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display:** `'Anton', Impact, 'Arial Narrow', sans-serif`
+- **Body:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Massive Hero | Anton | 240px | 400 | 0.88 | -2px UPPER |
+| Display Hero | Anton | 180px | 400 | 0.90 | -1.5px UPPER |
+| Display Large | Anton | 120px | 400 | 0.92 | -1px UPPER |
+| Display Medium | Anton | 88px | 400 | 0.94 | -0.5px UPPER |
+| Big Number | Anton | 140px | 400 | 0.90 | -1px |
+| Bracket Number | Anton | 56px | 400 | 1.0 | 0 |
+| Heading 1 | Inter | 28px | 700 | 1.25 | -0.2px |
+| Heading 2 | Inter | 20px | 700 | 1.30 | 0 |
+| Label Caps | Inter | 13px | 600 | 1.20 | 2px UPPER |
+| Label Caps Small | Inter | 11px | 700 | 1.20 | 1.8px UPPER |
+| Body Large | Inter | 18px | 500 | 1.55 | 0 |
+| Body | Inter | 15px | 500 | 1.60 | 0 |
+| Body Small | Inter | 13px | 500 | 1.55 | 0 |
+| Subtitle Red | Inter | 16px | 700 | 1.30 | 0.5px UPPER |
+
+**Principles**
+
+- Anton is one weight (400 native heavy) — size = impact. Nearly fills frame width.
+- Red display headlines ALL CAPS. Body stays espresso-black mixed case.
+- Red is reserved for display, bracketed numbers, and subtitle tags.
+
+## Layout
+
+- Full-bleed cream paper `#F2EEE2`.
+- Two-column or three-column editorial grid where space allows.
+- Bracket numbers `[1]` `[2]` for list markers; parenthetical `(05)` for page/slide numbers.
+- Hairline rules `1px solid rgba(43,33,25,0.15)` between body items.
+- Photography framed in `#E4DCC8` paper-fold inset.
+
+## Do / Don't
+
+**Do**
+
+- Use Anton at 180-240px in tomato red for cover and section headlines.
+- Use bracket markers (`[1]`, `(05)`) in red Anton for list and page numbers.
+- Use Inter espresso-black mixed case for all body text.
+- Use uppercase tracked Inter labels (13px, 2px tracking) for corner metadata like "PRESENTED BY / OLIVIA WILSON".
+- Use hairline rules to separate list items and columns.
+
+**Don't**
+
+- Don't use red for body text — only display, bracket numbers, and subtitle tags.
+- Don't mix case on display headlines — UPPERCASE.
+- Don't use serif fonts anywhere.
+- Don't use saturated accents besides the tomato red.
+- Don't use heavy shadows — this is print; elevation is through scale and rule.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-cream: #F2EEE2;
+  --color-red: #C33A1F;
+  --color-espresso: #2B2119;
+  --color-ink-med: #4A3E33;
+  --color-ink-light: #7A6B5C;
+  --color-brick: #A82E17;
+  --color-cream-deep: #ECE6D6;
+  --color-paper-fold: #E4DCC8;
+  --color-hairline: rgba(43, 33, 25, 0.15);
+
+  --font-display: 'Anton', Impact, 'Arial Narrow', sans-serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+}
+```
+
+### Cover hero (massive red display)
+
+```html
+<div style="background:#F2EEE2; padding:60px; min-height:100vh; position:relative;">
+  <div style="display:flex; justify-content:space-between; align-items:flex-start; border-bottom:1px solid rgba(43,33,25,0.15); padding-bottom:16px; margin-bottom:60px;">
+    <p style="font-family:'Inter',sans-serif; font-size:13px; font-weight:600; letter-spacing:2px; text-transform:uppercase; color:#2B2119; margin:0;">PRESENTED BY / OLIVIA WILSON</p>
+    <p style="font-family:'Anton',sans-serif; font-size:56px; line-height:1.0; color:#C33A1F; margin:0;">(05)</p>
+  </div>
+
+  <h1 style="font-family:'Anton',sans-serif; font-size:240px; font-weight:400; line-height:0.88; letter-spacing:-2px; text-transform:uppercase; color:#C33A1F; margin:0;">PITCH<br>DECK.</h1>
+
+  <p style="font-family:'Inter',sans-serif; font-size:16px; font-weight:700; letter-spacing:0.5px; text-transform:uppercase; color:#C33A1F; margin:40px 0 0;">MARKETING EXPERTS AT YOUR SERVICE</p>
+  <p style="font-family:'Inter',sans-serif; font-size:18px; font-weight:500; line-height:1.55; color:#2B2119; max-width:640px; margin:16px 0 0;">A four-part framework for teams that want to ship their first campaign before the quarter ends.</p>
+</div>
+```
+
+### Bracketed list
+
+```html
+<div style="background:#F2EEE2; padding:48px 60px;">
+  <div style="display:flex; gap:32px; padding:24px 0; border-bottom:1px solid rgba(43,33,25,0.15);">
+    <span style="font-family:'Anton',sans-serif; font-size:56px; line-height:1.0; color:#C33A1F; flex-shrink:0;">[1]</span>
+    <div>
+      <h3 style="font-family:'Inter',sans-serif; font-size:28px; font-weight:700; letter-spacing:-0.2px; color:#2B2119; margin:0 0 8px;">Find the sharpest question</h3>
+      <p style="font-family:'Inter',sans-serif; font-size:15px; font-weight:500; line-height:1.60; color:#4A3E33; margin:0;">Every deck has one slide that earns the meeting. Work backward from that slide.</p>
+    </div>
+  </div>
+</div>
+```
+
+### Photo caption card
+
+```html
+<div style="background:#E4DCC8; padding:16px;">
+  <div style="background:#7A6B5C; height:280px;"></div>
+  <p style="font-family:'Inter',sans-serif; font-size:11px; font-weight:700; letter-spacing:1.8px; text-transform:uppercase; color:#2B2119; margin:12px 0 0;">OLIVIA WILSON · FOUNDER</p>
+</div>
+```
+
+### CTA (red block)
+
+```html
+<a style="display:inline-block; background:#C33A1F; color:#F2EEE2; font-family:'Inter',sans-serif; font-size:13px; font-weight:700; letter-spacing:2px; text-transform:uppercase; text-decoration:none; padding:14px 28px;">READ THE ESSAY →</a>
+```

--- a/skills/composites/goose-graphics/styles/masked-object-editorial.md
+++ b/skills/composites/goose-graphics/styles/masked-object-editorial.md
@@ -1,0 +1,139 @@
+# Masked Object Editorial
+
+Royal-navy canvas with a pale-cream italic Playfair Display hero headline over a photograph that's been CSS-clipped into an object silhouette (bottle, lamp, sculpture, plant). Pure white Inter body sits beneath in stacked 3-line declaratives. A powder-blue footer band runs full width holding a navy CTA label.
+
+> Full prose reference: `styles/_full/masked-object-editorial.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#112A70` | Royal navy — primary background, every slide |
+| `#F5F0E6` | Pale cream — italic serif display headlines |
+| `#FFFFFF` | Pure white — sans body copy |
+| `#B8D4E8` | Powder blue — full-width footer band |
+| `#112A70` | Navy on powder — footer CTA label text |
+| `#0A1F55` | Deep navy shadow — optional inset |
+| `rgba(245,240,230,0.75)` | Cream soft — attributions |
+| `rgba(245,240,230,0.40)` | Cream muted — slide numbers |
+| `rgba(245,240,230,0.18)` | Hairline cream — rare divider |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@1,600;1,700;1,800&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+```
+
+- **Display:** `'Playfair Display', Georgia, 'Times New Roman', serif` (always italic)
+- **Body:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Style | Line-height | Tracking |
+|------|------|------|--------|-------|-------------|----------|
+| Display Hero | Playfair Display | 72px | 700 | italic | 1.05 | -0.5px |
+| Display Large | Playfair Display | 60px | 700 | italic | 1.08 | -0.5px |
+| Section Heading | Playfair Display | 48px | 700 | italic | 1.10 | -0.25px |
+| Sub-heading | Playfair Display | 36px | 600 | italic | 1.15 | 0 |
+| Body Large | Inter | 28px | 500 | normal | 1.30 | 0 |
+| Body | Inter | 22px | 500 | normal | 1.40 | 0 |
+| Body Small | Inter | 18px | 400 | normal | 1.50 | 0 |
+| Big Number | Playfair Display | 96px | 800 | italic | 1.00 | -1px |
+| Footer CTA | Inter | 22px | 600 | normal | 1.00 | 0.2px |
+| Small Caps Label | Inter | 13px | 600 | normal | 1.00 | 1.5px UPPER |
+
+**Principles**
+
+- Every Playfair Display use is italic — never upright.
+- Body is ALWAYS stacked 3 short declarative lines in white Inter 500.
+- One serif italic headline + one sans body stack + one object mask per slide.
+
+## Layout
+
+- Full-bleed royal navy `#112A70`.
+- Hero object: a photograph masked into an object silhouette using `clip-path`. Shapes: wine bottle, table lamp, perfume, plant, sculpture.
+- Italic cream headline centered or lower-left.
+- Body: 3 short stacked declarative lines in white Inter.
+- Full-width powder-blue footer band (32-48px tall) at bottom holding navy CTA label.
+
+## Do / Don't
+
+**Do**
+
+- CSS `clip-path` the photograph into a single object silhouette (bottle, lamp, plant).
+- Use italic Playfair Display for every display role.
+- Stack body copy on exactly 3 short declarative lines.
+- Use the powder-blue footer band as the signature closing element.
+- Use Inter uppercase tracked labels only for small metadata.
+
+**Don't**
+
+- Don't use upright Playfair — italic is mandatory.
+- Don't use colors outside the navy + cream + powder palette.
+- Don't center the masked object in every slide — offset it for visual rhythm.
+- Don't write body copy in more than 3 lines.
+- Don't replace the footer band with a button.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --c-navy: #112A70;
+  --c-cream: #F5F0E6;
+  --c-white: #FFFFFF;
+  --c-powder: #B8D4E8;
+  --c-cream-soft: rgba(245, 240, 230, 0.75);
+  --c-cream-muted: rgba(245, 240, 230, 0.40);
+
+  --font-display: 'Playfair Display', Georgia, 'Times New Roman', serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+}
+```
+
+### Bottle clip-path
+
+```css
+.mask-bottle {
+  clip-path: polygon(
+    40% 0%, 60% 0%,
+    60% 15%, 65% 20%, 65% 30%,
+    70% 35%, 70% 95%, 65% 100%,
+    35% 100%, 30% 95%, 30% 35%,
+    35% 30%, 35% 20%, 40% 15%
+  );
+}
+```
+
+### Full composition
+
+```html
+<div style="background:#112A70; min-height:960px; position:relative; display:flex; flex-direction:column;">
+
+  <div style="flex:1; display:grid; grid-template-columns:1fr 1fr; gap:40px; padding:80px 60px;">
+    <div>
+      <p style="font-family:'Inter',sans-serif; font-size:13px; font-weight:600; letter-spacing:1.5px; text-transform:uppercase; color:rgba(245,240,230,0.75); margin:0 0 24px;">NO. 04 · AUTUMN</p>
+      <h1 style="font-family:'Playfair Display',serif; font-style:italic; font-size:72px; font-weight:700; line-height:1.05; letter-spacing:-0.5px; color:#F5F0E6; margin:0 0 40px;">A quieter shape<br>for a louder<br>hour.</h1>
+      <p style="font-family:'Inter',sans-serif; font-size:28px; font-weight:500; line-height:1.30; color:#FFFFFF; margin:0;">One bottle.<br>One evening.<br>Half the noise.</p>
+    </div>
+
+    <div style="display:flex; align-items:center; justify-content:center;">
+      <div style="width:240px; height:440px; background-image:url('bottle-photo.jpg'); background-size:cover; clip-path:polygon(40% 0%, 60% 0%, 60% 15%, 65% 20%, 65% 30%, 70% 35%, 70% 95%, 65% 100%, 35% 100%, 30% 95%, 30% 35%, 35% 30%, 35% 20%, 40% 15%);"></div>
+    </div>
+  </div>
+
+  <div style="background:#B8D4E8; padding:16px 60px;">
+    <p style="font-family:'Inter',sans-serif; font-size:22px; font-weight:600; line-height:1.00; letter-spacing:0.2px; color:#112A70; margin:0; text-align:center;">Shop the autumn edit →</p>
+  </div>
+</div>
+```
+
+### Italic stat
+
+```html
+<div style="background:#112A70; padding:60px; text-align:center;">
+  <p style="font-family:'Playfair Display',serif; font-style:italic; font-size:96px; font-weight:800; line-height:1.00; letter-spacing:-1px; color:#F5F0E6; margin:0;">47%</p>
+  <p style="font-family:'Inter',sans-serif; font-size:13px; font-weight:600; letter-spacing:1.5px; text-transform:uppercase; color:rgba(245,240,230,0.75); margin:8px 0 0;">REORDER WITHIN THE FIRST MONTH</p>
+</div>
+```

--- a/skills/composites/goose-graphics/styles/matt-gray.md
+++ b/skills/composites/goose-graphics/styles/matt-gray.md
@@ -1,0 +1,160 @@
+# Matt Gray
+
+Founder-creator Instagram-carousel aesthetic: Playfair Display headlines on a light gray canvas, with key phrases set in *italic forest green* as the signature "hook word" treatment, and yellow-lime pill tags labeling steps and frameworks. Inter handles all body copy in bold 600-700 for a confident, direct voice. Light gray (`#ececec`) reads as premium paper, not clinical white.
+
+> Full prose reference: `styles/_full/matt-gray.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#ececec` | Background (primary canvas) |
+| `#1a1a1a` | Near-black primary text, dark pill CTA fill |
+| `#2d5a1e` | Forest green — italic headline emphasis, decorative dots |
+| `#1e4015` | Dark green hover/active state |
+| `#d4e8d0` | Light green subtle tint |
+| `#e5f59e` | Yellow-lime pill tags (steps, frameworks, categories) |
+| `rgba(255,255,255,0.3)` | Card surface |
+| `rgba(0,0,0,0.12)` | Card border |
+| `#4a4a4a` | Secondary text (subtitles, descriptions) |
+| `#777777` | Tertiary text (metadata, attributions) |
+| `rgba(0,0,0,0.25)` | Muted (slide numbers) |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400;1,500;1,600;1,700;1,800&family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+```
+
+- **Display:** `'Playfair Display', Georgia, 'Times New Roman', serif`
+- **Body:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Playfair Display | 72px | 700 | 1.10 | -1px |
+| Section Heading | Playfair Display | 48px | 700 | 1.15 | -0.5px |
+| Sub-heading | Playfair Display | 32px | 600 | 1.20 | 0 |
+| Body Large | Inter | 22px | 500 | 1.55 | 0 |
+| Body | Inter | 18px | 600 | 1.55 | 0 |
+| Big Number | Playfair Display | 64px | 800 | 1.00 | -0.5px |
+| Tag Label | Inter | 14px | 600 | 1.00 | 0 |
+| Framework Label | Inter | 14px | 500 | 1.00 | 2px UPPER |
+| CTA | Inter | 16px | 700 | 1.00 | 0.3px |
+
+**Principles**
+
+- The "italic green hook": in every headline, set the key 2-3 words in `font-style: italic; color: #2d5a1e`. This is the style's identity.
+- Inter at 600-700 for body, never under 500 — voice is direct, not airy.
+- Uppercase is reserved for small framework labels only.
+
+## Layout
+
+- Format padding: carousel 60px · infographic 60/80 · slides 80px · poster 60/80 · story 120/60 (safe zones 160px top/bottom).
+- Left-align content slides; center-align title and CTA slides.
+- Cards: 12px radius, 1px border `rgba(0,0,0,0.12)`, 28px internal padding, semi-transparent white bg.
+- Focus grid: one full-width card on top, two half-width cards below, sharing borders.
+- Dot-grid texture (`radial-gradient(circle, rgba(0,0,0,0.06) 1.5px, transparent 1.5px)` @ 32px) only on title + CTA slides.
+- Vertical rhythm: 40-48px between top-level sections; 12px between tag and body inside cards.
+- Never more than 3 cards per slide.
+
+## Do / Don't
+
+**Do**
+
+- Use italic forest green for the headline hook phrase — the single most important visual element.
+- Use yellow-lime pill tags for step numbers, category labels, framework markers.
+- Use dark pill CTA buttons (`#1a1a1a` bg, white text, 40px radius).
+- Include a bold one-line closing statement on content slides.
+- Apply the dot-grid texture sparingly (title + CTA only).
+
+**Don't**
+
+- Don't use green for anything except italic emphasis and small decorative dots.
+- Don't use body weights under 500 — this style speaks boldly.
+- Don't use serif for body text (Playfair is headlines only).
+- Don't use other accent colors (blue, red, orange) — only green + yellow-lime.
+- Don't center-align body on content slides.
+- Don't use sharp corners; 12px radius is mandatory on cards.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-bg: #ececec;
+  --color-near-black: #1a1a1a;
+  --color-green: #2d5a1e;
+  --color-yellow-tag: #e5f59e;
+  --color-card-white: rgba(255, 255, 255, 0.3);
+  --color-card-border: rgba(0, 0, 0, 0.12);
+  --color-secondary: #4a4a4a;
+  --color-tertiary: #777777;
+
+  --font-display: 'Playfair Display', Georgia, 'Times New Roman', serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --radius-card: 12px;
+  --radius-tag: 20px;
+  --radius-cta: 40px;
+
+  --dot-grid: radial-gradient(circle, rgba(0,0,0,0.06) 1.5px, transparent 1.5px);
+  --dot-grid-size: 32px 32px;
+}
+```
+
+### Title block (with dot grid + italic green hook)
+
+```html
+<div style="background:var(--color-bg); padding:80px 60px; text-align:center; position:relative;">
+  <div style="position:absolute; inset:0; background-image:var(--dot-grid); background-size:var(--dot-grid-size); pointer-events:none;"></div>
+  <div style="position:relative; z-index:1;">
+    <div style="display:inline-block; font-family:var(--font-body); font-size:14px; font-weight:500; letter-spacing:2px; text-transform:uppercase; border:1px solid rgba(0,0,0,0.12); padding:8px 24px; background:rgba(255,255,255,0.5); margin-bottom:48px;">FRAMEWORK</div>
+    <h1 style="font-family:var(--font-display); font-size:72px; font-weight:700; line-height:1.10; letter-spacing:-1px; color:var(--color-near-black); margin:0 0 32px;">
+      How to build<br>
+      <em style="color:var(--color-green);">a personal brand</em><br>
+      (in just 7 days)
+    </h1>
+    <p style="font-family:var(--font-body); font-size:22px; font-weight:500; line-height:1.55; color:var(--color-secondary); max-width:650px; margin:0 auto;">A step-by-step framework for founders who want to build in public.</p>
+  </div>
+</div>
+```
+
+### Numbered step with yellow pill tag
+
+```html
+<div style="padding:32px 0;">
+  <span style="display:inline-block; background:var(--color-yellow-tag); font-family:var(--font-body); font-size:14px; font-weight:600; padding:6px 16px; border-radius:var(--radius-tag); margin-bottom:12px;">Step 1</span>
+  <p style="font-family:var(--font-body); font-size:18px; font-weight:700; line-height:1.55; color:var(--color-near-black); margin:0;">
+    Build your personal brand.<br>
+    Attention is the new oil.<br>
+    Your personal brand is the pipeline.
+  </p>
+</div>
+```
+
+### Bordered card with tag
+
+```html
+<div style="border:1px solid var(--color-card-border); border-radius:var(--radius-card); padding:28px 24px; background:var(--color-card-white);">
+  <span style="display:inline-block; background:var(--color-yellow-tag); font-family:var(--font-body); font-size:14px; font-weight:600; padding:6px 16px; border-radius:var(--radius-tag); margin-bottom:12px;">1. Writing</span>
+  <p style="font-family:var(--font-body); font-size:18px; font-weight:600; line-height:1.55; margin:0;">It's your superpower. SEO is writing. Sales is writing. Hiring is writing.</p>
+</div>
+```
+
+### CTA block (dark pill button)
+
+```html
+<a style="display:inline-block; background:var(--color-near-black); color:#fff; font-family:var(--font-body); font-size:16px; font-weight:700; letter-spacing:0.3px; text-decoration:none; padding:20px 52px; border-radius:var(--radius-cta);">Get Started Free</a>
+```
+
+### Stat block (big number + yellow tag)
+
+```html
+<div style="text-align:center; padding:40px 24px; border:1px solid var(--color-card-border); border-radius:var(--radius-card); background:var(--color-card-white);">
+  <p style="font-family:var(--font-display); font-size:64px; font-weight:800; letter-spacing:-0.5px; color:var(--color-green); margin:0 0 8px;">47%</p>
+  <span style="display:inline-block; background:var(--color-yellow-tag); font-family:var(--font-body); font-size:14px; font-weight:600; padding:6px 16px; border-radius:var(--radius-tag);">FASTER RESPONSE</span>
+</div>
+```

--- a/skills/composites/goose-graphics/styles/midnight-editorial.md
+++ b/skills/composites/goose-graphics/styles/midnight-editorial.md
@@ -1,0 +1,161 @@
+# Midnight Editorial
+
+Luxury magazine aesthetic rendered in darkness. Near-black canvas with warm cream text and copper accents — reads like a foil-stamped spine or an invitation-only programme. Playfair Display headlines carry the authority of letterpress; Inter body text at light weights defers to the serif display.
+
+> Full prose reference: `styles/_full/midnight-editorial.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#0d0d0d` | Midnight background (primary canvas) |
+| `#f5f0e8` | Cream — primary text |
+| `#c17f59` | Copper — accent (numbering, rules, CTA) |
+| `#a89067` | Muted gold — secondary accent, captions |
+| `#9a6347` | Deep copper hover/active |
+| `#ede7db` | Warm white — high-emphasis text |
+| `#1a1a1a` | Charcoal — card/container surface |
+| `#141414` | Surface inset |
+| `#2a2a2a` | Dark gray — nested containers |
+| `#6b6b6b` | Soft gray — tertiary text |
+| `rgba(245,240,232,0.1)` | Whisper-thin border |
+| `rgba(193,127,89,0.3)` | Copper-tinted border (featured) |
+| `rgba(197,127,89,0.08)` | Warm shadow |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400;1,700&family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
+```
+
+- **Display:** `'Playfair Display', Georgia, 'Times New Roman', serif`
+- **Body:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Playfair Display | 72px | 700 | 1.05 | -1.5px |
+| Section Heading | Playfair Display | 48px | 700 | 1.10 | -1px |
+| Sub-heading | Playfair Display | 32px | 700 | 1.15 | -0.5px |
+| Body Large | Inter | 20px | 300 | 1.60 | 0 |
+| Body | Inter | 16px | 400 | 1.65 | 0 |
+| Caption | Inter | 13px | 400 | 1.50 | 0.3px |
+| Big Number | Playfair Display | 64px | 900 | 1.00 | -1px |
+| Numbered Label | Inter | 14px | 600 | 1.00 | 2px UPPER |
+| CTA | Inter | 15px | 600 | 1.00 | 0.8px UPPER |
+
+**Principles**
+
+- Light body (300-400), heavy display (700-900) — the weight contrast carries hierarchy.
+- Negative tracking on display (-1.5 to -0.5px); positive tracking on labels/CTAs (0.3-2px).
+- Body line-height 1.60-1.65 — generous reading rhythm on dark.
+- Uppercase only for numbered labels and CTA buttons.
+
+## Layout
+
+- Format padding: carousel 60px · infographic 60/80 · slides 80px · poster 60/80.
+- Left-align body content; center-align hero titles, stats, and CTAs.
+- Copper rules: 2px tall × 60px wide, centered, used as section dividers.
+- Cards: `#1a1a1a` bg, 4px radius, whisper-thin border, copper-tinted border for featured.
+- 48px gaps between top-level sections; 24px between items within a section.
+- Big serif numerals (`01`, `02`) in copper at 48px drive numbered lists.
+
+## Do / Don't
+
+**Do**
+
+- Let the darkness do the work — treat `#0d0d0d` as a stage, not a void.
+- Use copper (`#c17f59`) sparingly for focal points: CTA fill, numbers, rules, left-borders on quotes.
+- Pair a 60×2px copper bar above and below title-slide headlines as the signature ornament.
+- Use warm-tinted shadows (`rgba(197,127,89,0.08)`) to keep elevation on-palette.
+- Italic Playfair at 400 for pull quotes.
+
+**Don't**
+
+- Don't use pure black (`#000`) or pure white — both break the warm palette.
+- Don't use heavy Inter weights (600+) for body text — hierarchy depends on airy body against heavy serif.
+- Don't use cool-tinted shadows or blue accents.
+- Don't use decoration beyond the copper rules and accent borders.
+- Don't uppercase headlines.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-midnight: #0d0d0d;
+  --color-cream: #f5f0e8;
+  --color-copper: #c17f59;
+  --color-muted-gold: #a89067;
+  --color-deep-copper: #9a6347;
+  --color-charcoal: #1a1a1a;
+  --color-surface-inset: #141414;
+  --color-soft-gray: #6b6b6b;
+  --color-border-default: rgba(245, 240, 232, 0.1);
+  --color-border-accent: rgba(193, 127, 89, 0.3);
+  --color-border-strong: rgba(245, 240, 232, 0.2);
+  --shadow-warm: 0 8px 24px rgba(197, 127, 89, 0.08);
+
+  --font-display: 'Playfair Display', Georgia, 'Times New Roman', serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --radius-card: 4px;
+}
+```
+
+### Title block (with copper rules)
+
+```html
+<div style="background:var(--color-midnight); padding:80px 60px; text-align:center;">
+  <div style="width:60px; height:2px; background:var(--color-copper); margin:0 auto 32px;"></div>
+  <h1 style="font-family:var(--font-display); font-size:72px; font-weight:700; line-height:1.05; letter-spacing:-1.5px; color:var(--color-cream); margin:0 0 24px;">The Future of<br>Autonomous Work</h1>
+  <p style="font-family:var(--font-body); font-size:20px; font-weight:300; line-height:1.60; color:var(--color-muted-gold); max-width:600px; margin:0 auto;">How AI coworkers are reshaping how teams operate, collaborate, and deliver results.</p>
+  <div style="width:60px; height:2px; background:var(--color-copper); margin:40px auto 0;"></div>
+</div>
+```
+
+### Numbered item (big copper numeral)
+
+```html
+<div style="display:flex; gap:24px; align-items:flex-start; padding:32px 0; border-bottom:1px solid var(--color-border-default);">
+  <span style="font-family:var(--font-display); font-size:48px; font-weight:700; line-height:1.00; color:var(--color-copper); min-width:72px;">01</span>
+  <div>
+    <p style="font-family:var(--font-body); font-size:14px; font-weight:600; letter-spacing:2px; text-transform:uppercase; color:var(--color-muted-gold); margin:0 0 8px;">SIGNAL-BASED OUTBOUND</p>
+    <h3 style="font-family:var(--font-display); font-size:32px; font-weight:700; line-height:1.15; letter-spacing:-0.5px; color:var(--color-cream); margin:0 0 12px;">Find buyers before they find you</h3>
+    <p style="font-family:var(--font-body); font-size:16px; font-weight:400; line-height:1.65; color:var(--color-soft-gray); margin:0;">Monitor hiring signals, funding events, and tech-stack changes to identify high-intent prospects.</p>
+  </div>
+</div>
+```
+
+### Pull quote (copper left bar, italic serif)
+
+```html
+<div style="padding:48px 40px; border-left:2px solid var(--color-copper); background:var(--color-surface-inset);">
+  <p style="font-family:var(--font-display); font-size:32px; font-weight:400; font-style:italic; line-height:1.35; letter-spacing:-0.5px; color:var(--color-cream); margin:0 0 24px;">"It felt less like configuring software and more like onboarding a new team member."</p>
+  <div style="display:flex; align-items:center; gap:12px;">
+    <div style="width:32px; height:2px; background:var(--color-copper);"></div>
+    <p style="font-family:var(--font-body); font-size:14px; font-weight:600; letter-spacing:2px; text-transform:uppercase; color:var(--color-muted-gold); margin:0;">SARAH CHEN, VP OPERATIONS</p>
+  </div>
+</div>
+```
+
+### CTA block
+
+```html
+<div style="text-align:center; padding:60px 40px; background:var(--color-charcoal); border:1px solid var(--color-border-accent); border-radius:var(--radius-card);">
+  <h2 style="font-family:var(--font-display); font-size:40px; font-weight:700; line-height:1.10; letter-spacing:-0.75px; color:var(--color-cream); margin:0 0 16px;">Ready to meet your team?</h2>
+  <p style="font-family:var(--font-body); font-size:18px; font-weight:300; line-height:1.60; color:var(--color-soft-gray); max-width:480px; margin:0 auto 32px;">Deploy your first AI coworker in under five minutes.</p>
+  <a style="display:inline-block; background:var(--color-copper); color:var(--color-midnight); font-family:var(--font-body); font-size:15px; font-weight:600; letter-spacing:0.8px; text-transform:uppercase; text-decoration:none; padding:16px 40px; border-radius:var(--radius-card);">Get Started</a>
+</div>
+```
+
+### Stat display
+
+```html
+<div style="text-align:center; padding:40px 24px; background:var(--color-charcoal); border:1px solid var(--color-border-default); border-radius:var(--radius-card);">
+  <p style="font-family:var(--font-display); font-size:64px; font-weight:900; line-height:1.00; letter-spacing:-1px; color:var(--color-copper); margin:0 0 8px;">47%</p>
+  <p style="font-family:var(--font-body); font-size:14px; font-weight:600; letter-spacing:2px; text-transform:uppercase; color:var(--color-cream); margin:0;">FASTER RESPONSE</p>
+</div>
+```

--- a/skills/composites/goose-graphics/styles/mint-pixel-corporate.md
+++ b/skills/composites/goose-graphics/styles/mint-pixel-corporate.md
@@ -1,0 +1,157 @@
+# Mint Pixel Corporate
+
+Friendly corporate template with a forest-green cover and mint-cream content slides. Signature move: pixel-staircase corner decorations (4-6 lime-green blocks ascending diagonally) and a lime slab running behind the content headline. Inter-replacement Nunito handles every role. Canva-business-template energy, warmed up.
+
+> Full prose reference: `styles/_full/mint-pixel-corporate.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#207A3E` | Forest green — cover slide background |
+| `#EAF4C3` | Mint cream — content slide background |
+| `#1E6B3A` | Dark forest — primary text on mint, pixel accent |
+| `#A4D23C` | Lime green — headline slabs, pixel accent, accent squares |
+| `#B4DC48` | Lime light — secondary pixel squares, hover |
+| `#F5F8E6` | Cream — text on forest green cover |
+| `#3E8A4E` | Text secondary — metadata, captions |
+| `#6BA36B` | Text muted — tertiary |
+| `rgba(30,107,58,0.2)` | Border soft — header strip dividers |
+| `rgba(30,107,58,0.4)` | Border strong — prominent dividers |
+| `rgba(30,107,58,0.08)` | Shadow ambient |
+| `rgba(30,107,58,0.15)` | Shadow deep |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+```
+
+- **Display / Body:** `'Nunito', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Cover Hero | Nunito | 52px | 700 | 1.15 | -0.3px |
+| Section Heading | Nunito | 40px | 700 | 1.18 | -0.2px |
+| Sub-heading | Nunito | 28px | 700 | 1.25 | 0 |
+| Body Large | Nunito | 18px | 400 | 1.60 | 0 |
+| Body | Nunito | 16px | 400 | 1.65 | 0 |
+| Body Bold | Nunito | 16px | 700 | 1.65 | 0 |
+| Metadata | Nunito | 12px | 600 | 1.40 | 0.3px |
+| Footer Label | Nunito | 13px | 600 | 1.40 | 0.2px |
+| Caption | Nunito | 12px | 500 | 1.50 | 0 |
+| Big Number | Nunito | 64px | 800 | 1.00 | -0.5px |
+| CTA | Nunito | 14px | 700 | 1.00 | 0.3px |
+
+**Principles**
+
+- Rounded geometric Nunito carries the friendly-corporate identity.
+- Body always justified (`text-align: justify`) on content slides.
+- Cover uses forest green; content uses mint cream.
+
+## Layout
+
+- Cover slide: forest-green `#207A3E` background, cream text, pixel-staircase decoration in lime.
+- Content slide: mint-cream `#EAF4C3` background, dark-forest text, lime slab behind headline.
+- Pixel-staircase: 4-6 flat lime squares (48-64px each) ascending diagonally from a corner, offset by their side length.
+- Lime slab: horizontal rectangle `#A4D23C` running full width or 2/3, 80-120px tall, with the section heading set on top.
+- Header strip: metadata row (brand name · category · date) with soft dividers.
+- Footer: author name + handle.
+
+## Do / Don't
+
+**Do**
+
+- Use forest green for cover and mint cream for content — alternating creates the rhythm.
+- Add pixel-staircase decorations in lime at one corner of each slide (cover or content).
+- Run a lime slab behind the content headline for the template look.
+- Justify body copy on content slides.
+- Use Nunito 800 for big numbers — the rounded heavy face reads as friendly-authoritative.
+
+**Don't**
+
+- Don't use both pixel-staircase corners simultaneously on one slide — pick one.
+- Don't replace Nunito with another sans-serif — the roundness is the identity.
+- Don't use colors outside the green/mint/lime family.
+- Don't center-align body — justified or left-aligned only.
+- Don't skip the metadata header strip — it's part of the template.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --c-forest: #207A3E;
+  --c-forest-dark: #1E6B3A;
+  --c-mint: #EAF4C3;
+  --c-lime: #A4D23C;
+  --c-lime-light: #B4DC48;
+  --c-cream: #F5F8E6;
+  --c-text-2: #3E8A4E;
+  --c-text-3: #6BA36B;
+
+  --font: 'Nunito', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+}
+```
+
+### Pixel-staircase corner
+
+```html
+<div style="position:absolute; bottom:0; left:0; display:grid; grid-template-columns:repeat(6, 48px); grid-template-rows:repeat(6, 48px);">
+  <div style="grid-column:1; grid-row:6; background:#A4D23C;"></div>
+  <div style="grid-column:2; grid-row:6; background:#A4D23C;"></div>
+  <div style="grid-column:2; grid-row:5; background:#B4DC48;"></div>
+  <div style="grid-column:3; grid-row:5; background:#A4D23C;"></div>
+  <div style="grid-column:3; grid-row:4; background:#B4DC48;"></div>
+  <div style="grid-column:4; grid-row:4; background:#A4D23C;"></div>
+</div>
+```
+
+### Cover slide
+
+```html
+<div style="background:#207A3E; padding:60px; min-height:960px; position:relative;">
+  <p style="font-family:'Nunito',sans-serif; font-size:12px; font-weight:600; letter-spacing:0.3px; color:#F5F8E6; margin:0 0 60px;">Arowwai Industries · Business Tips · December, 2028</p>
+  <h1 style="font-family:'Nunito',sans-serif; font-size:52px; font-weight:700; line-height:1.15; letter-spacing:-0.3px; color:#F5F8E6; margin:0 0 24px; max-width:720px;">Small business marketing playbook for a quiet quarter.</h1>
+  <p style="font-family:'Nunito',sans-serif; font-size:18px; font-weight:400; line-height:1.60; color:#F5F8E6; max-width:520px; margin:0;">A 12-slide deck for founders, owner-operators, and solo marketers who want momentum without a bigger budget.</p>
+
+  <div style="position:absolute; bottom:0; left:0; display:grid; grid-template-columns:repeat(5, 56px); grid-template-rows:repeat(5, 56px);">
+    <div style="grid-column:1; grid-row:5; background:#A4D23C;"></div>
+    <div style="grid-column:2; grid-row:5; background:#A4D23C;"></div>
+    <div style="grid-column:2; grid-row:4; background:#B4DC48;"></div>
+    <div style="grid-column:3; grid-row:4; background:#A4D23C;"></div>
+    <div style="grid-column:3; grid-row:3; background:#B4DC48;"></div>
+  </div>
+</div>
+```
+
+### Content slide with lime slab
+
+```html
+<div style="background:#EAF4C3; padding:60px; min-height:960px; position:relative;">
+  <div style="display:flex; justify-content:space-between; border-bottom:1px solid rgba(30,107,58,0.2); padding-bottom:12px; margin-bottom:40px;">
+    <p style="font-family:'Nunito',sans-serif; font-size:12px; font-weight:600; letter-spacing:0.3px; color:#3E8A4E; margin:0;">Arowwai Industries</p>
+    <p style="font-family:'Nunito',sans-serif; font-size:12px; font-weight:600; letter-spacing:0.3px; color:#3E8A4E; margin:0;">Business Tips · 03/12</p>
+  </div>
+
+  <div style="background:#A4D23C; padding:20px 24px; display:inline-block; margin-bottom:32px;">
+    <h2 style="font-family:'Nunito',sans-serif; font-size:40px; font-weight:700; line-height:1.18; letter-spacing:-0.2px; color:#1E6B3A; margin:0;">Start with one customer conversation a week.</h2>
+  </div>
+
+  <p style="font-family:'Nunito',sans-serif; font-size:16px; font-weight:400; line-height:1.65; color:#1E6B3A; text-align:justify; max-width:720px; margin:0 0 40px;">Most small-business marketing fails not from bad ideas but from untested ones. A weekly fifteen-minute customer call compounds faster than any ad spend — you'll know what people actually want by the end of the quarter, and half your campaign copy will write itself.</p>
+
+  <p style="font-family:'Nunito',sans-serif; font-size:13px; font-weight:600; letter-spacing:0.2px; color:#3E8A4E; margin:0;">Olivia Wilson · @oliviaw</p>
+</div>
+```
+
+### Big number card
+
+```html
+<div style="background:#EAF4C3; border:1px solid rgba(30,107,58,0.2); padding:24px;">
+  <p style="font-family:'Nunito',sans-serif; font-size:64px; font-weight:800; line-height:1.00; letter-spacing:-0.5px; color:#1E6B3A; margin:0;">47%</p>
+  <p style="font-family:'Nunito',sans-serif; font-size:14px; font-weight:700; letter-spacing:0.3px; color:#3E8A4E; margin:4px 0 0;">FASTER RESPONSE</p>
+</div>
+```

--- a/skills/composites/goose-graphics/styles/paper-and-ink.md
+++ b/skills/composites/goose-graphics/styles/paper-and-ink.md
@@ -1,0 +1,135 @@
+# Paper & Ink
+
+Classic editorial print aesthetic. Cormorant Garamond display with Lora body on warm cream paper, deep red (`#c41e3a`) as the singular accent — drop caps, hairline rules, pull quotes, pagination. Reads like a Penguin paperback or an old-world newspaper spread.
+
+> Full prose reference: `styles/_full/paper-and-ink.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#faf8f5` | Paper background |
+| `#000000` | Ink — primary text |
+| `#c41e3a` | Deep red — accent (drop caps, rules, CTAs) |
+| `#9e1830` | Dark red — hover/active |
+| `#1a1a18` | Near-black — secondary headlines |
+| `#6b6560` | Warm gray — secondary text, captions |
+| `#9a9590` | Medium gray — placeholder |
+| `#c8c4c0` | Light gray — hairline rules |
+| `#e8e5e0` | Pale gray — faint dividers |
+| `#f4f1ec` | Off-white — alternate surface |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500&display=swap" rel="stylesheet">
+```
+
+- **Display:** `'Cormorant Garamond', Garamond, 'Times New Roman', serif`
+- **Body:** `'Lora', Georgia, 'Times New Roman', serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Cormorant Garamond | 72px | 700 | 1.05 | -1px |
+| Section Heading | Cormorant Garamond | 48px | 700 | 1.10 | -0.5px |
+| Sub-heading | Cormorant Garamond | 32px | 600 | 1.20 | 0 |
+| Body Large | Lora | 20px | 400 | 1.70 | 0 |
+| Body | Lora | 16px | 400 | 1.75 | 0.1px |
+| Caption | Lora | 13px | 400 | 1.50 | 0.3px |
+| Big Number | Cormorant Garamond | 72px | 700 | 1.00 | -1px |
+| Pull Quote | Cormorant Garamond | 36px | 400 italic | 1.35 | 0 |
+| Drop Cap | Cormorant Garamond | 80px | 700 | 0.85 | 0 |
+| Byline Label | Lora | 12px | 600 | 1.00 | 1.5px UPPER |
+| CTA | Lora | 15px | 600 | 1.00 | 0.5px |
+
+**Principles**
+
+- Serif display + serif body — the entire reading experience is serifed.
+- Italic Cormorant for pull quotes at weight 400.
+- Drop caps in deep red on opening paragraphs.
+- Generous body line-height (1.70-1.75) for unhurried print rhythm.
+
+## Layout
+
+- Format padding: carousel 60px · infographic 60/80 · slides 80px · poster 60/80.
+- Hairline rules: `1px solid #c8c4c0` for column dividers; 2px `#c41e3a` for hero section divider.
+- Cards: `#f4f1ec` alt surface, 2px radius. Classic, not modern.
+- Two-column body text where space allows (widescreen + infographic).
+- Pagination mark (small red circle + number) top-right of each major slide.
+
+## Do / Don't
+
+**Do**
+
+- Use deep red (`#c41e3a`) sparingly: drop caps, pagination marks, hairline rules, pull-quote marks.
+- Apply CSS `::first-letter` drop caps on opening body paragraphs in red.
+- Set pull quotes in italic Cormorant Garamond at 36px with big red quote marks.
+- Use byline labels (`BY SARAH CHEN`) in uppercase tracked Lora 600.
+- Use hairline light-gray rules (`#c8c4c0`) as column dividers.
+
+**Don't**
+
+- Don't use sans-serif anywhere.
+- Don't use bright or saturated accents — deep red only.
+- Don't use modern radii (> 4px). Print is squared.
+- Don't use drop shadows. Elevation is through rule and margin only.
+- Don't use decorative illustrations. Typography and rules are the entire ornament.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-paper: #faf8f5;
+  --color-ink: #000000;
+  --color-red: #c41e3a;
+  --color-red-dark: #9e1830;
+  --color-near-black: #1a1a18;
+  --color-warm-gray: #6b6560;
+  --color-hairline: #c8c4c0;
+  --color-alt-surface: #f4f1ec;
+
+  --font-display: 'Cormorant Garamond', Garamond, 'Times New Roman', serif;
+  --font-body: 'Lora', Georgia, 'Times New Roman', serif;
+
+  --radius-card: 2px;
+}
+```
+
+### Title block (with hairline rules)
+
+```html
+<div style="background:#faf8f5; padding:80px 60px; text-align:center;">
+  <p style="font-family:'Lora',serif; font-size:12px; font-weight:600; letter-spacing:1.5px; text-transform:uppercase; color:#c41e3a; margin:0 0 24px;">FEATURE · VOL. IV</p>
+  <h1 style="font-family:'Cormorant Garamond',serif; font-size:72px; font-weight:700; line-height:1.05; letter-spacing:-1px; color:#000; margin:0 0 24px;">The Future of<br>Autonomous Work</h1>
+  <div style="width:60px; height:2px; background:#c41e3a; margin:32px auto;"></div>
+  <p style="font-family:'Lora',serif; font-size:20px; font-weight:400; font-style:italic; line-height:1.70; color:#6b6560; max-width:560px; margin:0 auto;">How AI coworkers are reshaping how teams operate, collaborate, and deliver results.</p>
+</div>
+```
+
+### Body paragraph with drop cap
+
+```html
+<p style="font-family:'Lora',serif; font-size:16px; font-weight:400; line-height:1.75; color:#000; margin:0 0 20px;">
+  <span style="float:left; font-family:'Cormorant Garamond',serif; font-size:80px; font-weight:700; line-height:0.85; color:#c41e3a; padding-right:8px; padding-top:6px;">I</span>
+  n a world where every team is measured by the speed of its feedback loop, the question is no longer whether to adopt AI — it is how quickly you can wire it into the workflow.
+</p>
+```
+
+### Pull quote (italic serif, red left rule)
+
+```html
+<div style="padding:32px 40px; border-left:3px solid #c41e3a;">
+  <p style="font-family:'Cormorant Garamond',serif; font-size:36px; font-weight:400; font-style:italic; line-height:1.35; color:#000; margin:0 0 20px;">"It felt less like configuring software and more like onboarding a new team member."</p>
+  <p style="font-family:'Lora',serif; font-size:12px; font-weight:600; letter-spacing:1.5px; text-transform:uppercase; color:#6b6560; margin:0;">— SARAH CHEN, VP OPERATIONS</p>
+</div>
+```
+
+### CTA (solid red pill)
+
+```html
+<a style="display:inline-block; background:#c41e3a; color:#faf8f5; font-family:'Lora',serif; font-size:15px; font-weight:600; letter-spacing:0.5px; text-decoration:none; padding:14px 36px; border-radius:2px;">Read the essay</a>
+```

--- a/skills/composites/goose-graphics/styles/pastel-organic-shapes.md
+++ b/skills/composites/goose-graphics/styles/pastel-organic-shapes.md
@@ -1,0 +1,132 @@
+# Pastel Organic Shapes
+
+Quiet wellness feel. Warm cream canvas with a large pistachio-green circle half off-frame as the signature decorative anchor, and a lighter cream oval at center holding ALL-CAPS Playfair Display headlines at tight tracking. Inter in tracked uppercase for metadata. Minimal, airy, yoga-studio-brochure calm.
+
+> Full prose reference: `styles/_full/pastel-organic-shapes.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#F5F1E6` | Warm cream — primary background |
+| `#FAF7EC` | Lighter cream — inner cream oval container |
+| `#DCEAB4` | Pale pistachio — signature off-frame circle |
+| `#C9DDA0` | Deeper pistachio — hover/active |
+| `#BFD390` | Pistachio outline — optional thin frame |
+| `#1A1A1A` | Near-black — primary text, arrow icon |
+| `#4A4A4A` | Secondary text — body copy |
+| `#5C5C5C` | Metadata — tracked labels |
+| `rgba(26,26,26,0.5)` | Muted text — slide numbers |
+| `rgba(26,26,26,0.4)` | Thin border — arrow container outline |
+| `rgba(26,26,26,0.35)` | Outline thin — optional frame outline |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;500&family=Inter:wght@400;500&display=swap" rel="stylesheet">
+```
+
+- **Display:** `'Playfair Display', Georgia, 'Times New Roman', serif`
+- **Body / Metadata:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking | Case |
+|------|------|------|--------|-------------|----------|------|
+| Display Hero | Playfair Display | 56px | 400 | 1.18 | 2px | UPPER |
+| Section Heading | Playfair Display | 40px | 400 | 1.20 | 1.5px | UPPER |
+| Sub-heading | Playfair Display | 28px | 400 | 1.25 | 1px | UPPER |
+| Inner Headline | Playfair Display | 20px | 500 | 1.30 | 0.5px | UPPER |
+| Body Large | Inter | 16px | 400 | 1.65 | 0.3px | normal |
+| Body | Inter | 13px | 400 | 1.65 | 0.5px | UPPER |
+| Metadata | Inter | 12px | 500 | 1.40 | 1.5px | UPPER |
+| Caption | Inter | 11px | 500 | 1.40 | 1px | UPPER |
+| Big Number | Playfair Display | 72px | 400 | 1.00 | 1px | — |
+
+**Principles**
+
+- Playfair Display in ALL CAPS with positive tracking (1-2px) — signature move.
+- Sparse body copy; composition is the communication.
+- Inter 1-1.5px tracked UPPER for all metadata (`@handle`, "STUDIO NAME").
+
+## Layout
+
+- Full-bleed warm cream `#F5F1E6` background.
+- One large pistachio circle (600-900px) positioned half off-frame (bottom-left, right edge, etc.) — crops dramatically.
+- Inner cream oval container (`#FAF7EC`) at center of composition, 60-70% frame width.
+- Arrow icon in thin-bordered circle for navigation markers.
+- Metadata row at bottom: `@handle · STUDIO NAME · 01/05`.
+
+## Do / Don't
+
+**Do**
+
+- Position one pistachio circle half off-frame as the compositional anchor.
+- Use Playfair Display ALL CAPS with 1-2px tracking for every heading.
+- Use a cream oval `#FAF7EC` as the inner content container.
+- Keep body copy sparse — 1-2 lines maximum inside the oval.
+- Use Inter 1.5px tracked UPPER for handles and metadata.
+
+**Don't**
+
+- Don't use heavy Playfair weights — 400-500 only.
+- Don't center the pistachio circle — it must be partially off-frame.
+- Don't use sentence case on display headings — UPPERCASE mandatory.
+- Don't use multiple accent colors — pistachio green only.
+- Don't fill the canvas with text — whitespace is the mood.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-cream: #F5F1E6;
+  --color-cream-inner: #FAF7EC;
+  --color-pistachio: #DCEAB4;
+  --color-pistachio-deep: #C9DDA0;
+  --color-ink: #1A1A1A;
+  --color-text-2: #4A4A4A;
+  --color-text-meta: #5C5C5C;
+
+  --font-display: 'Playfair Display', Georgia, 'Times New Roman', serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+}
+```
+
+### Composition with off-frame circle
+
+```html
+<div style="background:#F5F1E6; padding:60px; min-height:960px; position:relative; overflow:hidden;">
+  <div style="position:absolute; bottom:-280px; left:-200px; width:720px; height:720px; border-radius:50%; background:#DCEAB4;"></div>
+
+  <div style="position:relative; z-index:1; max-width:720px; margin:120px auto 0; background:#FAF7EC; border-radius:280px; padding:80px 60px; text-align:center;">
+    <h1 style="font-family:'Playfair Display',serif; font-size:56px; font-weight:400; line-height:1.18; letter-spacing:2px; text-transform:uppercase; color:#1A1A1A; margin:0 0 24px;">Soft Mornings.<br>Quiet Practice.</h1>
+    <p style="font-family:'Inter',sans-serif; font-size:13px; font-weight:400; line-height:1.65; letter-spacing:0.5px; text-transform:uppercase; color:#4A4A4A; max-width:420px; margin:0 auto;">A five-week sequence for teams that want to slow down before they scale up.</p>
+  </div>
+
+  <div style="position:absolute; bottom:40px; left:0; right:0; display:flex; justify-content:space-between; padding:0 60px; font-family:'Inter',sans-serif; font-size:12px; font-weight:500; letter-spacing:1.5px; text-transform:uppercase; color:#5C5C5C;">
+    <span>@soft.practice</span>
+    <span>STUDIO ELM · 01/05</span>
+  </div>
+</div>
+```
+
+### Arrow button (thin circle)
+
+```html
+<div style="display:inline-flex; align-items:center; justify-content:center; width:48px; height:48px; border-radius:50%; border:1px solid rgba(26,26,26,0.4);">
+  <span style="font-size:20px; color:#1A1A1A;">→</span>
+</div>
+```
+
+### Inner small-circle variant
+
+```html
+<div style="background:#FAF7EC; width:320px; height:320px; border-radius:50%; border:1px solid rgba(26,26,26,0.35); display:flex; align-items:center; justify-content:center; text-align:center; padding:32px;">
+  <div>
+    <p style="font-family:'Playfair Display',serif; font-size:20px; font-weight:500; line-height:1.30; letter-spacing:0.5px; text-transform:uppercase; color:#1A1A1A; margin:0 0 12px;">Breathe First.</p>
+    <p style="font-family:'Inter',sans-serif; font-size:13px; font-weight:400; line-height:1.65; letter-spacing:0.5px; text-transform:uppercase; color:#4A4A4A; margin:0;">The work waits.</p>
+  </div>
+</div>
+```

--- a/skills/composites/goose-graphics/styles/peach-pop.md
+++ b/skills/composites/goose-graphics/styles/peach-pop.md
@@ -1,0 +1,139 @@
+# Peach Pop
+
+DTC beauty / wellness aesthetic. Peach canvas, cornflower-blue geometric blocks, monospaced Space Mono testimonials in ALL CAPS tracked. Every slide is a product card that could live on a modern skincare brand's homepage — warm, confident, approachable.
+
+> Full prose reference: `styles/_full/peach-pop.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#fce8d8` | Peach — primary background |
+| `#1a1a2e` | Dark navy — primary text |
+| `#3B9BFF` | Cornflower blue — accent (stars, blocks, CTAs) |
+| `#2878D0` | Deep blue — hover |
+| `#fdd9c4` | Light peach — subtle emphasis, borders |
+| `#8CC5FF` | Pale blue — secondary highlights |
+| `#fef4ec` | Cream — card surface, photo frames |
+| `#f8e4d2` | Surface inset |
+| `#f5d6c3` | Blush — nested containers |
+| `#e8c4ad` | Warm border |
+| `#b89a8a` | Dusty rose — disabled |
+| `#8a7668` | Warm gray — tertiary, attribution |
+| `#5c4a3e` | Cocoa — secondary body |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Space+Mono:wght@400;700&family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display / Monospace:** `'Space Mono', 'Courier New', Courier, monospace`
+- **Body:** `'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Space Mono | 56px | 700 | 1.10 | 2px UPPER |
+| Section Heading | Space Mono | 36px | 700 | 1.15 | 1.5px UPPER |
+| Testimonial Quote | Space Mono | 22px | 700 | 1.30 | 1px UPPER |
+| Sub-heading | DM Sans | 28px | 700 | 1.25 | -0.25px |
+| Body Large | DM Sans | 20px | 400 | 1.65 | 0 |
+| Body | DM Sans | 16px | 400 | 1.65 | 0.1px |
+| Attribution | DM Sans | 13px | 400 | 1.40 | 1.5px UPPER |
+| Caption | DM Sans | 12px | 400 | 1.50 | 0.3px |
+| Big Number | Space Mono | 64px | 700 | 1.00 | 0 |
+| CTA | DM Sans | 15px | 700 | 1.00 | 0.5px |
+
+**Principles**
+
+- Space Mono testimonials in ALL CAPS with 1-2px tracking — the signature move.
+- DM Sans for explanatory body in mixed case.
+- Hierarchy through size + tracking, not weight shifts (mono is always 700).
+
+## Layout
+
+- Background: flat peach `#fce8d8`.
+- Geometric blocks: solid `#3B9BFF` squares and rectangles as decorative framing.
+- Cards: cream `#fef4ec`, 2-6px radius, warm `#e8c4ad` border.
+- Photo frames: blush `#f5d6c3` border, 2-4px radius.
+- Blue star characters `★★★★★` in cornflower blue for ratings.
+- Left-align testimonials; center-align hero statements.
+
+## Do / Don't
+
+**Do**
+
+- Use Space Mono 700 ALL CAPS for all testimonial quotes.
+- Use cornflower blue geometric blocks/squares as decorative composition elements.
+- Use cream cards `#fef4ec` with warm borders against the peach ground.
+- Use blue star characters for ratings.
+- Use DM Sans mixed case for supporting body copy.
+
+**Don't**
+
+- Don't use peach for cards — cream (`#fef4ec`) is the card surface.
+- Don't use bright saturated colors beyond the blue accent.
+- Don't mix case on testimonial quotes — uppercase only.
+- Don't use curved organic shapes — straight geometric blocks only.
+- Don't use serif fonts.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-peach: #fce8d8;
+  --color-navy: #1a1a2e;
+  --color-blue: #3B9BFF;
+  --color-blue-deep: #2878D0;
+  --color-cream: #fef4ec;
+  --color-blush: #f5d6c3;
+  --color-border: #e8c4ad;
+  --color-cocoa: #5c4a3e;
+  --color-warm-gray: #8a7668;
+
+  --font-mono: 'Space Mono', 'Courier New', monospace;
+  --font-body: 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --radius-card: 4px;
+}
+```
+
+### Testimonial card
+
+```html
+<div style="background:#fef4ec; border:1px solid #e8c4ad; border-radius:4px; padding:32px;">
+  <p style="font-family:'DM Sans',sans-serif; font-size:20px; color:#3B9BFF; letter-spacing:2px; margin:0 0 16px;">★★★★★</p>
+  <p style="font-family:'Space Mono',monospace; font-size:22px; font-weight:700; line-height:1.30; letter-spacing:1px; text-transform:uppercase; color:#1a1a2e; margin:0 0 20px;">"THIS CHANGED THE WAY OUR TEAM WORKS. WE'RE NEVER GOING BACK."</p>
+  <p style="font-family:'DM Sans',sans-serif; font-size:13px; font-weight:400; letter-spacing:1.5px; text-transform:uppercase; color:#8a7668; margin:0;">— SARAH CHEN, VP OPERATIONS</p>
+</div>
+```
+
+### Hero with blue geometric block
+
+```html
+<div style="background:#fce8d8; padding:80px 60px; position:relative;">
+  <div style="position:absolute; top:60px; right:60px; width:160px; height:160px; background:#3B9BFF;"></div>
+  <p style="font-family:'DM Sans',sans-serif; font-size:13px; font-weight:400; letter-spacing:1.5px; text-transform:uppercase; color:#8a7668; margin:0 0 24px;">— TRUSTED BY FOUNDERS</p>
+  <h1 style="font-family:'Space Mono',monospace; font-size:56px; font-weight:700; line-height:1.10; letter-spacing:2px; text-transform:uppercase; color:#1a1a2e; margin:0 0 24px; max-width:640px;">"THE FUTURE OF AUTONOMOUS WORK."</h1>
+  <p style="font-family:'DM Sans',sans-serif; font-size:16px; font-weight:400; line-height:1.65; color:#5c4a3e; max-width:520px; margin:0;">Goose deploys AI coworkers that handle research, drafting, and follow-up — so your team can focus on decisions.</p>
+</div>
+```
+
+### Blue CTA
+
+```html
+<a style="display:inline-block; background:#3B9BFF; color:#fff; font-family:'DM Sans',sans-serif; font-size:15px; font-weight:700; letter-spacing:0.5px; text-decoration:none; padding:14px 32px; border-radius:4px;">Shop the routine</a>
+```
+
+### Stat with mono number
+
+```html
+<div style="text-align:center; padding:40px; background:#fef4ec; border:1px solid #e8c4ad;">
+  <p style="font-family:'Space Mono',monospace; font-size:64px; font-weight:700; color:#3B9BFF; margin:0 0 8px;">47%</p>
+  <p style="font-family:'DM Sans',sans-serif; font-size:13px; font-weight:400; letter-spacing:1.5px; text-transform:uppercase; color:#5c4a3e; margin:0;">FASTER RESPONSE</p>
+</div>
+```

--- a/skills/composites/goose-graphics/styles/product-minimal.md
+++ b/skills/composites/goose-graphics/styles/product-minimal.md
@@ -1,0 +1,129 @@
+# Product Minimal
+
+Apple-style product presentation. Pure white canvas, product photograph occupies the top ~60% of the frame with a subtle drop shadow, modest centered Inter headline + body beneath, and an underlined gray URL instead of a button CTA. The photograph is the hero; type is caption. No decoration, no color, no framing.
+
+> Full prose reference: `styles/_full/product-minimal.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#FFFFFF` | Pure white — primary background |
+| `#1A1A1A` | Near-black — primary headline, URL hover |
+| `#555555` | Body gray — paragraph color |
+| `#777777` | URL gray — underlined URL CTA |
+| `#999999` | Metadata gray — footer text |
+| `#CCCCCC` | Disabled gray |
+| `#FAFAFA` | Photo frame — barely-there photo container tint |
+| `rgba(0,0,0,0.08)` | Photo shadow, footer rule |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+```
+
+- **Display / Body:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Inter | 48px | 700 | 1.15 | -0.75px |
+| Headline | Inter | 36px | 700 | 1.20 | -0.5px |
+| Sub-heading | Inter | 24px | 700 | 1.25 | -0.25px |
+| Body Large | Inter | 20px | 400 | 1.55 | 0 |
+| Body | Inter | 18px | 400 | 1.55 | 0 |
+| Caption | Inter | 14px | 400 | 1.50 | 0.1px |
+| URL CTA | Inter | 16px | 500 | 1.00 | 0 |
+| Footer | Inter | 12px | 400 | 1.50 | 0.3px |
+| Big Number | Inter | 56px | 700 | 1.00 | -1px |
+
+**Principles**
+
+- Inter at 400, 500, 700 — three weights, one family.
+- Headlines are captions to the product photo, not competing statements — keep modest (36px).
+- Body at `#555555` (not near-black) so headline has visual primacy.
+
+## Layout
+
+- Pure white `#FFFFFF` background, no color.
+- Product photo: top 60% of frame, 60-80px padding on all sides, `object-fit: contain` (never crop).
+- Photo drop shadow: `filter: drop-shadow(0 24px 48px rgba(0,0,0,0.08))`.
+- Type block: centered beneath photo. Headline, 8-12px gap, body paragraph, 20px gap, underlined URL.
+- Underlined URL CTA: `#777777`, Inter 500, `text-decoration: underline; text-underline-offset: 4px`.
+- No buttons, no cards, no borders, no decoration anywhere.
+- Optional footer: 1px rule `rgba(0,0,0,0.08)` above footer text.
+
+## Do / Don't
+
+**Do**
+
+- Use pure white `#FFFFFF` as the background — genuinely pure, because the photo sets the temperature.
+- Apply `filter: drop-shadow(0 24px 48px rgba(0,0,0,0.08))` to every product photo.
+- Use underlined URLs as the CTA pattern — no filled buttons, ever.
+- Center-align the text block below the photo.
+- Keep headlines modest (36px) — they are captions, not heroes.
+- Use `#555555` for body (never near-black) so the headline stays primary.
+
+**Don't**
+
+- Don't use colored backgrounds — not warm white, not tinted anything.
+- Don't use filled button CTAs — underlined URL only.
+- Don't use more than 3 text colors (`#1A1A1A`, `#555555`, `#777777`).
+- Don't add any colored accents — no brand colors anywhere.
+- Don't add borders to content elements — no cards, no frames.
+- Don't use rounded corners — not on the photo, not on anything.
+- Don't decorate — no icons, emoji, illustrations, patterns.
+- Don't left-align — always centered below the photo.
+- Don't scale headlines above 48px — they are not hero type.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-bg: #FFFFFF;
+  --color-headline: #1A1A1A;
+  --color-body: #555555;
+  --color-url: #777777;
+  --color-metadata: #999999;
+
+  --font: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --shadow-photo: 0 24px 48px rgba(0, 0, 0, 0.08);
+}
+```
+
+### Product composition
+
+```html
+<div style="background:#fff; padding:60px 40px; min-height:960px; display:flex; flex-direction:column; align-items:center; justify-content:center;">
+  <div style="max-width:720px; width:100%; margin-bottom:60px;">
+    <img src="product.png" style="width:100%; height:auto; object-fit:contain; filter:drop-shadow(0 24px 48px rgba(0,0,0,0.08));" alt="Product">
+  </div>
+  <div style="text-align:center; max-width:560px;">
+    <h1 style="font-family:'Inter',sans-serif; font-size:36px; font-weight:700; line-height:1.20; letter-spacing:-0.5px; color:#1A1A1A; margin:0 0 16px;">The everyday carry, remade.</h1>
+    <p style="font-family:'Inter',sans-serif; font-size:18px; font-weight:400; line-height:1.55; color:#555555; margin:0 0 28px;">A single object that replaces the five things you never quite liked about the rest of them.</p>
+    <a style="font-family:'Inter',sans-serif; font-size:16px; font-weight:500; color:#777777; text-decoration:underline; text-underline-offset:4px;">buy at acme.com/carry</a>
+  </div>
+</div>
+```
+
+### Footer with hairline rule
+
+```html
+<div style="padding:24px 40px; border-top:1px solid rgba(0,0,0,0.08); text-align:center;">
+  <p style="font-family:'Inter',sans-serif; font-size:12px; font-weight:400; letter-spacing:0.3px; color:#999999; margin:0;">Photographed by Olivia Wilson · December 2026</p>
+</div>
+```
+
+### Stat variant (replaces product photo)
+
+```html
+<div style="background:#fff; padding:120px 40px; text-align:center;">
+  <p style="font-family:'Inter',sans-serif; font-size:56px; font-weight:700; line-height:1.00; letter-spacing:-1px; color:#1A1A1A; margin:0 0 16px;">47%</p>
+  <p style="font-family:'Inter',sans-serif; font-size:18px; font-weight:400; line-height:1.55; color:#555555; margin:0;">of customers reorder within the first month.</p>
+</div>
+```

--- a/skills/composites/goose-graphics/styles/retro-line-art.md
+++ b/skills/composites/goose-graphics/styles/retro-line-art.md
@@ -1,0 +1,135 @@
+# Retro Line Art
+
+Powder-blue canvas with cream hand-drawn cocktail-poster line art. Oversized Playfair 900 "PARTY" display word in cream, with an italic Cormorant Garamond "Cocktail" script overlapping slightly above. One letter of the display word gets a blue-shadow offset echo. Hand-drawn sparkles, cocktail glasses, and flourishes float as decorative accents.
+
+> Full prose reference: `styles/_full/retro-line-art.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#7BA3C6` | Powder blue — primary background canvas |
+| `#F5F0E6` | Cream — primary ink, all type, all line art |
+| `#5A84AA` | Blue shadow — offset echo on one display letter |
+| `#FAF5EB` | Cream glow — micro-highlights on sparkles |
+| `#6E9BC0` | Blue mid — alternate canvas for Story format |
+| `#3D5A75` | Ink dark — dense decorative grit only |
+| `rgba(245,240,230,0.80)` | Cream 80 — secondary metadata |
+| `rgba(245,240,230,0.60)` | Cream 60 — tertiary |
+| `rgba(245,240,230,0.40)` | Cream 40 — hairline dividers |
+| `rgba(245,240,230,0.35)` | Hairline cream border |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@1,500&family=Playfair+Display:wght@900&family=DM+Sans:wght@500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Script Display:** `'Cormorant Garamond', Garamond, serif` (italic, weight 500)
+- **Upright Display:** `'Playfair Display', Georgia, serif` (weight 900)
+- **Body / Metadata:** `'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Script Display | Cormorant Garamond Italic | 160px | 500 | 1.00 | -2px |
+| Upright Display | Playfair Display | 240px | 900 | 0.95 | -6px UPPER |
+| Section Heading | Playfair Display | 88px | 900 | 1.00 | -2px UPPER |
+| Sub-heading | Cormorant Garamond Italic | 56px | 500 | 1.10 | -0.5px |
+| Metadata Strip | DM Sans | 14px | 600 | 1.25 | 1.8px UPPER |
+| Metadata Bold | DM Sans | 16px | 700 | 1.20 | 1.5px UPPER |
+| Body | DM Sans | 18px | 500 | 1.55 | 0.3px |
+| Big Number | Playfair Display | 120px | 900 | 1.00 | -3px |
+| Caption | DM Sans | 12px | 500 | 1.30 | 1.5px UPPER |
+| CTA | DM Sans | 14px | 700 | 1.20 | 2px UPPER |
+
+**Principles**
+
+- Italic Cormorant Garamond script overlaps with upright Playfair display — the composed pair is the hero.
+- One letter of the Playfair display word gets a `#5A84AA` shadow offset to the bottom-right for the "echo" effect.
+- DM Sans 1.8px tracked UPPER is the only structural metadata voice.
+
+## Layout
+
+- Full-bleed powder blue `#7BA3C6` canvas.
+- Hand-drawn line art: cream SVG strokes at 2-3px weight — cocktail glasses, sparkles, flourishes, dashed borders.
+- Sparkles: 4-point star shapes, 8-24px, scattered around the composition.
+- Dashed borders for frames: `border: 2px dashed rgba(245,240,230,0.35)`.
+- Script sits above the display word, lower-right-overlapping the first letter.
+
+## Do / Don't
+
+**Do**
+
+- Pair italic Cormorant script + upright Playfair display as the signature composition.
+- Add hand-drawn SVG line-art elements (sparkles, glasses, dashed frames) in cream.
+- Use blue-shadow offset echo on one display letter.
+- Use DM Sans UPPER with 1.8-2.5px tracking for every metadata role.
+- Keep every ink in the cream family (no other colors for type).
+
+**Don't**
+
+- Don't use flat vector shapes — line art only, 2-3px stroke weight.
+- Don't use colors beyond powder blue, cream, and their shades.
+- Don't use sans-serif for display — Playfair 900 + Cormorant italic are mandatory.
+- Don't use mixed case on the display word — UPPERCASE.
+- Don't use heavy fills — everything is outlined.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-blue: #7BA3C6;
+  --color-cream: #F5F0E6;
+  --color-blue-shadow: #5A84AA;
+  --color-cream-80: rgba(245, 240, 230, 0.80);
+  --color-cream-60: rgba(245, 240, 230, 0.60);
+  --color-hairline: rgba(245, 240, 230, 0.35);
+
+  --font-script: 'Cormorant Garamond', Garamond, serif;
+  --font-upright: 'Playfair Display', Georgia, serif;
+  --font-body: 'DM Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+}
+```
+
+### Hero composition
+
+```html
+<div style="background:#7BA3C6; padding:60px; min-height:100vh; position:relative;">
+  <p style="font-family:'DM Sans',sans-serif; font-size:14px; font-weight:600; letter-spacing:1.8px; text-transform:uppercase; color:#F5F0E6; margin:0 0 40px;">— VOL. IV · SUMMER SERIES —</p>
+
+  <div style="position:relative;">
+    <span style="position:absolute; top:20px; right:120px; font-family:'Cormorant Garamond',serif; font-style:italic; font-size:160px; font-weight:500; line-height:1.00; letter-spacing:-2px; color:#F5F0E6; z-index:2;">Cocktail</span>
+    <h1 style="font-family:'Playfair Display',serif; font-size:240px; font-weight:900; line-height:0.95; letter-spacing:-6px; text-transform:uppercase; color:#F5F0E6; margin:0;">
+      P<span style="color:#5A84AA; position:relative; left:4px; top:4px;">A</span>RTY
+    </h1>
+  </div>
+
+  <svg width="48" height="48" viewBox="0 0 48 48" style="position:absolute; top:200px; right:120px;">
+    <path d="M24 4 L28 20 L44 24 L28 28 L24 44 L20 28 L4 24 L20 20 Z" stroke="#F5F0E6" stroke-width="2" fill="none"/>
+  </svg>
+
+  <div style="display:flex; justify-content:space-between; margin-top:80px; border-top:2px dashed rgba(245,240,230,0.35); padding-top:24px;">
+    <p style="font-family:'DM Sans',sans-serif; font-size:16px; font-weight:700; letter-spacing:1.5px; text-transform:uppercase; color:#F5F0E6; margin:0;">STARTING AT 08:00 PM</p>
+    <p style="font-family:'DM Sans',sans-serif; font-size:16px; font-weight:700; letter-spacing:1.5px; text-transform:uppercase; color:#F5F0E6; margin:0;">20 OCT · PALACE HALL</p>
+  </div>
+</div>
+```
+
+### Dashed frame card
+
+```html
+<div style="border:2px dashed rgba(245,240,230,0.35); padding:32px; background:transparent;">
+  <p style="font-family:'Cormorant Garamond',serif; font-style:italic; font-size:56px; font-weight:500; line-height:1.10; color:#F5F0E6; margin:0 0 16px;">the house rules</p>
+  <p style="font-family:'DM Sans',sans-serif; font-size:18px; font-weight:500; line-height:1.55; color:#F5F0E6; margin:0;">Leave your phone at the door. Trade stories. Dance badly. Laugh loud.</p>
+</div>
+```
+
+### CTA (underlined uppercase)
+
+```html
+<a style="display:inline-block; color:#F5F0E6; font-family:'DM Sans',sans-serif; font-size:14px; font-weight:700; letter-spacing:2px; text-transform:uppercase; text-decoration:underline; text-decoration-thickness:2px; text-underline-offset:6px;">— RSVP NOW —</a>
+```

--- a/skills/composites/goose-graphics/styles/social-post-card.md
+++ b/skills/composites/goose-graphics/styles/social-post-card.md
@@ -1,0 +1,139 @@
+# Social Post Card
+
+Blurred real-world scene as full-bleed backdrop; a simulated Instagram post card occupies the hero. Inside the card: profile header (avatar + username), square photo, action icons (heart, comment, share), caption text with a red heart accent. The illusion is that someone shared a moment on Instagram and you're looking at the screenshot.
+
+> Full prose reference: `styles/_full/social-post-card.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#ffffff` | Card white — post card surface |
+| `#111111` | Near-black — primary text inside card |
+| `#262626` | Icon gray — action icon strokes |
+| `#8e8e8e` | Timestamp gray — meta text |
+| `#ed4956` | Instagram red — active heart |
+| `#00376b` | Link blue — caption mentions and links |
+| `#eeeae5` | Scene backdrop — fallback solid if photo fails |
+| `#efefef` | Divider gray — hairline separators |
+| `#f2f2f2` | Surface photo — inner photo bg |
+| `#555555` | Secondary text — sub-username |
+| `#c7c7c7` | Disabled |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display / Body:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Inter | 48px | 700 | 1.15 | -0.5px |
+| Section Heading | Inter | 32px | 700 | 1.20 | -0.3px |
+| Username | Inter | 15px | 600 | 1.20 | -0.1px |
+| Sub-username | Inter | 12px | 500 | 1.30 | 0 |
+| Caption Body | Inter | 16px | 400 | 1.45 | 0 |
+| Caption Bold | Inter | 16px | 600 | 1.45 | 0 |
+| Action Count | Inter | 14px | 600 | 1.20 | 0 |
+| Timestamp | Inter | 11px | 500 | 1.00 | 0.4px UPPER |
+| CTA | Inter | 15px | 600 | 1.00 | 0 |
+
+**Principles**
+
+- The IG card is a near-pixel-perfect recreation — username bold, 1px divider between header and photo, action row below photo.
+- Caption body is Inter 400 left-aligned with inline `@mentions` and `#hashtags` in link-blue (`#00376b`).
+- Optional poster headline lives ABOVE or BELOW the card — never inside it.
+
+## Layout
+
+- Full-bleed backdrop: blurred real-world photo (café, city, garden) with 30-50px Gaussian blur, or fallback solid `#eeeae5`.
+- Card width: 480-560px, centered. Drop shadow `0 24px 48px rgba(0,0,0,0.16)`, radius 0-4px (IG is sharp).
+- Card header: 14-16px padding, avatar circle (32-40px) left, username bold next to it, `⋯` right.
+- Photo: 1:1 aspect, fills card width, hairline `#efefef` divider above and below.
+- Action row: heart + comment + share icons in `#262626`, save icon right-aligned.
+- Caption below action row: username bold + caption body.
+- Timestamp at bottom: uppercase tracked gray.
+
+## Do / Don't
+
+**Do**
+
+- Blur the backdrop heavily (30-50px) so the card stays primary.
+- Use the exact Instagram red `#ed4956` for the active heart icon.
+- Include all IG UI affordances (header, divider, action row, caption, timestamp).
+- Use link-blue `#00376b` for `@mentions` and `#hashtags` in the caption.
+- Use a 1px `#efefef` divider between sections of the card.
+
+**Don't**
+
+- Don't use radius > 4px on the card — IG is sharp-cornered.
+- Don't place headline copy INSIDE the card — external headlines only.
+- Don't color the backdrop — a blurred photo or `#eeeae5` solid fallback only.
+- Don't fake the username — use realistic handles like `@oliviawilson`.
+- Don't skip the timestamp — it's part of the authenticity.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --c-card: #ffffff;
+  --c-text: #111111;
+  --c-icon: #262626;
+  --c-timestamp: #8e8e8e;
+  --c-heart: #ed4956;
+  --c-link: #00376b;
+  --c-backdrop: #eeeae5;
+  --c-divider: #efefef;
+  --c-photo-bg: #f2f2f2;
+
+  --font: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --shadow-card: 0 24px 48px rgba(0, 0, 0, 0.16);
+}
+```
+
+### Full composition
+
+```html
+<div style="position:relative; min-height:1080px; overflow:hidden; background:#eeeae5;">
+  <div style="position:absolute; inset:-40px; background-image:url('scene.jpg'); background-size:cover; background-position:center; filter:blur(40px); transform:scale(1.1); z-index:0;"></div>
+
+  <div style="position:relative; z-index:1; display:flex; align-items:center; justify-content:center; min-height:1080px; padding:60px;">
+    <div style="width:520px; background:#ffffff; box-shadow:0 24px 48px rgba(0,0,0,0.16);">
+
+      <div style="display:flex; align-items:center; padding:14px 16px; gap:12px;">
+        <div style="width:36px; height:36px; border-radius:50%; background:#f2f2f2;"></div>
+        <div style="flex:1;">
+          <p style="font-family:'Inter',sans-serif; font-size:15px; font-weight:600; letter-spacing:-0.1px; color:#111; margin:0;">oliviawilson</p>
+          <p style="font-family:'Inter',sans-serif; font-size:12px; font-weight:500; color:#555; margin:0;">Brooklyn, New York</p>
+        </div>
+        <span style="font-size:20px; color:#262626;">⋯</span>
+      </div>
+
+      <div style="width:100%; aspect-ratio:1; background:#f2f2f2; background-image:url('post.jpg'); background-size:cover; background-position:center;"></div>
+
+      <div style="display:flex; align-items:center; padding:12px 16px; gap:16px;">
+        <span style="font-size:24px; color:#ed4956;">♥</span>
+        <span style="font-size:22px; color:#262626;">💬</span>
+        <span style="font-size:22px; color:#262626;">↪</span>
+        <span style="font-size:22px; color:#262626; margin-left:auto;">⌂</span>
+      </div>
+
+      <div style="padding:0 16px 12px;">
+        <p style="font-family:'Inter',sans-serif; font-size:14px; font-weight:600; color:#111; margin:0 0 8px;">1,248 likes</p>
+        <p style="font-family:'Inter',sans-serif; font-size:16px; font-weight:400; line-height:1.45; color:#111; margin:0 0 4px;">
+          <span style="font-weight:600;">oliviawilson</span> The morning after we shipped v1.0. Six months of quiet work, one afternoon of everything clicking. <span style="color:#00376b;">@teamsignal</span> <span style="color:#00376b;">#launched</span>
+        </p>
+        <p style="font-family:'Inter',sans-serif; font-size:11px; font-weight:500; letter-spacing:0.4px; text-transform:uppercase; color:#8e8e8e; margin:8px 0 0;">2 HOURS AGO</p>
+      </div>
+
+    </div>
+  </div>
+</div>
+```

--- a/skills/composites/goose-graphics/styles/soft-cloud.md
+++ b/skills/composites/goose-graphics/styles/soft-cloud.md
@@ -1,0 +1,139 @@
+# Soft Cloud
+
+Airy, approachable SaaS. Pastel lavender-to-mint gradient background, white cards with generous rounded corners, purple + mint dual-accent system. Plus Jakarta Sans carries all type. The mood is a modern wellness app landing page or a friendly-but-serious B2B product.
+
+> Full prose reference: `styles/_full/soft-cloud.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#e8e0f0` | Lavender — gradient start |
+| `#d8f0e8` | Mint — gradient end |
+| `#ffffff` | White — card surface |
+| `#2d2d3d` | Dark charcoal — primary text |
+| `#8b6cc7` | Soft purple — accent (buttons, stats, focal) |
+| `#5cb8a5` | Mint — secondary accent (success, tags) |
+| `#6b4fa7` | Deep purple — hover |
+| `#a78fd4` | Light purple — badge backgrounds |
+| `#d0f0e4` | Light mint — success bg |
+| `#4a4a5a` | Charcoal — secondary text |
+| `#6b6b7a` | Warm gray — tertiary text |
+| `#9a9aaa` | Medium gray — placeholder |
+| `#c8c8d4` | Light gray — borders |
+| `#f0eef4` | Pale gray — hover surface |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
+```
+
+- **Display / Body:** `'Plus Jakarta Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Plus Jakarta Sans | 64px | 700 | 1.10 | -1px |
+| Section Heading | Plus Jakarta Sans | 40px | 700 | 1.15 | -0.5px |
+| Sub-heading | Plus Jakarta Sans | 28px | 600 | 1.20 | -0.25px |
+| Body Large | Plus Jakarta Sans | 20px | 500 | 1.60 | 0 |
+| Body | Plus Jakarta Sans | 16px | 400 | 1.65 | 0 |
+| Caption | Plus Jakarta Sans | 13px | 500 | 1.50 | 0.2px |
+| Big Number | Plus Jakarta Sans | 56px | 700 | 1.00 | -0.5px |
+| Label | Plus Jakarta Sans | 13px | 600 | 1.00 | 0.5px UPPER |
+| CTA | Plus Jakarta Sans | 15px | 600 | 1.00 | 0.3px |
+
+**Principles**
+
+- Medium body weights (400-500) — avoid 300, feels too thin for the friendly voice.
+- Hierarchy via size + weight; never switch families.
+- Warm, approachable — open counters, friendly curves.
+
+## Layout
+
+- Format padding: carousel 60px · infographic 60/80 · slides 80px · poster 60/80.
+- Background: `linear-gradient(135deg, #e8e0f0 0%, #d8f0e8 100%)` — never flat.
+- Cards: white `#ffffff`, 16-20px radius, soft shadow `0 8px 24px rgba(45,45,61,0.06)`.
+- Generous internal padding (32-40px) and whitespace.
+- Purple for primary CTAs and stats; mint for tags, success states, tertiary buttons.
+
+## Do / Don't
+
+**Do**
+
+- Use gradient background edge-to-edge.
+- Use large rounded corners (16-20px) on cards for a soft, bubbly feel.
+- Use purple (`#8b6cc7`) and mint (`#5cb8a5`) as the dual accent system.
+- Use soft diffuse shadows `0 8px 24px rgba(45,45,61,0.06)` for card elevation.
+- Use badge pills with `#a78fd4` light-purple backgrounds.
+
+**Don't**
+
+- Don't use dark backgrounds — the gradient is the identity.
+- Don't use sharp corners (radius < 8px).
+- Don't use heavy or harsh shadows — only soft diffuse elevation.
+- Don't use pure black for text — always `#2d2d3d` warm charcoal.
+- Don't use red, orange, or high-saturation accents.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-grad-start: #e8e0f0;
+  --color-grad-end: #d8f0e8;
+  --color-card: #ffffff;
+  --color-text: #2d2d3d;
+  --color-purple: #8b6cc7;
+  --color-purple-deep: #6b4fa7;
+  --color-purple-light: #a78fd4;
+  --color-mint: #5cb8a5;
+  --color-mint-light: #d0f0e4;
+  --color-gray-2: #4a4a5a;
+  --color-gray-3: #6b6b7a;
+  --color-border: #c8c8d4;
+
+  --font: 'Plus Jakarta Sans', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --radius-card: 20px;
+  --shadow-soft: 0 8px 24px rgba(45, 45, 61, 0.06);
+}
+```
+
+### Gradient title block
+
+```html
+<div style="background:linear-gradient(135deg,#e8e0f0 0%,#d8f0e8 100%); padding:80px 60px; text-align:center;">
+  <span style="display:inline-block; background:#a78fd4; color:#fff; font-family:'Plus Jakarta Sans',sans-serif; font-size:13px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; padding:6px 16px; border-radius:20px; margin-bottom:24px;">NEW</span>
+  <h1 style="font-family:'Plus Jakarta Sans',sans-serif; font-size:64px; font-weight:700; line-height:1.10; letter-spacing:-1px; color:#2d2d3d; margin:0 0 24px;">The Future of<br>Autonomous Work</h1>
+  <p style="font-family:'Plus Jakarta Sans',sans-serif; font-size:20px; font-weight:500; line-height:1.60; color:#4a4a5a; max-width:560px; margin:0 auto;">How AI coworkers are reshaping how teams operate.</p>
+</div>
+```
+
+### White card
+
+```html
+<div style="background:#fff; border-radius:20px; padding:32px; box-shadow:0 8px 24px rgba(45,45,61,0.06);">
+  <span style="display:inline-block; background:#d0f0e4; color:#5cb8a5; font-family:'Plus Jakarta Sans',sans-serif; font-size:13px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; padding:4px 12px; border-radius:12px; margin-bottom:16px;">LIVE</span>
+  <h3 style="font-family:'Plus Jakarta Sans',sans-serif; font-size:28px; font-weight:600; color:#2d2d3d; margin:0 0 12px;">Find buyers before they find you</h3>
+  <p style="font-family:'Plus Jakarta Sans',sans-serif; font-size:16px; font-weight:400; line-height:1.65; color:#6b6b7a; margin:0;">Monitor hiring signals, funding events, tech-stack changes.</p>
+</div>
+```
+
+### Purple CTA pill
+
+```html
+<a style="display:inline-block; background:#8b6cc7; color:#fff; font-family:'Plus Jakarta Sans',sans-serif; font-size:15px; font-weight:600; letter-spacing:0.3px; text-decoration:none; padding:16px 40px; border-radius:28px;">Start free</a>
+```
+
+### Stat (big purple number)
+
+```html
+<div style="text-align:center; padding:40px 24px; background:#fff; border-radius:20px; box-shadow:0 8px 24px rgba(45,45,61,0.06);">
+  <p style="font-family:'Plus Jakarta Sans',sans-serif; font-size:56px; font-weight:700; line-height:1.00; letter-spacing:-0.5px; color:#8b6cc7; margin:0 0 8px;">47%</p>
+  <p style="font-family:'Plus Jakarta Sans',sans-serif; font-size:13px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; color:#6b6b7a; margin:0;">FASTER RESPONSE</p>
+</div>
+```

--- a/skills/composites/goose-graphics/styles/split-yellow-product.md
+++ b/skills/composites/goose-graphics/styles/split-yellow-product.md
@@ -1,0 +1,134 @@
+# Split Yellow Product
+
+Two-thirds vivid-yellow headline slab on top, one-third warm-pale-gray body panel on bottom, with a yellow-gradient product photo panel on the side. Inter 900 at 92px stacked headlines; Inter 500 body for product descriptions. A stacked 2-line tracked wordmark anchors bottom-left. Premium packaging-brand poster.
+
+> Full prose reference: `styles/_full/split-yellow-product.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#f4d624` | Vivid yellow — primary surface, top block |
+| `#141414` | Near-black — all text, wordmark, CTA fill |
+| `#e8e5dd` | Warm pale gray — body copy panel (replaces white) |
+| `#e5c51a` | Dark mustard — top of product photo gradient |
+| `#b59a00` | Olive — bottom of product photo gradient |
+| `#e8c91a` | Yellow hover |
+| `#d9d6ce` | Gray deep — secondary surface |
+| `#3a3a38` | Secondary gray — metadata |
+| `rgba(20,20,20,0.12)` | Hairline border |
+| `rgba(20,20,20,0.55)` | Muted text |
+| `rgba(120,100,0,0.35)` | Product cast shadow |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;900&display=swap" rel="stylesheet">
+```
+
+- **Display / Body:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Inter | 92px | 900 | 0.95 | -2px |
+| Display Small | Inter | 72px | 900 | 0.98 | -1.5px |
+| Section Heading | Inter | 48px | 900 | 1.00 | -1px |
+| Sub-heading | Inter | 28px | 700 | 1.15 | -0.3px |
+| Body Large | Inter | 22px | 500 | 1.45 | 0 |
+| Body | Inter | 20px | 500 | 1.50 | 0 |
+| Body Bold | Inter | 20px | 700 | 1.50 | 0 |
+| Caption | Inter | 14px | 500 | 1.45 | 0.2px |
+| Big Number | Inter | 96px | 900 | 0.95 | -2.5px |
+| Wordmark | Inter | 14px | 700 | 1.10 | 2.5px UPPER |
+| CTA | Inter | 16px | 700 | 1.00 | 0.4px |
+
+**Principles**
+
+- 2/3 yellow + 1/3 pale gray layout ratio — the split is the identity.
+- Inter 900 headlines tightly tracked and crowding the yellow block.
+- Inter 500 default body weight for product copy.
+
+## Layout
+
+- Grid: top 2/3 of canvas = yellow `#f4d624` block holding display headline; bottom 1/3 = warm pale gray `#e8e5dd` holding body copy.
+- Side product panel (25-35% frame width on right) = yellow gradient `linear-gradient(180deg, #e5c51a, #b59a00)` with centered product photo and heavy cast shadow.
+- Wordmark stacked 2 lines, bottom-left, tracked UPPER.
+- Hairline dividers `1px rgba(20,20,20,0.12)` between split zones.
+
+## Do / Don't
+
+**Do**
+
+- Enforce the 2/3 yellow + 1/3 gray vertical split — the proportion matters.
+- Use a yellow-gradient product photo panel as the dedicated side column.
+- Stack the wordmark 2 lines with 2.5px tracking in the bottom-left.
+- Use Inter 500 for body (not 400) — keeps the voice confident.
+- Apply a product-cast shadow (`rgba(120,100,0,0.35)`) for depth under the product.
+
+**Don't**
+
+- Don't use white — warm pale gray `#e8e5dd` replaces white.
+- Don't use alternative accent colors — yellow is the only chromatic voice.
+- Don't let headlines spill into the gray body zone.
+- Don't use Inter weights between 500 and 900 for headlines.
+- Don't curve the product photo frame — straight edges only.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --c-yellow: #f4d624;
+  --c-yellow-dark: #e5c51a;
+  --c-olive: #b59a00;
+  --c-ink: #141414;
+  --c-gray: #e8e5dd;
+  --c-gray-deep: #d9d6ce;
+  --c-gray-text-2: #3a3a38;
+
+  --font: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --shadow-product: 0 24px 48px rgba(120, 100, 0, 0.35);
+}
+```
+
+### Full split composition
+
+```html
+<div style="display:grid; grid-template-columns:1fr 420px; grid-template-rows:640px 320px; min-height:960px;">
+
+  <div style="background:#f4d624; padding:60px; display:flex; flex-direction:column; justify-content:space-between;">
+    <p style="font-family:'Inter',sans-serif; font-size:14px; font-weight:700; letter-spacing:2.5px; text-transform:uppercase; color:#141414; margin:0;">THE PRESS KIT · 2026</p>
+    <h1 style="font-family:'Inter',sans-serif; font-size:92px; font-weight:900; line-height:0.95; letter-spacing:-2px; color:#141414; margin:0;">
+      Built<br>for the<br>everyday.
+    </h1>
+  </div>
+
+  <div style="background:linear-gradient(180deg,#e5c51a,#b59a00); grid-row:1 / 3; display:flex; align-items:center; justify-content:center; padding:60px;">
+    <img src="product.png" style="max-width:100%; height:auto; filter:drop-shadow(0 24px 48px rgba(120,100,0,0.35));" alt="Product">
+  </div>
+
+  <div style="background:#e8e5dd; padding:40px 60px; border-top:1px solid rgba(20,20,20,0.12);">
+    <p style="font-family:'Inter',sans-serif; font-size:20px; font-weight:500; line-height:1.50; color:#141414; margin:0 0 16px; max-width:560px;">A product catalog for the objects that belong in every room — quietly useful, honestly made, priced like you'd expect a well-made object to be priced.</p>
+    <p style="font-family:'Inter',sans-serif; font-size:14px; font-weight:700; letter-spacing:2.5px; text-transform:uppercase; color:#141414; margin:0;">STUDIO<br>WILSON</p>
+  </div>
+</div>
+```
+
+### Big number variant
+
+```html
+<div style="background:#f4d624; padding:60px;">
+  <p style="font-family:'Inter',sans-serif; font-size:96px; font-weight:900; line-height:0.95; letter-spacing:-2.5px; color:#141414; margin:0;">$42</p>
+  <p style="font-family:'Inter',sans-serif; font-size:22px; font-weight:500; line-height:1.45; color:#141414; margin:12px 0 0;">flat shipping on every order, every day of the year.</p>
+</div>
+```
+
+### CTA
+
+```html
+<a style="display:inline-block; background:#141414; color:#f4d624; font-family:'Inter',sans-serif; font-size:16px; font-weight:700; letter-spacing:0.4px; text-transform:uppercase; text-decoration:none; padding:14px 28px;">SHOP THE KIT →</a>
+```

--- a/skills/composites/goose-graphics/styles/sunburst-editorial.md
+++ b/skills/composites/goose-graphics/styles/sunburst-editorial.md
@@ -1,0 +1,151 @@
+# Sunburst Editorial
+
+Mid-century book cover feel. Cream canvas with DM Serif Display stacked two-line headlines, Lora serif body, and a signature sunburst collage block (mustard yellow + forest green hard-cornered shapes with radiating ink lines). The sunburst appears on alternating slides — rhythm of collage slide, no-collage slide. Editorial, restrained, long-form.
+
+> Full prose reference: `styles/_full/sunburst-editorial.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#FBFAF4` | Cream — primary background (every slide) |
+| `#1A1A1A` | Near-black — primary text, sunburst lines, markers |
+| `#C85A1F` | Rust orange — footer brand, URL, page numbers, stat accents |
+| `#D8AD38` | Mustard yellow — sunburst collage block only |
+| `#1E4A30` | Forest green — sunburst collage block only |
+| `#A54617` | Rust deep — hover/active |
+| `#F4F1E8` | Cream deep — inset panels |
+| `#3D3A36` | Secondary text |
+| `#6B6660` | Tertiary text — metadata |
+| `rgba(26,26,26,0.65)` | Pencil gray — thin outline of numbered marker |
+| `rgba(26,26,26,0.12)` | Hairline section divider |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Lora:ital,wght@0,400;0,500;1,400&display=swap" rel="stylesheet">
+```
+
+- **Display:** `'DM Serif Display', Georgia, 'Times New Roman', serif`
+- **Body:** `'Lora', Georgia, 'Times New Roman', serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | DM Serif Display | 84px | 400 | 1.05 | -1.5px |
+| Section Heading | DM Serif Display | 72px | 400 | 1.05 | -1px |
+| Sub-heading | DM Serif Display | 44px | 400 | 1.15 | -0.5px |
+| Body Large | Lora | 20px | 400 | 1.65 | 0 |
+| Body | Lora | 18px | 400 | 1.65 | 0 |
+| Body Italic | Lora Italic | 18px | 400 | 1.65 | 0 |
+| Caption | Lora | 13px | 500 | 1.50 | 0.2px |
+| Big Number | DM Serif Display | 72px | 400 | 1.00 | -1px |
+| Numbered Marker | DM Serif Display | 32px | 400 | 1.00 | 0 |
+| Footer Brand | Lora | 14px | 500 | 1.40 | 0.3px |
+| Footer URL | Lora | 14px | 500 | 1.40 | 0.3px |
+
+**Principles**
+
+- DM Serif Display only has one weight (400) — never apply `font-weight: 700`, renders as faux-bold.
+- Break every headline into 2 lines manually with `<br>`.
+- Italic Lora for gentle emphasis — never bold for body.
+- Left-align everything.
+
+## Layout
+
+- Cream `#FBFAF4` everywhere — no alternate page color.
+- Sunburst collage: inline SVG with radiating 1-2px ink lines + mustard + forest-green hard-cornered rectangles. Appears on alternating slides.
+- Numbered marker: thin-outlined circle (≈48px) with a small gap at the top and the number in DM Serif 32px centered.
+- Footer on every carousel slide: rust orange brand mark + URL left, page number right, Lora 14px.
+- Left-align headlines, body, numbered items, pull-quotes.
+
+## Do / Don't
+
+**Do**
+
+- Use DM Serif Display at weight 400 for all headlines — stack on 2 lines.
+- Use the sunburst collage on alternating slides (1, 3, 5…), not every slide.
+- Use rust orange only for footer marks, page numbers, stat accents, pull-quote rules.
+- Use italic Lora for gentle emphasis in body prose.
+- Keep geometric collage shapes hard-cornered — no `border-radius`.
+- Include footer (brand + URL) on every carousel slide.
+
+**Don't**
+
+- Don't use sans-serif for headlines — the style is serif-only.
+- Don't use pure white or pure black — cream and `#1A1A1A` are non-negotiable.
+- Don't center-align anything.
+- Don't use mustard or forest green for text — collage blocks only.
+- Don't use rust orange for headlines or body — small editorial marks only.
+- Don't use yellow pill tags or modern framework UI — this is editorial, not creator-carousel.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-cream: #FBFAF4;
+  --color-ink: #1A1A1A;
+  --color-rust: #C85A1F;
+  --color-mustard: #D8AD38;
+  --color-forest: #1E4A30;
+  --color-text-2: #3D3A36;
+  --color-text-3: #6B6660;
+  --color-hairline: rgba(26, 26, 26, 0.12);
+
+  --font-display: 'DM Serif Display', Georgia, 'Times New Roman', serif;
+  --font-body: 'Lora', Georgia, 'Times New Roman', serif;
+}
+```
+
+### Sunburst collage SVG
+
+```html
+<svg viewBox="0 0 200 200" width="200" height="200">
+  <rect x="80" y="60" width="60" height="80" fill="#D8AD38"/>
+  <rect x="100" y="100" width="70" height="40" fill="#1E4A30"/>
+  <g stroke="#1A1A1A" stroke-width="1.5" stroke-linecap="round">
+    <line x1="100" y1="10" x2="100" y2="30"/>
+    <line x1="140" y1="20" x2="130" y2="40"/>
+    <line x1="170" y1="60" x2="150" y2="70"/>
+    <line x1="180" y1="100" x2="160" y2="100"/>
+    <line x1="170" y1="140" x2="150" y2="130"/>
+    <line x1="60" y1="20" x2="70" y2="40"/>
+    <line x1="30" y1="60" x2="50" y2="70"/>
+    <line x1="20" y1="100" x2="40" y2="100"/>
+    <line x1="30" y1="140" x2="50" y2="130"/>
+  </g>
+</svg>
+```
+
+### Content slide with numbered marker
+
+```html
+<div style="background:#FBFAF4; padding:60px; min-height:960px; position:relative;">
+  <div style="position:absolute; top:60px; left:60px; width:48px; height:48px; border:1px solid rgba(26,26,26,0.65); border-radius:50%; display:flex; align-items:center; justify-content:center;">
+    <span style="font-family:'DM Serif Display',serif; font-size:32px; color:#1A1A1A;">2</span>
+  </div>
+
+  <div style="margin-top:120px;">
+    <h2 style="font-family:'DM Serif Display',serif; font-size:72px; font-weight:400; line-height:1.05; letter-spacing:-1px; color:#1A1A1A; margin:0 0 32px;">Write the<br>first chapter.</h2>
+    <p style="font-family:'Lora',serif; font-size:18px; font-weight:400; line-height:1.65; color:#3D3A36; margin:0 0 20px; max-width:560px;">The first chapter is the thing most founders skip. It's the one where you write down what you actually believe — before the market, the team, and the investors talk you out of it.</p>
+    <p style="font-family:'Lora',serif; font-style:italic; font-size:18px; font-weight:400; line-height:1.65; color:#3D3A36; margin:0; max-width:560px;">Start there.</p>
+  </div>
+
+  <div style="position:absolute; bottom:40px; left:60px; right:60px; display:flex; justify-content:space-between; font-family:'Lora',serif; font-size:14px; font-weight:500; letter-spacing:0.3px;">
+    <span style="color:#C85A1F;">THE FOUNDER DIARIES · founderdiaries.co</span>
+    <span style="color:#C85A1F;">02</span>
+  </div>
+</div>
+```
+
+### Pull quote (rust rule)
+
+```html
+<div style="padding:32px 0; border-left:3px solid #C85A1F; padding-left:24px;">
+  <p style="font-family:'DM Serif Display',serif; font-size:44px; font-weight:400; line-height:1.15; letter-spacing:-0.5px; color:#1A1A1A; margin:0 0 16px;">"Write the thing nobody asked for."</p>
+  <p style="font-family:'Lora',serif; font-size:13px; font-weight:500; letter-spacing:0.2px; color:#6B6660; margin:0;">— CHAPTER TWO</p>
+</div>
+```

--- a/skills/composites/goose-graphics/styles/terminal.md
+++ b/skills/composites/goose-graphics/styles/terminal.md
@@ -1,0 +1,135 @@
+# Terminal
+
+CLI / hacker aesthetic. JetBrains Mono everywhere, matrix green on near-black, amber for warnings. Every surface behaves like a terminal pane — command prompts (`$`, `>`), ASCII box-drawing borders, status bars, and uppercase tracked labels. No decorative anything; everything is structural signal.
+
+> Full prose reference: `styles/_full/terminal.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#1a1a2e` | Terminal dark background |
+| `#00ff41` | Matrix green — primary text, rules, active |
+| `#ffb000` | Amber — secondary accent (warnings, labels) |
+| `#33ff66` | Bright green — hover |
+| `#cc8e00` | Dark amber — hover |
+| `#00cc33` | Dim green — secondary/body |
+| `#00d4ff` | Cyan — tertiary (links, sparingly) |
+| `#222240` | Mid dark — card surface |
+| `#12122a` | Surface inset |
+| `#2a2a3e` | Ghost gray — nested |
+| `#3a3a4e` | Faint gray — secondary borders |
+| `#4a4a5a` | Dim gray — grid lines, inactive |
+| `#00802a` | Muted green — disabled |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display / Body:** `'JetBrains Mono', 'Courier New', Courier, monospace`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | JetBrains Mono | 56px | 700 | 1.10 | -0.5px |
+| Section Heading | JetBrains Mono | 36px | 700 | 1.15 | 0 |
+| Sub-heading | JetBrains Mono | 24px | 600 | 1.20 | 0 |
+| Body Large | JetBrains Mono | 18px | 400 | 1.70 | 0 |
+| Body | JetBrains Mono | 15px | 400 | 1.75 | 0.2px |
+| Caption | JetBrains Mono | 12px | 400 | 1.50 | 0.5px |
+| Big Number | JetBrains Mono | 56px | 700 | 1.00 | 0 |
+| System Label | JetBrains Mono | 12px | 600 | 1.00 | 3px UPPER |
+| CTA | JetBrains Mono | 14px | 600 | 1.00 | 2px UPPER |
+| Prompt Prefix | JetBrains Mono | 15px | 500 | 1.00 | 0 |
+
+**Principles**
+
+- Monospace only — every character takes equal space. This is the identity.
+- Prompt prefixes (`$`, `>`, `//`) in amber precede commands and titles.
+- Uppercase labels with 3px tracking for system messages.
+
+## Layout
+
+- Format padding: carousel 60px · infographic 60/80 · slides 80px · poster 60/80.
+- ASCII box-drawing borders: `┌──┐ │ └──┘` or `+---+` using 1px green borders with mono characters.
+- Rules: 1px solid `#00ff41` (often with `box-shadow: 0 0 8px rgba(0,255,65,0.3)` for CRT glow).
+- Cards: 0-2px radius. Squared, structural.
+- Status bars at top/bottom: `[STATUS: ACTIVE]` `[MEM: 47%]` `[UPTIME: 99.9%]`.
+
+## Do / Don't
+
+**Do**
+
+- Use command prefixes (`$`, `>`, `//`) before commands, headlines, and callouts.
+- Use uppercase tracked labels for system messages.
+- Apply subtle CRT glow `text-shadow: 0 0 8px rgba(0,255,65,0.3)` on primary green text.
+- Use ASCII box-drawing or `+---+` borders for containers when appropriate.
+- Use amber (`#ffb000`) for warnings, highlights, and secondary markers.
+
+**Don't**
+
+- Don't use any sans-serif or serif font — monospace only.
+- Don't use colors beyond green/amber/cyan/grays. No reds, blues, purples, pinks.
+- Don't use border-radius > 2px.
+- Don't use decorative shadows (only CRT glow on accent elements).
+- Don't use warm palettes.
+- Don't mix case on system labels — always UPPERCASE with tracking.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-bg: #1a1a2e;
+  --color-green: #00ff41;
+  --color-amber: #ffb000;
+  --color-dim-green: #00cc33;
+  --color-cyan: #00d4ff;
+  --color-surface: #222240;
+  --color-surface-inset: #12122a;
+  --color-border: #4a4a5a;
+
+  --font: 'JetBrains Mono', 'Courier New', Courier, monospace;
+
+  --glow-green: 0 0 8px rgba(0, 255, 65, 0.3);
+}
+```
+
+### Title block with prompt prefix
+
+```html
+<div style="background:#1a1a2e; padding:80px 60px; font-family:'JetBrains Mono',monospace;">
+  <p style="font-size:12px; font-weight:600; letter-spacing:3px; text-transform:uppercase; color:#ffb000; margin:0 0 12px;">[SYSTEM: INITIALIZED]</p>
+  <h1 style="font-size:56px; font-weight:700; line-height:1.10; letter-spacing:-0.5px; color:#00ff41; margin:0 0 24px; text-shadow:0 0 8px rgba(0,255,65,0.3);">&gt; The future of<br>&gt; autonomous_work.exe</h1>
+  <p style="font-size:18px; font-weight:400; line-height:1.70; color:#00cc33; max-width:600px; margin:0;">// how AI coworkers are reshaping the way teams operate</p>
+</div>
+```
+
+### Numbered step with command prompt
+
+```html
+<div style="border:1px solid #4a4a5a; padding:24px; background:#222240;">
+  <p style="font-family:'JetBrains Mono',monospace; font-size:12px; font-weight:600; letter-spacing:3px; text-transform:uppercase; color:#ffb000; margin:0 0 8px;">&gt; STEP_01 // RESEARCH</p>
+  <h3 style="font-family:'JetBrains Mono',monospace; font-size:24px; font-weight:600; color:#00ff41; margin:0 0 12px;">Find buyers before they find you</h3>
+  <p style="font-family:'JetBrains Mono',monospace; font-size:15px; font-weight:400; line-height:1.75; color:#00cc33; margin:0;">$ monitor --hiring --funding --stack</p>
+</div>
+```
+
+### Stat in terminal frame
+
+```html
+<div style="border:1px solid #00ff41; padding:32px; background:#12122a; text-align:center;">
+  <p style="font-family:'JetBrains Mono',monospace; font-size:56px; font-weight:700; color:#00ff41; margin:0; text-shadow:0 0 12px rgba(0,255,65,0.3);">47%</p>
+  <p style="font-family:'JetBrains Mono',monospace; font-size:12px; font-weight:600; letter-spacing:3px; text-transform:uppercase; color:#ffb000; margin:8px 0 0;">FASTER_RESPONSE</p>
+</div>
+```
+
+### CTA pill (uppercase tracked)
+
+```html
+<a style="display:inline-block; background:#00ff41; color:#1a1a2e; font-family:'JetBrains Mono',monospace; font-size:14px; font-weight:600; letter-spacing:2px; text-transform:uppercase; text-decoration:none; padding:14px 36px; border-radius:2px;">&gt; GET_STARTED</a>
+```

--- a/skills/composites/goose-graphics/styles/venn-infographic.md
+++ b/skills/composites/goose-graphics/styles/venn-infographic.md
@@ -1,0 +1,161 @@
+# Venn Infographic
+
+HBR-style explainer. Paper off-white background with three translucent Venn-diagram circles (sage, coral, soft-blue at 0.7 opacity) intersecting to show overlapping concepts. Numbered white info cards sit in a grid alongside the Venn, each with an `01`/`02`/`03` label. Inter only; no decoration besides the circles and cards.
+
+> Full prose reference: `styles/_full/venn-infographic.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#F6F5F2` | Paper — primary background (warm off-white) |
+| `#1A1A1A` | Near-black — primary text, headlines, icon strokes |
+| `#B8D4A8` | Sage green — Venn circle 1 (at 0.7 opacity) |
+| `#E8A89E` | Coral — Venn circle 2 (at 0.7 opacity) |
+| `#A8C4D8` | Soft blue — Venn circle 3 (at 0.7 opacity) |
+| `#FFFFFF` | Card white — info card backgrounds |
+| `#6B6B6B` | Secondary text — subtitles, body |
+| `#9A9A9A` | Tertiary text — metadata, small labels |
+| `#F0EEE8` | Surface inset — recessed panels |
+| `#E8E6E0` | Divider — hairlines |
+| `rgba(0,0,0,0.06)` | Card shadow |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+```
+
+- **Display / Body:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Inter | 44px | 700 | 1.15 | -0.3px |
+| Section Heading | Inter | 36px | 700 | 1.20 | -0.3px |
+| Sub-heading | Inter | 22px | 700 | 1.25 | -0.2px |
+| Body Large | Inter | 18px | 400 | 1.55 | 0 |
+| Body | Inter | 16px | 400 | 1.55 | 0 |
+| Body Bold | Inter | 16px | 600 | 1.55 | 0 |
+| Caption | Inter | 13px | 500 | 1.50 | 0.1px |
+| Big Number (Card) | Inter | 20px | 700 | 1.00 | 0 |
+| Big Number (Venn) | Inter | 24px | 700 | 1.00 | -0.2px |
+| Numbered Label Small | Inter | 13px | 600 | 1.00 | 0.5px UPPER |
+| CTA | Inter | 15px | 600 | 1.00 | 0.2px |
+
+**Principles**
+
+- Single family, weight-driven hierarchy (400, 600, 700).
+- Restrained headline size (44-36px) — this is an explainer, not a poster.
+- Secondary text uses `#6B6B6B`, never black — keeps hierarchy readable.
+
+## Layout
+
+- Full-bleed paper `#F6F5F2`.
+- Three Venn circles in sage, coral, and soft blue at 0.7 opacity, overlapping at center. 240-320px diameter, `mix-blend-mode: multiply` optional for richer overlap.
+- Each circle labeled with a number (24px Inter 700) at center or just inside.
+- Info cards: `#FFFFFF` surface, 12-16px radius, 1px border `#E8E6E0`, soft shadow `0 2px 8px rgba(0,0,0,0.06)`.
+- Each card header: `01 / RESEARCH` in Inter tracked uppercase.
+- Content grid: Venn on one side (60%), info cards stacked on the other (40%).
+
+## Do / Don't
+
+**Do**
+
+- Use three Venn circles at 0.7 opacity so overlaps create visible blended colors.
+- Number each circle and each card (01, 02, 03) — sequence is the communication.
+- Use soft-shadow white cards with generous 16-20px padding.
+- Use Inter 400 body text at `#6B6B6B` for all card descriptions.
+- Left-align content inside cards.
+
+**Don't**
+
+- Don't use opaque Venn circles — the overlap is the point.
+- Don't use more than 3 Venn circles — stick to three.
+- Don't use serif fonts or display faces.
+- Don't use saturated pure colors — the palette is muted.
+- Don't over-decorate — this style is intentionally clean and data-forward.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --c-paper: #F6F5F2;
+  --c-ink: #1A1A1A;
+  --c-sage: #B8D4A8;
+  --c-coral: #E8A89E;
+  --c-blue: #A8C4D8;
+  --c-card: #FFFFFF;
+  --c-text-2: #6B6B6B;
+  --c-text-3: #9A9A9A;
+  --c-divider: #E8E6E0;
+
+  --font: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --radius-card: 16px;
+  --shadow-card: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+```
+
+### Venn diagram SVG
+
+```html
+<svg viewBox="0 0 400 300" width="100%">
+  <g style="mix-blend-mode:multiply;">
+    <circle cx="140" cy="150" r="100" fill="#B8D4A8" opacity="0.7"/>
+    <circle cx="260" cy="150" r="100" fill="#E8A89E" opacity="0.7"/>
+    <circle cx="200" cy="220" r="100" fill="#A8C4D8" opacity="0.7"/>
+  </g>
+  <text x="100" y="120" font-family="Inter" font-size="24" font-weight="700" fill="#1A1A1A">01</text>
+  <text x="280" y="120" font-family="Inter" font-size="24" font-weight="700" fill="#1A1A1A">02</text>
+  <text x="200" y="260" font-family="Inter" font-size="24" font-weight="700" fill="#1A1A1A" text-anchor="middle">03</text>
+</svg>
+```
+
+### Explainer card
+
+```html
+<div style="background:#FFFFFF; border:1px solid #E8E6E0; border-radius:16px; padding:24px; box-shadow:0 2px 8px rgba(0,0,0,0.06);">
+  <p style="font-family:'Inter',sans-serif; font-size:13px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; color:#9A9A9A; margin:0 0 8px;">01 / RESEARCH</p>
+  <h3 style="font-family:'Inter',sans-serif; font-size:22px; font-weight:700; line-height:1.25; letter-spacing:-0.2px; color:#1A1A1A; margin:0 0 12px;">Find the signal</h3>
+  <p style="font-family:'Inter',sans-serif; font-size:16px; font-weight:400; line-height:1.55; color:#6B6B6B; margin:0;">Scan hiring pages, funding rounds, and recent tech-stack changes to surface companies in motion.</p>
+</div>
+```
+
+### Full infographic layout
+
+```html
+<div style="background:#F6F5F2; padding:60px; min-height:1080px;">
+  <h1 style="font-family:'Inter',sans-serif; font-size:44px; font-weight:700; line-height:1.15; letter-spacing:-0.3px; color:#1A1A1A; margin:0 0 16px; max-width:720px;">Three practices that distinguish the teams shipping weekly from the teams shipping quarterly.</h1>
+  <p style="font-family:'Inter',sans-serif; font-size:18px; font-weight:400; line-height:1.55; color:#6B6B6B; margin:0 0 48px; max-width:560px;">A pattern analysis of 120 product teams, 2023 — 2026.</p>
+
+  <div style="display:grid; grid-template-columns:60% 40%; gap:40px;">
+    <div>
+      <svg viewBox="0 0 400 300" width="100%">
+        <g style="mix-blend-mode:multiply;">
+          <circle cx="140" cy="150" r="100" fill="#B8D4A8" opacity="0.7"/>
+          <circle cx="260" cy="150" r="100" fill="#E8A89E" opacity="0.7"/>
+          <circle cx="200" cy="220" r="100" fill="#A8C4D8" opacity="0.7"/>
+        </g>
+      </svg>
+    </div>
+    <div style="display:flex; flex-direction:column; gap:16px;">
+      <div style="background:#fff; border:1px solid #E8E6E0; border-radius:16px; padding:20px; box-shadow:0 2px 8px rgba(0,0,0,0.06);">
+        <p style="font-family:'Inter',sans-serif; font-size:13px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; color:#9A9A9A; margin:0 0 4px;">01 · RESEARCH</p>
+        <p style="font-family:'Inter',sans-serif; font-size:16px; font-weight:400; line-height:1.55; color:#6B6B6B; margin:0;">Weekly customer conversations, logged.</p>
+      </div>
+      <div style="background:#fff; border:1px solid #E8E6E0; border-radius:16px; padding:20px; box-shadow:0 2px 8px rgba(0,0,0,0.06);">
+        <p style="font-family:'Inter',sans-serif; font-size:13px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; color:#9A9A9A; margin:0 0 4px;">02 · DEFAULT</p>
+        <p style="font-family:'Inter',sans-serif; font-size:16px; font-weight:400; line-height:1.55; color:#6B6B6B; margin:0;">A visible, simple next-step for every meeting.</p>
+      </div>
+      <div style="background:#fff; border:1px solid #E8E6E0; border-radius:16px; padding:20px; box-shadow:0 2px 8px rgba(0,0,0,0.06);">
+        <p style="font-family:'Inter',sans-serif; font-size:13px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; color:#9A9A9A; margin:0 0 4px;">03 · REVIEW</p>
+        <p style="font-family:'Inter',sans-serif; font-size:16px; font-weight:400; line-height:1.55; color:#6B6B6B; margin:0;">Retrospective every Friday — what shipped, what stalled.</p>
+      </div>
+    </div>
+  </div>
+</div>
+```

--- a/skills/composites/goose-graphics/styles/vintage-duotone-poster.md
+++ b/skills/composites/goose-graphics/styles/vintage-duotone-poster.md
@@ -1,0 +1,139 @@
+# Vintage Duotone Poster
+
+1950s letterpress poster. Forest green canvas with dusty pink as the entire type and duotone photo system. Oversized Oswald 900 impact word at 240px (ALL CAPS, nearly edge-to-edge) paired with a smaller tilted Alfa Slab One "emotional word" that overlaps it. Halftone dot patterns optional. Feels like a vintage concert poster or mid-century book jacket.
+
+> Full prose reference: `styles/_full/vintage-duotone-poster.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#2D4D3A` | Forest green — primary background (only canvas color) |
+| `#EDB5A7` | Dusty pink — primary text, all accents, photo tint |
+| `#1F3528` | Deep green — photo shadows, duotone deep |
+| `#F5CFC6` | Pink highlight — photo highlights |
+| `#D9948A` | Pink shadow — deep pink, rare emphasis |
+| `rgba(237,181,167,0.65)` | Pink text muted — metadata |
+| `rgba(237,181,167,0.35)` | Pink text faint — borders, divider rules |
+| `#264030` | Green inset — rare recessed panel |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Alfa+Slab+One&family=Oswald:wght@500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+```
+
+- **Display Script:** `'Alfa Slab One', Georgia, 'Times New Roman', serif`
+- **Display Impact:** `'Oswald', Impact, 'Arial Narrow', sans-serif`
+- **Body:** `'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Script | Alfa Slab One | 140px | 400 | 0.95 | -2px |
+| Display Impact | Oswald | 240px | 700 | 0.85 | -4px UPPER |
+| Section Heading | Oswald | 72px | 700 | 0.95 | -1px UPPER |
+| Sub-heading | Oswald | 48px | 600 | 1.05 | 0 UPPER |
+| Body Large | Inter | 22px | 500 | 1.55 | 0.3px |
+| Body | Inter | 18px | 500 | 1.55 | 0.3px |
+| Metadata Large | Oswald | 32px | 600 | 1.10 | 2px UPPER |
+| Metadata | Oswald | 18px | 600 | 1.20 | 2px UPPER |
+| Metadata Small | Oswald | 14px | 600 | 1.20 | 2.5px UPPER |
+| Big Number | Oswald | 180px | 700 | 0.90 | -3px UPPER |
+| CTA Label | Oswald | 24px | 700 | 1.00 | 3px UPPER |
+
+**Principles**
+
+- Alfa Slab One "emotional word" tilted `transform: rotate(-3deg)`, overlapping the Oswald impact word slightly.
+- Oswald 700 impact word is the entire hero — edge to edge.
+- Everything else (metadata, body) is Oswald tracked uppercase.
+
+## Layout
+
+- Full-bleed forest green `#2D4D3A` background.
+- Photography: duotone-mapped into deep green → dusty pink.
+- Apply halftone dot overlay via SVG or CSS radial-gradient pattern at 6-12px spacing for print feel (optional).
+- Impact word fills 90-100% of frame width, bottom-aligned.
+- "Emotional word" in script tucks into the top-left or right of the impact word, rotated -3°.
+
+## Do / Don't
+
+**Do**
+
+- Duotone-map any photograph into deep-green and dusty-pink.
+- Set the impact word at 240px Oswald 700 ALL CAPS, edge-to-edge.
+- Tilt the Alfa Slab One emotional word -3° and overlap it with the impact word.
+- Use Oswald 2px-tracked UPPER for all metadata and body substitute.
+- Add optional halftone dot overlay for 1950s letterpress feel.
+
+**Don't**
+
+- Don't use any color outside forest green + dusty pink (plus their deeper shades).
+- Don't use sentence-case display type — impact word is always UPPER.
+- Don't use sans-serif webfonts for display — Oswald + Alfa Slab One only.
+- Don't use photography in original colors — always duotone.
+- Don't use borders above 1-2px — this is poster ink, not UI.
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-forest: #2D4D3A;
+  --color-pink: #EDB5A7;
+  --color-green-deep: #1F3528;
+  --color-pink-hi: #F5CFC6;
+  --color-pink-deep: #D9948A;
+  --color-pink-muted: rgba(237, 181, 167, 0.65);
+  --color-pink-faint: rgba(237, 181, 167, 0.35);
+
+  --font-script: 'Alfa Slab One', Georgia, 'Times New Roman', serif;
+  --font-impact: 'Oswald', Impact, 'Arial Narrow', sans-serif;
+  --font-body: 'Inter', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+}
+```
+
+### Duotone photo filter
+
+```css
+.duotone {
+  filter: grayscale(1) contrast(1.1);
+  background: linear-gradient(180deg, #1F3528, #EDB5A7);
+  background-blend-mode: multiply;
+}
+```
+
+### Poster hero
+
+```html
+<div style="background:#2D4D3A; padding:60px; min-height:100vh; position:relative; overflow:hidden;">
+  <p style="font-family:'Oswald',sans-serif; font-size:14px; font-weight:600; letter-spacing:2.5px; text-transform:uppercase; color:#EDB5A7; margin:0 0 80px;">VOL. IV — SUMMER 1957</p>
+
+  <div style="position:relative;">
+    <span style="position:absolute; top:-40px; left:40px; transform:rotate(-3deg); font-family:'Alfa Slab One',serif; font-size:140px; line-height:0.95; letter-spacing:-2px; color:#EDB5A7; z-index:2;">After the</span>
+    <h1 style="font-family:'Oswald',sans-serif; font-size:240px; font-weight:700; line-height:0.85; letter-spacing:-4px; text-transform:uppercase; color:#EDB5A7; margin:0;">LONG<br>WAIT.</h1>
+  </div>
+
+  <div style="display:flex; justify-content:space-between; align-items:flex-end; margin-top:60px;">
+    <p style="font-family:'Oswald',sans-serif; font-size:32px; font-weight:600; letter-spacing:2px; text-transform:uppercase; color:#EDB5A7; margin:0;">08 / 09 · 10 PM</p>
+    <p style="font-family:'Oswald',sans-serif; font-size:18px; font-weight:600; letter-spacing:2px; text-transform:uppercase; color:rgba(237,181,167,0.65); margin:0;">THE OLD PALACE · 45¢</p>
+  </div>
+</div>
+```
+
+### Big stat number (Oswald 180px)
+
+```html
+<div style="background:#2D4D3A; padding:60px; text-align:center;">
+  <p style="font-family:'Oswald',sans-serif; font-size:180px; font-weight:700; line-height:0.90; letter-spacing:-3px; color:#EDB5A7; margin:0;">47%</p>
+  <p style="font-family:'Oswald',sans-serif; font-size:18px; font-weight:600; letter-spacing:2px; text-transform:uppercase; color:#EDB5A7; margin:8px 0 0;">FASTER RESPONSE</p>
+</div>
+```
+
+### CTA (pink on green, tracked)
+
+```html
+<a style="display:inline-block; border:2px solid #EDB5A7; color:#EDB5A7; font-family:'Oswald',sans-serif; font-size:24px; font-weight:700; letter-spacing:3px; text-transform:uppercase; text-decoration:none; padding:16px 32px;">SEE THE SHOW →</a>
+```

--- a/skills/composites/goose-graphics/styles/warm-earth.md
+++ b/skills/composites/goose-graphics/styles/warm-earth.md
@@ -1,0 +1,138 @@
+# Warm Earth
+
+Organic, artisanal, craft-lifestyle aesthetic. Terracotta + sage + cream palette with Nunito's rounded geometric sans handling every role. The mood is a ceramic studio catalog or an indie roastery's packaging system — warm, hand-finished, quietly considered.
+
+> Full prose reference: `styles/_full/warm-earth.md`
+
+## Palette
+
+| Hex | Role |
+|-----|------|
+| `#faf3eb` | Cream background |
+| `#3d2b1f` | Dark brown — primary text |
+| `#c67a4a` | Terracotta — accent (numbers, rules, CTAs) |
+| `#7a9e7e` | Sage green — secondary accent (tags, icons) |
+| `#5c8060` | Deep sage — hover |
+| `#d4a574` | Warm tan — lighter terracotta variant |
+| `#a85e30` | Deep terracotta — hover |
+| `#f5ece0` | Linen — card surface |
+| `#f0e6d8` | Surface inset |
+| `#ebe0d0` | Sand — nested containers |
+| `#d9cbb8` | Tan border |
+| `#a89a8a` | Warm medium — disabled |
+| `#8a7b6b` | Clay gray — tertiary text |
+| `#6b5d4f` | Earth gray — secondary text |
+
+## Typography
+
+**Google Fonts**
+
+```html
+<link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;1,300;1,400&display=swap" rel="stylesheet">
+```
+
+- **Display / Body:** `'Nunito', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif`
+
+| Role | Font | Size | Weight | Line-height | Tracking |
+|------|------|------|--------|-------------|----------|
+| Display Hero | Nunito | 72px | 800 | 1.10 | -1px |
+| Section Heading | Nunito | 48px | 700 | 1.15 | -0.5px |
+| Sub-heading | Nunito | 32px | 700 | 1.20 | -0.25px |
+| Body Large | Nunito | 20px | 300 | 1.70 | 0 |
+| Body | Nunito | 16px | 400 | 1.70 | 0.1px |
+| Caption | Nunito | 13px | 400 | 1.50 | 0.3px |
+| Big Number | Nunito | 64px | 800 | 1.00 | -0.5px |
+| Numbered Label | Nunito | 14px | 600 | 1.00 | 1.5px UPPER |
+| CTA | Nunito | 15px | 700 | 1.00 | 0.5px |
+
+**Principles**
+
+- Rounded geometric letterforms signal warmth — never switch to sharp or high-contrast type.
+- Light body (300) creates airy reading against cream; display heavy (700-800).
+
+## Layout
+
+- Format padding: carousel 60px · infographic 60/80 · slides 80px · poster 60/80.
+- Cards: `#f5ece0` linen surface, 8-12px radius (rounded, organic), `#d9cbb8` border.
+- Rules: 1-2px terracotta, often short (60-80px), sometimes with sage end caps.
+- Organic shapes: occasional hand-drawn style circles (CSS border-radius: 50% on irregular sizes).
+- Sage icons (small, 24-32px) for positive/natural markers; terracotta numbers for sequence.
+
+## Do / Don't
+
+**Do**
+
+- Pair terracotta and sage as complementary accents — never solo.
+- Use 8-12px radius on cards — rounded but not bubbly.
+- Use sage (`#7a9e7e`) for positive states, success, "with Goose" columns.
+- Use warm tan (`#d4a574`) for lighter decorative fills and border variants.
+- Use earth gray (`#6b5d4f`) for body text, not pure black.
+
+**Don't**
+
+- Don't use cool grays or cool blues. Warm palette only.
+- Don't use sharp borders or perfect geometry — the aesthetic is hand-finished.
+- Don't use bright/saturated colors (neon, electric, fluorescent).
+- Don't use serif fonts — Nunito's rounded terminals are the identity.
+- Don't use more than 2 accents per section (terracotta + sage).
+
+## CSS snippets
+
+### `:root` variables
+
+```css
+:root {
+  --color-cream: #faf3eb;
+  --color-brown: #3d2b1f;
+  --color-terracotta: #c67a4a;
+  --color-sage: #7a9e7e;
+  --color-deep-sage: #5c8060;
+  --color-tan: #d4a574;
+  --color-linen: #f5ece0;
+  --color-tan-border: #d9cbb8;
+  --color-earth-gray: #6b5d4f;
+  --color-clay-gray: #8a7b6b;
+
+  --font: 'Nunito', -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif;
+
+  --radius-card: 12px;
+}
+```
+
+### Title block
+
+```html
+<div style="background:#faf3eb; padding:80px 60px; text-align:center;">
+  <div style="width:60px; height:3px; background:#c67a4a; margin:0 auto 32px; border-radius:2px;"></div>
+  <h1 style="font-family:'Nunito',sans-serif; font-size:72px; font-weight:800; line-height:1.10; letter-spacing:-1px; color:#3d2b1f; margin:0 0 24px;">The Future of<br>Autonomous Work</h1>
+  <p style="font-family:'Nunito',sans-serif; font-size:20px; font-weight:300; line-height:1.70; color:#6b5d4f; max-width:560px; margin:0 auto;">How AI coworkers are reshaping how teams operate.</p>
+</div>
+```
+
+### Numbered step (terracotta numeral, sage icon)
+
+```html
+<div style="display:flex; gap:24px; align-items:flex-start; padding:32px 0; border-bottom:1px solid #d9cbb8;">
+  <span style="font-family:'Nunito',sans-serif; font-size:48px; font-weight:800; line-height:1.00; color:#c67a4a; min-width:72px;">01</span>
+  <div>
+    <p style="font-family:'Nunito',sans-serif; font-size:14px; font-weight:600; letter-spacing:1.5px; text-transform:uppercase; color:#7a9e7e; margin:0 0 8px;">HARVEST</p>
+    <h3 style="font-family:'Nunito',sans-serif; font-size:32px; font-weight:700; line-height:1.20; letter-spacing:-0.25px; color:#3d2b1f; margin:0 0 12px;">Find buyers before they find you</h3>
+    <p style="font-family:'Nunito',sans-serif; font-size:16px; font-weight:400; line-height:1.70; color:#6b5d4f; margin:0;">Monitor hiring signals and funding events.</p>
+  </div>
+</div>
+```
+
+### Card (linen surface, tan border)
+
+```html
+<div style="background:#f5ece0; border:1px solid #d9cbb8; border-radius:12px; padding:28px 24px;">
+  <h3 style="font-family:'Nunito',sans-serif; font-size:32px; font-weight:700; color:#3d2b1f; margin:0 0 12px;">Made for makers</h3>
+  <p style="font-family:'Nunito',sans-serif; font-size:16px; font-weight:400; line-height:1.70; color:#6b5d4f; margin:0;">Tools that feel like the craft they serve.</p>
+</div>
+```
+
+### CTA (terracotta pill)
+
+```html
+<a style="display:inline-block; background:#c67a4a; color:#faf3eb; font-family:'Nunito',sans-serif; font-size:15px; font-weight:700; letter-spacing:0.5px; text-decoration:none; padding:16px 40px; border-radius:8px;">Start your batch</a>
+```


### PR DESCRIPTION
## Summary

Introduces **`goose-graphics`** — a portable visual skill pack for the Agent Skills ecosystem (Claude Code, Claude Desktop, Claude Cowork, Claude Design, Block Goose, Cursor, OpenAI Codex). Consolidates 36 curated aesthetic presets, 7 social-first format specs, `extract-style` (image → DESIGN.md), and a Playwright PNG export pipeline into one installable skill. Deprecates `create-html-carousel` and `create-html-slides` which are now supersets of this pack.

## What's new

### `skills/composites/goose-graphics/`
- **SKILL.md** with args-based invocation (`--style`, `--format`, `--brief`, `--ref`) and a host compatibility matrix explaining how each Agent Skills host picks the pack up
- **skill.meta.json** — composite-category skill, installs via `npx goose-skills install goose-graphics --claude|--cursor|--codex`
- **36 style presets** × two tiers:
  - `styles/<slug>.md` — slim (~6KB, agent-load-optimized)
  - `styles/_full/<slug>.md` — VoltAgent 9-section DESIGN.md format, ready for direct upload into Claude Design
- **7 format specs** — carousel (1080×1080), story (1080×1920), infographic (1080×variable), slides (1920×1080), poster (1080×1350), chart (1080×1080), tweet (1080×1080)
- **Image sourcing** — `sources/unsplash.md` + `sources/ascii-art.md`
- **`extract-style.md`** — turn any reference image into a reusable DESIGN.md preset
- **Screenshot tool** — Playwright-based HTML→PNG renderer with per-format dimensions in `FORMAT_CONFIGS`
- **`styles/index.json`** — canonical slug list + mood groupings

### Deprecations (files retained for one release cycle)
- `skills/capabilities/create-html-carousel` — superseded by `goose-graphics --format carousel`. Banner added, `deprecated: true` in meta
- `skills/capabilities/create-html-slides` — superseded by `goose-graphics --format slides`. Banner added, `deprecated: true` in meta

### Root changes
- `README.md` — Content section bumped 10 → 11, new row for goose-graphics, deprecation notes on the two old skills
- `skills-index.json` — regenerated; `validate-skills.js` passes 178/178

## Host compatibility

| Host | Install |
|---|---|
| Claude Code | `npx goose-skills install goose-graphics --claude` |
| Claude Desktop | (same — auto-shared via `~/.claude/skills/`) |
| Claude Cowork | (same — built on Claude Desktop) |
| Goose (Block) | (same — auto-discovers `~/.claude/skills/` + `~/.config/goose/skills/`) |
| Cursor | `npx goose-skills install goose-graphics --cursor --project-dir .` |
| Codex | `npx goose-skills install goose-graphics --codex` |
| Claude Design | Manual upload of any `styles/_full/<slug>.md` to CD's "Create new design system" |

## Context

Originally developed at `goose-agent-ops/goose-graphics/`. Anthropic announced Claude Design on 2026-04-17, which reshaped the positioning: `goose-graphics` is now framed explicitly as an **upstream** portable skill pack that any Agent Skills host can load — not a CD competitor or a renderer of CD exports.

Ref: GOOSE-1355 (v2 epic), GOOSE-1358 (migration workstream), GOOSE-1386 (Claude Design pivot)

## Test plan

- [x] `node scripts/validate-skills.js` → passes 178 skills
- [x] `node scripts/build-index.js` → produces `skills-index.json` with 183 skills, 1 pack; `goose-graphics` entry present
- [x] `node bin/goose-skills.js install goose-graphics --claude` → files land at `~/.claude/skills/goose-graphics/` (local smoke-tested in prior dev session)
- [ ] Reviewer: inspect `styles/_full/DESIGN_MD_COVERAGE.md` — all 36 styles cover the 9-section VoltAgent format
- [ ] Reviewer: spot-check `skills/composites/goose-graphics/SKILL.md` Host compatibility section
- [ ] Reviewer: confirm deprecation banners read cleanly in `create-html-carousel/SKILL.md` + `create-html-slides/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)