### PR TITLE
Add goose-video umbrella skill pack

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-04-21",
+  "generated": "2026-04-22",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -1198,6 +1198,77 @@
         },
         "requires_skills": [
           "seo-domain-analyzer"
+        ]
+      }
+    },
+    {
+      "slug": "goose-video",
+      "name": "goose-video",
+      "category": "composites",
+      "description": "Portable video skill pack for the Agent Skills ecosystem. Wraps five video-production skills (product reels, talking-head, clip repurposing, screen-recording polish, beat-sync reels) under one invocation, with aspect-ratio formats and visual style presets.",
+      "tags": "content, video, social, brand",
+      "path": "skills/composites/goose-video",
+      "files": [
+        "skills/composites/goose-video/README.md",
+        "skills/composites/goose-video/SKILL.md",
+        "skills/composites/goose-video/examples/.gitkeep",
+        "skills/composites/goose-video/formats/index.json",
+        "skills/composites/goose-video/formats/landscape-long.md",
+        "skills/composites/goose-video/formats/landscape-short.md",
+        "skills/composites/goose-video/formats/square-social.md",
+        "skills/composites/goose-video/formats/vertical-short.md",
+        "skills/composites/goose-video/formats/vertical-story.md",
+        "skills/composites/goose-video/modes/beat-sync-reel.md",
+        "skills/composites/goose-video/modes/clip-repurpose.md",
+        "skills/composites/goose-video/modes/index.json",
+        "skills/composites/goose-video/modes/polish.md",
+        "skills/composites/goose-video/modes/product-reel.md",
+        "skills/composites/goose-video/modes/talking-head.md",
+        "skills/composites/goose-video/skill.meta.json",
+        "skills/composites/goose-video/sources/captions.md",
+        "skills/composites/goose-video/sources/music.md",
+        "skills/composites/goose-video/sources/stock-footage.md",
+        "skills/composites/goose-video/styles/cinematic.md",
+        "skills/composites/goose-video/styles/documentary.md",
+        "skills/composites/goose-video/styles/energetic.md",
+        "skills/composites/goose-video/styles/index.json",
+        "skills/composites/goose-video/styles/kinetic-type.md",
+        "skills/composites/goose-video/styles/minimal.md",
+        "skills/composites/goose-video/styles/motion-graphic.md",
+        "skills/composites/goose-video/styles/tutorial.md",
+        "skills/composites/goose-video/styles/ugc-handheld.md"
+      ],
+      "metadata": {
+        "slug": "goose-video",
+        "category": "composites",
+        "tags": [
+          "content",
+          "video",
+          "social",
+          "brand"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install goose-video",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ],
+          "dependencies": [
+            "packs/video-production/beat-sync-reel",
+            "packs/video-production/product-reel-generator",
+            "packs/video-production/talking-head-video",
+            "packs/video-production/video-clipper",
+            "packs/video-production/video-polish"
+          ]
+        },
+        "features": [
+          "5 modes (product-reel, talking-head, clip-repurpose, polish, beat-sync-reel)",
+          "5 aspect-ratio formats (vertical-short, vertical-story, square-social, landscape-short, landscape-long)",
+          "8 visual style presets (cinematic, energetic, minimal, documentary, tutorial, ugc-handheld, motion-graphic, kinetic-type)",
+          "Dispatches to underlying packs/video-production/ skills",
+          "Args-based slash command invocation",
+          "Interactive fallback when args are missing"
         ]
       }
     },

--- a/skills/composites/goose-video/README.md
+++ b/skills/composites/goose-video/README.md
@@ -1,0 +1,123 @@
+# goose-video — Agent Skills pack for video creation
+
+`goose-video` is a portable video skill pack for the Agent Skills ecosystem. It's a **router** skill — it does not generate video itself. It dispatches to the five standalone skills in `packs/video-production/`, layering on two additional axes (**format** + **style**) so the same underlying skill can output to different aspect ratios and visual treatments.
+
+It loads in any host that reads `SKILL.md` — Claude Code, Claude Desktop, Claude Cowork, Goose, Cursor, Codex.
+
+## Design principles
+
+- **Wrap, don't absorb.** The five sub-skills remain directly invocable on their own. `/goose-video` is the umbrella for users who'd rather describe the outcome than pick a skill up front.
+- **Three orthogonal axes.** A video is defined by: (1) mode — what kind of video, (2) format — aspect ratio and duration target, (3) style — visual treatment.
+- **Deterministic delegation.** Once mode + format + style are known, this skill invokes the appropriate sub-skill with the right parameters and hands off.
+
+## Directory Structure
+
+```
+goose-video/
+  SKILL.md                        # Entry-point skill (router)
+  README.md                       # This file
+  skill.meta.json                 # Goose-skills installation metadata
+  modes/                          # Dispatch specs — one per sub-skill
+    index.json
+    product-reel.md
+    talking-head.md
+    clip-repurpose.md
+    polish.md
+    beat-sync-reel.md
+  formats/                        # Aspect ratio + duration specs
+    index.json
+    vertical-short.md
+    vertical-story.md
+    square-social.md
+    landscape-short.md
+    landscape-long.md
+  styles/                         # Visual treatment presets
+    index.json
+    cinematic.md
+    energetic.md
+    minimal.md
+    documentary.md
+    tutorial.md
+    ugc-handheld.md
+    motion-graphic.md
+    kinetic-type.md
+  sources/
+    stock-footage.md              # Pexels / Pixabay
+    music.md                      # Royalty-free music selection
+    captions.md                   # Whisper + Remotion captions
+  examples/
+    <mode-slug>/                  # Per-mode example outputs
+```
+
+## Modes (5)
+
+| Mode | Delegates to | Best for |
+|------|-------|----------|
+| **product-reel** | `packs/video-production/product-reel-generator` | Instagram-ready product reels from an e-commerce page URL |
+| **talking-head** | `packs/video-production/talking-head-video` | AI-avatar narration over screenshots/slides (HeyGen) |
+| **clip-repurpose** | `packs/video-production/video-clipper` | Long-form → short vertical clips with auto-captions |
+| **polish** | `packs/video-production/video-polish` | Zoom/pan on an existing screen recording (Remotion) |
+| **beat-sync-reel** | `packs/video-production/beat-sync-reel` | Product image cuts synced to audio beats — free, no AI video gen |
+
+## Formats (5)
+
+| Format | Aspect | Duration | Platforms |
+|--------|--------|----------|-----------|
+| vertical-short | 9:16 | 15–60s | TikTok, Reels, YouTube Shorts |
+| vertical-story | 9:16 | 15–30s | Stories, Snapchat |
+| square-social | 1:1 | 15–30s | Instagram/LinkedIn feed |
+| landscape-short | 16:9 | 30–90s | YouTube, LinkedIn, X |
+| landscape-long | 16:9 | 3–10min | Tutorials, long-form |
+
+## Styles (8 starter presets)
+
+cinematic · energetic · minimal · documentary · tutorial · ugc-handheld · motion-graphic · kinetic-type
+
+See `styles/index.json` for the canonical list and `styles/<slug>.md` for per-style specs (palette, typography, pacing, caption style, music genre hints, transition recipes).
+
+## Args-based Invocation
+
+```bash
+# Full args — one-shot
+/goose-video --mode product-reel --format vertical-short --style energetic --source https://shop.example.com/products/widget
+
+# Partial — skill asks for the missing pieces
+/goose-video --mode talking-head --brief "How we cut onboarding time by 40%"
+
+# No args — full interactive flow
+/goose-video
+```
+
+Flags:
+
+- `--mode <slug>` — one of the 5 modes
+- `--format <slug>` — one of the 5 formats
+- `--style <slug>` — optional; defaults per mode if omitted
+- `--brief "..."` — topic / description
+- `--source <path-or-url>` — input material (required for most modes)
+
+## Installation
+
+```bash
+npx goose-skills install goose-video
+```
+
+Installing `goose-video` also installs the five underlying skills from `packs/video-production/` as dependencies.
+
+See `skill.meta.json` for installation metadata.
+
+## Usage
+
+Invoke via `/goose-video` in Claude Code. The skill walks you through mode selection, format choice, style selection, and source collection, then dispatches to the right sub-skill — or jump straight to generate by passing args (see above).
+
+## Relationship to `packs/video-production/`
+
+The five video sub-skills ship in `packs/video-production/` and remain **directly invocable** on their own:
+
+- `/product-reel-generator`
+- `/talking-head-video`
+- `/video-clipper`
+- `/video-polish`
+- `/beat-sync-reel`
+
+`goose-video` is the **wrap** — a higher-level interface that adds format + style axes and a unified invocation. Choose the umbrella when you want to describe the outcome; choose the individual skill when you know exactly which tool you need.

