### PR TITLE
Quote argument-hint values in 2 pack SKILL.md files (GOOSE-1501)

### DIFF
--- a/skills/packs/lead-gen-devtools/github-repo-signals/SKILL.md
+++ b/skills/packs/lead-gen-devtools/github-repo-signals/SKILL.md
@@ -3,7 +3,7 @@ name: github-repo-signals
 description: Extract and score leads from GitHub repositories by analyzing stars, forks, issues, PRs, comments, and contributions. Produces unified multi-repo CSV with deduplicated user profiles. No paid API credits required.
 user-invocable: true
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob
-argument-hint: [owner/repo1,owner/repo2] [limit]
+argument-hint: "[owner/repo1,owner/repo2] [limit]"
 ---
 
 # GitHub Repository Signals

--- a/skills/packs/video-production/beat-sync-reel/SKILL.md
+++ b/skills/packs/video-production/beat-sync-reel/SKILL.md
@@ -3,7 +3,7 @@ name: beat-sync-reel
 description: Generates Instagram Reels where product image cuts are synced to audio beats. Accepts audio as a local file, URL, or search query. Uses librosa for beat detection, FFmpeg Ken Burns for scene animation, and Pillow for text overlays. No AI video generation — fully free, fast, and scalable.
 user-invocable: true
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebSearch
-argument-hint: [product-url-or-image-paths] [audio-source]
+argument-hint: "[product-url-or-image-paths] [audio-source]"
 ---
 
 # Beat-Sync Reel Generator


### PR DESCRIPTION
## Summary

Two pack sub-skills had **invalid YAML frontmatter** that the strict parser (`gray-matter`, used by the backend predefined-skills sync) rejects:

\`\`\`yaml
argument-hint: [owner/repo1,owner/repo2] [limit]   # github-repo-signals
argument-hint: [product-url-or-image-paths] [audio-source]   # beat-sync-reel
\`\`\`

YAML sees the first \`[...]\` as a flow sequence and chokes on the trailing tokens after the closing \`]\`. The custom regex parser in \`scripts/build-index.js\` silently accepts these (so they appear in the index), but the backend sync at \`gooseworks-app/backend/src/services/predefined-skills-sync.service.ts\` uses \`gray-matter\` and throws:

\`\`\`
[PredefinedSkillsSync] Failed to sync slug "beat-sync-reel"
{ error: 'can not read an implicit mapping pair; a colon is missed
  at line 6, column 59...' }
\`\`\`

Result: these 2 slugs are stuck never syncing to the backend DB, leaving the install catalog short by 2 every hourly sync.

## Fix

Wrap the values in double quotes — same content, YAML-safe. Verified by re-running \`gray-matter\` against both files — both now parse cleanly.

## Why these 2 specifically

Audited all 11 pack sub-skill SKILL.md files. Only these two have the dual-\`[...] [...]\` pattern. The other 9 have single bracket values (\`[website-url]\`, \`[config-json-path]\`, etc.) which YAML happily parses as single-element flow sequences.

## Verification

\`\`\`bash
$ node -e 'const m = require(\"gray-matter\"); const f = require(\"fs\");
  for (const p of [\"skills/packs/lead-gen-devtools/github-repo-signals/SKILL.md\",
                   \"skills/packs/video-production/beat-sync-reel/SKILL.md\"]) {
    console.log(p, \"→\", m(f.readFileSync(p, \"utf8\")).data[\"argument-hint\"]);
  }'
skills/packs/lead-gen-devtools/github-repo-signals/SKILL.md → [owner/repo1,owner/repo2] [limit]
skills/packs/video-production/beat-sync-reel/SKILL.md → [product-url-or-image-paths] [audio-source]
\`\`\`

\`skills-index.json\` regenerates byte-identical (the custom build-index parser was already silently handling these). Only the source SKILL.md files changed.

## Companion fix

A separate gooseworks-app PR will bump the Trigger.dev machine size on \`syncPredefinedSkillsCatalogHourly\` to fix \`TASK_PROCESS_OOM_KILLED\` — that's an unrelated memory-pressure issue from holding 199 skills' worth of content in process memory during sync.

## Future hardening (not in this PR)

\`scripts/validate-skills.js\` should add a strict YAML parse step on every frontmatter (using \`js-yaml\` or \`gray-matter\` as a devDep). That would catch this class of bug at validate time instead of at backend-sync time. Worth a follow-up — wanted to keep this PR minimal so it ships fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)