### PR TITLE
Add social-content skill bundle (X + LinkedIn + voice guide + orchestrator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ npx gooseworks credits                     # Check your credit balance
 npx gooseworks update                      # Update to latest skill version
 ```
 
-## Available Skills (104)
+## Available Skills (108)
 
-**48 Capabilities** (atomic, single-purpose tools) | **51 Composites** (multi-skill chains) | **5 Playbooks** (end-to-end workflows)
+**51 Capabilities** (atomic, single-purpose tools) | **52 Composites** (multi-skill chains) | **5 Playbooks** (end-to-end workflows)
 
 ### Ads (9)
 | Skill | Type | Description |
@@ -59,7 +59,7 @@ npx gooseworks update                      # Update to latest skill version
 | `seo-traffic-analyzer` | Cap | Website traffic and keyword analysis |
 | `tech-stack-teardown` | Cap | Reverse-engineer a company's sales/marketing tech stack |
 
-### Content (11)
+### Content (15)
 | Skill | Type | Description |
 |-------|------|-------------|
 | `blog-feed-monitor` | Cap | Scrape blogs via RSS feeds with Apify fallback |
@@ -68,11 +68,15 @@ npx gooseworks update                      # Update to latest skill version
 | `content-brief-factory` | Comp | Detailed content briefs at scale with SERP analysis |
 | `create-html-carousel` | Cap | *(deprecated — use `goose-graphics`)* Create LinkedIn carousel posts as PNG images |
 | `create-html-slides` | Cap | *(deprecated — use `goose-graphics`)* Create animation-rich HTML presentations |
-| `goose-graphics` | Comp | 36 aesthetic presets across 7 formats (carousel, story, infographic, slides, poster, chart, tweet) with Unsplash/ASCII sourcing and Playwright PNG export |
+| `create-linkedin-content` | Cap | Draft voice-tuned LinkedIn post variants from a brief, with LinkedIn defaults and banned-phrase self-check |
 | `create-workflow-diagram` | Cap | Create FigJam/Miro-style workflow diagrams as PNGs |
+| `create-x-content` | Cap | Draft voice-tuned X/Twitter post variants with distinct framings and banned-phrase self-check |
 | `feature-launch-playbook` | Comp | Generate full launch kit from a feature/update |
+| `generate-voice-guide` | Cap | Generate a personal voice guide for X and/or LinkedIn from past posts via iterative sample-and-feedback loops |
+| `goose-graphics` | Comp | 36 aesthetic presets across 7 formats (carousel, story, infographic, slides, poster, chart, tweet) with Unsplash/ASCII sourcing and Playwright PNG export |
 | `help-center-article-generator` | Comp | Generate structured help center articles |
 | `site-content-catalog` | Cap | Full website content inventory |
+| `social-kit` | Comp | One command → voice-tuned X + LinkedIn drafts + matching graphic, orchestrating create-x-content, create-linkedin-content, and goose-graphics |
 
 ### Lead Generation (23)
 | Skill | Type | Description |

--- a/schemas/skill-meta.schema.json
+++ b/schemas/skill-meta.schema.json
@@ -8,7 +8,7 @@
     "category": { "type": "string", "enum": ["capabilities", "composites", "playbooks"] },
     "tags": {
       "type": "array",
-      "items": { "type": "string", "enum": ["All", "ads", "brand", "competitive-intel", "content", "design", "lead-generation", "monitoring", "outreach", "research", "seo"] },
+      "items": { "type": "string", "enum": ["All", "ads", "brand", "competitive-intel", "content", "design", "lead-generation", "monitoring", "outreach", "research", "seo", "social"] },
       "uniqueItems": true
     },
     "installation": {

--- a/scripts/validate-skills.js
+++ b/scripts/validate-skills.js
@@ -5,6 +5,7 @@ const path = require('path');
 
 const ROOT = path.resolve(__dirname, '..');
 const CATEGORIES = ['capabilities', 'composites'];
+const SCHEMA_PATH = path.join(ROOT, 'schemas', 'skill-meta.schema.json');
 
 function fail(messages) {
   console.error('Skill validation failed:');
@@ -15,6 +16,9 @@ function fail(messages) {
 function isValidSlug(slug) {
   return /^[a-z0-9-]+$/.test(slug);
 }
+
+const schema = JSON.parse(fs.readFileSync(SCHEMA_PATH, 'utf8'));
+const allowedTags = new Set(schema.properties.tags.items.enum);
 
 const errors = [];
 const slugs = new Set();
@@ -58,6 +62,14 @@ for (const category of CATEGORIES) {
     }
     if (!Array.isArray(meta.tags)) {
       errors.push(`tags must be an array in ${category}/${slug}`);
+    } else {
+      const invalidTags = meta.tags.filter((t) => !allowedTags.has(t));
+      if (invalidTags.length) {
+        errors.push(
+          `invalid tag(s) in ${category}/${slug}: ${invalidTags.join(', ')}. ` +
+            `Allowed: ${[...allowedTags].sort().join(', ')}`
+        );
+      }
     }
     if (!meta.installation || typeof meta.installation.base_command !== 'string' || !meta.installation.base_command.trim()) {
       errors.push(`installation.base_command required in ${category}/${slug}`);

--- a/skills-index.json
+++ b/skills-index.json
@@ -725,7 +725,7 @@
       "name": "create-dashboard",
       "category": "capabilities",
       "description": ">",
-      "tags": "dashboard, visualization, frontend",
+      "tags": "content, design",
       "path": "skills/capabilities/create-dashboard",
       "files": [
         "skills/capabilities/create-dashboard/SKILL.md",
@@ -735,9 +735,8 @@
         "slug": "create-dashboard",
         "category": "capabilities",
         "tags": [
-          "dashboard",
-          "visualization",
-          "frontend"
+          "content",
+          "design"
         ],
         "installation": {
           "base_command": "npx goose-skills install create-dashboard",
@@ -818,7 +817,7 @@
       "name": "create-linkedin-content",
       "category": "capabilities",
       "description": ">",
-      "tags": "content, social, linkedin",
+      "tags": "content, social",
       "path": "skills/capabilities/create-linkedin-content",
       "files": [
         "skills/capabilities/create-linkedin-content/SKILL.md",
@@ -829,8 +828,7 @@
         "category": "capabilities",
         "tags": [
           "content",
-          "social",
-          "linkedin"
+          "social"
         ],
         "installation": {
           "base_command": "npx goose-skills install create-linkedin-content",
@@ -878,7 +876,7 @@
       "name": "create-x-content",
       "category": "capabilities",
       "description": ">",
-      "tags": "content, social, x, twitter",
+      "tags": "content, social",
       "path": "skills/capabilities/create-x-content",
       "files": [
         "skills/capabilities/create-x-content/SKILL.md",
@@ -889,9 +887,7 @@
         "category": "capabilities",
         "tags": [
           "content",
-          "social",
-          "x",
-          "twitter"
+          "social"
         ],
         "installation": {
           "base_command": "npx goose-skills install create-x-content",
@@ -1180,7 +1176,7 @@
       "name": "generate-voice-guide",
       "category": "capabilities",
       "description": ">",
-      "tags": "content, voice, social",
+      "tags": "content, social",
       "path": "skills/capabilities/generate-voice-guide",
       "files": [
         "skills/capabilities/generate-voice-guide/SKILL.md",
@@ -1191,7 +1187,6 @@
         "category": "capabilities",
         "tags": [
           "content",
-          "voice",
           "social"
         ],
         "installation": {
@@ -1298,7 +1293,7 @@
       "name": "goose-graphics",
       "category": "composites",
       "description": "Portable visual skill pack for the Agent Skills ecosystem (Claude Code, Claude Desktop, Claude Cowork, Claude Design, Goose, Cursor, Codex). Ships 36 aesthetic presets in DESIGN.md format, 7 social-first format specs, extract-style from reference images, and automatic PNG export via Playwright.",
-      "tags": "content, design, graphics, social",
+      "tags": "content, design, social",
       "path": "skills/composites/goose-graphics",
       "files": [
         "skills/composites/goose-graphics/README.md",
@@ -1401,7 +1396,6 @@
         "tags": [
           "content",
           "design",
-          "graphics",
           "social"
         ],
         "installation": {
@@ -2062,7 +2056,7 @@
       "name": "linkedin-message-writer",
       "category": "capabilities",
       "description": ">",
-      "tags": "outreach, linkedin",
+      "tags": "outreach, social",
       "path": "skills/capabilities/linkedin-message-writer",
       "files": [
         "skills/capabilities/linkedin-message-writer/SKILL.md",
@@ -2073,7 +2067,7 @@
         "category": "capabilities",
         "tags": [
           "outreach",
-          "linkedin"
+          "social"
         ],
         "installation": {
           "base_command": "npx goose-skills install linkedin-message-writer",
@@ -5025,7 +5019,7 @@
       "name": "social-kit",
       "category": "composites",
       "description": ">",
-      "tags": "content, social, composite",
+      "tags": "content, social",
       "path": "skills/composites/social-kit",
       "files": [
         "skills/composites/social-kit/SKILL.md",
@@ -5036,8 +5030,7 @@
         "category": "composites",
         "tags": [
           "content",
-          "social",
-          "composite"
+          "social"
         ],
         "installation": {
           "base_command": "npx goose-skills install social-kit",

--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-04-21",
+  "generated": "2026-04-22",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -814,6 +814,35 @@
       }
     },
     {
+      "slug": "create-linkedin-content",
+      "name": "create-linkedin-content",
+      "category": "capabilities",
+      "description": ">",
+      "tags": "content, social, linkedin",
+      "path": "skills/capabilities/create-linkedin-content",
+      "files": [
+        "skills/capabilities/create-linkedin-content/SKILL.md",
+        "skills/capabilities/create-linkedin-content/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "create-linkedin-content",
+        "category": "capabilities",
+        "tags": [
+          "content",
+          "social",
+          "linkedin"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install create-linkedin-content",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
+      }
+    },
+    {
       "slug": "create-workflow-diagram",
       "name": "create-workflow-diagram",
       "category": "capabilities",
@@ -836,6 +865,36 @@
         ],
         "installation": {
           "base_command": "npx goose-skills install create-workflow-diagram",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
+      }
+    },
+    {
+      "slug": "create-x-content",
+      "name": "create-x-content",
+      "category": "capabilities",
+      "description": ">",
+      "tags": "content, social, x, twitter",
+      "path": "skills/capabilities/create-x-content",
+      "files": [
+        "skills/capabilities/create-x-content/SKILL.md",
+        "skills/capabilities/create-x-content/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "create-x-content",
+        "category": "capabilities",
+        "tags": [
+          "content",
+          "social",
+          "x",
+          "twitter"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install create-x-content",
           "supports": [
             "claude",
             "cursor",
@@ -1114,6 +1173,35 @@
           "email-drafting",
           "linkedin-outreach"
         ]
+      }
+    },
+    {
+      "slug": "generate-voice-guide",
+      "name": "generate-voice-guide",
+      "category": "capabilities",
+      "description": ">",
+      "tags": "content, voice, social",
+      "path": "skills/capabilities/generate-voice-guide",
+      "files": [
+        "skills/capabilities/generate-voice-guide/SKILL.md",
+        "skills/capabilities/generate-voice-guide/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "generate-voice-guide",
+        "category": "capabilities",
+        "tags": [
+          "content",
+          "voice",
+          "social"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install generate-voice-guide",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
       }
     },
     {
@@ -4930,6 +5018,49 @@
             "codex"
           ]
         }
+      }
+    },
+    {
+      "slug": "social-kit",
+      "name": "social-kit",
+      "category": "composites",
+      "description": ">",
+      "tags": "content, social, composite",
+      "path": "skills/composites/social-kit",
+      "files": [
+        "skills/composites/social-kit/SKILL.md",
+        "skills/composites/social-kit/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "social-kit",
+        "category": "composites",
+        "tags": [
+          "content",
+          "social",
+          "composite"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install social-kit",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "requires_skills": [
+          "create-x-content",
+          "create-linkedin-content",
+          "goose-graphics"
+        ],
+        "recommends_skills": [
+          "generate-voice-guide"
+        ],
+        "features": [
+          "One command → X + LinkedIn drafts + matching graphic",
+          "Heuristic-driven graphic format recommendations",
+          "Voice-guide-aware drafting (via generate-voice-guide)",
+          "Skip flags for partial runs (--skip-graphic, --skip-x, --skip-linkedin)"
+        ]
       }
     },
     {

--- a/skills/capabilities/create-dashboard/SKILL.md
+++ b/skills/capabilities/create-dashboard/SKILL.md
@@ -5,7 +5,7 @@ description: >
   the agent's Turso database. The dashboard is served on port 3847 and the user sees it
   live in the "App" tab in Gooseworks. Use when the user asks for a dashboard,
   visualization, chart, metric view, or any custom UI powered by their agent's data.
-tags: [dashboard, visualization, frontend]
+tags: [content, design]
 ---
 
 You are helping the user build a custom dashboard from a starter template. The dashboard lives in the sandbox, is served on port 3847 by a single Express process (which also serves the React SPA — no CORS), and is viewable in the Gooseworks "App" tab.

--- a/skills/capabilities/create-dashboard/skill.meta.json
+++ b/skills/capabilities/create-dashboard/skill.meta.json
@@ -2,9 +2,8 @@
   "slug": "create-dashboard",
   "category": "capabilities",
   "tags": [
-    "dashboard",
-    "visualization",
-    "frontend"
+    "content",
+    "design"
   ],
   "installation": {
     "base_command": "npx goose-skills install create-dashboard",

--- a/skills/capabilities/create-linkedin-content/SKILL.md
+++ b/skills/capabilities/create-linkedin-content/SKILL.md
@@ -6,7 +6,7 @@ description: >
   distinct framings, applies LinkedIn-specific defaults (arrow bullets, "why this
   matters" beat, 150–500 words), and self-checks against the voice guide's banned
   phrases before returning.
-tags: [content, social, linkedin]
+tags: [content, social]
 ---
 
 # Create LinkedIn Content
@@ -100,7 +100,7 @@ Plus LinkedIn-specific:
 
 ### Phase 5 — Save outputs
 
-File naming (★ prefix distinguishes from X variants when they live in the same folder):
+File naming (the `linkedin-` prefix distinguishes from X variants when they live in the same folder):
 ```
 linkedin-<letter>-<framing-slug>.md
 ```

--- a/skills/capabilities/create-linkedin-content/SKILL.md
+++ b/skills/capabilities/create-linkedin-content/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: create-linkedin-content
+description: >
+  Draft voice-tuned LinkedIn post variants from a free-form brief. Reads a personal
+  voice guide (generated via generate-voice-guide), produces 2–5 variants with
+  distinct framings, applies LinkedIn-specific defaults (arrow bullets, "why this
+  matters" beat, 150–500 words), and self-checks against the voice guide's banned
+  phrases before returning.
+tags: [content, social, linkedin]
+---
+
+# Create LinkedIn Content
+
+Draft LinkedIn post variants that sound like a real human practitioner, not a LinkedIn thought-leader persona. Reads a voice guide the user has already generated (or prompts to create one), produces multiple framings of the same idea, and saves each variant as its own markdown file with frontmatter.
+
+**This is an agent-executed skill** — the agent does the drafting and self-check inline. No Python script.
+
+Mirrors `create-x-content` structurally; differences are marked ★.
+
+## Quick Start
+
+```
+/create-linkedin-content --brief "New open-source CLI that turns Figma files into React components. Called figma2react. Free, MIT licensed."
+```
+
+Or interactively:
+```
+/create-linkedin-content
+```
+
+## Inputs
+
+| Flag | Required | Default |
+|------|----------|---------|
+| `--brief` | Yes (asked interactively if missing) | — |
+| `--variants` | No | Skill decides based on brief richness (2–5) |
+| `--voice-guide` | No | Resolved via chain below |
+| `--output` | No | `./content/YYYY-MM-DD-<topic-slug>/` |
+| `--topic` | No | Derived from brief |
+
+## Voice Guide Resolution
+
+Resolve in this order, stop at first hit:
+
+1. `--voice-guide <path>` flag
+2. `~/.goose-skills/config.json` → `voice_guides.linkedin`
+3. `~/.goose-skills/voice-guides/voice-linkedin.md` (default path)
+4. **Fallback prompt** — no guide found. Three options:
+   - (a) Paste a path to an existing guide
+   - (b) Run `/generate-voice-guide --platforms linkedin` now to create one (recommended)
+   - (c) Proceed with a neutral default (warn that variants will sound generic)
+
+## LinkedIn-Specific Defaults ★
+
+Apply these unless the voice guide explicitly says otherwise:
+
+- **Length:** 150–500 words per variant (LinkedIn rewards longer than X but shorter than a blog post)
+- **Bullets:** arrow style (`→`) for workflow steps — this is LinkedIn-native
+- **Numbered steps:** emoji numbers `1️⃣ 2️⃣ 3️⃣` allowed sparingly for installation/quickstart type posts
+- **"Why this matters" beat:** every post should have one — LinkedIn audiences want the *so what?* more explicitly than X audiences
+- **Hashtags:** 0–2 max. Prefer zero.
+- **CTAs:** "Link in comments" pattern is LinkedIn-native; inline links are fine too. Avoid "Follow me for more."
+- **Openings:** more scene-setting is ok (1–2 lines of context before the hook). Unlike X, you don't have to hook-first.
+
+## Workflow
+
+### Phase 1 — Load the voice guide
+
+Same as `create-x-content` Phase 1 — load voice guide, extract banned phrases, hook patterns, format rules, dos/don'ts, examples.
+
+### Phase 2 — Parse the brief and decide variant count
+
+Same 2–5 decision rubric. LinkedIn briefs often warrant fewer variants than X because LinkedIn posts are longer and the audience expects more narrative coherence — 3 strong framings usually beats 5.
+
+### Phase 3 — Generate variants with LinkedIn-appropriate framings
+
+Framings tuned for LinkedIn (subset of the X framings, plus a few LinkedIn-native ones):
+
+| Framing | Structure | When to use |
+|---------|-----------|-------------|
+| `builder-story` ★ | "I built X. Here's why. Here's what I learned." | LinkedIn-native — builder stories outperform tactical posts here |
+| `product-launch` ★ | Clear hook + 2-step quickstart + link | New tool/product announcements |
+| `problem-first` | Open with the pain, then solution | Universal |
+| `ecosystem-map` | Curated list of N related tools/companies | Landscape posts |
+| `contrarian-insight` | "Your X might be worth more than Y" | Opinion pieces with a fresh take |
+| `workflow-tutorial` | Arrow-bulleted step-by-step, with numbers | Tactical how-tos (denser than X version) |
+
+### Phase 4 — Self-check against the voice guide
+
+Same 4 checks as `create-x-content`:
+1. Banned phrase check
+2. Length check (150–500 for LinkedIn)
+3. "Meat" check — specific tools/numbers/builds
+4. Voice-match spot check
+
+Plus LinkedIn-specific:
+5. **Arrow-bullet check** — if the post uses lists, are they `→` style (or numbered emojis), matching the LinkedIn convention?
+6. **"Why this matters" check** — does the post explain the stakes, or does it just state the facts? Add a "why this matters" beat if missing.
+7. **No corporate tone** — does it sound like a press release? If yes, rewrite to sound like a human practitioner.
+
+### Phase 5 — Save outputs
+
+File naming (★ prefix distinguishes from X variants when they live in the same folder):
+```
+linkedin-<letter>-<framing-slug>.md
+```
+Examples: `linkedin-a-builder-story.md`, `linkedin-b-product-launch.md`.
+
+Frontmatter:
+```yaml
+---
+id: <topic-slug>-li-<letter>
+platform: linkedin
+format: standard | long
+topic: <slug>
+framing: <framing-slug>
+status: draft
+---
+```
+
+### Phase 6 — Deliver
+
+Print output directory, file list, framing summary, suggested next step.
+
+## Outputs
+
+- `<output>/linkedin-<letter>-<framing>.md` per variant
+
+## Examples
+
+**Builder story brief:**
+```
+/create-linkedin-content --brief "Built a CRM for my AI agents using just markdown files and Claude Code. No Salesforce, no HubSpot. Works better than both."
+```
+→ 3 variants (builder-story, contrarian-insight, workflow-tutorial)
+
+**Launch brief:**
+```
+/create-linkedin-content --brief "Launching goose-aeo — open-source CLI that measures your brand's visibility on AI search engines like ChatGPT, Perplexity, Gemini. npm install, three commands to run."
+```
+→ 3 variants (product-launch, problem-first, workflow-tutorial)
+
+## Dependencies
+
+- A voice guide at the resolved path
+- `generate-voice-guide` skill (for creating one when missing)
+
+## Tips
+
+- **Arrow bullets are a LinkedIn signal.** When in doubt, use them. They make the post scan-friendly and land as "LinkedIn-native."
+- **Never open with "I'm humbled" or "Grateful for..."** — LinkedIn performative cringe. The voice guide should flag these; honor it.
+- **Cross-reference ecosystems.** LinkedIn readers like knowing the landscape. If you mention a tool, it's fine to note 1–2 comparable ones.
+- **End with a forward-looking line.** "Fast-forward 3 model generations" or "This will change X over the next 12 months" — beats a soft "thoughts?"

--- a/skills/capabilities/create-linkedin-content/skill.meta.json
+++ b/skills/capabilities/create-linkedin-content/skill.meta.json
@@ -3,8 +3,7 @@
   "category": "capabilities",
   "tags": [
     "content",
-    "social",
-    "linkedin"
+    "social"
   ],
   "installation": {
     "base_command": "npx goose-skills install create-linkedin-content",

--- a/skills/capabilities/create-linkedin-content/skill.meta.json
+++ b/skills/capabilities/create-linkedin-content/skill.meta.json
@@ -1,0 +1,17 @@
+{
+  "slug": "create-linkedin-content",
+  "category": "capabilities",
+  "tags": [
+    "content",
+    "social",
+    "linkedin"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install create-linkedin-content",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}

--- a/skills/capabilities/create-x-content/SKILL.md
+++ b/skills/capabilities/create-x-content/SKILL.md
@@ -5,7 +5,7 @@ description: >
   voice guide (generated via generate-voice-guide), produces 2–5 variants with
   distinct framings (simple-howto, problem-first, hype, mechanism-breakdown, etc.),
   and self-checks against the voice guide's banned phrases before returning.
-tags: [content, social, x, twitter]
+tags: [content, social]
 ---
 
 # Create X Content
@@ -106,7 +106,7 @@ variant-<letter>-<framing-slug>.md
 ```
 Examples: `variant-a-simple-howto.md`, `variant-b-problem-first.md`.
 
-Frontmatter schema (matches `content/2026-04-21-email-deliverability/variant-*.md` convention):
+Frontmatter schema:
 ```yaml
 ---
 id: <topic-slug>-<letter>

--- a/skills/capabilities/create-x-content/SKILL.md
+++ b/skills/capabilities/create-x-content/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: create-x-content
+description: >
+  Draft voice-tuned X (Twitter) post variants from a free-form brief. Reads a personal
+  voice guide (generated via generate-voice-guide), produces 2–5 variants with
+  distinct framings (simple-howto, problem-first, hype, mechanism-breakdown, etc.),
+  and self-checks against the voice guide's banned phrases before returning.
+tags: [content, social, x, twitter]
+---
+
+# Create X Content
+
+Draft X/Twitter post variants that sound like you, not like an AI. Reads a voice guide the user has already generated (or prompts to create one), produces multiple framings of the same idea, and saves each variant as its own markdown file with frontmatter.
+
+**This is an agent-executed skill** — the agent does the drafting and self-check inline. No Python script.
+
+## Quick Start
+
+```
+/create-x-content --brief "New open-source CLI that turns Figma files into React components. Called figma2react. Free, MIT licensed."
+```
+
+Or interactively:
+```
+/create-x-content
+```
+
+## Inputs
+
+| Flag | Required | Default |
+|------|----------|---------|
+| `--brief` | Yes (asked interactively if missing) | — |
+| `--variants` | No | Skill decides based on brief richness (2–5) |
+| `--voice-guide` | No | Resolved via chain below |
+| `--output` | No | `./content/YYYY-MM-DD-<topic-slug>/` |
+| `--topic` | No | Derived from brief |
+
+## Voice Guide Resolution
+
+Resolve in this order, stop at first hit:
+
+1. `--voice-guide <path>` flag
+2. `~/.goose-skills/config.json` → `voice_guides.x`
+3. `~/.goose-skills/voice-guides/voice-x.md` (default path)
+4. **Fallback prompt** — no guide found. Give the user three options:
+   - (a) Paste a path to an existing guide
+   - (b) Run `/generate-voice-guide --platforms x` now to create one (recommended)
+   - (c) Proceed with a neutral default (warn that variants will sound generic)
+
+Never silently skip the voice guide. Generic posts are the failure mode to avoid.
+
+## Workflow
+
+### Phase 1 — Load the voice guide
+
+Read the resolved voice guide into context. Extract, for use throughout drafting:
+- **Banned phrases** — treat as hard blocks
+- **Hook patterns** — sample these for variant framings
+- **Format rules** — length ranges, line-break style, emoji policy
+- **Dos/don'ts** — apply to every variant
+- **Example posts** — use as calibration targets
+
+### Phase 2 — Parse the brief and decide variant count
+
+Decide variant count by richness:
+- **2 variants** — one-line opinions, single-angle hot takes, simple tool mentions with no mechanism
+- **3 variants** — typical tool spotlights, single how-tos, observations with one clear angle
+- **4 variants** — multi-angle topics (a how-to + a problem-first frame + a hype frame + a mechanism breakdown)
+- **5 variants** — rich, mechanism-heavy content where several distinct hooks all have real substance
+
+If `--variants` is explicitly set, respect it. Otherwise pick the smallest count where each variant genuinely adds a different angle. **Quality > quantity.** 2 strong variants beat 5 watered-down ones.
+
+### Phase 3 — Generate variants with explicit framing
+
+Each variant gets a distinct *framing label* that determines its structure and hook:
+
+| Framing | Structure | When to use |
+|---------|-----------|-------------|
+| `simple-howto` | Bare steps, no mechanism | Tool install + usage, 2–3 line how-to |
+| `howto-plus-mechanism` | How-to + "here's how it works" breakdown | Tools where the mechanism is interesting |
+| `problem-first` | Open with the pain, then solution | When the problem is visceral/relatable |
+| `hype` | Punchy "someone just dropped X" energy | Launches, new OSS releases, cool builds |
+| `mechanism-breakdown` | Focus on the *how* | Technical builds, systems, architectures |
+| `ecosystem-map` | Curated list of N related tools/companies | Landscape posts |
+| `contrarian` | "Most people do X wrong" opener | Opinion pieces with a clear counter-take |
+| `personal-experience` | "We've been doing X. Here's what I learned" | Field notes, lessons learned |
+
+Use framings the voice guide's hook patterns actually support. Don't force framings the user never employs.
+
+### Phase 4 — Self-check against the voice guide
+
+Before saving, run each variant through these checks:
+
+1. **Banned phrase check** — does the variant use any phrase from the voice guide's banned list? If yes, rewrite that line.
+2. **Length check** — does it fit the voice guide's format rules (short-form <280, long-form 100–1000, etc.)?
+3. **"Meat" check** — does it have at least one concrete reference: a specific tool, number, workflow, or build? If not, it's filler — rewrite.
+4. **Voice-match spot check** — would this plausibly appear in the example posts section of the voice guide? If it reads like a generic AI tweet, rewrite.
+
+If a variant fails any check and two rewrite attempts don't fix it, drop the variant rather than ship something weak.
+
+### Phase 5 — Save outputs
+
+Write each variant as its own `.md` file. File naming:
+```
+variant-<letter>-<framing-slug>.md
+```
+Examples: `variant-a-simple-howto.md`, `variant-b-problem-first.md`.
+
+Frontmatter schema (matches `content/2026-04-21-email-deliverability/variant-*.md` convention):
+```yaml
+---
+id: <topic-slug>-<letter>
+platform: x
+format: short | long
+topic: <slug>
+framing: <framing-slug>
+status: draft
+---
+```
+
+Body: just the post text. No commentary, no surrounding markdown.
+
+### Phase 6 — Deliver
+
+Print to the user:
+- Output directory path
+- List of files created
+- Variant count + framings used
+- Suggested next step (review, tweak, or run `/social-kit` for a matching graphic)
+
+## Outputs
+
+- `<output>/variant-<letter>-<framing>.md` per variant
+- No index file — each variant is self-contained
+
+## Examples
+
+**Simple brief:**
+```
+/create-x-content --brief "npx goose-skills install claude-code-hooks — a new skill that adds pre-commit, pre-tool-use, and post-response hooks to Claude Code so you can enforce coding standards automatically."
+```
+→ 3 variants (howto, hype, mechanism)
+
+**Rich brief:**
+```
+/create-x-content --brief "Built a Claude-driven lead gen system. Scrapes Reddit for people asking about email deliverability, finds their domains, verifies their business email via Hunter, drafts a personalized DM. 47 leads in 6 hours at $0.03/lead."
+```
+→ 5 variants (personal-experience, mechanism-breakdown, hype, problem-first, simple-howto)
+
+## Dependencies
+
+- A voice guide at the resolved path (see Voice Guide Resolution above)
+- `generate-voice-guide` skill (for creating one when missing)
+
+## Tips
+
+- **Default to fewer variants.** Five weak ones is worse than two strong ones. The skill should feel picky, not generous.
+- **Framings must actually differ.** Don't write five variants with the same opening hook and minor tweaks. Each variant = a different lens on the same idea.
+- **Quote the brief's specifics verbatim in the variant.** Numbers, tool names, prices — these are the "meat." Losing them to paraphrasing kills the post.
+- **If the voice guide has a "field-notes deep-dive" hook pattern and the brief is rich enough, include one long-form variant.** That format tends to outperform on X.

--- a/skills/capabilities/create-x-content/skill.meta.json
+++ b/skills/capabilities/create-x-content/skill.meta.json
@@ -3,9 +3,7 @@
   "category": "capabilities",
   "tags": [
     "content",
-    "social",
-    "x",
-    "twitter"
+    "social"
   ],
   "installation": {
     "base_command": "npx goose-skills install create-x-content",

--- a/skills/capabilities/create-x-content/skill.meta.json
+++ b/skills/capabilities/create-x-content/skill.meta.json
@@ -1,0 +1,18 @@
+{
+  "slug": "create-x-content",
+  "category": "capabilities",
+  "tags": [
+    "content",
+    "social",
+    "x",
+    "twitter"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install create-x-content",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}

--- a/skills/capabilities/generate-voice-guide/SKILL.md
+++ b/skills/capabilities/generate-voice-guide/SKILL.md
@@ -7,7 +7,7 @@ description: >
   create-linkedin-content) consume to draft in-voice posts. Different from
   brand-voice-extractor, which analyses company blogs/landing pages — this skill is
   for personal social voice.
-tags: [content, voice, social]
+tags: [content, social]
 ---
 
 # Generate Voice Guide

--- a/skills/capabilities/generate-voice-guide/SKILL.md
+++ b/skills/capabilities/generate-voice-guide/SKILL.md
@@ -33,14 +33,14 @@ Interactive:
 
 Args mode:
 ```
-/generate-voice-guide --profile @shivsakhuja --platforms x,linkedin --output ~/.goose-skills/voice-guides
+/generate-voice-guide --profile @GooseworksAI --platforms x,linkedin --output ~/.goose-skills/voice-guides
 ```
 
 ## Discovery Questions (front-loaded)
 
 Ask these up front if not supplied via flags:
 
-1. **Whose voice?** "Paste an X/Twitter handle (e.g. `@shivsakhuja`), a LinkedIn profile URL, or both. You can mimic your own voice or someone else's."
+1. **Whose voice?** "Paste an X/Twitter handle (e.g. `@GooseworksAI`), a LinkedIn profile URL, or both. You can mimic your own voice or someone else's."
 2. **Which platforms?** "Generate a voice guide for X, LinkedIn, or both?"
 3. **How many posts to scan?** "Default: 50 X posts / 25 LinkedIn posts. Higher = more signal, more tokens, slower."
 4. **Save location?** "Default: `~/.goose-skills/voice-guides/voice-{x,linkedin}.md`. Ok to use that, or prefer a different path?"

--- a/skills/capabilities/generate-voice-guide/SKILL.md
+++ b/skills/capabilities/generate-voice-guide/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: generate-voice-guide
+description: >
+  Generate a personal voice guide for X (Twitter) and/or LinkedIn by scanning a user's
+  past posts and iteratively refining with sample-and-feedback loops. Produces a
+  structured markdown voice guide that sibling skills (create-x-content,
+  create-linkedin-content) consume to draft in-voice posts. Different from
+  brand-voice-extractor, which analyses company blogs/landing pages — this skill is
+  for personal social voice.
+tags: [content, voice, social]
+---
+
+# Generate Voice Guide
+
+Turn a real person's past posts into a structured voice guide that other skills can use to draft in-voice content. Produces one guide per platform (X, LinkedIn, or both) with persona, dos/don'ts, banned phrases, hook patterns, format rules, and example posts.
+
+**This is an agent-executed skill** — the agent handles scraping, analysis, drafting, and iteration via the tools available in the session. No bundled Python script.
+
+## When to use
+
+- A user wants to build a personal voice guide for social content
+- Another skill (e.g. `create-x-content`, `create-linkedin-content`, `social-kit`) needs a voice guide and one doesn't exist
+- The user wants to mimic someone else's public voice (for ghostwriting, parody, or study)
+
+**When NOT to use:** For analysing a company's blog/landing-page voice, use `brand-voice-extractor` instead. That's for corporate marketing voice; this one is for individual social voice.
+
+## Quick Start
+
+Interactive:
+```
+/generate-voice-guide
+```
+
+Args mode:
+```
+/generate-voice-guide --profile @shivsakhuja --platforms x,linkedin --output ~/.goose-skills/voice-guides
+```
+
+## Discovery Questions (front-loaded)
+
+Ask these up front if not supplied via flags:
+
+1. **Whose voice?** "Paste an X/Twitter handle (e.g. `@shivsakhuja`), a LinkedIn profile URL, or both. You can mimic your own voice or someone else's."
+2. **Which platforms?** "Generate a voice guide for X, LinkedIn, or both?"
+3. **How many posts to scan?** "Default: 50 X posts / 25 LinkedIn posts. Higher = more signal, more tokens, slower."
+4. **Save location?** "Default: `~/.goose-skills/voice-guides/voice-{x,linkedin}.md`. Ok to use that, or prefer a different path?"
+
+## Workflow
+
+### Phase 1 — Scrape past posts
+
+**For X:**
+- Use Apify actor `apidojo/twitter-user-tweets-scraper` (or whichever X scraper is available in the session) keyed to the handle.
+- Fetch the target count (default 50). Exclude replies, retweets, and quote tweets unless the user specifies otherwise — we want original voice.
+- Requires `APIFY_API_TOKEN` env var. If missing, surface a clear error with the setup link.
+
+**For LinkedIn:**
+- Use Apify actor `harvestapi/linkedin-profile-posts` keyed to the profile URL.
+- Fetch the target count (default 25). Include only original posts (no reshares).
+
+**Fallback (no scraper available or posts paywalled):** ask the user to paste 15–25 posts as plain text.
+
+Store raw post text, engagement metrics (likes, views if available), and timestamps.
+
+### Phase 2 — Generate v1 voice guide
+
+Use `voice-x.md` / `voice-linkedin.md` template references (see "Template Skeleton" below) to produce v1 of the guide. Do NOT copy content from them — only the *structure*.
+
+Analyse the scraped posts for:
+
+- **Persona** — inferred role, audience, credentials, tone spectrum
+- **The "meat" principle** — what concrete substance typically appears: tools, numbers, builds, steps, links
+- **Dos** — observed hook patterns, connective phrases, list style, casual asides, emoji usage, CTA patterns
+- **Don'ts** — patterns the author conspicuously avoids (no threads, no engagement bait, etc.)
+- **Banned phrases** — common LLM-speak the author never uses (`excited to share`, `leverage`, `game-changing`, `thrilled`, etc.). List 10–20.
+- **Hook patterns** — 5–8 distinct opening-line templates drawn from real posts
+- **Format rules** — word count ranges, bullet style, density, line-break rhythm
+- **Tone calibration** — educator vs conversational ratio; when each applies
+- **Example posts with analysis** — pull 4–6 real posts and explain *why* each works, what pattern it exemplifies
+
+### Phase 3 — Sample + feedback loop (5+ iterations)
+
+This is where voice-guide quality is made. Do NOT skip iterations.
+
+Each iteration:
+
+1. **Generate 3 sample posts** from the current guide, each using a different hook pattern from the guide. Use topics from the user's own posting history so they're easy to judge (e.g. if they post about AI agents, draft on AI agents).
+2. **Show the user:**
+   - Which hook pattern each sample used
+   - The 3 sample posts
+   - 1–2 lines from the current guide that most influenced the samples
+3. **Ask for feedback** — specific prompts:
+   - "Which samples sound like you? Which don't?"
+   - "What's the most off-sounding phrase or pattern?"
+   - "What's missing — a hook you use, a rule you follow?"
+4. **Apply feedback** — revise the guide. Update dos/don'ts, hook patterns, banned phrases, examples. Note what changed in a short changelog at the top of the guide during iteration.
+5. **Repeat.**
+
+**Stopping rule:** continue until the user explicitly says "this is good" AND at least 5 iterations have completed. 5 is a floor, not a ceiling. If the user says "good enough" at iteration 2, push back: "Voice guides need at least 5 rounds to actually lock in. Can we do 3 more?"
+
+### Phase 4 — Save + register
+
+1. Write the final guide to the resolved output path (default `~/.goose-skills/voice-guides/voice-<platform>.md`).
+2. Strip the iteration changelog — only keep the final clean guide.
+3. Update `~/.goose-skills/config.json`:
+   ```json
+   {
+     "voice_guides": {
+       "x": "<absolute path to voice-x.md>",
+       "linkedin": "<absolute path to voice-linkedin.md>"
+     }
+   }
+   ```
+   Create the directory/file if missing. Merge with existing config if present (don't overwrite other keys).
+4. Print a confirmation with the saved paths and a next-step suggestion: "You can now run `/create-x-content --brief \"...\"` and it'll use this voice guide automatically."
+
+## Template Skeleton
+
+Every generated voice guide should have these top-level sections, in order:
+
+```
+# Voice Guide: <Platform> — <Handle or Name>
+
+## Persona
+## The "Meat" Principle
+## Dos
+## Don'ts
+## Banned Phrases
+## Hook Patterns
+## CTA Guidelines
+## Format Rules
+## Tone Calibration
+## Example Posts That Exemplify The Voice
+```
+
+Match the depth and specificity of a well-written voice guide — prose for persona, numbered lists for dos/don'ts, quoted examples with analysis. Aim for 120–250 lines.
+
+## Config File
+
+`~/.goose-skills/config.json` is a lightweight cross-skill config. Schema:
+
+```json
+{
+  "voice_guides": {
+    "x": "/absolute/path/to/voice-x.md",
+    "linkedin": "/absolute/path/to/voice-linkedin.md"
+  }
+}
+```
+
+Sibling skills read this to discover voice guide paths. Always use absolute paths.
+
+## Inputs
+
+| Input | Required | Default |
+|-------|----------|---------|
+| `--profile` | Yes (one of X handle, LinkedIn URL, or both) | — |
+| `--platforms` | No | `x,linkedin` if both profiles given, else matches supplied profiles |
+| `--posts-x` | No | 50 |
+| `--posts-linkedin` | No | 25 |
+| `--output` | No | `~/.goose-skills/voice-guides` |
+| `--iterations-min` | No | 5 |
+
+## Outputs
+
+- `<output>/voice-x.md` and/or `<output>/voice-linkedin.md`
+- Updated `~/.goose-skills/config.json` with voice guide paths
+- Stdout summary: paths written + quick-start command for next step
+
+## Dependencies
+
+- Apify API token (`APIFY_API_TOKEN`) for scraping
+- No other paid services required
+- Voice guide *structural* references (open via `WebFetch` or read locally if the user has them) — not required to run
+
+## Tips
+
+- **5+ iterations is the floor.** If the user pushes to stop early, explain that voice guides are only good after ~5 rounds.
+- **Use the user's own topics for samples.** Draft samples on subjects they've posted about — makes it much easier for them to spot an off-key line.
+- **Quote real posts in the examples section.** Never paraphrase — use direct verbatim quotes with a source link.
+- **Call out ghost-writing or assistant-authored posts.** If some posts feel dramatically different, flag it: "These 3 posts read differently — worth checking if they're yours or ghost-written."
+- **Don't lean on LLM clichés in the banned-phrases list.** Derive bans from actual absence in the user's writing, not a generic blocklist.

--- a/skills/capabilities/generate-voice-guide/skill.meta.json
+++ b/skills/capabilities/generate-voice-guide/skill.meta.json
@@ -3,7 +3,6 @@
   "category": "capabilities",
   "tags": [
     "content",
-    "voice",
     "social"
   ],
   "installation": {

--- a/skills/capabilities/generate-voice-guide/skill.meta.json
+++ b/skills/capabilities/generate-voice-guide/skill.meta.json
@@ -1,0 +1,17 @@
+{
+  "slug": "generate-voice-guide",
+  "category": "capabilities",
+  "tags": [
+    "content",
+    "voice",
+    "social"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install generate-voice-guide",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}

--- a/skills/capabilities/linkedin-message-writer/SKILL.md
+++ b/skills/capabilities/linkedin-message-writer/SKILL.md
@@ -7,7 +7,7 @@ description: >
   and generates messages tailored to each lead's background, interests, and recent activity.
   Exports tool-ready CSVs for Dripify, Expandi, Botdog, PhantomBuster, or generic format.
   No LinkedIn cookies or login required.
-tags: [outreach, linkedin]
+tags: [outreach, social]
 ---
 
 # LinkedIn Message Writer

--- a/skills/capabilities/linkedin-message-writer/skill.meta.json
+++ b/skills/capabilities/linkedin-message-writer/skill.meta.json
@@ -3,7 +3,7 @@
   "category": "capabilities",
   "tags": [
     "outreach",
-    "linkedin"
+    "social"
   ],
   "installation": {
     "base_command": "npx goose-skills install linkedin-message-writer",

--- a/skills/composites/goose-graphics/skill.meta.json
+++ b/skills/composites/goose-graphics/skill.meta.json
@@ -4,7 +4,6 @@
   "tags": [
     "content",
     "design",
-    "graphics",
     "social"
   ],
   "installation": {

--- a/skills/composites/social-kit/SKILL.md
+++ b/skills/composites/social-kit/SKILL.md
@@ -6,7 +6,7 @@ description: >
   create-x-content + create-linkedin-content + goose-graphics in one invocation.
   Asks about graphic format when not specified, with heuristic-driven
   recommendations.
-tags: [content, social, composite]
+tags: [content, social]
 ---
 
 # Social Kit

--- a/skills/composites/social-kit/SKILL.md
+++ b/skills/composites/social-kit/SKILL.md
@@ -217,4 +217,4 @@ Voice guides + config at `~/.goose-skills/voice-guides/` and `~/.goose-skills/co
 - **When the recommended format feels off, it probably is.** The heuristic is a starting point — trust your read of the brief more than the recommendation.
 - **Pair drafts with graphics intentionally.** A long `mechanism-breakdown` X variant pairs with a carousel. A short `hype` variant pairs with a poster. The file naming makes these pairings easy to spot.
 - **Iterate on voice before iterating on content.** If your drafts feel off, 80% of the fix is re-running `/generate-voice-guide` with more recent posts or more iterations — not rewriting the skill prompts.
-- **Output path convention:** matches the Shiv-canonical `content/YYYY-MM-DD-<topic>/` layout already in use. Keep it consistent for easier cross-referencing later.
+- **Output path convention:** uses a standard `content/YYYY-MM-DD-<topic>/` layout. Keep it consistent for easier cross-referencing later.

--- a/skills/composites/social-kit/SKILL.md
+++ b/skills/composites/social-kit/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: social-kit
+description: >
+  End-to-end composite that turns a single brief into voice-tuned X post variants,
+  LinkedIn post variants, and a matching social graphic. Orchestrates
+  create-x-content + create-linkedin-content + goose-graphics in one invocation.
+  Asks about graphic format when not specified, with heuristic-driven
+  recommendations.
+tags: [content, social, composite]
+---
+
+# Social Kit
+
+One command → X variants + LinkedIn variants + a graphic. A thin orchestrator that chains `create-x-content`, `create-linkedin-content`, and `goose-graphics`, with sensible defaults and a pre-flight check for voice guides.
+
+## Invocation
+
+Full args:
+```
+/social-kit --brief "..." --format poster --style matt-gray --output ./content/2026-04-21-my-topic/
+```
+
+Partial (asks for format):
+```
+/social-kit --brief "..."
+```
+
+Interactive:
+```
+/social-kit
+```
+
+## Inputs
+
+| Flag | Required | Default |
+|------|----------|---------|
+| `--brief` | Yes (asked if missing) | — |
+| `--format` | No | Asked with recommendations |
+| `--style` | No | `matt-gray` if the user has no stated preference; otherwise asked |
+| `--output` | No | `./content/YYYY-MM-DD-<topic-slug>/` |
+| `--variants-x` | No | `create-x-content` decides |
+| `--variants-linkedin` | No | `create-linkedin-content` decides |
+| `--skip-graphic` | No | false |
+| `--skip-x` | No | false |
+| `--skip-linkedin` | No | false |
+
+## Workflow
+
+### Step 1 — Intake
+
+1. Resolve the brief (prompt if missing).
+2. Derive a `topic-slug` from the brief (short kebab-case, 2–4 words).
+3. Resolve `<output>` — default `./content/YYYY-MM-DD-<topic-slug>/`. Create the directory if it doesn't exist.
+
+### Step 2 — Pre-flight voice guide check
+
+Check `~/.goose-skills/config.json` for `voice_guides.x` and `voice_guides.linkedin`. If either is missing and that platform isn't skipped:
+
+```
+Missing voice guide for <platform>.
+  (a) Generate one now via /generate-voice-guide --platforms <platform>
+  (b) Paste an existing path
+  (c) Skip <platform> for this run
+```
+
+Do not proceed without resolving every non-skipped platform.
+
+### Step 3 — Draft X variants
+
+Invoke `/create-x-content` with:
+```
+--brief "<brief>"
+--output <resolved-output>
+[--variants <N>]
+```
+
+Wait for completion. Capture the list of created files + the most substantive variant for use in Step 5's graphic brief.
+
+Skip if `--skip-x`.
+
+### Step 4 — Draft LinkedIn variants
+
+Invoke `/create-linkedin-content` with the same args. Wait for completion.
+
+Skip if `--skip-linkedin`.
+
+### Step 5 — Pick a graphic format
+
+If `--format` was passed, use it.
+
+Otherwise, analyse the brief and recommend 1–2 formats using this heuristic:
+
+| Brief shape | Recommended format |
+|-------------|-------------------|
+| One strong claim, stat, or launch announcement | **poster** (1080×1350) |
+| Numbered steps, how-to, or sequential process | **carousel** (1080×1080 per slide) |
+| Mechanism/data/timeline with multiple sections | **infographic** (1080×variable) |
+| Single testimonial, quote, or result metric | **tweet** (1080×1080) |
+| Vertical, mobile-first, under 6 beats | **story** (1080×1920) |
+| Widescreen presentation or demo | **slides** (1920×1080) |
+| Chart or data visualization | **chart** (1080×1080) |
+
+Present recommendations as a short menu:
+
+```
+Based on the brief, I'd recommend one of these:
+  1. poster — single strong claim, fits the "X costs $0.01 to run" shape
+  2. carousel — if you want to walk through the how-it-works steps
+
+Which? (or paste another format name)
+```
+
+Skip this step if `--skip-graphic`.
+
+### Step 6 — Pick a style
+
+If `--style` was passed, use it.
+
+Otherwise, default to `matt-gray` unless the user stops the skill to pick another. To change the default per-user, a future enhancement can add a `style_default` key to `~/.goose-skills/config.json`.
+
+### Step 7 — Generate the graphic
+
+Invoke `/goose-graphics` with:
+```
+--style <style>
+--format <format>
+--brief "<distilled-brief>"
+```
+
+Point output at `<resolved-output>/graphic/`. The distilled brief should include:
+- The headline/hook from the most substantive X variant
+- 2–4 key beats (steps, numbers, or sections)
+- Any specific strings that must appear verbatim (tool names, commands, prices)
+
+Wait for completion. Capture paths to PNG exports + index.html.
+
+Skip if `--skip-graphic`.
+
+### Step 8 — Deliver
+
+Print a summary:
+
+```
+Social kit ready at <resolved-output>/
+
+X drafts (N variants):
+  - variant-a-<framing>.md
+  - variant-b-<framing>.md
+  - ...
+
+LinkedIn drafts (N variants):
+  - linkedin-a-<framing>.md
+  - linkedin-b-<framing>.md
+  - ...
+
+Graphic (<format>, <style>):
+  - graphic/slides/          (HTML source)
+  - graphic/exports/         (PNG files, N files)
+  - graphic/index.html       (preview in browser)
+
+Next steps:
+  - Open graphic/index.html to review visuals
+  - Open any variant-*.md to copy/paste
+  - Pair a variant with a graphic for LinkedIn/X
+```
+
+## Output Layout
+
+```
+content/YYYY-MM-DD-<topic>/
+├── variant-a-<framing>.md        # X drafts
+├── variant-b-<framing>.md
+├── ...
+├── linkedin-a-<framing>.md       # LinkedIn drafts
+├── linkedin-b-<framing>.md
+└── graphic/
+    ├── slides/                   # HTML source (1+ files depending on format)
+    ├── exports/                  # PNG exports
+    └── index.html                # preview
+```
+
+## Dependencies
+
+Required skills:
+- `create-x-content`
+- `create-linkedin-content`
+- `goose-graphics`
+
+Recommended:
+- `generate-voice-guide` (create voice guides once before first use of social-kit)
+
+Voice guides + config at `~/.goose-skills/voice-guides/` and `~/.goose-skills/config.json` are discovered automatically.
+
+## Examples
+
+**Typical run (format asked):**
+```
+/social-kit --brief "Claude can now verify email deliverability for $0.01 per check. Install gooseworks and ask. Runs MX, SMTP, RCPT TO, catch-all, disposable, blocklist checks."
+```
+→ Drafts X + LinkedIn variants → asks "poster or carousel?" → generates graphic → delivers.
+
+**Full args (one-shot):**
+```
+/social-kit --brief "Someone vibe-coded a full lead gen tool in Claude Code in 2 weeks. Scrapes every business off Google Maps with 30+ data fields, pulls verified emails, reads up to 50 reviews to find pain points. Running $4200 ACV deals." --format carousel --style heatwave-orange
+```
+→ Runs end-to-end with no prompts.
+
+**Skip graphic:**
+```
+/social-kit --brief "..." --skip-graphic
+```
+→ Just the X + LinkedIn drafts.
+
+## Tips
+
+- **First-time users:** run `/generate-voice-guide` once before your first `/social-kit` invocation. This is a one-time setup.
+- **When the recommended format feels off, it probably is.** The heuristic is a starting point — trust your read of the brief more than the recommendation.
+- **Pair drafts with graphics intentionally.** A long `mechanism-breakdown` X variant pairs with a carousel. A short `hype` variant pairs with a poster. The file naming makes these pairings easy to spot.
+- **Iterate on voice before iterating on content.** If your drafts feel off, 80% of the fix is re-running `/generate-voice-guide` with more recent posts or more iterations — not rewriting the skill prompts.
+- **Output path convention:** matches the Shiv-canonical `content/YYYY-MM-DD-<topic>/` layout already in use. Keep it consistent for easier cross-referencing later.

--- a/skills/composites/social-kit/skill.meta.json
+++ b/skills/composites/social-kit/skill.meta.json
@@ -3,8 +3,7 @@
   "category": "composites",
   "tags": [
     "content",
-    "social",
-    "composite"
+    "social"
   ],
   "installation": {
     "base_command": "npx goose-skills install social-kit",

--- a/skills/composites/social-kit/skill.meta.json
+++ b/skills/composites/social-kit/skill.meta.json
@@ -1,0 +1,31 @@
+{
+  "slug": "social-kit",
+  "category": "composites",
+  "tags": [
+    "content",
+    "social",
+    "composite"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install social-kit",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "requires_skills": [
+    "create-x-content",
+    "create-linkedin-content",
+    "goose-graphics"
+  ],
+  "recommends_skills": [
+    "generate-voice-guide"
+  ],
+  "features": [
+    "One command → X + LinkedIn drafts + matching graphic",
+    "Heuristic-driven graphic format recommendations",
+    "Voice-guide-aware drafting (via generate-voice-guide)",
+    "Skip flags for partial runs (--skip-graphic, --skip-x, --skip-linkedin)"
+  ]
+}


### PR DESCRIPTION
## Summary
Four new skills that turn a single brief into voice-tuned X post variants + LinkedIn post variants + a matching social graphic.

- **generate-voice-guide** (capability): scrapes a user's past posts, iteratively refines a voice guide via 5+ sample/feedback loops, saves to `~/.goose-skills/voice-guides/` and registers paths in `~/.goose-skills/config.json`
- **create-x-content** (capability): drafts 2–5 X variants from a brief using the resolved voice guide, with distinct framing labels and banned-phrase self-check
- **create-linkedin-content** (capability): mirrors create-x-content with LinkedIn defaults (arrow bullets, "why this matters" beat, 150–500 words)
- **social-kit** (composite): orchestrates the three above plus goose-graphics, asks for graphic format when unspecified with heuristic-driven recommendations

Depends on `goose-graphics` composite (merged via PR #14).

## Notes
This PR replaces #15, which had accumulated 23 commits and 548 changed files due to rebase drift. Rebuilt cleanly on top of current `main` (which now includes goose-graphics). #15 should be closed.

Refs GOOSE-1428

🤖 Generated with [Claude Code](https://claude.com/claude-code)