--- a/skills/composites/goose-video/SKILL.md
+++ b/skills/composites/goose-video/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: goose-video
+description: Portable video skill pack for the Agent Skills ecosystem. Wraps five video-production skills (product reels, talking-head, clip repurposing, screen-recording polish, beat-sync reels) under one invocation, with aspect-ratio formats and visual style presets.
+---
+
+## 1. Overview
+
+`goose-video` is a portable video skill pack for the Agent Skills ecosystem. It's a router skill — it does not generate video itself. Instead, it dispatches to the five standalone skills in `packs/video-production/`, layering on two additional axes (format + style) so the same underlying skill can output to different aspect ratios and visual treatments.
+
+Design principles:
+
+- **Wrap, don't absorb.** The five sub-skills remain directly invocable on their own. `/goose-video` is the umbrella entry point for users who'd rather describe the outcome ("a 30-second TikTok about our launch") than pick a skill name up front.
+- **Three orthogonal axes.** A video is defined by: (1) **mode** — what kind of video, (2) **format** — aspect ratio and duration target, (3) **style** — visual treatment.
+- **Deterministic delegation.** Once mode + format + style are known, this skill invokes the appropriate sub-skill with the right parameters and hands off. No magic.
+
+It loads in any host that reads `SKILL.md` — Claude Code, Claude Desktop, Claude Cowork, Goose, Cursor, Codex.
+
+## 2. Invocation
+
+```
+/goose-video --mode <slug> --format <format> [--style <slug>] [--brief "..."] [--source <path-or-url>]
+```
+
+- `--mode <slug>` — one of `product-reel`, `talking-head`, `clip-repurpose`, `polish`, `beat-sync-reel`. See `modes/index.json`.
+- `--format <slug>` — one of `vertical-short`, `vertical-story`, `square-social`, `landscape-short`, `landscape-long`. See `formats/index.json`.
+- `--style <slug>` — optional; one of the presets in `styles/index.json`. Defaults per mode if omitted.
+- `--brief "..."` — topic / description / source content.
+- `--source <path-or-url>` — input material (product page URL, source video path, script path, etc.). Required for most modes.
+
+**Three branches (same pattern as goose-graphics §2.1):**
+
+1. **All required args present** → skip discovery, dispatch directly to the chosen mode's sub-skill with format + style applied.
+2. **Partial args** → ask only for missing pieces. If `--mode` is set but `--format` is not, ask only for format.
+3. **No args** → run the interactive flow from §3.
+
+### 2.1 Examples
+
+```bash
+# Full args — one-shot reel from product page
+/goose-video --mode product-reel --format vertical-short --style energetic --source https://shop.example.com/products/widget
+
+# Repurpose a long podcast into TikTok clips
+/goose-video --mode clip-repurpose --format vertical-short --source ~/Downloads/episode-47.mp4
+
+# Talking-head explainer, square for LinkedIn feed
+/goose-video --mode talking-head --format square-social --brief "How we cut onboarding time by 40%" --source ~/docs/onboarding-redesign.md
+
+# Polish an existing demo recording
+/goose-video --mode polish --format landscape-short --style tutorial --source ~/demos/q2-demo.mov
+
+# No args — full interactive flow
+/goose-video
+```
+
+## 3. Host compatibility
+
+`SKILL.md` (this file) auto-loads on most Agent Skills hosts once installed. The router reads its sub-skill references via the local skill directory.
+
+| Host | Install | Notes |
+|---|---|---|
+| Claude Code | `npx goose-skills install goose-video --claude` | Lands at `~/.claude/skills/goose-video/` |
+| Claude Desktop | (same install as above) | Auto-shared — Desktop reads `~/.claude/skills/` |
+| Claude Cowork | (same install as above) | Built on Claude Desktop; same skill dir |
+| Goose (Block) | (same install as above) | Auto-discovers `~/.claude/skills/` + `~/.config/goose/skills/` |
+| Cursor | `npx goose-skills install goose-video --cursor --project-dir .` | Writes `.cursor/rules/goose-goose-video.mdc` |
+| Codex (OpenAI) | `npx goose-skills install goose-video --codex` | Writes `~/.codex/skills/goose-video/` |
+
+Installing `goose-video` also installs the five underlying skills from `packs/video-production/` as dependencies — the router needs them to dispatch.
+
+## 4. First-Run Setup
+
+Each mode has its own environment requirements — API keys, Python packages, fonts, etc. The router reads the target mode's sub-skill and surfaces any missing setup before invocation.
+
+Common requirements:
+
+- **FFmpeg** — required by `beat-sync-reel`, `product-reel-generator`, `video-clipper`, `video-polish`
+- **Python 3.10+** with `librosa`, `Pillow`, `requests` — `beat-sync-reel`, `product-reel-generator`
+- **Remotion** (Node) — `video-polish`
+- **HeyGen API key** (`HEYGEN_API_KEY`) — `talking-head-video`
+- **Higgsfield API key** (`HIGGSFIELD_API_KEY`) — `product-reel-generator`
+
+See each sub-skill's SKILL.md for exact setup steps.
+
+## 5. Interactive Workflow
+
+```
+1. Discover Intent   --> What kind of video? (pick a mode)
+2. Select Format     --> What aspect ratio + duration target?
+3. Select Style      --> Visual treatment (optional — mode has a default)
+4. Collect Source    --> Input material for the mode
+5. Dispatch          --> Hand off to the sub-skill with parameters
+6. Deliver           --> Return the sub-skill's output
+```
+
+## 6. Step 1: Discover Intent
+
+Ask the user what kind of video they want to make. Present the five modes:
+
+| Mode | Best For | Input |
+|------|----------|-------|
+| **product-reel** | Instagram-ready product reels from e-commerce pages | Product page URL |
+| **talking-head** | Explainer videos with AI avatar narration over slides/screenshots | Source docs, changelogs, script |
+| **clip-repurpose** | Short-form clips extracted from a long-form video | Long-form video file or URL |
+| **polish** | Professional zoom/pan on an existing screen recording | Existing recording file |
+| **beat-sync-reel** | Product image cuts synced to audio beats — free, fast, no AI video gen | Product images + audio |
+
+Read the corresponding file in `modes/<slug>.md` for the full dispatch spec.
+
+## 7. Step 2: Select Format
+
+Present the format options — aspect ratio + duration target, independent of mode:
+
+| Format | Aspect | Duration | Platforms |
+|--------|--------|----------|-----------|
+| **vertical-short** | 9:16 | 15–60s | TikTok, Reels, YouTube Shorts |
+| **vertical-story** | 9:16 | 15–30s | Instagram/LinkedIn Stories, Snapchat |
+| **square-social** | 1:1 | 15–30s | Instagram feed, LinkedIn feed |
+| **landscape-short** | 16:9 | 30–90s | YouTube, LinkedIn, Twitter/X |
+| **landscape-long** | 16:9 | 3–10min | YouTube long-form, tutorials, webinars |
+
+See `formats/<slug>.md` for dimensions, safe zones, and per-platform caveats.
+
+Not every mode supports every format — check `modes/<slug>.md` for the `supports` list. For example, `beat-sync-reel` is vertical-only; `polish` accepts whatever the source recording's aspect ratio is.
+
+## 8. Step 3: Select Style (Optional)
+
+Each mode has a default style. If the user wants a specific visual treatment, present the style presets from `styles/index.json`:
+
+- **cinematic** — film-grain, letterbox bars, slow handheld pans, muted palette
+- **energetic** — fast cuts, bass-heavy beats, bold text overlays, saturated color
+- **minimal** — clean backgrounds, simple type, generous whitespace, quiet audio
+- **documentary** — B-roll heavy, interview-style framing, soft music, natural palette
+- **tutorial** — screencast-driven, zoom/pan emphasis, explanation-forward captions
+- **ugc-handheld** — phone-camera feel, raw edits, authentic and unpolished
+- **motion-graphic** — animated type, shape play, no live footage
+- **kinetic-type** — word-heavy, text-as-subject, rhythmic cuts to beats
+
+After the user selects, read `styles/<slug>.md` for the full treatment spec (palette, typography, pacing, caption style, music genre hints, transition recipes).
+
+## 9. Step 4: Collect Source
+
+Each mode needs input material. Consult `modes/<slug>.md` for the required input type and collection workflow:
+
+- `product-reel` — product page URL
+- `talking-head` — source content path (docs/notes/script)
+- `clip-repurpose` — long-form video path or URL
+- `polish` — existing video file path
+- `beat-sync-reel` — product images + audio (file, URL, or search query)
+
+## 10. Step 5: Dispatch
+
+Once mode + format + style + source are known, invoke the underlying sub-skill with the consolidated parameters. The router is responsible for translating format + style into sub-skill parameters (e.g., setting aspect ratio flags, selecting a music track, applying a caption template).
+
+See `modes/<slug>.md` for the exact dispatch contract per mode.
+
+## 11. Step 6: Deliver
+
+Return the sub-skill's output to the user. Standardize the delivery format:
+
+- Output video file path(s) with duration, resolution, file size
+- Thumbnail/poster frame if applicable
+- Caption file (.srt or .vtt) if captions were generated
+- Per-platform upload hints if format maps cleanly to a known platform
+
+## 12. Special Modes
+
+- **"Surprise me"** — Pick `product-reel` with `vertical-short` format and `energetic` style. Ask only for the product URL.
+- **Multi-format** — If the user says "make this as both a vertical-short and a square-social," run the mode twice with different format flags. Save outputs in separate subdirectories.
+- **Mode preview** — Before committing to full generation, produce a single-scene preview so the user can approve the visual direction before paying for full API calls (especially relevant for `product-reel` via Higgsfield and `talking-head` via HeyGen).
+
+## 13. File Reference
+
+### Modes
+| File | Description |
+|------|-------------|
+| `modes/index.json` | Canonical list of all modes |
+| `modes/product-reel.md` | Dispatch spec for `packs/video-production/product-reel-generator` |
+| `modes/talking-head.md` | Dispatch spec for `packs/video-production/talking-head-video` |
+| `modes/clip-repurpose.md` | Dispatch spec for `packs/video-production/video-clipper` |
+| `modes/polish.md` | Dispatch spec for `packs/video-production/video-polish` |
+| `modes/beat-sync-reel.md` | Dispatch spec for `packs/video-production/beat-sync-reel` |
+
+### Formats
+| File | Description |
+|------|-------------|
+| `formats/index.json` | Canonical list of all formats |
+| `formats/vertical-short.md` | 9:16, 15–60s (TikTok, Reels, Shorts) |
+| `formats/vertical-story.md` | 9:16, 15–30s (Stories) |
+| `formats/square-social.md` | 1:1, 15–30s (Instagram/LinkedIn feed) |
+| `formats/landscape-short.md` | 16:9, 30–90s (YouTube, LinkedIn) |
+| `formats/landscape-long.md` | 16:9, 3–10min (long-form, tutorials) |
+
+### Styles
+| File | Description |
+|------|-------------|
+| `styles/index.json` | Canonical list of all style presets |
+| `styles/<slug>.md` | Per-style spec: palette, typography, pacing, caption style, music hints |
+
+### Sources
+| File | Description |
+|------|-------------|
+| `sources/stock-footage.md` | Pexels / Pixabay video search and embedding |
+| `sources/music.md` | Royalty-free music selection |
+| `sources/captions.md` | Transcription + caption styling (Whisper, Remotion captions) |

