### PR TITLE
Rename create-goose-graphics-style → goose-graphics-create-style

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -749,43 +749,6 @@
       }
     },
     {
-      "slug": "create-goose-graphics-style",
-      "name": "create-goose-graphics-style",
-      "category": "composites",
-      "description": ">",
-      "tags": "design, content",
-      "path": "skills/composites/create-goose-graphics-style",
-      "files": [
-        "skills/composites/create-goose-graphics-style/SKILL.md",
-        "skills/composites/create-goose-graphics-style/skill.meta.json"
-      ],
-      "metadata": {
-        "slug": "create-goose-graphics-style",
-        "category": "composites",
-        "tags": [
-          "design",
-          "content"
-        ],
-        "installation": {
-          "base_command": "npx goose-skills install create-goose-graphics-style",
-          "supports": [
-            "claude",
-            "cursor",
-            "codex"
-          ]
-        },
-        "requires_skills": [
-          "goose-graphics"
-        ],
-        "features": [
-          "Reference image → fully installed style preset in one command",
-          "Generates all 7 format examples (poster, infographic, carousel, slides, story, chart, tweet) using a standard brief",
-          "Auto-renders PNGs via the goose-graphics Playwright pipeline",
-          "Registers the new style in styles/index.json and examples/manifest.json"
-        ]
-      }
-    },
-    {
       "slug": "create-html-carousel",
       "name": "create-html-carousel",
       "category": "capabilities",
@@ -1909,6 +1872,43 @@
           "Playwright PNG export",
           "Image-to-style extraction",
           "Args-based slash command invocation"
+        ]
+      }
+    },
+    {
+      "slug": "goose-graphics-create-style",
+      "name": "goose-graphics-create-style",
+      "category": "composites",
+      "description": ">",
+      "tags": "design, content",
+      "path": "skills/composites/goose-graphics-create-style",
+      "files": [
+        "skills/composites/goose-graphics-create-style/SKILL.md",
+        "skills/composites/goose-graphics-create-style/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "goose-graphics-create-style",
+        "category": "composites",
+        "tags": [
+          "design",
+          "content"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install goose-graphics-create-style",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "requires_skills": [
+          "goose-graphics"
+        ],
+        "features": [
+          "Reference image → fully installed style preset in one command",
+          "Generates all 7 format examples (poster, infographic, carousel, slides, story, chart, tweet) using a standard brief",
+          "Auto-renders PNGs via the goose-graphics Playwright pipeline",
+          "Registers the new style in styles/index.json and examples/manifest.json"
         ]
       }
     },

--- a/skills/composites/goose-graphics-create-style/SKILL.md
+++ b/skills/composites/goose-graphics-create-style/SKILL.md
@@ -1,11 +1,11 @@
 ---
-name: create-goose-graphics-style
+name: goose-graphics-create-style
 description: >
   End-to-end skill that turns a single reference image into a fully-installed,
   example-rendered style preset for the goose-graphics composite. Analyzes the
   image, writes the slim style spec, registers it in styles/index.json, generates
   all 7 format examples using the standard brief, renders PNGs via Playwright,
-  and updates examples/manifest.json. Invoke with /create-goose-graphics-style.
+  and updates examples/manifest.json. Invoke with /goose-graphics-create-style.
 tags: [design, content]
 ---
 
@@ -36,7 +36,7 @@ finish, the user should be able to immediately call
 ## Invocation
 
 ```
-/create-goose-graphics-style --ref <image-path> [--name <slug>] [--group <group-name>]
+/goose-graphics-create-style --ref <image-path> [--name <slug>] [--group <group-name>]
 ```
 
 - `--ref <image-path>` (required) — path to the reference image (PNG/JPG/WebP).

--- a/skills/composites/goose-graphics-create-style/skill.meta.json
+++ b/skills/composites/goose-graphics-create-style/skill.meta.json
@@ -1,12 +1,12 @@
 {
-  "slug": "create-goose-graphics-style",
+  "slug": "goose-graphics-create-style",
   "category": "composites",
   "tags": [
     "design",
     "content"
   ],
   "installation": {
-    "base_command": "npx goose-skills install create-goose-graphics-style",
+    "base_command": "npx goose-skills install goose-graphics-create-style",
     "supports": [
       "claude",
       "cursor",

--- a/skills/composites/goose-graphics/SKILL.md
+++ b/skills/composites/goose-graphics/SKILL.md
@@ -24,7 +24,7 @@ This skill supports **three invocation modes** — all-args, partial-args, and i
 - `--style <slug>` — one of the preset slugs (see `styles/index.json` or §6). Required for style-selected generation. Omit to let the user pick interactively.
 - `--format <format>` — one of `carousel`, `story`, `infographic`, `slides`, `poster`, `chart`, `tweet`. Required for format-selected generation.
 - `--brief "..."` — the topic / content description. Replaces the Content Discovery phase.
-- `--ref <image-path>` — if present, extract an ad-hoc style from the reference image for this single render instead of using a preset. When `--ref` is provided, `--style` is ignored. **For creating a persistent named style preset that includes example renders, use the dedicated `/create-goose-graphics-style` skill instead.**
+- `--ref <image-path>` — if present, extract an ad-hoc style from the reference image for this single render instead of using a preset. When `--ref` is provided, `--style` is ignored. **For creating a persistent named style preset that includes example renders, use the dedicated `/goose-graphics-create-style` skill instead.**
 
 **Three branches:**
 
@@ -48,7 +48,7 @@ This skill supports **three invocation modes** — all-args, partial-args, and i
 /goose-graphics
 ```
 
-To **create a persistent named style preset** (slim spec + all 7 format example renders + index/manifest registration), use the dedicated `/create-goose-graphics-style` skill instead.
+To **create a persistent named style preset** (slim spec + all 7 format example renders + index/manifest registration), use the dedicated `/goose-graphics-create-style` skill instead.
 
 ### 2.3 Defaults when args are partial but unambiguous
 
@@ -258,7 +258,7 @@ Present the results to the user:
 
 The canonical list of all 36 style presets lives in `styles/index.json` (slug, display name, mood group, one-line tagline). Individual slim style files at `styles/<slug>.md` give you the full spec (palette, typography, layout, do/don't, CSS snippets). Archived full-prose versions live in `styles/_full/<slug>.md` if you need the deeper atmospheric reference.
 
-Ad-hoc styles extracted via `--ref` or the "I have a reference image" interactive option may be saved to `styles/<name>.md` in the same slim format as presets, but they are not added to `index.json` and ship without example renders. To create a properly registered preset with full example coverage, use the `/create-goose-graphics-style` skill.
+Ad-hoc styles extracted via `--ref` or the "I have a reference image" interactive option may be saved to `styles/<name>.md` in the same slim format as presets, but they are not added to `index.json` and ship without example renders. To create a properly registered preset with full example coverage, use the `/goose-graphics-create-style` skill.
 
 ### Image Sources
 | File | Description |


### PR DESCRIPTION
## Summary
- Rename the `create-goose-graphics-style` composite skill to `goose-graphics-create-style` so the slug groups alphabetically next to its parent `goose-graphics` skill in directory listings, the catalog UI, and the picker.
- Updates the skill's frontmatter `name`, `slug`, `base_command`, and invocation examples; updates 3 cross-references in `goose-graphics/SKILL.md`; regenerates `skills-index.json`.
- Pure rename, no behavior change.

## Test plan
- [x] `node scripts/validate-skills.js` passes
- [x] No remaining references to the old slug (`git grep create-goose-graphics-style` returns nothing)
- [x] `skills-index.json` regenerated via `scripts/build-index.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)