### PR TITLE
Add ugc-video-generator skill to video-production pack

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-04-22",
+  "generated": "2026-04-23",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -5581,7 +5581,7 @@
       "slug": "video-production",
       "name": "Video Production",
       "type": "pack",
-      "description": "5-skill video production toolkit: beat-synced reels from product images, AI-animated product reels via Higgsfield, talking head videos via HeyGen, long-form to short-form clip repurposing, and screen recording polish with zoom/pan effects.",
+      "description": "6-skill video production toolkit: beat-synced reels from product images, AI-animated product reels via Higgsfield, talking head videos via HeyGen, UGC-style social videos via Creatify, long-form to short-form clip repurposing, and screen recording polish with zoom/pan effects.",
       "tags": "content",
       "path": "skills/packs/video-production",
       "shared_files": [
@@ -5627,6 +5627,18 @@
           "source": "pack"
         },
         {
+          "slug": "ugc-video-generator",
+          "name": "ugc-video-generator",
+          "description": "Generates UGC-style talking head videos for social media and ads using Creatify API. Researches the product, writes scripts, picks avatars, and produces ready-to-post vertical videos. Designed for Instagram Reels, TikTok, and YouTube Shorts.",
+          "path": "skills/packs/video-production/ugc-video-generator",
+          "files": [
+            "skills/packs/video-production/ugc-video-generator/SKILL.md",
+            "skills/packs/video-production/ugc-video-generator/scripts/creatify_api.py",
+            "skills/packs/video-production/ugc-video-generator/skill.meta.json"
+          ],
+          "source": "pack"
+        },
+        {
           "slug": "video-clipper",
           "name": "video-clipper",
           "description": "Repurposes long-form video (podcasts, interviews, talks) into short-form vertical clips for Instagram Reels, TikTok, and YouTube Shorts. Handles transcription, moment selection, clip extraction, speaker-tracked reframing (16:9 to 9:16), and animated captions.",
@@ -5652,7 +5664,7 @@
       "metadata": {
         "slug": "video-production",
         "name": "Video Production",
-        "description": "5-skill video production toolkit: beat-synced reels from product images, AI-animated product reels via Higgsfield, talking head videos via HeyGen, long-form to short-form clip repurposing, and screen recording polish with zoom/pan effects.",
+        "description": "6-skill video production toolkit: beat-synced reels from product images, AI-animated product reels via Higgsfield, talking head videos via HeyGen, UGC-style social videos via Creatify, long-form to short-form clip repurposing, and screen recording polish with zoom/pan effects.",
         "tags": [
           "content"
         ],
@@ -5660,6 +5672,7 @@
           "beat-sync-reel",
           "product-reel-generator",
           "talking-head-video",
+          "ugc-video-generator",
           "video-clipper",
           "video-polish"
         ],

--- a/skills/packs/video-production/.env.example
+++ b/skills/packs/video-production/.env.example
@@ -7,6 +7,11 @@ HIGGSFIELD_API_KEY_SECRET=
 # Sign up at https://app.heygen.com
 HEYGEN_API_KEY=
 
+# Creatify API (ugc-video-generator)
+# Sign up at https://app.creatify.ai
+CREATIFY_API_ID=
+CREATIFY_API_KEY=
+
 # Klap API (video-clipper)
 # Sign up at https://klap.app
 KLAP_API_KEY=

--- a/skills/packs/video-production/pack.meta.json
+++ b/skills/packs/video-production/pack.meta.json
@@ -1,7 +1,7 @@
 {
   "slug": "video-production",
   "name": "Video Production",
-  "description": "5-skill video production toolkit: beat-synced reels from product images, AI-animated product reels via Higgsfield, talking head videos via HeyGen, long-form to short-form clip repurposing, and screen recording polish with zoom/pan effects.",
+  "description": "6-skill video production toolkit: beat-synced reels from product images, AI-animated product reels via Higgsfield, talking head videos via HeyGen, UGC-style social videos via Creatify, long-form to short-form clip repurposing, and screen recording polish with zoom/pan effects.",
   "tags": [
     "content"
   ],
@@ -9,6 +9,7 @@
     "beat-sync-reel",
     "product-reel-generator",
     "talking-head-video",
+    "ugc-video-generator",
     "video-clipper",
     "video-polish"
   ],

--- a/skills/packs/video-production/ugc-video-generator/SKILL.md
+++ b/skills/packs/video-production/ugc-video-generator/SKILL.md
@@ -1,0 +1,448 @@
+---
+name: ugc-video-generator
+description: Generates UGC-style talking head videos for social media and ads using Creatify API. Researches the product, writes scripts, picks avatars, and produces ready-to-post vertical videos. Designed for Instagram Reels, TikTok, and YouTube Shorts.
+user-invocable: true
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
+argument-hint: [product-url-or-description]
+---
+
+# UGC Video Generator
+
+You are a UGC video production skill that takes a product URL or description and produces ready-to-post talking head videos using Creatify's API. You handle everything: research, scripting, avatar selection, voice selection, and video generation.
+
+The output is UGC-style vertical video (9:16) optimized for Instagram Reels, TikTok, and YouTube Shorts — casual, first-person, scroll-stopping content that looks like a real person sharing their experience.
+
+---
+
+## Before Starting: Verify Dependencies
+
+Before doing any work, verify the Creatify API credentials are available.
+
+**Check for credentials:**
+
+1. Look for `CREATIFY_API_ID` and `CREATIFY_API_KEY` in a `.env` file. Search the current directory first, then walk up parent directories.
+2. If found, verify they work by hitting the API:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" -X GET "https://api.creatify.ai/api/personas/" \
+  -H "X-API-ID: <CREATIFY_API_ID>" \
+  -H "X-API-KEY: <CREATIFY_API_KEY>"
+```
+
+A `200` response means credentials are valid. Any other response means they are invalid.
+
+3. If credentials are not found or invalid, guide the user:
+
+> "I need Creatify API credentials to generate videos. Here is how to set them up:
+>
+> 1. Sign up at https://app.creatify.ai
+> 2. Go to **Settings > API** in your dashboard
+> 3. Copy your **API ID** and **API Key**
+> 4. Add them to a `.env` file in your project:
+>
+> ```
+> CREATIFY_API_ID=your-api-id-here
+> CREATIFY_API_KEY=your-api-key-here
+> ```
+>
+> Let me know once you have done this."
+
+Do not proceed until credentials are verified.
+
+---
+
+## Input
+
+The user provides one or more of the following:
+
+| Input | Required | Example |
+|---|---|---|
+| **Product URL or description** | Yes | A URL or short description of the product/company |
+| **Goal and relationship** | Yes (ask if not provided) | What the user wants this video to achieve and the relationship they are building with the audience |
+| **Target persona** | Yes (ask if not provided) | The specific person this video is speaking to |
+
+**Understanding the goal is critical.** UGC videos serve very different purposes depending on who the company is trying to reach and why. The goal must capture both *what action* the user wants and *what relationship* they are building with the audience. Common patterns:
+
+| Relationship | Example Goal | How It Changes the Script |
+|---|---|---|
+| **Acquiring customers (ICP)** | "Get SaaS founders to sign up for our analytics tool" | Script speaks as a peer who solved the same problem. Pain point → discovery → result. |
+| **Acquiring suppliers / contributors** | "Recruit freelance designers to join our marketplace" | Script speaks as someone who earns/benefits from contributing. Opportunity → ease → outcome. |
+| **Hiring / recruiting** | "Attract senior engineers to apply at our company" | Script speaks as an employee sharing their experience. Culture → work → why they stay. |
+| **Building community / creators** | "Get content creators to use our platform and post about it" | Script speaks as a creator who found a tool that works. Discovery → workflow → results. |
+| **Brand awareness** | "Make our brand known among startup founders" | Script is thought-leadership adjacent. Insight → how the product relates → soft CTA. |
+
+**Understanding the target persona is critical.** Do not accept vague descriptions like "developers" or "young adults." The persona must be specific enough that you can write a script that feels like it was made for *that person*. Push the user to be specific:
+
+- Not "developers" → "backend engineers at Series A startups who are drowning in observability tool costs"
+- Not "small business owners" → "solo e-commerce founders doing $10K-50K/month who handle their own marketing"
+- Not "young adults" → "college students looking for flexible side income they can do from their phone"
+
+If the user provides only a URL, ask for the goal and persona in one message — do not ask them one at a time. Frame it as:
+
+> "Two things before I start:
+> 1. **What is this video for?** What action do you want viewers to take, and what is their relationship to your company — are they potential customers, suppliers, recruits, creators, or something else?
+> 2. **Who exactly is this person?** Describe the specific person this video should feel like it was made for — their role, situation, and what motivates them."
+
+---
+
+## Pipeline
+
+### Step 1: Research the Product and Audience
+
+Use web search to understand both the product and the target audience deeply. Do not rely solely on scraping the URL — web search gives richer context.
+
+**Research the product:**
+- What it does and its core value proposition
+- How it positions itself (landing page copy, taglines)
+- What users say about it (reviews, social mentions)
+- Key benefits and differentiators
+- The language and tone it uses (casual, professional, technical)
+- Any specific claims or proof points (numbers, testimonials, stats)
+
+**Research the target audience:**
+- What motivates this persona (what do they care about, what are their pain points)
+- Where they spend time online (which platforms, communities, subreddits)
+- What language and tone resonates with them (formal vs casual, aspirational vs practical)
+- What objections or hesitations they might have
+- What other products or solutions they currently use
+
+**Extract and note:**
+- Product name (exact casing and spelling)
+- One-line value prop
+- 3-5 key benefits/features relevant to *this specific persona*
+- The intersection: why this product matters to this persona specifically
+- Language cues: words and phrases this audience actually uses (not marketing speak)
+
+This research directly feeds the script. The product research ensures accuracy. The audience research ensures the script *feels* like it was written by someone who understands the viewer.
+
+### Step 2: Select Avatar and Voice
+
+Based on the target audience from Step 1, automatically select an avatar and voice from Creatify's library.
+
+**Fetch available avatars:**
+```bash
+curl -s -X GET "https://api.creatify.ai/api/personas/" \
+  -H "X-API-ID: <CREATIFY_API_ID>" \
+  -H "X-API-KEY: <CREATIFY_API_KEY>"
+```
+
+**Avatar selection criteria:**
+- **Style:** Always pick `selfie` or `ugc` style — these look like real people filming on their phone
+- **Age range:** Match the target audience. If the audience is young adults, pick `adult` age range avatars
+- **Gender:** Pick two different genders for the two video variants (one female, one male) to test what resonates
+- **Location:** Prefer `indoor` — bedrooms, living rooms, and casual settings feel most authentic for UGC
+- **Industries:** If the product maps to specific industries in the persona data, prefer those matches
+
+**Pick two avatars** — one for each video variant. Different genders, different backgrounds.
+
+**Fetch available voices:**
+```bash
+curl -s -X GET "https://api.creatify.ai/api/voices/" \
+  -H "X-API-ID: <CREATIFY_API_ID>" \
+  -H "X-API-KEY: <CREATIFY_API_KEY>"
+```
+
+**Voice selection criteria:**
+- Match the gender of the selected avatar
+- Prefer American English accent (broadest appeal for social media)
+- Pick conversational/warm-sounding voices over formal ones
+- Use the `preview_url` on each accent to help the user audition voices if they want to override
+
+### Step 3: Write Scripts
+
+Generate two scripts using proven UGC formulas. Each script should be **under 25 seconds when spoken** (roughly 60-75 words). Shorter is better — social media rewards brevity.
+
+**Script A — Testimonial Style**
+
+Structure: Personal discovery, experience, result, recommendation
+
+```
+"[Hook — personal discovery] I found this [product type] called [product name]
+where you [core action in simple terms].
+[Experience — what it was like] I tried it for [timeframe] and [authentic reaction].
+[Value — why it matters] [Key benefit in user's words, not marketing speak].
+[CTA — casual recommendation] If you [audience identifier], you should try this."
+```
+
+Rules:
+- First person, past tense ("I found", "I tried")
+- Include a genuine-sounding reaction ("honestly", "I was surprised", "it was so easy")
+- Mention the product name naturally, not as a pitch
+- End with a soft CTA — recommendation, not a hard sell
+
+**Script B — Hook/Ad Style**
+
+Structure: Attention-grabbing hook, problem/opportunity, solution, urgency
+
+```
+"[Hook — provocative statement or question] [Surprising claim about the audience's situation].
+[Bridge — connect to the product] [Product name] [what it does in one sentence].
+[Proof — why it is credible] [Specific detail, number, or feature].
+[CTA — direct action] [Short, clear next step]."
+```
+
+Rules:
+- Open with a scroll-stopping first sentence (the hook determines everything)
+- More direct and energetic than the testimonial
+- Include at least one specific detail (a number, a feature, a timeframe)
+- End with a clear action ("check it out", "link in bio", "try it free")
+
+**Script quality checks before proceeding:**
+- No marketing jargon ("revolutionary", "game-changing", "unlock")
+- No robotic phrasing — read it out loud mentally and check if a real person would say this
+- Contractions throughout ("don't" not "do not", "it's" not "it is")
+- Product name appears exactly once or twice, not more
+- Each script is 60-75 words max
+
+### Step 4: Review Gate
+
+**This step is mandatory.** Present the full production plan to the user for approval before spending any credits.
+
+Show:
+
+> **UGC Video Production Plan**
+>
+> **Product:** [product name]
+> **Goal:** [user's stated goal]
+> **Audience:** [target audience]
+>
+> ---
+>
+> **Video A — Testimonial**
+> - Script: "[full script text]"
+> - Avatar: [name] — [gender], [style], [scene description]
+> - Voice: [name] — [accent]
+>
+> **Video B — Hook/Ad**
+> - Script: "[full script text]"
+> - Avatar: [name] — [gender], [style], [scene description]
+> - Voice: [name] — [accent]
+>
+> ---
+>
+> **Settings**
+> - Model: `aurora_v1_fast` (good quality, moderate cost)
+> - Aspect ratio: 9:16 (vertical — Instagram/TikTok/Shorts)
+> - Captions: On
+> - Music: Off
+>
+> **Estimated cost:** [N] credits ([cost breakdown per video])
+>
+> ---
+>
+> You can:
+> - **Approve** — I will generate both videos
+> - **Edit scripts** — tell me what to change
+> - **Change avatar or voice** — describe what you want instead
+> - **Change settings** — e.g., switch to `aurora_v1` for higher quality (2x cost)
+>
+> What would you like to do?
+
+**Credit cost estimation:**
+Estimate output duration from word count: ~3 words per second of speech. A 70-word script produces roughly 23 seconds of video. Then calculate credits based on the model version's cost-per-time-block (see Cost Reference section). Always present this as an estimate — actual cost depends on final video duration.
+
+Wait for explicit approval before proceeding to Step 5.
+
+### Step 5: Generate Videos
+
+After approval, generate both videos sequentially.
+
+**Submit each video:**
+
+```bash
+curl -s -X POST "https://api.creatify.ai/api/lipsyncs/" \
+  -H "X-API-ID: <CREATIFY_API_ID>" \
+  -H "X-API-KEY: <CREATIFY_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "<SCRIPT_TEXT>",
+    "creator": "<PERSONA_ID>",
+    "accent": "<VOICE_ACCENT_ID>",
+    "aspect_ratio": "9:16",
+    "model_version": "aurora_v1_fast",
+    "no_caption": false,
+    "no_music": true
+  }'
+```
+
+The API returns a task `id` and `status: "pending"`.
+
+**Poll for completion:**
+
+```bash
+curl -s -X GET "https://api.creatify.ai/api/lipsyncs/<TASK_ID>/" \
+  -H "X-API-ID: <CREATIFY_API_ID>" \
+  -H "X-API-KEY: <CREATIFY_API_KEY>"
+```
+
+Poll every 10 seconds. Status progresses: `pending` -> `running` -> `done` (or `failed`).
+
+When `status` is `done`, the `output` field contains the video download URL.
+
+**Download the videos** to the working directory:
+
+```bash
+curl -s -o "ugc_video_a_testimonial.mp4" "<OUTPUT_URL>"
+curl -s -o "ugc_video_b_hook.mp4" "<OUTPUT_URL>"
+```
+
+If a video fails, report the `failed_reason` to the user and offer to retry with the same or adjusted settings.
+
+### Step 6: Deliver and Suggest Improvements
+
+Present the results and offer clear upgrade paths.
+
+> **Videos Generated**
+>
+> | Video | File | Duration | Credits Used |
+> |---|---|---|---|
+> | A — Testimonial | `ugc_video_a_testimonial.mp4` | [X]s | [N] credits |
+> | B — Hook/Ad | `ugc_video_b_hook.mp4` | [X]s | [N] credits |
+>
+> **Total credits used:** [N]
+>
+> ---
+>
+> **To improve these videos, you can:**
+>
+> **Script and Content**
+> - Adjust the script — change the hook, tone, or length
+> - Try a different avatar or voice
+>
+> **Video Quality**
+> - Switch to `aurora_v1` model for higher fidelity (2x credit cost)
+> - Provide your own audio file (e.g., from ElevenLabs) for more natural voice — pass it as the `audio` parameter instead of `text`
+>
+> **Advanced**
+> - Create a custom avatar from your own photo or video using `POST /api/personas_v2/`
+> - Use multi-scene format (Creatify V2 API) for videos with scene cuts — hook scene, value prop scene, CTA scene
+>
+> What would you like to try?
+
+If the user requests an improvement, loop back to the relevant step:
+- Script change -> Step 3 (rewrite) -> Step 4 (review) -> Step 5 (generate)
+- Avatar/voice change -> Step 2 (reselect) -> Step 4 (review) -> Step 5 (generate)
+- Model change -> Update settings -> Step 4 (review) -> Step 5 (generate)
+
+---
+
+## Creatify API Reference
+
+**Base URL:** `https://api.creatify.ai`
+
+**Authentication headers (required on all requests):**
+```
+X-API-ID: <CREATIFY_API_ID>
+X-API-KEY: <CREATIFY_API_KEY>
+```
+
+### Endpoints Used
+
+| Method | Endpoint | Purpose |
+|---|---|---|
+| `GET` | `/api/personas/` | List available avatars |
+| `GET` | `/api/voices/` | List available voices with accent variants |
+| `POST` | `/api/lipsyncs/` | Submit a video generation request |
+| `GET` | `/api/lipsyncs/{id}/` | Check video generation status |
+
+### Lipsync Request Parameters
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `text` | string | Yes* | Script text for voiceover (max 8,000 chars) |
+| `audio` | URL | Yes* | External audio file URL (overrides `text` if both provided) |
+| `creator` | UUID | No | Persona ID from `/api/personas/` |
+| `accent` | UUID | No | Voice accent ID from `/api/voices/` |
+| `model_version` | string | No | `standard`, `aurora_v1_fast`, or `aurora_v1` (default: `standard`) |
+| `aspect_ratio` | string | Yes | `9x16`, `16x9`, or `1x1` |
+| `no_caption` | boolean | No | `false` to show captions, `true` to hide (default: `true`) |
+| `no_music` | boolean | No | `false` to add music, `true` to skip (default: `true`) |
+| `caption_style` | string | No | Caption preset (e.g., `normal-black`, `neo`, `brick`) |
+| `green_screen` | boolean | No | Black background for compositing (default: `false`) |
+| `transparent_background` | boolean | No | .webm with alpha channel (default: `false`) |
+| `webhook_url` | URL | No | Callback URL for completion notification |
+
+*Either `text` or `audio` is required. If both are provided, `audio` is used.
+
+### Lipsync Response Fields
+
+| Field | Description |
+|---|---|
+| `id` | Task UUID |
+| `status` | `pending`, `running`, `done`, or `failed` |
+| `output` | Video download URL (when `status: done`) |
+| `progress` | Completion percentage (0 to 1) |
+| `credits_used` | Credits consumed |
+| `duration` | Video length in seconds |
+| `failed_reason` | Error details (when `status: failed`) |
+
+### Persona Object Fields
+
+| Field | Description |
+|---|---|
+| `id` | UUID — use as `creator` parameter |
+| `creator_name` | Display name (e.g., "Imane", "Chase") |
+| `gender` | `f` or `m` |
+| `age_range` | `young_adult`, `adult`, `senior` |
+| `style` | `selfie`, `ugc`, `presenter` |
+| `location` | `indoor`, `outdoor` |
+| `video_scene` | Scene description (e.g., "bedroom", "office") |
+| `suitable_industries` | Array of industry tags |
+
+### Voice Object Fields
+
+| Field | Description |
+|---|---|
+| `name` | Voice name (e.g., "Sophie", "Austin") |
+| `gender` | `female`, `male`, or null |
+| `accents` | Array of accent variants, each with `id`, `accent_name`, and `preview_url` |
+
+Use the `id` from the accents array as the `accent` parameter in lipsync requests.
+
+---
+
+## Cost Reference
+
+**Note:** Credit costs and plan pricing change over time. The values below were accurate as of April 2026. Before quoting costs to the user, verify current rates at https://creatify.ai/pricing and https://docs.creatify.ai.
+
+**Credit costs by model (as of April 2026):**
+
+| Model Version | Cost | Per |
+|---|---|---|
+| `standard` | 5 credits | 30 seconds |
+| `aurora_v1_fast` | 10 credits | 15 seconds |
+| `aurora_v1` | 20 credits | 15 seconds |
+
+Credit costs are per time block, rounded up. A 16-second video on `aurora_v1_fast` costs 20 credits (two 15-second blocks), not 10.
+
+When presenting credit estimates at the review gate, calculate based on estimated video duration (~3 words per second of speech) and always note that actual costs may vary based on output duration.
+
+---
+
+## Opinionated Defaults
+
+These defaults are chosen for the best quality-to-cost ratio for social media UGC content. They are shown to the user at the review gate and can be overridden.
+
+| Setting | Default | Why |
+|---|---|---|
+| `model_version` | `aurora_v1_fast` | Best balance of quality and cost. `standard` looks noticeably worse. `aurora_v1` is 2x the cost for marginal improvement. |
+| `aspect_ratio` | `9:16` | Vertical video for Instagram Reels, TikTok, YouTube Shorts |
+| `no_caption` | `false` (captions on) | 80%+ of social media users watch with sound off |
+| `no_music` | `true` (music off) | Background music competes with voice. Users can add trending audio in their editing app. |
+| Avatar style | `selfie` or `ugc` | UGC must look like a real person filming on their phone, not a corporate presenter |
+| Avatar gender | One male, one female (two variants) | A/B test which messenger resonates with the audience |
+| Voice accent | American English | Broadest appeal for social media content |
+| Script length | Under 25 seconds (~60-75 words) | Sweet spot for social media engagement. Keeps credit costs down. |
+| Number of variants | 2 (testimonial + hook) | Built-in A/B testing. Two proven UGC formulas. |
+
+---
+
+## Limitations
+
+1. **No talking head from custom image via lipsync endpoint.** The lipsync endpoint uses stock personas. To use a custom image, use the Aurora endpoint (`POST /api/aurora/`) which requires you to provide your own image URL and audio URL separately.
+2. **Generated files are hosted temporarily.** Download videos immediately after generation. Creatify stores output files for a minimum of 7 days.
+3. **Voice quality is model-dependent.** Creatify's built-in TTS is good but not perfect. For the most natural voice, generate audio externally (e.g., ElevenLabs) and pass it as the `audio` parameter.
+4. **Scripts longer than 30 seconds** can start to feel robotic. Keep UGC scripts short and punchy.
+5. **No built-in video editing.** The output is a raw MP4. Add trending audio, additional text overlays, or transitions in a video editor (CapCut, InShot, etc.) before posting.
+6. **Avatar quality varies.** Not all avatars are equal. The skill filters for `selfie`/`ugc` style which tends to be the most realistic, but some avatars look more natural than others.
+7. **API pricing may change.** Credit costs and plan pricing referenced in this skill are estimates. Always check https://creatify.ai/pricing for current rates.

--- a/skills/packs/video-production/ugc-video-generator/scripts/creatify_api.py
+++ b/skills/packs/video-production/ugc-video-generator/scripts/creatify_api.py
@@ -1,0 +1,292 @@
+"""
+Creatify API - UGC Video Generator Helper
+
+Handles API interactions with Creatify for generating UGC-style talking head videos.
+Used by the ugc-video-generator skill.
+
+Usage:
+    # List avatars (filtered for UGC style)
+    python scripts/creatify_api.py avatars --gender f --style selfie
+
+    # List voices (filtered by gender and accent)
+    python scripts/creatify_api.py voices --gender female --accent american
+
+    # Generate a video
+    python scripts/creatify_api.py generate \
+        --text "Your script here" \
+        --creator <persona-id> \
+        --accent <voice-accent-id> \
+        --model aurora_v1_fast \
+        --output video.mp4
+
+    # Check status of a generation
+    python scripts/creatify_api.py status --id <task-id>
+
+Requires CREATIFY_API_ID and CREATIFY_API_KEY in .env
+"""
+
+import os
+import sys
+import json
+import time
+import argparse
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+
+def _find_and_load_env():
+    """Walk up from script location to find and load .env file."""
+    current = Path(__file__).resolve().parent
+    while current != current.parent:
+        env_file = current / ".env"
+        if env_file.exists():
+            with open(env_file) as f:
+                for line in f:
+                    line = line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    if "=" in line:
+                        key, _, value = line.partition("=")
+                        os.environ.setdefault(key.strip(), value.strip())
+            return
+        current = current.parent
+
+
+_find_and_load_env()
+
+BASE_URL = "https://api.creatify.ai"
+API_ID = os.getenv("CREATIFY_API_ID")
+API_KEY = os.getenv("CREATIFY_API_KEY")
+
+
+def api_request(method, endpoint, data=None):
+    """Make an authenticated request to the Creatify API."""
+    if not API_ID or not API_KEY:
+        print("Error: CREATIFY_API_ID and CREATIFY_API_KEY must be set in .env")
+        sys.exit(1)
+
+    url = f"{BASE_URL}{endpoint}"
+    headers = {
+        "X-API-ID": API_ID,
+        "X-API-KEY": API_KEY,
+        "Content-Type": "application/json",
+    }
+    body = json.dumps(data).encode() if data else None
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode()
+        print(f"API Error {e.code}: {error_body}", file=sys.stderr)
+        sys.exit(1)
+
+
+def list_avatars(gender=None, style=None, age_range=None, limit=20):
+    """List available avatars, filtered for UGC suitability."""
+    personas = api_request("GET", "/api/personas/")
+
+    filtered = []
+    for p in personas:
+        if not p.get("is_active"):
+            continue
+        if style and p.get("style") != style:
+            continue
+        if gender and p.get("gender") != gender:
+            continue
+        if age_range and p.get("age_range") != age_range:
+            continue
+        filtered.append(p)
+
+    # Sort by UGC suitability: selfie > ugc > presenter
+    style_priority = {"selfie": 0, "ugc": 1, "presenter": 2}
+    filtered.sort(key=lambda p: style_priority.get(p.get("style", ""), 99))
+
+    for p in filtered[:limit]:
+        industries = ", ".join((p.get("suitable_industries") or [])[:3])
+        scene = p.get("video_scene") or "N/A"
+        print(
+            f"{p['id']}  |  {p.get('creator_name', 'Unknown'):15s}  |  "
+            f"{p.get('gender', '?')}  |  {p.get('style', '?'):10s}  |  "
+            f"{p.get('age_range', '?'):10s}  |  {scene[:30]:30s}  |  {industries}"
+        )
+
+    print(f"\nShowing {min(limit, len(filtered))} of {len(filtered)} matching avatars")
+    return filtered[:limit]
+
+
+def list_voices(gender=None, accent_filter=None, limit=20):
+    """List available voices, filtered by gender and accent."""
+    voices = api_request("GET", "/api/voices/")
+
+    results = []
+    for v in voices:
+        v_gender = v.get("gender") or ""
+        if gender and gender.lower() not in v_gender.lower():
+            continue
+
+        for a in v.get("accents") or []:
+            accent_name = a.get("accent_name") or ""
+            if accent_filter and accent_filter.lower() not in accent_name.lower():
+                continue
+            results.append({
+                "name": v.get("name", "Unknown"),
+                "gender": v_gender,
+                "accent_name": accent_name,
+                "accent_id": a.get("id", ""),
+                "preview_url": a.get("preview_url", ""),
+            })
+
+    for r in results[:limit]:
+        print(
+            f"{r['accent_id']}  |  {r['name']:20s}  |  "
+            f"{r['gender']:8s}  |  {r['accent_name']}"
+        )
+
+    print(f"\nShowing {min(limit, len(results))} of {len(results)} matching voices")
+    return results[:limit]
+
+
+def generate_video(text=None, audio=None, creator=None, accent=None,
+                   model="aurora_v1_fast", aspect_ratio="9:16",
+                   no_caption=False, no_music=True, output_path=None):
+    """Submit a video generation request and poll until complete."""
+    payload = {
+        "aspect_ratio": aspect_ratio,
+        "model_version": model,
+        "no_caption": no_caption,
+        "no_music": no_music,
+    }
+
+    if audio:
+        payload["audio"] = audio
+    elif text:
+        payload["text"] = text
+    else:
+        print("Error: Either --text or --audio is required", file=sys.stderr)
+        sys.exit(1)
+
+    if creator:
+        payload["creator"] = creator
+    if accent:
+        payload["accent"] = accent
+
+    # Submit
+    result = api_request("POST", "/api/lipsyncs/", payload)
+    task_id = result["id"]
+    print(f"Task submitted: {task_id}")
+    print(f"Status: {result.get('status', 'unknown')}")
+
+    # Poll
+    while True:
+        time.sleep(10)
+        status = api_request("GET", f"/api/lipsyncs/{task_id}/")
+        current = status.get("status", "unknown")
+        progress = status.get("progress", 0)
+        print(f"  Status: {current} | Progress: {progress:.0%}")
+
+        if current == "done":
+            output_url = status.get("output", "")
+            credits = status.get("credits_used", 0)
+            duration = status.get("duration", 0)
+            print(f"\n  Video ready: {output_url}")
+            print(f"  Duration: {duration}s")
+            print(f"  Credits used: {credits}")
+
+            # Download if output path specified
+            if output_path and output_url:
+                print(f"  Downloading to: {output_path}")
+                urllib.request.urlretrieve(output_url, output_path)
+                print(f"  Downloaded: {output_path}")
+
+            return {
+                "id": task_id,
+                "status": "done",
+                "url": output_url,
+                "duration": duration,
+                "credits_used": credits,
+            }
+
+        if current == "failed":
+            reason = status.get("failed_reason", "Unknown error")
+            print(f"\n  FAILED: {reason}", file=sys.stderr)
+            return {
+                "id": task_id,
+                "status": "failed",
+                "error": reason,
+            }
+
+
+def check_status(task_id):
+    """Check the status of a generation task."""
+    status = api_request("GET", f"/api/lipsyncs/{task_id}/")
+    print(json.dumps(status, indent=2, default=str))
+    return status
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Creatify API helper for UGC video generation")
+    subparsers = parser.add_subparsers(dest="command", help="Command to run")
+
+    # avatars
+    avatars_parser = subparsers.add_parser("avatars", help="List available avatars")
+    avatars_parser.add_argument("--gender", choices=["f", "m"], help="Filter by gender")
+    avatars_parser.add_argument("--style", default="selfie", help="Filter by style (default: selfie)")
+    avatars_parser.add_argument("--age", default=None, help="Filter by age range")
+    avatars_parser.add_argument("--limit", type=int, default=20, help="Max results")
+
+    # voices
+    voices_parser = subparsers.add_parser("voices", help="List available voices")
+    voices_parser.add_argument("--gender", help="Filter by gender (female/male)")
+    voices_parser.add_argument("--accent", default="american", help="Filter by accent (default: american)")
+    voices_parser.add_argument("--limit", type=int, default=20, help="Max results")
+
+    # generate
+    gen_parser = subparsers.add_parser("generate", help="Generate a video")
+    gen_parser.add_argument("--text", help="Script text for voiceover")
+    gen_parser.add_argument("--audio", help="Audio file URL (overrides text)")
+    gen_parser.add_argument("--creator", help="Persona UUID")
+    gen_parser.add_argument("--accent", help="Voice accent UUID")
+    gen_parser.add_argument("--model", default="aurora_v1_fast",
+                           choices=["standard", "aurora_v1_fast", "aurora_v1"])
+    gen_parser.add_argument("--ratio", default="9:16", help="Aspect ratio")
+    gen_parser.add_argument("--captions", action="store_true", default=True,
+                           help="Enable captions (default: on)")
+    gen_parser.add_argument("--no-captions", action="store_true", help="Disable captions")
+    gen_parser.add_argument("--music", action="store_true", help="Enable background music")
+    gen_parser.add_argument("--output", help="Output file path")
+
+    # status
+    status_parser = subparsers.add_parser("status", help="Check generation status")
+    status_parser.add_argument("--id", required=True, help="Task ID")
+
+    args = parser.parse_args()
+
+    if args.command == "avatars":
+        list_avatars(gender=args.gender, style=args.style,
+                    age_range=args.age, limit=args.limit)
+    elif args.command == "voices":
+        list_voices(gender=args.gender, accent_filter=args.accent,
+                   limit=args.limit)
+    elif args.command == "generate":
+        generate_video(
+            text=args.text,
+            audio=args.audio,
+            creator=args.creator,
+            accent=args.accent,
+            model=args.model,
+            aspect_ratio=args.ratio,
+            no_caption=args.no_captions,
+            no_music=not args.music,
+            output_path=args.output,
+        )
+    elif args.command == "status":
+        check_status(args.id)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/packs/video-production/ugc-video-generator/skill.meta.json
+++ b/skills/packs/video-production/ugc-video-generator/skill.meta.json
@@ -1,0 +1,17 @@
+{
+  "slug": "ugc-video-generator",
+  "category": "packs/video-production",
+  "tags": [
+    "content",
+    "video",
+    "ads"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install video-production/ugc-video-generator",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- New skill that generates UGC-style talking head videos for social media and ads using Creatify API
- Full pipeline: product & audience research → avatar/voice auto-selection → script writing (testimonial + hook formats) → mandatory review gate → video generation → delivery with improvement suggestions
- Opinionated defaults for best quality-to-cost ratio (aurora_v1_fast, 9:16 vertical, captions on, two A/B variants)
- Helper script (`creatify_api.py`) for avatar listing, voice listing, video generation, and status polling
- Updated pack.meta.json, .env.example, and skills-index.json

## Test plan
- [ ] Install skill and verify Creatify API credential setup flow works
- [ ] Test with a product URL to verify research → script → review gate flow
- [ ] Verify avatar and voice auto-selection picks appropriate UGC-style personas
- [ ] Generate test videos and confirm download works
- [ ] Verify credit cost estimates are shown at review gate
- [ ] Test improvement loop (edit script → regenerate)
- [ ] Run skill-pr-validator — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)