--- a/skills/composites/goose-video/formats/index.json
+++ b/skills/composites/goose-video/formats/index.json
@@ -1,0 +1,44 @@
+{
+  "formats": [
+    {
+      "slug": "vertical-short",
+      "name": "Vertical Short",
+      "aspect_ratio": "9:16",
+      "dimensions": "1080x1920",
+      "duration_range": "15-60s",
+      "platforms": ["TikTok", "Instagram Reels", "YouTube Shorts"]
+    },
+    {
+      "slug": "vertical-story",
+      "name": "Vertical Story",
+      "aspect_ratio": "9:16",
+      "dimensions": "1080x1920",
+      "duration_range": "15-30s",
+      "platforms": ["Instagram Stories", "LinkedIn Stories", "Snapchat"]
+    },
+    {
+      "slug": "square-social",
+      "name": "Square Social",
+      "aspect_ratio": "1:1",
+      "dimensions": "1080x1080",
+      "duration_range": "15-30s",
+      "platforms": ["Instagram feed", "LinkedIn feed", "Twitter/X"]
+    },
+    {
+      "slug": "landscape-short",
+      "name": "Landscape Short",
+      "aspect_ratio": "16:9",
+      "dimensions": "1920x1080",
+      "duration_range": "30-90s",
+      "platforms": ["YouTube", "LinkedIn", "Twitter/X", "website embed"]
+    },
+    {
+      "slug": "landscape-long",
+      "name": "Landscape Long",
+      "aspect_ratio": "16:9",
+      "dimensions": "1920x1080",
+      "duration_range": "3-10min",
+      "platforms": ["YouTube long-form", "tutorials", "webinars", "course content"]
+    }
+  ]
+}

--- a/skills/composites/goose-video/formats/landscape-long.md
+++ b/skills/composites/goose-video/formats/landscape-long.md
@@ -1,0 +1,32 @@
+# Format: landscape-long
+
+**Aspect:** 16:9 · **Dimensions:** 1920×1080 · **Duration:** 3–10 minutes
+
+## Platforms
+
+- **YouTube long-form** — the native home for 5–10min explainers
+- **Webinar platforms** — Zoom recordings, Riverside, Descript
+- **Course content** — Teachable, Thinkific, internal LMS
+- **Website embeds** — detailed walkthroughs, onboarding flows
+
+## Safe zones
+
+Same as `landscape-short` — 60px margin on all sides, critical content in center 1800×960.
+
+## Audio
+
+- Sound-on viewing is the norm
+- Music beds should be quiet (background)
+- Voiceover quality matters more — invest in clean audio capture
+
+## Modes that support this format
+
+`talking-head`, `polish`
+
+## Tips
+
+- **Structure with chapters** — YouTube auto-detects from timestamps in description; viewers use them to skip
+- **Retention graph is your guide** — watch where viewers drop off, iterate
+- **Intro under 15s** — don't waste the first quarter-minute on branding
+- **Outro with a CTA** — clear next step: subscribe, visit landing page, try the product
+- **Pacing tolerance** — longer videos can breathe more (5–10s cuts), but every beat should carry weight

--- a/skills/composites/goose-video/formats/landscape-short.md
+++ b/skills/composites/goose-video/formats/landscape-short.md
@@ -1,0 +1,33 @@
+# Format: landscape-short
+
+**Aspect:** 16:9 · **Dimensions:** 1920×1080 · **Duration:** 30–90s
+
+## Platforms
+
+- **YouTube** — standard landscape; main home-feed format
+- **LinkedIn** — 16:9 posts; strong for B2B thought leadership
+- **Twitter/X** — 16:9 supported; autoplay-first
+- **Website embeds** — hero videos, product pages
+
+## Safe zones
+
+- **All sides:** 60px margin
+- **Critical rectangle:** x∈[60, 1860], y∈[60, 1020]
+- **YouTube thumbnail safe zone:** center 1280×720 (avoid critical content near edges)
+
+## Audio
+
+- Sound-on viewing is more common than short-form verticals
+- Music beds and voiceover are both normal
+- Still — burn captions where possible; ~70% of muted autoplay still applies on LinkedIn
+
+## Modes that support this format
+
+`talking-head` (default), `polish` (default), `landscape-long` variants
+
+## Tips
+
+- **Hook in 5s** — more forgiving than short-form, but YouTube still rewards strong openings
+- **Pacing is slower** — 3–5s cuts vs. 1–3s for vertical
+- **Thumbnail design matters** — on YouTube especially, the thumbnail drives CTR more than the video itself
+- **Chapters for longer videos** — YouTube rewards structured content

--- a/skills/composites/goose-video/formats/square-social.md
+++ b/skills/composites/goose-video/formats/square-social.md
@@ -1,0 +1,31 @@
+# Format: square-social
+
+**Aspect:** 1:1 · **Dimensions:** 1080×1080 · **Duration:** 15–30s (Instagram feed up to 60s)
+
+## Platforms
+
+- **Instagram feed** — 1:1 performs on par with 4:5 portrait; both supported
+- **LinkedIn feed** — 1:1 is widely supported and mobile-friendly
+- **Twitter/X** — 1:1 or 16:9 both supported
+
+## Safe zones
+
+- **All sides:** 40px margin for text
+- **Critical rectangle:** x∈[40, 1040], y∈[40, 1040]
+- No platform UI overlays in-feed (unlike Stories/Reels)
+
+## Audio
+
+- Feed content often plays muted — **bake in captions or on-screen text**
+- Short musical cues (stingers, transitions) work better than long music beds
+
+## Modes that support this format
+
+`talking-head`, `product-reel`, `clip-repurpose`
+
+## Tips
+
+- **Optimized for feed scroll** — competing with static images for attention
+- **Strong first frame** — the poster thumbnail is what viewers see before autoplay
+- **LinkedIn tip** — keep the first 3 seconds text-forward. LinkedIn feed previews are short.
+- **Shorter is better** — 15–20s often outperforms 30+s in feed contexts

--- a/skills/composites/goose-video/formats/vertical-short.md
+++ b/skills/composites/goose-video/formats/vertical-short.md
@@ -1,0 +1,35 @@
+# Format: vertical-short
+
+**Aspect:** 9:16 · **Dimensions:** 1080×1920 · **Duration:** 15–60s
+
+## Platforms
+
+- **TikTok** — 15–60s, native 9:16
+- **Instagram Reels** — up to 90s, native 9:16 (15–30s performs best)
+- **YouTube Shorts** — up to 60s, native 9:16
+
+## Safe zones
+
+- **Top safe zone:** 220px (TikTok username/caption UI)
+- **Bottom safe zone:** 340px (TikTok like/comment/share + caption area)
+- **Left safe zone:** 40px
+- **Right safe zone:** 140px (TikTok right-side action rail)
+
+Critical content (text overlays, faces, product focal points) must live inside the safe rectangle: roughly x∈[40, 940], y∈[220, 1580].
+
+## Audio
+
+- Many platforms auto-play muted — include captions or on-screen text for muted viewers
+- Keep hooks (the first 2 seconds) visually legible without audio
+- Music: use trending sounds on TikTok when possible; royalty-free on Reels/Shorts
+
+## Modes that support this format
+
+`product-reel` (default), `clip-repurpose` (default), `beat-sync-reel` (default), `talking-head`, `vertical-story` variants
+
+## Tips
+
+- **Hook in 2s** — the first 2 seconds determine retention. Open with motion or a pattern interrupt.
+- **Cut every 1–3s** — viewers scroll fast. Keep pace high.
+- **Burn captions** — don't rely on platform auto-captions for post-hoc edits; bake them in.
+- **Square text is safer than rotated text** — keep text in the safe zone, horizontally aligned.

--- a/skills/composites/goose-video/formats/vertical-story.md
+++ b/skills/composites/goose-video/formats/vertical-story.md
@@ -1,0 +1,32 @@
+# Format: vertical-story
+
+**Aspect:** 9:16 · **Dimensions:** 1080×1920 · **Duration:** 15–30s (single slide up to 60s on some platforms)
+
+## Platforms
+
+- **Instagram Stories** — 15s per slide, up to 60s single clip
+- **LinkedIn Stories** — 20s per slide (deprecated on some rollouts; check availability)
+- **Snapchat** — 10s per slide by default, up to 60s combined
+
+## Safe zones
+
+- **Top safe zone:** 250px (profile chrome + time indicator)
+- **Bottom safe zone:** 300px (reply composer + interaction prompts)
+- **Critical rectangle:** x∈[40, 1040], y∈[250, 1620]
+
+## Audio
+
+- Stories auto-play with sound on most platforms (unlike feed content)
+- Music bed is common; voiceover optional
+- Under 15s — no music is also fine
+
+## Modes that support this format
+
+`product-reel`, `clip-repurpose`, `beat-sync-reel` (shorter variants)
+
+## Tips
+
+- **One idea per slide** — stories are disposable; don't cram
+- **Swipe-up / link stickers** — design for the interaction target (product page, sign-up, lead magnet)
+- **Polls & questions** — native engagement primitives boost reach
+- **Lower production bar** — stories tolerate rougher edits; "publish fast" beats "polish slowly"

--- a/skills/composites/goose-video/modes/beat-sync-reel.md
+++ b/skills/composites/goose-video/modes/beat-sync-reel.md
@@ -1,0 +1,57 @@
+# Mode: beat-sync-reel
+
+Delegates to `packs/video-production/beat-sync-reel`.
+
+## What it does
+
+Generates Instagram Reels where product image cuts are synced to audio beats. Accepts audio as a local file, URL, or search query. Uses librosa for beat detection, FFmpeg Ken Burns for scene animation, and Pillow for text overlays.
+
+**No AI video generation** — fully free, fast, and scalable. Best mode when budget matters and you have strong product photography already.
+
+## When to pick this mode
+
+- User has product images (photography, renders) and wants a reel fast and free
+- Goal is rhythm-driven pacing (cuts on the beat)
+- User wants to avoid paid AI video APIs
+
+## Required input
+
+- `--source <product-images-plus-audio>` — can be one of:
+  - Directory path containing product images + an audio file
+  - List of image paths/URLs + `--audio <path-url-or-query>`
+
+Optional:
+- `--audio <path|url|search-query>` — audio source. If a search query (e.g., "upbeat lofi"), the sub-skill resolves via its configured music source.
+- `--brief "..."` — optional text overlay content
+
+## Format support
+
+- `vertical-short` (9:16, default) — TikTok/Reels/Shorts
+- `vertical-story` (9:16, shorter) — Stories
+
+Square and landscape unsupported — this mode is vertical-first.
+
+## Style hints
+
+Default: `energetic`. Good alternatives: `kinetic-type`, `minimal`.
+
+Style affects: cut frequency (beat density), text overlay treatment, Ken Burns intensity, color grading.
+
+## Dispatch
+
+Invoke the sub-skill with:
+
+```
+beat-sync-reel <images-and-audio>
+  [--duration <seconds>]
+  [--text "..."]
+  [--text-style <mapped-from-style>]
+```
+
+## Environment
+
+- Python 3.10+ with `librosa`, `Pillow`, `numpy`, `requests`
+- FFmpeg on PATH
+- No paid API keys required (unless `--audio` resolves via a paid music source)
+
+See `packs/video-production/beat-sync-reel/SKILL.md` for full setup.

--- a/skills/composites/goose-video/modes/clip-repurpose.md
+++ b/skills/composites/goose-video/modes/clip-repurpose.md
@@ -1,0 +1,54 @@
+# Mode: clip-repurpose
+
+Delegates to `packs/video-production/video-clipper`.
+
+## What it does
+
+Repurposes long-form video (podcasts, interviews, talks) into short-form vertical clips for Instagram Reels, TikTok, and YouTube Shorts. Handles transcription, moment selection, clip extraction, speaker-tracked reframing (16:9 → 9:16), and animated captions.
+
+## When to pick this mode
+
+- User has an existing long-form video (30min+ podcast, keynote, webinar)
+- Goal is to extract the best 3–10 moments as standalone vertical clips
+- User wants speaker-aware reframing and animated captions baked in
+
+## Required input
+
+- `--source <long-form-video-path-or-url>` — local file or YouTube/Vimeo/etc. URL
+
+Optional:
+- `--brief "..."` — topic or angle guidance for moment selection (e.g., "focus on hiring stories")
+
+## Format support
+
+- `vertical-short` (9:16, default) — TikTok/Reels/Shorts
+- `vertical-story` (9:16, shorter) — Stories
+- `square-social` (1:1) — feed variants
+
+Landscape formats unsupported — this mode is specifically about the 16:9 → 9:16 reframe transformation. For landscape pass-through, use `polish` instead.
+
+## Style hints
+
+Default: `documentary`. Good alternatives: `energetic`, `ugc-handheld`.
+
+Style affects: caption styling (font, animation, position), music bed (if audio is added), cut timing, hook-first ordering.
+
+## Dispatch
+
+Invoke the sub-skill with:
+
+```
+video-clipper <source-video-path-or-url>
+  [--num-clips <n>]
+  [--min-duration <seconds>]
+  [--max-duration <seconds>]
+  [--caption-style <mapped-from-style>]
+```
+
+## Environment
+
+- OpenAI API key (or local Whisper) for transcription
+- FFmpeg on PATH
+- Python for speaker tracking
+
+See `packs/video-production/video-clipper/SKILL.md` for full setup.

--- a/skills/composites/goose-video/modes/index.json
+++ b/skills/composites/goose-video/modes/index.json
@@ -1,0 +1,54 @@
+{
+  "modes": [
+    {
+      "slug": "product-reel",
+      "name": "Product Reel",
+      "tagline": "Instagram-ready reel from an e-commerce product page",
+      "delegates_to": "packs/video-production/product-reel-generator",
+      "default_format": "vertical-short",
+      "default_style": "energetic",
+      "supports_formats": ["vertical-short", "vertical-story", "square-social"],
+      "required_input": "product-page-url"
+    },
+    {
+      "slug": "talking-head",
+      "name": "Talking Head",
+      "tagline": "AI avatar narrates over slides / screenshots (HeyGen)",
+      "delegates_to": "packs/video-production/talking-head-video",
+      "default_format": "landscape-short",
+      "default_style": "minimal",
+      "supports_formats": ["landscape-short", "landscape-long", "square-social", "vertical-short"],
+      "required_input": "source-content-path"
+    },
+    {
+      "slug": "clip-repurpose",
+      "name": "Clip Repurpose",
+      "tagline": "Long-form video → short vertical clips with captions",
+      "delegates_to": "packs/video-production/video-clipper",
+      "default_format": "vertical-short",
+      "default_style": "documentary",
+      "supports_formats": ["vertical-short", "vertical-story", "square-social"],
+      "required_input": "long-form-video-path-or-url"
+    },
+    {
+      "slug": "polish",
+      "name": "Polish",
+      "tagline": "Zoom/pan + audio polish on an existing screen recording",
+      "delegates_to": "packs/video-production/video-polish",
+      "default_format": "landscape-short",
+      "default_style": "tutorial",
+      "supports_formats": ["landscape-short", "landscape-long"],
+      "required_input": "existing-video-file-path"
+    },
+    {
+      "slug": "beat-sync-reel",
+      "name": "Beat-Sync Reel",
+      "tagline": "Product image cuts synced to audio beats — free, no AI video gen",
+      "delegates_to": "packs/video-production/beat-sync-reel",
+      "default_format": "vertical-short",
+      "default_style": "energetic",
+      "supports_formats": ["vertical-short", "vertical-story"],
+      "required_input": "product-images-plus-audio"
+    }
+  ]
+}

--- a/skills/composites/goose-video/modes/polish.md
+++ b/skills/composites/goose-video/modes/polish.md
@@ -1,0 +1,52 @@
+# Mode: polish
+
+Delegates to `packs/video-production/video-polish`.
+
+## What it does
+
+Takes an existing screen recording or demo video and adds professional zoom/pan effects synchronized to the narration. Uses transcript-driven zoom targeting and Remotion for rendering. Optionally replaces audio with a soundtrack.
+
+## When to pick this mode
+
+- User has an existing screen recording (product demo, tutorial, walkthrough)
+- Goal is to make it feel polished — zoom into relevant UI elements as narration references them
+- User wants captions and/or replacement audio
+
+## Required input
+
+- `--source <existing-video-file-path>` — local video file (mp4, mov preferred)
+
+Optional:
+- `--brief "..."` — emphasis hints for zoom targeting
+
+## Format support
+
+- `landscape-short` (16:9, default) — 30–90s polished demos
+- `landscape-long` (16:9) — 3–10min full walkthroughs
+
+Vertical and square formats unsupported — polish preserves the source aspect ratio, which is typically landscape for screen recordings. Use `clip-repurpose` if you need to reframe to vertical.
+
+## Style hints
+
+Default: `tutorial`. Good alternatives: `minimal`, `cinematic`.
+
+Style affects: zoom speed and easing, caption styling, music bed, transition treatment.
+
+## Dispatch
+
+Invoke the sub-skill with:
+
+```
+video-polish <existing-video-file-path>
+  [--zoom-intensity <low|medium|high>]
+  [--replace-audio <path-or-slug>]
+  [--caption-style <mapped-from-style>]
+```
+
+## Environment
+
+- Remotion (Node — run `npm install` in the sub-skill directory)
+- OpenAI API key (or local Whisper) for transcript + zoom targeting
+- FFmpeg on PATH
+
+See `packs/video-production/video-polish/SKILL.md` for full setup.

--- a/skills/composites/goose-video/modes/product-reel.md
+++ b/skills/composites/goose-video/modes/product-reel.md
@@ -1,0 +1,50 @@
+# Mode: product-reel
+
+Delegates to `packs/video-production/product-reel-generator`.
+
+## What it does
+
+Generates Instagram-ready product reels from any e-commerce product page URL. Scrapes product images, classifies by type, generates AI-animated clips via Higgsfield API, creates text overlays with style presets, and composes a 15–20s reel with music.
+
+## When to pick this mode
+
+- User has a product page URL and wants a social-ready reel
+- Goal is new asset creation (not repurposing existing video)
+- User is okay with AI-generated animated clips (paid API — Higgsfield)
+
+## Required input
+
+- `--source <product-page-url>` — live e-commerce product page (Shopify, WooCommerce, etc.)
+
+## Format support
+
+- `vertical-short` (9:16, default) — TikTok/Reels/Shorts
+- `vertical-story` (9:16, 15–30s) — Stories
+- `square-social` (1:1) — Instagram/LinkedIn feed
+
+Not supported: landscape formats (sub-skill is tuned for vertical output).
+
+## Style hints
+
+Default: `energetic`. Good alternatives: `minimal`, `cinematic`.
+
+The underlying skill has its own style-preset system. The router translates `goose-video` style slugs into the sub-skill's internal preset flags — see the sub-skill's SKILL.md for the full list.
+
+## Dispatch
+
+Invoke the sub-skill with:
+
+```
+product-reel-generator <product-page-url>
+  [--aspect-ratio <mapped-from-format>]
+  [--style <mapped-from-style>]
+  [--brief "..."]
+```
+
+## Environment
+
+- `HIGGSFIELD_API_KEY` required
+- Python 3.10+ with `librosa`, `Pillow`, `requests`
+- FFmpeg on PATH
+
+See `packs/video-production/product-reel-generator/SKILL.md` for full setup.

--- a/skills/composites/goose-video/modes/talking-head.md
+++ b/skills/composites/goose-video/modes/talking-head.md
@@ -1,0 +1,51 @@
+# Mode: talking-head
+
+Delegates to `packs/video-production/talking-head-video`.
+
+## What it does
+
+Creates talking-head videos from any source material (docs, changelogs, blog posts, notes, transcripts). Produces multi-scene videos with AI-avatar narration over screenshots/images via HeyGen v2 API. Supports Quick Shot and Full Producer modes.
+
+## When to pick this mode
+
+- User has written content (docs, changelog, blog post) and wants a narrated explainer
+- Goal is AI-avatar narration (no real person on camera)
+- User is okay with paid AI narration (HeyGen API)
+
+## Required input
+
+- `--source <source-content-path>` — path to the source material (markdown, text, PDF, or URL)
+
+Optional:
+- `--brief "..."` — additional framing or emphasis for the script
+
+## Format support
+
+- `landscape-short` (16:9, 30–90s, default) — YouTube/LinkedIn
+- `landscape-long` (16:9, 3–10min) — tutorials, webinars
+- `square-social` (1:1) — Instagram/LinkedIn feed
+- `vertical-short` (9:16) — TikTok/Reels (avatar reframed to vertical safe zone)
+
+## Style hints
+
+Default: `minimal`. Good alternatives: `tutorial`, `documentary`, `cinematic`.
+
+Style affects: caption styling, background treatment, pacing, music bed selection. The underlying avatar choice is separate — see `talking-head-video/AVATAR-CONFIG.example.md`.
+
+## Dispatch
+
+Invoke the sub-skill with:
+
+```
+talking-head-video <source-content-path>
+  [--aspect-ratio <mapped-from-format>]
+  [--avatar <configured>]
+  [--producer-mode quick|full]
+```
+
+## Environment
+
+- `HEYGEN_API_KEY` required
+- Avatar configured via `AVATAR-CONFIG.md` in the sub-skill
+
+See `packs/video-production/talking-head-video/SKILL.md` for full setup.

--- a/skills/composites/goose-video/skill.meta.json
+++ b/skills/composites/goose-video/skill.meta.json
@@ -1,0 +1,33 @@
+{
+  "slug": "goose-video",
+  "category": "composites",
+  "tags": [
+    "content",
+    "video",
+    "social",
+    "brand"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install goose-video",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ],
+    "dependencies": [
+      "packs/video-production/beat-sync-reel",
+      "packs/video-production/product-reel-generator",
+      "packs/video-production/talking-head-video",
+      "packs/video-production/video-clipper",
+      "packs/video-production/video-polish"
+    ]
+  },
+  "features": [
+    "5 modes (product-reel, talking-head, clip-repurpose, polish, beat-sync-reel)",
+    "5 aspect-ratio formats (vertical-short, vertical-story, square-social, landscape-short, landscape-long)",
+    "8 visual style presets (cinematic, energetic, minimal, documentary, tutorial, ugc-handheld, motion-graphic, kinetic-type)",
+    "Dispatches to underlying packs/video-production/ skills",
+    "Args-based slash command invocation",
+    "Interactive fallback when args are missing"
+  ]
+}

--- a/skills/composites/goose-video/sources/captions.md
+++ b/skills/composites/goose-video/sources/captions.md
@@ -1,0 +1,43 @@
+# Source: Captions
+
+Generate and style burned-in captions for muted autoplay and accessibility.
+
+## Transcription
+
+### OpenAI Whisper (API or local)
+- API: `openai.Audio.transcriptions.create(model="whisper-1", file=...)`
+- Local: `openai-whisper` Python package (works offline, slower)
+- Output: SRT, VTT, or JSON with word-level timestamps
+
+### Remotion Captions (for polish mode)
+- Built into the video-polish sub-skill
+- Uses Whisper under the hood
+- Renders captions as part of the Remotion composition
+
+## Caption styling by style preset
+
+| Style | Caption treatment |
+|-------|-------------------|
+| cinematic | lower-third, thin sans, 70–85% opacity, fade in/out |
+| energetic | large, centered, word-by-word reveal, bounce/pop |
+| minimal | centered, static, fade in/out, single line |
+| documentary | lower-third, clean sans, includes speaker name |
+| tutorial | bottom-center, large, word-by-word for technical terms |
+| ugc-handheld | TikTok-style (white + black stroke, or black + yellow highlight), word-by-word |
+| motion-graphic | integrated into the motion-graphic system (no separate caption layer) |
+| kinetic-type | captions ARE the content; no separate layer |
+
+## Workflow
+
+1. **Transcribe** — run Whisper on the audio track, get word-level timestamps
+2. **Segment** — break into caption chunks (max 2 lines, max ~7 words per line, respect sentence boundaries)
+3. **Style** — apply the chosen style's caption treatment
+4. **Burn in** — render captions into the video (preferred for social), OR produce a sidecar SRT/VTT for platforms that support overlays (YouTube)
+
+## Best practices
+
+- **Bake captions in for social** — most muted autoplay won't use platform-native CC
+- **Provide a sidecar SRT for YouTube** — helps SEO and accessibility
+- **Keep lines short** — 2 lines max, readable at a glance
+- **Respect language direction** — RTL languages need aligned treatment
+- **Proofread names and jargon** — Whisper struggles with brand names and technical terms; post-edit these

--- a/skills/composites/goose-video/sources/music.md
+++ b/skills/composites/goose-video/sources/music.md
@@ -1,0 +1,53 @@
+# Source: Music
+
+Select and integrate royalty-free music for video backgrounds.
+
+## Providers
+
+### Pixabay Music (free, API key required)
+- Part of the Pixabay API
+- Requires `PIXABAY_API_KEY` env var
+- Good for: generic background music, broad genre coverage
+- Attribution: not required
+
+### Free Music Archive (free, no API key)
+- Public collection of CC-licensed tracks
+- Good for: editorial, documentary, and lo-fi content
+- Attribution: varies by license (check each track)
+
+### Epidemic Sound (paid subscription)
+- Higher production quality; broader trending-sound coverage
+- Requires active subscription + API key
+- Good for: commercial use, social-ready tracks
+
+### Platform-native trending sounds
+- For TikTok/Reels: use trending platform-native audio if available via Orthogonal's TikTok/Instagram scrapers
+- Native sounds boost algorithmic reach
+
+## Style → genre mapping
+
+| Style | Music genre hints |
+|-------|-------------------|
+| cinematic | cinematic, ambient, trailer, indie film score |
+| energetic | hip-hop, edm, trap, hyperpop, trending |
+| minimal | ambient, piano, lo-fi, (or none) |
+| documentary | documentary, emotional, inspirational, corporate soft |
+| tutorial | lo-fi, ambient, corporate background, (or none) |
+| ugc-handheld | trending, pop, viral, or platform-native sound |
+| motion-graphic | motion graphic, corporate upbeat, electronic, explainer |
+| kinetic-type | hip-hop, rhythmic, percussion, drum and bass |
+
+## Selection workflow
+
+1. Map the chosen style → genre tags
+2. Query the provider(s) for matching tracks
+3. Filter by:
+   - BPM (match to format's target pace — 120–160 for energetic, 80–100 for documentary)
+   - Duration (at least as long as the video; trim to fit)
+   - Energy level
+4. Auto-select top candidate; let user swap if desired
+5. Fade-in (500ms) at start, fade-out (500ms) at end unless the style dictates otherwise
+
+## Licensing
+
+Always confirm the license covers the intended use (commercial, organic social, paid ads). Some royalty-free tracks exclude paid advertising or broadcast.

--- a/skills/composites/goose-video/sources/stock-footage.md
+++ b/skills/composites/goose-video/sources/stock-footage.md
@@ -1,0 +1,44 @@
+# Source: Stock Footage
+
+Embed royalty-free stock video for B-roll, transitions, and atmospheric scenes.
+
+## Providers
+
+### Pexels Videos (free, no API key required for basic)
+- API: https://www.pexels.com/api/documentation/
+- Requires `PEXELS_API_KEY` env var for programmatic access
+- Good for: broad lifestyle/nature/urban footage
+- Attribution: not required but appreciated
+
+### Pixabay Videos (free, API key required)
+- API: https://pixabay.com/api/docs/
+- Requires `PIXABAY_API_KEY` env var
+- Good for: CC0-style permissive licensing
+- Attribution: not required
+
+### Orthogonal video search (if available)
+- Check `orthogonal-scrapecreators` or `orthogonal-search` for video asset search via Orthogonal's API surface
+
+## Search workflow
+
+1. Extract keywords from the `--brief` or the user's described scenes
+2. Query the chosen provider with each keyword
+3. Filter results by:
+   - Minimum resolution (1920×1080 for landscape, 1080×1920 for vertical)
+   - Duration match (within ±3s of required scene length, or trimmable)
+   - License compatibility
+4. Download top candidates to a local `stock-footage/` directory
+5. Present to the user for approval before compositing
+
+## Embedding
+
+- Download full-resolution, then re-encode to match project output specs
+- Trim to scene length
+- Apply style's color grade during compositing
+- Credit the creator in the final export's metadata (optional but good practice)
+
+## When to skip stock footage
+
+- `polish` mode — the source recording is the content; stock footage would be awkward
+- `talking-head` mode — the avatar + slides are self-contained; stock is rarely needed
+- Kinetic-type / motion-graphic styles — no live footage by definition

--- a/skills/composites/goose-video/styles/cinematic.md
+++ b/skills/composites/goose-video/styles/cinematic.md
@@ -1,0 +1,39 @@
+# Style: cinematic
+
+Film-grain, letterbox, slow handheld pans, muted palette. Feels like a trailer or indie short film.
+
+## Palette
+
+- **Dominant:** deep desaturated teals and oranges (cinema grade)
+- **Accent:** warm highlights, crushed blacks
+- **Avoid:** saturated primaries, digital pure whites
+
+## Typography
+
+- **Headlines:** serif display or condensed grotesque, tight tracking
+- **Captions:** thin sans-serif, soft opacity (70–85%)
+- **Position:** lower-third or centered, never busy corners
+
+## Pacing
+
+- Slow to medium (3–5s cuts)
+- Holds breathe — don't rush between scenes
+- Transitions: cross-dissolves, fade-to-black for act breaks
+
+## Caption style
+
+- Burned-in, fade in/out with the clip
+- Single line when possible; max 2 lines
+- No animated bounces — stillness is the point
+
+## Music hints
+
+- Orchestral, ambient synth, or cinematic piano
+- Swells that match the edit — cut to music beats softly, not aggressively
+- Genre tags for music APIs: `cinematic`, `ambient`, `trailer`, `indie film score`
+
+## Transitions
+
+- Cross-dissolve (300–500ms)
+- Fade-to-black for act changes
+- Avoid: hard cuts on every beat, flashy wipes, zoom punches

--- a/skills/composites/goose-video/styles/documentary.md
+++ b/skills/composites/goose-video/styles/documentary.md
@@ -1,0 +1,40 @@
+# Style: documentary
+
+B-roll heavy, interview-style framing, soft music, natural palette. For narrative storytelling and thought-leadership content.
+
+## Palette
+
+- **Dominant:** natural tones — warm wood, soft earth, muted blues
+- **Accent:** warm highlights, golden-hour color grading
+- **Avoid:** oversaturation, digital pure whites, neon
+
+## Typography
+
+- **Lower-thirds:** clean sans-serif with a thin underline or rule
+- **Chapter titles:** editorial serif, centered, holds for 2–3s
+- **Position:** lower-third for speaker identification, centered for chapter markers
+
+## Pacing
+
+- Medium to slow (3–5s cuts)
+- B-roll overlays cut to the narration rhythm
+- Interview segments breathe — don't over-cut speaking heads
+
+## Caption style
+
+- Clean, readable, lower-third or bottom-center
+- No animated effects — respect the subject matter
+- Include speaker names on first appearance
+
+## Music hints
+
+- Soft piano, ambient guitar, subtle strings
+- Never overpower the voiceover
+- Genre tags for music APIs: `documentary`, `emotional`, `inspirational`, `corporate soft`
+
+## Transitions
+
+- Hard cuts between B-roll
+- Cross-dissolves (200–400ms) for scene transitions
+- Fade-to-black only for major chapter breaks
+- Never: whip pans, zoom punches, flashy FX

--- a/skills/composites/goose-video/styles/energetic.md
+++ b/skills/composites/goose-video/styles/energetic.md
@@ -1,0 +1,40 @@
+# Style: energetic
+
+Fast cuts, bass-heavy beats, bold text overlays, saturated color. The default for short-form social that needs to stop the scroll.
+
+## Palette
+
+- **Dominant:** saturated and bright — yellows, hot pinks, electric blues
+- **Accent:** high-contrast black or pure white
+- **Avoid:** muted earth tones, washed pastels
+
+## Typography
+
+- **Headlines:** heavy sans-serif, condensed, all-caps
+- **Captions:** large, high-contrast (white on black box, or yellow highlight)
+- **Position:** large, centered, sometimes tilted for energy
+
+## Pacing
+
+- Fast (1–2s cuts)
+- Cuts on the beat — use `beat-sync-reel` if rhythm-first
+- Quick zooms and punch-ins for emphasis
+
+## Caption style
+
+- Word-by-word or phrase-by-phrase reveal
+- Bounce, pop, or shake animations on key words
+- Emoji-friendly
+
+## Music hints
+
+- Bass-heavy EDM, hip-hop, drill, hyperpop, trending TikTok sounds
+- High BPM (120–160+)
+- Genre tags for music APIs: `hip-hop`, `edm`, `trap`, `hyperpop`, `trending`
+
+## Transitions
+
+- Hard cuts on beat
+- Whip pans for scene changes
+- Zoom punches for emphasis
+- Flash frames, glitch FX sparingly

--- a/skills/composites/goose-video/styles/index.json
+++ b/skills/composites/goose-video/styles/index.json
@@ -1,0 +1,52 @@
+{
+  "styles": [
+    {
+      "slug": "cinematic",
+      "name": "Cinematic",
+      "tagline": "Film-grain, letterbox, slow pans, muted palette",
+      "mood_group": "Dramatic"
+    },
+    {
+      "slug": "energetic",
+      "name": "Energetic",
+      "tagline": "Fast cuts, bass-heavy beats, bold text, saturated color",
+      "mood_group": "High-energy"
+    },
+    {
+      "slug": "minimal",
+      "name": "Minimal",
+      "tagline": "Clean backgrounds, simple type, generous whitespace, quiet audio",
+      "mood_group": "Clean"
+    },
+    {
+      "slug": "documentary",
+      "name": "Documentary",
+      "tagline": "B-roll heavy, interview-style, soft music, natural palette",
+      "mood_group": "Narrative"
+    },
+    {
+      "slug": "tutorial",
+      "name": "Tutorial",
+      "tagline": "Screencast-driven, zoom/pan emphasis, explanation-forward captions",
+      "mood_group": "Instructional"
+    },
+    {
+      "slug": "ugc-handheld",
+      "name": "UGC Handheld",
+      "tagline": "Phone-camera feel, raw edits, authentic and unpolished",
+      "mood_group": "Authentic"
+    },
+    {
+      "slug": "motion-graphic",
+      "name": "Motion Graphic",
+      "tagline": "Animated type, shape play, no live footage",
+      "mood_group": "Abstract"
+    },
+    {
+      "slug": "kinetic-type",
+      "name": "Kinetic Type",
+      "tagline": "Word-heavy, text-as-subject, rhythmic cuts to beats",
+      "mood_group": "Typographic"
+    }
+  ]
+}

--- a/skills/composites/goose-video/styles/kinetic-type.md
+++ b/skills/composites/goose-video/styles/kinetic-type.md
@@ -1,0 +1,38 @@
+# Style: kinetic-type
+
+Word-heavy, text-as-subject, rhythmic cuts to beats. Minimal or no footage — the words are the show.
+
+## Palette
+
+- **Dominant:** 1–2 high-contrast colors (classic: black + yellow, or white + red)
+- **Accent:** one disruptor color used sparingly for emphasis
+- **Avoid:** gradients, multiple typefaces, visual noise
+
+## Typography
+
+- **Everything:** bold display type — Druk, Anton, Neue Haas Grotesk Black, Founders Grotesk X-Condensed
+- **Scale:** massive — the largest words should nearly fill the frame
+- **Variation:** switch weight/size/color for emphasis, not typeface
+
+## Pacing
+
+- Beat-driven — each word or phrase lands on a beat
+- Fast (0.3–1s per word)
+- Rhythmic — the edit is the music
+
+## Caption style
+
+- Captions are the content — no separate caption layer
+- Words appear, scale, slide, or flash with the beat
+
+## Music hints
+
+- Beat-heavy, rhythmic, clear downbeats
+- Hip-hop, drum-and-bass, percussion-forward electronic
+- Genre tags for music APIs: `hip-hop`, `rhythmic`, `percussion`, `drum and bass`
+
+## Transitions
+
+- Hard cuts on beats
+- Text-to-text transforms (scale, slide, morph)
+- No cross-dissolves — this style is about rhythm, not softness

--- a/skills/composites/goose-video/styles/minimal.md
+++ b/skills/composites/goose-video/styles/minimal.md
@@ -1,0 +1,38 @@
+# Style: minimal
+
+Clean backgrounds, simple type, generous whitespace, quiet audio. For content where the message does the work and production stays out of the way.
+
+## Palette
+
+- **Dominant:** near-white, warm gray, soft cream
+- **Accent:** single muted brand color (navy, forest green, dusty rose — pick one)
+- **Avoid:** gradients, multiple accent colors, saturation
+
+## Typography
+
+- **Headlines:** clean geometric sans (Inter, Söhne, Neue Haas Grotesk) or editorial serif
+- **Captions:** same family, smaller size, generous line-height
+- **Position:** centered or left-aligned with generous margins
+
+## Pacing
+
+- Medium (2–4s cuts)
+- Let holds breathe — empty space is the point
+- No rapid-fire editing
+
+## Caption style
+
+- Clean, static, fade-in/fade-out (no animation)
+- One line preferred, max 2
+- Sentence case (not all caps)
+
+## Music hints
+
+- Quiet ambient, piano, soft electronic, or no music at all
+- Genre tags for music APIs: `ambient`, `piano`, `lo-fi`, `none`
+
+## Transitions
+
+- Hard cuts (no tricks)
+- Occasional cross-dissolve for act changes
+- Never: zoom punches, flashy wipes, glitch FX

--- a/skills/composites/goose-video/styles/motion-graphic.md
+++ b/skills/composites/goose-video/styles/motion-graphic.md
@@ -1,0 +1,38 @@
+# Style: motion-graphic
+
+Animated type, shape play, no live footage. 100% motion-graphics — no B-roll, no cameras. For explainer content, announcements, and brand moments.
+
+## Palette
+
+- **Dominant:** 2–3 bold brand colors
+- **Accent:** high-contrast black or white
+- **Avoid:** photo-realistic color — this is a graphic world
+
+## Typography
+
+- **Headlines:** display fonts, heavy weights, animated
+- **Body:** clean sans, readable at speed
+- **Animation:** type reveals, scales, rotations, morphs
+
+## Pacing
+
+- Tight (1–3s per beat)
+- Every frame has motion — no static holds
+- Transitions are part of the content, not between content
+
+## Caption style
+
+- Type is the star — captions may not be separate from content
+- If needed, styled as part of the overall motion-graphic system
+
+## Music hints
+
+- Rhythmic, tight (for syncing motion to beats)
+- Electronic, modern pop, corporate-upbeat
+- Genre tags for music APIs: `motion graphic`, `corporate upbeat`, `electronic`, `explainer`
+
+## Transitions
+
+- Morphs, wipes, shape-tweens
+- Motion-driven — one beat flows into the next
+- Tools: Remotion, After Effects-style animation curves

--- a/skills/composites/goose-video/styles/tutorial.md
+++ b/skills/composites/goose-video/styles/tutorial.md
@@ -1,0 +1,39 @@
+# Style: tutorial
+
+Screencast-driven, zoom/pan emphasis, explanation-forward captions. For product walkthroughs, demos, and how-tos.
+
+## Palette
+
+- **Dominant:** determined by the UI being recorded
+- **Accent:** bright callout color (hot pink, cyan) for cursor highlights and annotations
+- **Avoid:** color grades that obscure UI legibility
+
+## Typography
+
+- **Headlines:** clean sans (Inter, SF Pro, system font)
+- **Callouts:** bold, high-contrast, same family
+- **Position:** near the element being discussed, with an optional arrow pointer
+
+## Pacing
+
+- Matches narration (2–5s cuts on topic changes)
+- Holds on UI demonstrations for long enough to follow (don't rush interactions)
+- Zoom into relevant UI elements as narration references them
+
+## Caption style
+
+- Large, readable, bottom-center
+- Burned-in to survive muted autoplay
+- Word-by-word reveal for heavy technical content
+
+## Music hints
+
+- Quiet, unobtrusive — background only
+- Lo-fi, soft electronic, or no music at all
+- Genre tags for music APIs: `lo-fi`, `ambient`, `corporate background`, `none`
+
+## Transitions
+
+- Hard cuts when switching UI views
+- Smooth zooms (500–1000ms ease-in-out) for emphasis
+- No flashy FX — the UI is the subject

--- a/skills/composites/goose-video/styles/ugc-handheld.md
+++ b/skills/composites/goose-video/styles/ugc-handheld.md
@@ -1,0 +1,39 @@
+# Style: ugc-handheld
+
+Phone-camera feel, raw edits, authentic and unpolished. Mimics creator content for organic reach and trust.
+
+## Palette
+
+- **Dominant:** natural phone-camera color (slight oversaturation, auto white balance)
+- **Accent:** none — avoid heavy color grading
+- **Avoid:** cinematic grades, polished looks, studio lighting
+
+## Typography
+
+- **On-screen text:** TikTok/Instagram native caption style (white with black stroke, or black with yellow highlight)
+- **Position:** varies — hand-placed feel, not rigid grid
+- **Font:** native platform fonts (Helvetica, SF Pro, system)
+
+## Pacing
+
+- Conversational — matches natural speech rhythm
+- Jump cuts on verbal ums/pauses (faster-than-natural edit)
+- Not overly cut — authenticity is the point
+
+## Caption style
+
+- Burned-in, TikTok-style word-by-word OR sentence-by-sentence
+- Emoji-friendly
+- Sometimes misspelled/casual for authenticity
+
+## Music hints
+
+- Trending sounds > original music
+- Music often barely audible — voice carries
+- Genre tags for music APIs: `trending`, `pop`, `viral`, or match to current platform trends
+
+## Transitions
+
+- Hard cuts, jump cuts
+- Occasional whip pan between scenes
+- Never: cross-dissolves, cinematic fades, polished effects


### PR DESCRIPTION
## Summary
- New `composites/goose-video/` umbrella skill that wraps the 5 existing skills in `packs/video-production/` without absorbing them
- Adds two orthogonal axes on top of the sub-skills: **format** (aspect ratio + duration target) and **style** (visual treatment preset)
- Mirrors the `goose-graphics` pattern — sub-skills remain directly invocable; the umbrella is for users who'd rather describe the outcome than pick a skill up front

## What's in it

- **SKILL.md router** — supports full-args (`/goose-video --mode X --format Y --style Z --source …`), partial, and interactive invocation
- **5 modes** (each delegates to the matching `packs/video-production/` skill):
  - `product-reel` → product-reel-generator
  - `talking-head` → talking-head-video
  - `clip-repurpose` → video-clipper
  - `polish` → video-polish
  - `beat-sync-reel` → beat-sync-reel
- **5 formats**: vertical-short (9:16 short), vertical-story (9:16 Story), square-social (1:1), landscape-short (16:9 short), landscape-long (16:9 long)
- **8 style presets**: cinematic, energetic, minimal, documentary, tutorial, ugc-handheld, motion-graphic, kinetic-type
- **3 source integrations**: stock footage (Pexels/Pixabay), music (Pixabay/FMA/Epidemic Sound), captions (Whisper + Remotion)
- Styles and format specs land at the right level of detail for Claude to reason about during generation

## Design decision: wrap, don't absorb

The 5 video-production sub-skills stay in `packs/video-production/` and remain directly invocable (`/product-reel-generator`, `/talking-head-video`, etc.). `goose-video` is a higher-level entry point that adds format + style axes on top — not a replacement.

Rationale: as the library grows, some users will want to invoke a specific skill directly. Wrapping keeps both options available without duplication.

## Linear
GOOSE-1429 — Goose Skills: taxonomy + CMS tiering overhaul. This ships the \`goose-video\` flagship umbrella skill that's one of the 5 featured entries in the new CMS taxonomy.

## Test plan
- [ ] Invoke `/goose-video --mode beat-sync-reel --format vertical-short --source <images-and-audio>` and confirm it dispatches to the sub-skill
- [ ] Invoke `/goose-video` with no args and confirm the interactive flow walks through mode → format → style → source
- [ ] Invoke each mode standalone (`/product-reel-generator`, etc.) and confirm they still work without the umbrella
- [ ] Confirm format × mode support matrix (e.g., `beat-sync-reel` rejects landscape formats, `polish` rejects vertical formats)

🤖 Generated with [Claude Code](https://claude.com/claude-code)