### PR TITLE
Revive 5 deleted skills (GOOSE-1506)

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -812,6 +812,38 @@
       }
     },
     {
+      "slug": "competitor-content-tracker",
+      "name": "competitor-content-tracker",
+      "category": "composites",
+      "description": ">",
+      "tags": "competitive-intel",
+      "path": "skills/composites/competitor-content-tracker",
+      "files": [
+        "skills/composites/competitor-content-tracker/SKILL.md",
+        "skills/composites/competitor-content-tracker/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "competitor-content-tracker",
+        "category": "composites",
+        "tags": [
+          "competitive-intel"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install competitor-content-tracker",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "requires_skills": [
+          "blog-feed-monitor",
+          "linkedin-profile-post-scraper",
+          "twitter-mention-tracker"
+        ]
+      }
+    },
+    {
       "slug": "competitor-intel",
       "name": "competitor-intel",
       "category": "composites",
@@ -1322,6 +1354,33 @@
         ],
         "installation": {
           "base_command": "npx goose-skills install customer-discovery",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
+      }
+    },
+    {
+      "slug": "customer-story-builder",
+      "name": "customer-story-builder",
+      "category": "composites",
+      "description": ">",
+      "tags": "content",
+      "path": "skills/composites/customer-story-builder",
+      "files": [
+        "skills/composites/customer-story-builder/SKILL.md",
+        "skills/composites/customer-story-builder/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "customer-story-builder",
+        "category": "composites",
+        "tags": [
+          "content"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install customer-story-builder",
           "supports": [
             "claude",
             "cursor",
@@ -2410,6 +2469,33 @@
         "requires_skills": [
           "content-asset-creator"
         ]
+      }
+    },
+    {
+      "slug": "icp-website-review",
+      "name": "icp-website-review",
+      "category": "capabilities",
+      "description": ">",
+      "tags": "research",
+      "path": "skills/capabilities/icp-website-review",
+      "files": [
+        "skills/capabilities/icp-website-review/SKILL.md",
+        "skills/capabilities/icp-website-review/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "icp-website-review",
+        "category": "capabilities",
+        "tags": [
+          "research"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install icp-website-review",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
       }
     },
     {
@@ -3577,6 +3663,34 @@
       }
     },
     {
+      "slug": "newsletter-sponsorship-finder",
+      "name": "newsletter-sponsorship-finder",
+      "category": "capabilities",
+      "description": ">",
+      "tags": "monitoring",
+      "path": "skills/capabilities/newsletter-sponsorship-finder",
+      "files": [
+        "skills/capabilities/newsletter-sponsorship-finder/SKILL.md",
+        "skills/capabilities/newsletter-sponsorship-finder/scripts/search_newsletters.py",
+        "skills/capabilities/newsletter-sponsorship-finder/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "newsletter-sponsorship-finder",
+        "category": "capabilities",
+        "tags": [
+          "monitoring"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install newsletter-sponsorship-finder",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
+      }
+    },
+    {
       "slug": "outbound-prospecting-engine",
       "name": "outbound-prospecting-engine",
       "category": "playbooks",
@@ -4458,6 +4572,33 @@
           "cold-email-outreach",
           "email-drafting"
         ]
+      }
+    },
+    {
+      "slug": "setup-outreach-campaign-smartlead",
+      "name": "setup-outreach-campaign-smartlead",
+      "category": "capabilities",
+      "description": ">",
+      "tags": "outreach",
+      "path": "skills/capabilities/setup-outreach-campaign-smartlead",
+      "files": [
+        "skills/capabilities/setup-outreach-campaign-smartlead/SKILL.md",
+        "skills/capabilities/setup-outreach-campaign-smartlead/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "setup-outreach-campaign-smartlead",
+        "category": "capabilities",
+        "tags": [
+          "outreach"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install setup-outreach-campaign-smartlead",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
       }
     },
     {

--- a/skills/capabilities/icp-website-review/SKILL.md
+++ b/skills/capabilities/icp-website-review/SKILL.md
@@ -1,0 +1,469 @@
+---
+name: icp-website-review
+description: >
+  Evaluate a website, landing page, content, or any online asset through the eyes of
+  pre-built synthetic ICP personas. Loads personas from buyer-persona-generator output,
+  then runs them against target URLs. Supports three modes: structured scorecard,
+  freeform focus group, and head-to-head competitive comparison. Reusable — run
+  against the same site after changes, or against new content anytime.
+tags: [research]
+---
+
+# ICP Website Review
+
+Evaluate any online asset through the eyes of pre-built synthetic ICP personas. This is the evaluation engine — it loads personas created by `buyer-persona-generator` and runs them against whatever you point it at.
+
+## Prerequisites
+
+Personas must exist at `clients/<client>/personas/personas.json`. If they don't, run `buyer-persona-generator` first.
+
+## Quick Start
+
+**Structured scorecard (default):**
+```
+Review [company]'s website using their ICP personas. Site: [url].
+```
+
+**Freeform focus group:**
+```
+Run a focus group on [company]'s new landing page: [url]. Use focus-group mode.
+```
+
+**Head-to-head competitive:**
+```
+Compare [company]'s site ([url]) against [competitor] ([url]) through ICP personas.
+```
+
+## Inputs
+
+| Input | Required | Source |
+|-------|----------|--------|
+| **Personas** | Yes | `clients/<client>/personas/personas.json` |
+| **Target URL(s)** | Yes | User provides |
+| **Mode** | No | `scorecard` (default), `focus-group`, or `head-to-head` |
+| **Competitor URL(s)** | For head-to-head | User provides |
+| **Specific pages** | No | Default: homepage + key pages discovered during crawl |
+| **Scope** | No | `full-site` (default) or specific page URL for a single-page review |
+
+## Modes
+
+### Mode 1: Structured Scorecard (Default)
+
+Rigorous, dimension-by-dimension evaluation with numerical scores. Best for:
+- Pre-redesign audits
+- Conversion optimization
+- Tracking improvement over time (comparable scores across runs)
+- Stakeholder presentations (data-driven)
+
+### Mode 2: Freeform Focus Group
+
+Each persona reacts naturally — stream of consciousness, emotional reactions, questions they'd have, things that confuse them. No rigid scoring. Best for:
+- Early-stage feedback on a draft or concept
+- Understanding emotional reactions and gut feelings
+- Surfacing unexpected issues the scorecard dimensions might miss
+- More natural, human-sounding feedback
+
+### Mode 3: Head-to-Head Competitive
+
+Each persona evaluates your site AND a competitor's site, then picks a winner with reasoning. Best for:
+- Competitive positioning
+- Understanding why prospects choose competitors
+- Finding specific areas where competitors outperform you
+- Sales battlecard input
+
+---
+
+## Process
+
+### Step 1: Load Personas
+
+Read `clients/<client>/personas/personas.json`. Confirm:
+- Personas exist and are well-formed
+- List the personas that will be used (name, title, segment)
+- If the user wants to use only specific personas, filter accordingly
+
+### Step 2: Crawl Target Pages
+
+Fetch the key pages each persona would realistically visit:
+
+1. **Homepage** (everyone starts here)
+2. **Pricing page** (if public)
+3. **Product/features page** (technical buyers)
+4. **Solutions/use-cases page** (business buyers)
+5. **About page** (trust/credibility check)
+6. **Case studies or testimonials** (social proof)
+7. **Blog** (1-2 recent posts, for content quality signal)
+8. **Documentation or resources** (if relevant for technical buyers)
+
+Use `WebFetch` for each page. Extract main content, headlines, CTAs, and overall structure. Note what's present and what's missing.
+
+Also check external presence:
+- **Search results**: WebSearch "[company name]" and "[company name] reviews"
+- **Review sites**: Quick G2/Capterra check
+- **Social proof signals**: Notable logos, press, trust badges
+
+For **head-to-head mode**, crawl the same pages on the competitor site.
+
+### Step 3: Run Evaluations (Mode-Dependent)
+
+---
+
+#### Scorecard Mode
+
+For each persona, evaluate on these dimensions:
+
+**A) First Impression (10 seconds)**
+- What do they think this company does?
+- Is it clear this is for them?
+- Does the headline speak to their pain point?
+- Trust level at first glance?
+- **Rating: 1-10**
+
+**B) Messaging Relevance**
+- Does the value proposition resonate with their specific pain?
+- Is the language familiar or alienating?
+- Do they see themselves in the messaging?
+- Are benefits framed in terms they care about?
+- **Rating: 1-10**
+
+**C) Trust & Credibility**
+- Social proof relevant to them? (Same industry, size, role)
+- Claims backed by evidence?
+- Team/about page build confidence?
+- Any red flags?
+- **Rating: 1-10**
+
+**D) Clarity & Information Architecture**
+- Can they find what they need quickly?
+- Is the product easy to understand?
+- Is pricing clear?
+- Are next steps obvious?
+- **Rating: 1-10**
+
+**E) Objection Handling**
+- Does the site address their likely objections?
+- Comparison pages or differentiators available?
+- Enough depth for their decision process?
+- **Rating: 1-10**
+
+**F) Overall Verdict**
+- Would they take the next step?
+- What's the #1 blocker?
+- Single most impactful improvement?
+- **Overall score: 1-10**
+
+---
+
+#### Focus Group Mode
+
+For each persona, produce a natural, first-person reaction. No rigid structure — let the persona talk.
+
+**Prompt each persona with:**
+> You are [persona name], [title] at [company type]. [Situation summary]. You just landed on this website. React naturally — what do you notice first? What confuses you? What excites you? What makes you skeptical? Would you keep exploring or bounce? If you stayed, where would you go next? What questions do you need answered before you'd take action?
+
+**Guidelines:**
+- Write in first person as the persona
+- Let their personality and skepticism level come through
+- Include emotional reactions ("this immediately makes me nervous because...")
+- Reference specific things on the page ("the headline says X but I was looking for Y")
+- Note what they'd do next ("I'd probably Google '[competitor] vs [company]' after seeing this")
+- End with a gut-level verdict: interested, skeptical, confused, or gone
+
+After all personas react, synthesize common themes and divergent opinions.
+
+---
+
+#### Head-to-Head Mode
+
+For each persona, evaluate BOTH sites, then compare.
+
+**Structure per persona:**
+
+1. **Quick take on Site A** (3-5 bullet reactions)
+2. **Quick take on Site B** (3-5 bullet reactions)
+3. **Dimension-by-dimension comparison:**
+
+| Dimension | Site A | Site B | Winner |
+|-----------|:------:|:------:|:------:|
+| First Impression | [X/10] | [X/10] | [A/B/Tie] |
+| Messaging Relevance | [X/10] | [X/10] | [A/B/Tie] |
+| Trust & Credibility | [X/10] | [X/10] | [A/B/Tie] |
+| Clarity & Navigation | [X/10] | [X/10] | [A/B/Tie] |
+| Objection Handling | [X/10] | [X/10] | [A/B/Tie] |
+| **Overall** | **[X/10]** | **[X/10]** | **[A/B/Tie]** |
+
+4. **"If I had to choose today..."** — Which site wins and why, in this persona's own words
+5. **What Site A could steal from Site B** — Specific things the competitor does better
+6. **What Site A does better** — Don't lose these advantages
+
+After all personas, produce a cross-persona competitive summary:
+- Where does each site win across most personas?
+- Which persona segments lean toward the competitor? (These are at-risk segments)
+- What are the competitor's key advantages to neutralize?
+- What are your unique advantages to amplify?
+
+---
+
+### Step 4: Cross-Persona Synthesis
+
+Regardless of mode, always produce:
+
+1. **Consensus issues** — Flagged by ALL personas (urgent)
+2. **Segment-specific gaps** — Only certain personas noticed (targeted fixes)
+3. **Messaging disconnects** — Site language vs. buyer language
+4. **Missing content** — Pages, sections, or proof points personas wanted
+5. **Strengths to preserve** — Don't break what works
+6. **Priority matrix** — Ranked by impact (personas affected) and effort
+
+## Output
+
+Save to `clients/<client-name>/icp-reviews/<date>-<mode>.md`
+
+This path allows multiple reviews over time — tracking improvements, comparing before/after redesigns, or accumulating competitive intel.
+
+### Scorecard Output Template
+
+```markdown
+# ICP Website Review: [Company Name]
+**Date:** [Date] | **Mode:** Scorecard | **URL:** [website]
+**Pages analyzed:** [N] | **Personas used:** [N]
+**Personas from:** `clients/<client>/personas/personas.json` (created [date])
+
+---
+
+## Executive Summary
+
+[3-5 sentences: overall assessment, biggest strengths, biggest gaps, top 3 recs]
+
+**Average score: [X/10]**
+
+| Persona | Segment | Score | Would Convert? |
+|---------|---------|:-----:|:-:|
+| [Name] | [Segment] | [X/10] | [Yes/Maybe/No] |
+| ... | ... | ... | ... |
+
+---
+
+## Persona Reviews
+
+### [Persona Name]'s Review
+
+**Arriving with:** [Their situation and buying trigger]
+
+| Dimension | Score | Summary |
+|-----------|:-----:|---------|
+| First Impression | [X/10] | [One line] |
+| Messaging Relevance | [X/10] | [One line] |
+| Trust & Credibility | [X/10] | [One line] |
+| Clarity & Navigation | [X/10] | [One line] |
+| Objection Handling | [X/10] | [One line] |
+| **Overall** | **[X/10]** | **[One line]** |
+
+**Liked:**
+- [Specific, with reference from the site]
+
+**Frustrated by:**
+- [Specific, with explanation of why THIS persona cares]
+
+**Wished they could find:**
+- [Missing content/info, why they need it]
+
+**Verdict:** [Would they convert? #1 blocker?]
+
+---
+
+[Repeat for each persona]
+
+---
+
+## Cross-Persona Analysis
+
+### Consensus Issues
+1. [Issue] — [Why it matters]
+
+### Segment-Specific Gaps
+| Gap | Affected Personas | Impact |
+|-----|------------------|--------|
+| [Gap] | [Names] | [High/Med/Low] |
+
+### Messaging Disconnects
+| Site says | Buyers say | Affected |
+|-----------|-----------|----------|
+| "[quote]" | "[quote]" | [Names] |
+
+### Strengths to Preserve
+- [What works]
+
+---
+
+## Prioritized Recommendations
+
+### High Impact
+1. **[Rec]** — Affects: [personas]. Current: [X]. Target: [Y].
+
+### Medium Impact
+2. **[Rec]**
+
+### Quick Wins
+- [Small changes]
+
+---
+
+## Score Matrix
+
+| Dimension | [P1] | [P2] | [P3] | [P4] | Avg |
+|-----------|:----:|:----:|:----:|:----:|:---:|
+| First Impression | | | | | |
+| Messaging | | | | | |
+| Trust | | | | | |
+| Clarity | | | | | |
+| Objections | | | | | |
+| **Overall** | | | | | |
+```
+
+### Focus Group Output Template
+
+```markdown
+# ICP Focus Group: [Company Name]
+**Date:** [Date] | **Mode:** Focus Group | **URL:** [website]
+**Personas used:** [N]
+
+---
+
+## Executive Summary
+
+[What the group collectively thought — 3-5 sentences]
+
+---
+
+## Persona Reactions
+
+### [Persona Name] — [Title]
+
+> [First-person narrative reaction, 200-400 words. Natural voice, emotional, specific.]
+
+**Gut verdict:** [One sentence — interested/skeptical/confused/gone]
+
+---
+
+[Repeat for each persona]
+
+---
+
+## Group Synthesis
+
+### What everyone noticed
+- [Theme]
+
+### Where opinions split
+| Topic | [P1] take | [P2] take |
+|-------|-----------|-----------|
+
+### Strongest reactions (positive)
+- [What got the most enthusiasm, from whom]
+
+### Strongest reactions (negative)
+- [What got the most criticism, from whom]
+
+### What nobody could answer
+- [Questions the site left unanswered]
+
+---
+
+## Recommendations
+[Prioritized, grouped by theme]
+```
+
+### Head-to-Head Output Template
+
+```markdown
+# Competitive Review: [Company] vs [Competitor]
+**Date:** [Date] | **Mode:** Head-to-Head
+**Site A:** [url] | **Site B:** [url]
+**Personas used:** [N]
+
+---
+
+## Executive Summary
+
+**Overall winner: [A/B/Split]**
+[3-5 sentences on where each site wins and loses]
+
+| Persona | Segment | Site A | Site B | Pick |
+|---------|---------|:------:|:------:|:----:|
+| [Name] | [Segment] | [X/10] | [X/10] | [A/B] |
+| ... | ... | ... | ... | ... |
+
+---
+
+## Persona Comparisons
+
+### [Persona Name]
+
+**Site A quick take:** [3-5 bullets]
+**Site B quick take:** [3-5 bullets]
+
+| Dimension | A | B | Winner |
+|-----------|:-:|:-:|:------:|
+| ... | | | |
+
+**"If I had to choose..."** [Persona's verdict in their own words]
+
+**What A should steal from B:** [Specific]
+**What A does better:** [Specific]
+
+---
+
+[Repeat for each persona]
+
+---
+
+## Competitive Summary
+
+### Where [Company] wins across personas
+- [Advantage, which personas care]
+
+### Where [Competitor] wins across personas
+- [Advantage, which personas care]
+
+### At-risk segments
+[Personas who lean toward competitor — these ICPs may be churning or not converting]
+
+### Priority moves
+1. **Neutralize:** [Competitor advantage to close the gap on]
+2. **Amplify:** [Your advantage to lean into harder]
+3. **Differentiate:** [Unique angle neither site owns yet]
+```
+
+## Running Repeat Reviews
+
+Since personas are saved separately, you can re-run this skill anytime:
+
+```
+Re-run the ICP website review for [client]. Use the existing personas.
+```
+
+Compare results across dates to track improvement:
+```
+Compare today's ICP review for [client] against the one from [date].
+```
+
+The dated output path (`icp-reviews/<date>-<mode>.md`) makes it easy to see the history of reviews and how scores change over time.
+
+## Tips
+
+- **Don't be nice.** Personas should be honest and critical. A persona that says "everything looks great" is useless.
+- **Vary the voices.** A CTO's review should read differently than a marketing manager's. Use different vocabulary, different focus, different emotional register.
+- **Ground in specifics.** Not "messaging is unclear" but "the headline 'Accelerate Your Workflow' doesn't tell me what this product does — I had to scroll to the third fold."
+- **Check the competition.** If personas mention alternatives, quickly check 1-2 competitor sites to see if they handle the same issues better.
+- **External presence matters.** What shows up when a persona Googles the company? Reviews? Press? That shapes trust before they even hit the site.
+- **Focus group mode is underrated.** The freeform reactions often surface things the scorecard misses — emotional reactions, unexpected confusion, things people wouldn't flag in a survey.
+- **Head-to-head is the killer use case.** Nothing clarifies your positioning gaps faster than seeing your site through a buyer's eyes right next to the competitor's.
+- **This skill has no code script.** It's agent-executed using WebSearch and WebFetch.
+
+## Dependencies
+
+- Pre-built personas (`buyer-persona-generator` output)
+- Web search capability (for external presence checks, competitor research)
+- Web fetch capability (for reading website pages)
+- No API keys or paid tools required

--- a/skills/capabilities/icp-website-review/skill.meta.json
+++ b/skills/capabilities/icp-website-review/skill.meta.json
@@ -1,0 +1,15 @@
+{
+  "slug": "icp-website-review",
+  "category": "capabilities",
+  "tags": [
+    "research"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install icp-website-review",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}

--- a/skills/capabilities/newsletter-sponsorship-finder/SKILL.md
+++ b/skills/capabilities/newsletter-sponsorship-finder/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: newsletter-sponsorship-finder
+description: >
+  Find newsletters relevant to a target audience/industry for sponsorship
+  opportunities. Discovers newsletters through web search, newsletter directories,
+  and industry research. Returns newsletter name, author, estimated audience,
+  topic focus, sponsorship rates (if available), and contact info.
+---
+
+# Newsletter Sponsorship Finder
+
+Find and rank newsletters for sponsorship opportunities targeting a specific ICP. Uses web search, newsletter directories, and competitor intelligence to build a prioritized list of sponsorship targets.
+
+## Quick Start
+
+```
+Find newsletter sponsorship opportunities for [client]. Target audience: [description]. Industry keywords: [keywords].
+```
+
+Or with optional filters:
+
+```
+Find newsletter sponsorship opportunities for [client].
+Target audience: CTOs and DevOps engineers at startups.
+Industry keywords: cloud, AWS, DevOps, infrastructure, FinOps.
+Budget: $500-2000/placement.
+Geographic focus: US.
+```
+
+## Inputs
+
+- **Target audience description** (required) — e.g., "CTOs and DevOps engineers at startups"
+- **Industry keywords** (required) — e.g., "cloud, AWS, DevOps, infrastructure, FinOps"
+- **Budget range** (optional) — for filtering newsletters by sponsorship cost
+- **Geographic focus** (optional) — e.g., "US", "Europe", "Global"
+- **Output path** (optional) — where to save results, defaults to `clients/<client>/leads/newsletter-sponsorships-YYYY-MM-DD.md`
+
+## Cost
+
+Free — all discovery is WebSearch-based. No API keys required.
+
+## Dependencies
+
+```
+pip3 install requests
+```
+
+Optional helper script for Substack directory search:
+
+```bash
+python3 skills/newsletter-sponsorship-finder/scripts/search_newsletters.py --keywords "cloud,AWS,DevOps" --output json
+```
+
+## Process
+
+### Phase 1: Define Target
+
+Accept from user:
+- Target audience description (e.g., "CTOs and DevOps engineers at startups")
+- Industry keywords (e.g., "cloud, AWS, DevOps, infrastructure, FinOps")
+- Budget range (optional, for filtering)
+- Geographic focus (optional)
+
+### Phase 2: Discovery (run searches in parallel)
+
+#### A) Direct newsletter search (WebSearch)
+
+Run these searches:
+- `"[industry] newsletter"`
+- `"[industry] weekly newsletter developer"`
+- `"best newsletters for [target audience]"`
+- `"[industry] newsletter sponsorship"`
+- `"advertise in [industry] newsletter"`
+
+#### B) Newsletter directory search
+
+Search Swapstack/Paved/SparkLoop for relevant newsletters:
+- `"site:swapstack.co [industry]"`
+- `"site:paved.com [industry]"`
+- WebFetch on directory result pages to find listings in the target niche
+
+#### C) Industry-specific discovery
+
+- Search for `"[industry] blog"` and `"[industry] content creator"` to find people who likely also have newsletters
+- Search for `"[industry] newsletter" site:linkedin.com` posts
+- Search for Substack newsletters: `"site:substack.com [industry keywords]"`
+- Optionally run the helper script: `python3 skills/newsletter-sponsorship-finder/scripts/search_newsletters.py --keywords "[keywords]" --output json`
+
+#### D) Competitor sponsorship research
+
+- Search `"[competitor name] sponsor newsletter"` or `"[competitor name] advertise"`
+- Check competitor websites for "As seen in" or press pages
+- This reveals which newsletters competitors already sponsor (proven audience match)
+
+### Phase 3: Enrich Each Newsletter
+
+For each discovered newsletter, use WebFetch to visit the newsletter page and try to find:
+
+1. **Name** — Newsletter name
+2. **Author/Organization** — Who runs it
+3. **URL** — Signup page or archive
+4. **Estimated audience** — subscriber count (often mentioned on sponsorship pages or About pages)
+5. **Topic focus** — What it covers
+6. **Frequency** — Daily, weekly, monthly
+7. **Sponsorship info** — Rates, format (dedicated send, banner, classified), contact
+8. **Audience quality** — Is the audience primarily decision-makers or junior folks?
+9. **Social proof** — Notable sponsors, testimonials
+
+### Phase 4: Score & Rank
+
+Score each newsletter (0-10):
+- Audience overlap with target ICP (+3 max)
+- Audience size (+2 for 10K+, +1 for 5K+)
+- Sponsorship availability confirmed (+2)
+- Reasonable pricing for budget (+1)
+- High engagement signals — open rates mentioned, active community (+1)
+- Competitors sponsor it — proven audience match (+1)
+
+### Phase 5: Output
+
+Save results to the specified output path as markdown:
+
+```markdown
+# Newsletter Sponsorship Opportunities
+**Target audience:** [description]
+**Industry:** [keywords]
+**Date:** YYYY-MM-DD
+
+## Tier 1: Must-Sponsor (Score 8+)
+| Newsletter | Author | Est. Audience | Frequency | Sponsorship Rate | Contact | Score |
+|-----------|--------|--------------|-----------|-----------------|---------|-------|
+
+## Tier 2: Strong Fit (Score 5-7)
+| Newsletter | Author | Est. Audience | Frequency | Sponsorship Rate | Contact | Score |
+|-----------|--------|--------------|-----------|-----------------|---------|-------|
+
+## Tier 3: Worth Exploring (Score 3-4)
+| Newsletter | Author | Est. Audience | Frequency | Sponsorship Rate | Contact | Score |
+|-----------|--------|--------------|-----------|-----------------|---------|-------|
+
+## Competitor Sponsorship Intel
+| Competitor | Newsletters They Sponsor | Notes |
+|-----------|------------------------|-------|
+
+## Next Steps
+1. Reach out to Tier 1 newsletters for rate cards
+2. Request media kits from Tier 2 newsletters
+3. Set calendar reminder to refresh this list quarterly
+4. Monitor competitor sponsorships monthly
+```
+
+## Tips
+
+- Run once per client to establish a sponsorship pipeline
+- Refresh quarterly as new newsletters launch frequently
+- Check competitor sponsorships monthly — if a competitor starts sponsoring a newsletter, it validates the audience
+- Combine with `agentmail` to automate initial outreach to newsletter operators
+- Use `company-contact-finder` when a newsletter's sponsorship contact is not publicly listed
+- Newsletters with 5K-50K subscribers often offer the best ROI for B2B sponsorships — large enough audience, small enough for personal touch

--- a/skills/capabilities/newsletter-sponsorship-finder/scripts/search_newsletters.py
+++ b/skills/capabilities/newsletter-sponsorship-finder/scripts/search_newsletters.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""
+search_newsletters.py — Helper script for the newsletter-sponsorship-finder skill.
+
+Searches the Substack directory for newsletters matching given keywords and
+returns structured results. This is a supplementary tool; the main discovery
+is done by the agent using WebSearch and WebFetch.
+
+Usage:
+    python3 search_newsletters.py --keywords "cloud,AWS,DevOps,infrastructure" --output json
+    python3 search_newsletters.py --keywords "fintech,banking" --output table
+"""
+
+import argparse
+import json
+import sys
+
+try:
+    import requests
+except ImportError:
+    print(
+        json.dumps(
+            {
+                "error": "requests library not installed. Run: pip3 install requests",
+                "results": [],
+            }
+        )
+    )
+    sys.exit(1)
+
+
+SUBSTACK_SEARCH_URL = "https://substack.com/api/v1/publication/search"
+
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/json",
+}
+
+
+def search_substack(keyword: str, limit: int = 20) -> list[dict]:
+    """Search Substack for newsletters matching a keyword."""
+    try:
+        resp = requests.get(
+            SUBSTACK_SEARCH_URL,
+            params={"query": keyword, "page": 0, "limit": limit},
+            headers=HEADERS,
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        results = []
+        publications = data if isinstance(data, list) else data.get("results", data.get("publications", []))
+
+        for pub in publications:
+            if isinstance(pub, dict):
+                results.append(
+                    {
+                        "name": pub.get("name", "Unknown"),
+                        "author": pub.get("author_name", pub.get("author", {}).get("name", "Unknown")),
+                        "description": pub.get("description", pub.get("hero_text", "")),
+                        "url": pub.get("custom_domain") or pub.get("custom_domain_optional") or f"https://{pub.get('subdomain', 'unknown')}.substack.com",
+                        "subscribers": pub.get("subscriber_count", pub.get("rankingDetail", {}).get("subscribers", "N/A")),
+                        "type": pub.get("type", "newsletter"),
+                        "keyword": keyword,
+                    }
+                )
+        return results
+
+    except requests.exceptions.HTTPError as e:
+        if e.response is not None and e.response.status_code == 403:
+            return [{"note": f"Substack blocked the request for '{keyword}'. Try WebSearch instead.", "keyword": keyword, "results": []}]
+        return [{"error": f"HTTP error searching for '{keyword}': {e}", "keyword": keyword, "results": []}]
+    except requests.exceptions.RequestException as e:
+        return [{"error": f"Request failed for '{keyword}': {e}", "keyword": keyword, "results": []}]
+    except (json.JSONDecodeError, KeyError, TypeError) as e:
+        return [{"error": f"Failed to parse Substack response for '{keyword}': {e}", "keyword": keyword, "results": []}]
+
+
+def format_table(results: list[dict]) -> str:
+    """Format results as a readable table."""
+    if not results:
+        return "No results found."
+
+    lines = [
+        f"{'Name':<40} {'Author':<25} {'Subscribers':<15} {'URL'}",
+        "-" * 120,
+    ]
+    for r in results:
+        if "error" in r or "note" in r:
+            lines.append(r.get("error", r.get("note", "")))
+            continue
+        name = (r.get("name", "Unknown"))[:38]
+        author = (r.get("author", "Unknown"))[:23]
+        subs = str(r.get("subscribers", "N/A"))[:13]
+        url = r.get("url", "")
+        lines.append(f"{name:<40} {author:<25} {subs:<15} {url}")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Search Substack for newsletters matching keywords."
+    )
+    parser.add_argument(
+        "--keywords",
+        required=True,
+        help="Comma-separated keywords to search for (e.g., 'cloud,AWS,DevOps')",
+    )
+    parser.add_argument(
+        "--output",
+        choices=["json", "table"],
+        default="json",
+        help="Output format: json or table (default: json)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=20,
+        help="Max results per keyword (default: 20)",
+    )
+    args = parser.parse_args()
+
+    keywords = [k.strip() for k in args.keywords.split(",") if k.strip()]
+
+    all_results = []
+    seen_urls = set()
+
+    for kw in keywords:
+        results = search_substack(kw, limit=args.limit)
+        for r in results:
+            url = r.get("url", "")
+            if url and url not in seen_urls:
+                seen_urls.add(url)
+                all_results.append(r)
+            elif "error" in r or "note" in r:
+                all_results.append(r)
+
+    if args.output == "json":
+        print(json.dumps({"keywords": keywords, "total": len(all_results), "results": all_results}, indent=2))
+    else:
+        print(f"\nSubstack Newsletter Search: {', '.join(keywords)}")
+        print(f"Found {len(all_results)} results\n")
+        print(format_table(all_results))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/capabilities/newsletter-sponsorship-finder/skill.meta.json
+++ b/skills/capabilities/newsletter-sponsorship-finder/skill.meta.json
@@ -1,0 +1,15 @@
+{
+  "slug": "newsletter-sponsorship-finder",
+  "category": "capabilities",
+  "tags": [
+    "monitoring"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install newsletter-sponsorship-finder",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}

--- a/skills/capabilities/setup-outreach-campaign-smartlead/SKILL.md
+++ b/skills/capabilities/setup-outreach-campaign-smartlead/SKILL.md
@@ -1,0 +1,414 @@
+---
+name: setup-outreach-campaign-smartlead
+description: >
+  Set up a complete outbound email campaign in Smartlead. Asks the user for
+  campaign goal, audience, messaging, schedule, and mailbox allocation.
+  Creates the campaign, adds leads, saves email sequences, sets schedule,
+  and assigns available mailboxes. Use when a user wants to launch email
+  outreach via Smartlead.
+tags: [outreach]
+
+graph:
+  provides:
+    - smartlead-campaign
+    - email-sequence
+  requires:
+    - lead-list
+  connects_to:
+    - skill: company-contact-finder
+      when: "User doesn't have a lead list and needs to find contacts first"
+      passes: nothing (upstream source)
+    - skill: contact-cache
+      when: "Before adding leads, deduplicate against already-contacted leads"
+      passes: lead-list (emails)
+    - skill: luma-event-attendees
+      when: "User wants event attendees as the lead source"
+      passes: person-list
+    - skill: conference-speaker-scraper
+      when: "User wants conference speakers as the lead source"
+      passes: person-list
+  capabilities: [smartlead-api]
+---
+
+# setup-outreach-campaign-smartlead
+
+Set up a complete outbound email campaign in Smartlead: create the campaign, add leads, write a 2-3 email sequence, configure the schedule, and allocate mailboxes.
+
+## Inputs
+
+| Input | Required | Default | Description |
+|-------|----------|---------|-------------|
+| campaign_name | Yes | -- | Name for the campaign (e.g., "Truewind - Accounting Firms - Feb 2026") |
+| campaign_goal | Yes | -- | What outcome the campaign drives (book demos, drive signups, etc.) |
+| lead_list | Yes | -- | CSV file path OR person-list JSON from upstream skill |
+| value_proposition | Yes | -- | Core pain point or benefit the emails address |
+| cta | Yes | -- | Call to action (e.g., "Book a 15-min demo", "Reply to learn more") |
+| tone | No | semi-formal | Email tone: casual, semi-formal, formal |
+| personalization_angle | No | -- | Hook for personalization (event attendance, job posting, news mention) |
+| timezone | No | America/New_York | Timezone for send schedule |
+| send_days | No | [1,2,3,4,5] | Days of week to send (0=Sun, 6=Sat) |
+| start_hour | No | 08:00 | Start of send window |
+| end_hour | No | 18:00 | End of send window |
+| max_leads_per_day | No | 20 | Max new leads contacted per day |
+| min_time_btw_emails | No | 10 | Minutes between emails from same mailbox |
+| num_mailboxes | No | 5 | Number of mailboxes to allocate |
+| mailbox_selection | No | auto | "auto" (pick free ones) or "manual" (show list to user) |
+
+## Setup
+
+Requires a Smartlead account with API access. **This skill does not use the Gooseworks proxy** — the user must supply their own Smartlead API key.
+
+```bash
+export SMARTLEAD_API_KEY=your_api_key_here
+```
+
+You can find your API key in the Smartlead dashboard under **Settings → API Keys**. If `SMARTLEAD_API_KEY` is not set, ask the user for it before proceeding.
+
+All API calls go to `https://server.smartlead.ai/api/v1` with `?api_key=$SMARTLEAD_API_KEY` appended.
+
+Rate limit: 10 requests per 2 seconds.
+
+## Procedure
+
+### Step 1: Gather Campaign Info
+
+Ask the user the following questions. Group them conversationally — don't dump all at once.
+
+**Campaign identity:**
+- "What is the name for this campaign?" (e.g., "Truewind - Accounting Firms - Feb 2026")
+- "What is the goal?" (e.g., book demos, drive trial signups, conference follow-up)
+
+**Audience & leads:**
+- "Who is the target audience?" (ICP: title, company type, size, industry)
+- "How are you providing the lead list?" — options: CSV file, output from a prior skill (company-contact-finder, luma-event-attendees), or "I need to find leads first" (chain to company-contact-finder)
+
+**Messaging:**
+- "What is the core value proposition or pain point?"
+- "What is the call to action?" (e.g., "Book a 15-min demo")
+- "What tone — casual, semi-formal, or formal?"
+- "Any personalization angle?" (e.g., reference their job posting, event, industry news)
+
+**Schedule:**
+- "What days should emails be sent?" (default: Mon-Fri)
+- "What hours and timezone?" (default: 8am-6pm ET)
+- "Max new leads per day?" (default: 20)
+- "When should the campaign start?" (default: tomorrow)
+
+**Mailboxes:**
+- "How many mailboxes to allocate?" (default: 5)
+- "Auto-select free mailboxes, or show me a list to choose from?"
+
+After gathering answers, present a summary and confirm before proceeding.
+
+### Step 2: Create the Campaign
+
+```
+POST https://server.smartlead.ai/api/v1/campaigns/create?api_key=$SMARTLEAD_API_KEY
+
+Body:
+{
+  "name": "<campaign_name>",
+  "client_id": null
+}
+```
+
+**Response:**
+```json
+{
+  "ok": true,
+  "id": 3023,
+  "name": "Test email campaign",
+  "created_at": "2022-11-07T16:23:24.025929+00:00"
+}
+```
+
+Capture `campaign_id` from `id`. All subsequent calls use this.
+
+### Step 3: Find and Allocate Mailboxes
+
+This step determines which mailboxes are available and assigns them to the campaign.
+
+#### 3a: Fetch all email accounts
+
+```
+GET https://server.smartlead.ai/api/v1/email-accounts/?api_key=$SMARTLEAD_API_KEY&offset=0&limit=100
+```
+
+Returns a list of all email accounts with `id`, `from_email`, `from_name`, `daily_sent_count`, `warmup_details`, `is_smtp_success`, `is_imap_success`.
+
+#### 3b: Identify which mailboxes are currently in use
+
+Fetch all campaigns:
+
+```
+GET https://server.smartlead.ai/api/v1/campaigns?api_key=$SMARTLEAD_API_KEY
+```
+
+For each campaign with `status` = `"ACTIVE"` or `"STARTED"`, fetch its email accounts:
+
+```
+GET https://server.smartlead.ai/api/v1/campaigns/{campaign_id}/email-accounts?api_key=$SMARTLEAD_API_KEY
+```
+
+Build a set of all `email_account_id` values currently assigned to active campaigns.
+
+#### 3c: Filter for free mailboxes
+
+A mailbox is "free" if:
+1. Its `id` is NOT in the active-campaign set from 3b
+2. `is_smtp_success` = true AND `is_imap_success` = true (account is functional)
+
+Sort free mailboxes by `daily_sent_count` ascending (prefer coolest/least-used mailboxes).
+
+#### 3d: Select and assign
+
+If `mailbox_selection` = "auto": select the first N free mailboxes.
+
+If `mailbox_selection` = "manual": display all accounts as a table (name, email, daily_sent_count, status) and let the user pick.
+
+If fewer than N free mailboxes are available, tell the user: "Only X free mailboxes found. Proceed with X, or pick some currently-in-use mailboxes?"
+
+Assign selected mailboxes:
+
+```
+POST https://server.smartlead.ai/api/v1/campaigns/{campaign_id}/email-accounts?api_key=$SMARTLEAD_API_KEY
+
+Body:
+{
+  "email_account_ids": [101, 204, 305, 412, 518]
+}
+```
+
+### Step 4: Ingest Leads
+
+#### 4a: Parse the lead list
+
+**From CSV:** Read the file, map columns to Smartlead fields. Flexible column matching:
+- `email` (required) — also matches `Email`, `email_address`
+- `first_name` — also matches `firstname`, `first`, `First Name`
+- `last_name` — also matches `lastname`, `last`, `Last Name`
+- `company_name` — also matches `company`, `organization`, `Company`
+- Any extra columns become `custom_fields`
+
+**From upstream skill (person-list JSON):** Map fields:
+```
+first_name  <- name.split()[0]
+last_name   <- name.split()[1:]
+email       <- email
+company_name <- company
+custom_fields <- { "title": title, "linkedin_url": linkedin_url }
+```
+
+#### 4b: Validate and deduplicate
+
+- Remove rows without a valid email
+- Deduplicate by email (keep first occurrence)
+- Report: total rows, valid, invalid, duplicates removed
+
+#### 4c: Upload in batches
+
+Smartlead accepts max 100 leads per call. Chunk the list and call for each batch:
+
+```
+POST https://server.smartlead.ai/api/v1/campaigns/{campaign_id}/leads?api_key=$SMARTLEAD_API_KEY
+
+Body:
+{
+  "lead_list": [
+    {
+      "first_name": "Jane",
+      "last_name": "Smith",
+      "email": "jane@example.com",
+      "company_name": "Acme Corp",
+      "custom_fields": {"title": "CFO"}
+    }
+  ],
+  "settings": {
+    "ignore_global_block_list": false,
+    "ignore_unsubscribe_list": false,
+    "ignore_duplicate_leads_in_other_campaign": false
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "ok": true,
+  "upload_count": 95,
+  "total_leads": 100,
+  "already_added_to_campaign": 2,
+  "duplicate_count": 1,
+  "invalid_email_count": 2,
+  "unsubscribed_leads": 0
+}
+```
+
+Report totals across all batches to the user.
+
+### Step 5: Craft the Email Sequence
+
+Write a 2-3 email sequence based on the user's inputs from Step 1. Default structure:
+
+**Email 1 — Cold intro (Day 0)**
+- Subject: short, curiosity-driven or relevant to their pain
+- Body: 3-5 sentences. Acknowledge their world, surface the problem, introduce the solution briefly, clear CTA
+- Personalize with `{{first_name}}` and any custom fields
+
+**Email 2 — Follow-up (Day 3)**
+- Subject: different angle (metric, case study, specific outcome)
+- Body: 2-4 sentences. Add value, restate CTA
+- Leave subject blank to send as same-thread reply
+
+**Email 3 — Breakup (Day 8)**
+- Subject: brief, direct ("Still relevant?", "Closing the loop")
+- Body: 2-3 sentences. Acknowledge they're busy, keep door open, soft CTA
+
+Present the full sequence to the user as a formatted table. Wait for approval or edits.
+
+After user approves, save:
+
+```
+POST https://server.smartlead.ai/api/v1/campaigns/{campaign_id}/sequences?api_key=$SMARTLEAD_API_KEY
+
+Body:
+{
+  "sequences": [
+    {
+      "seq_number": 1,
+      "seq_delay_details": { "delay_in_days": 0 },
+      "seq_variants": [
+        {
+          "subject": "Subject line here",
+          "email_body": "<p>Email body as HTML</p>",
+          "variant_label": "A"
+        }
+      ]
+    },
+    {
+      "seq_number": 2,
+      "seq_delay_details": { "delay_in_days": 3 },
+      "seq_variants": [
+        {
+          "subject": "",
+          "email_body": "<p>Follow-up body</p>",
+          "variant_label": "A"
+        }
+      ]
+    },
+    {
+      "seq_number": 3,
+      "seq_delay_details": { "delay_in_days": 5 },
+      "seq_variants": [
+        {
+          "subject": "",
+          "email_body": "<p>Breakup body</p>",
+          "variant_label": "A"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Note: blank `subject` on emails 2+ makes them send as replies in the same thread.
+
+### Step 6: Set the Schedule
+
+```
+POST https://server.smartlead.ai/api/v1/campaigns/{campaign_id}/schedule?api_key=$SMARTLEAD_API_KEY
+
+Body:
+{
+  "timezone": "America/New_York",
+  "days_of_the_week": [1, 2, 3, 4, 5],
+  "start_hour": "08:00",
+  "end_hour": "18:00",
+  "min_time_btw_emails": 10,
+  "max_new_leads_per_day": 20,
+  "schedule_start_time": "2026-02-25T00:00:00.000Z"
+}
+```
+
+`days_of_the_week`: 0=Sunday, 1=Monday, ..., 6=Saturday.
+
+### Step 7: Confirm and Optionally Start
+
+Present a full summary:
+
+```
+Campaign: "Truewind - Accounting Firms - Feb 2026"
+Campaign ID: 12345
+Leads added: 87 (3 rejected as duplicates)
+Email sequence: 3 emails (Day 0, Day 3, Day 8)
+Schedule: Mon-Fri, 8am-6pm ET, starting Feb 25
+Mailboxes: jane@truewind.ai, alex@truewind.ai (+3 more)
+Status: DRAFTED
+```
+
+Ask: "Do you want to START the campaign now, or leave it as a draft?"
+
+If start:
+```
+POST https://server.smartlead.ai/api/v1/campaigns/{campaign_id}/status?api_key=$SMARTLEAD_API_KEY
+
+Body:
+{ "status": "START" }
+```
+
+If draft: skip. User can start from Smartlead UI later.
+
+## Optional: Update Campaign Settings
+
+If the user wants to configure tracking or stop conditions, use:
+
+```
+POST https://server.smartlead.ai/api/v1/campaigns/{campaign_id}/settings?api_key=$SMARTLEAD_API_KEY
+
+Body:
+{
+  "track_settings": ["DONT_TRACK_EMAIL_OPEN"],
+  "stop_lead_settings": "REPLY_TO_AN_EMAIL",
+  "send_as_plain_text": false,
+  "follow_up_percentage": 100,
+  "enable_ai_esp_matching": true
+}
+```
+
+Allowed `track_settings`: `DONT_TRACK_EMAIL_OPEN`, `DONT_TRACK_LINK_CLICK`, `DONT_TRACK_REPLY_TO_AN_EMAIL`
+Allowed `stop_lead_settings`: `REPLY_TO_AN_EMAIL`, `CLICK_ON_A_LINK`, `OPEN_AN_EMAIL`
+
+## Smartlead API Reference
+
+All endpoints use base URL `https://server.smartlead.ai/api/v1` with `?api_key=` query param.
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/campaigns/create` | POST | Create a new campaign |
+| `/campaigns` | GET | List all campaigns |
+| `/campaigns/{id}` | GET | Get campaign by ID |
+| `/campaigns/{id}/schedule` | POST | Set campaign schedule |
+| `/campaigns/{id}/settings` | POST | Update tracking/stop settings |
+| `/campaigns/{id}/sequences` | POST | Save email sequences |
+| `/campaigns/{id}/leads` | POST | Add leads (max 100 per call) |
+| `/campaigns/{id}/email-accounts` | GET | List mailboxes on a campaign |
+| `/campaigns/{id}/email-accounts` | POST | Assign mailboxes to campaign |
+| `/campaigns/{id}/status` | POST | Change campaign status (START/PAUSED/STOPPED) |
+| `/campaigns/{id}/analytics` | GET | Top-level campaign analytics |
+| `/email-accounts/` | GET | List all email accounts (offset/limit) |
+
+## Example Prompts
+
+- "Set up a Smartlead campaign for Truewind targeting accounting firms"
+- "Create an outreach campaign — I have a CSV of leads"
+- "Launch a cold email campaign to CFOs at mid-market companies"
+- "Set up a 3-email sequence in Smartlead and allocate 5 free mailboxes"
+
+## Metadata
+
+```yaml
+metadata:
+  requires:
+    env: ["SMARTLEAD_API_KEY"]
+  cost: "Free (Smartlead API included with plan that has API access)"
+```

--- a/skills/capabilities/setup-outreach-campaign-smartlead/skill.meta.json
+++ b/skills/capabilities/setup-outreach-campaign-smartlead/skill.meta.json
@@ -1,0 +1,15 @@
+{
+  "slug": "setup-outreach-campaign-smartlead",
+  "category": "capabilities",
+  "tags": [
+    "outreach"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install setup-outreach-campaign-smartlead",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}

--- a/skills/composites/competitor-content-tracker/SKILL.md
+++ b/skills/composites/competitor-content-tracker/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: competitor-content-tracker
+description: >
+  Monitor competitor content across blogs, LinkedIn, and Twitter/X on a recurring basis.
+  Surfaces new posts, trending topics, and content gaps you can own. Chains blog-feed-monitor,
+  linkedin-profile-post-scraper, and twitter-mention-tracker. Use when you want a weekly digest
+  of what competitors are publishing and which topics are generating engagement.
+tags: [competitive-intel]
+---
+
+# Competitor Content Tracker
+
+Monitor competitor content activity across three channels — blog, LinkedIn, Twitter/X — and produce a consolidated digest highlighting what's new, what's getting traction, and where you have a content gap.
+
+## When to Use
+
+- "Track what [competitor] is publishing"
+- "Show me what my competitors posted this week"
+- "What topics are competitors winning on?"
+- "I want a weekly competitor content digest"
+
+## Phase 0: Intake
+
+### Competitors to Track
+1. List of competitor company names + blog URLs (e.g., `https://clay.com/blog`)
+2. LinkedIn profile URLs of competitor founders/CMOs to track (optional but high-value)
+3. Twitter/X handles of the competitors or their founders (optional)
+
+### Scope
+4. How far back? (default: 7 days for weekly digest, 30 days for first run)
+5. Any topics/keywords you care most about? (used to surface relevant posts first)
+
+### Output
+6. Format preference: full digest (everything) or highlights only (top 3-5 per competitor)?
+
+Save config to `clients/<client-name>/configs/competitor-content-tracker.json`.
+
+```json
+{
+  "competitors": [
+    {
+      "name": "Clay",
+      "blog_url": "https://clay.com/blog",
+      "linkedin_profiles": ["https://www.linkedin.com/in/kareem-amin/"],
+      "twitter_handles": ["@clay_hq", "@kareemamin"]
+    }
+  ],
+  "days_back": 7,
+  "keywords": ["GTM", "outbound", "AI agents", "growth"],
+  "output_mode": "highlights"
+}
+```
+
+## Phase 1: Scrape Blog Content
+
+Run `blog-feed-monitor` for each competitor blog URL:
+
+```bash
+python3 skills/capabilities/blog-feed-monitor/scripts/scrape_blogs.py \
+  --urls "<competitor_blog_url>" \
+  --days <days_back> \
+  --keywords "<keywords>" \
+  --output summary
+```
+
+Collect: post title, publish date, URL, excerpt.
+
+## Phase 2: Scrape LinkedIn Posts
+
+Run `linkedin-profile-post-scraper` for each tracked founder/executive LinkedIn URL:
+
+```bash
+python3 skills/capabilities/linkedin-profile-post-scraper/scripts/scrape_linkedin_posts.py \
+  --profiles "<linkedin_url_1>,<linkedin_url_2>" \
+  --days <days_back> \
+  --max-posts 20 \
+  --output summary
+```
+
+Collect: post text preview, date, reactions, comments, post URL.
+
+## Phase 3: Scrape Twitter/X
+
+Run `twitter-mention-tracker` for each handle:
+
+```bash
+python3 skills/capabilities/twitter-mention-tracker/scripts/search_twitter.py \
+  --query "from:<handle>" \
+  --since <YYYY-MM-DD> \
+  --until <YYYY-MM-DD> \
+  --max-tweets 20 \
+  --output summary
+```
+
+Collect: tweet text, date, likes, retweets, URL.
+
+## Phase 4: Analyze & Synthesize
+
+After collecting raw data, synthesize across all channels:
+
+### For each competitor, identify:
+- **New blog posts** — titles, dates, topics
+- **Top LinkedIn post** — by engagement (reactions + comments), topic, key message
+- **Top tweet** — by likes, topic
+- **Recurring themes** — what topics did they post about most this period?
+- **Content format patterns** — are they doing listicles, opinion pieces, case studies?
+
+### Cross-competitor analysis:
+- **Shared trending topics** — what are multiple competitors writing about?
+- **Coverage gaps** — topics they're covering that you're not
+- **Topics you own** — where you're publishing and they're not
+- **Engagement benchmarks** — average likes/reactions across competitors (context for your own performance)
+
+## Phase 5: Output Format
+
+Produce a structured markdown digest:
+
+```markdown
+# Competitor Content Digest — Week of [DATE]
+
+## Summary
+- [N] new blog posts tracked across [N] competitors
+- Top trending topic: [topic]
+- Biggest content gap for you: [topic]
+
+---
+
+## [Competitor Name]
+
+### Blog
+- [Post Title] — [Date] — [URL]
+  > [One-sentence summary]
+
+### LinkedIn (top post)
+> "[Post preview...]"
+— [Author], [Date] | [Reactions] reactions, [Comments] comments
+[URL]
+
+### Twitter/X (top tweet)
+> "[Tweet text]"
+— [@handle], [Date] | [Likes] likes
+[URL]
+
+### Themes this week: [tag1], [tag2], [tag3]
+
+---
+
+## Content Gap Analysis
+
+| Topic | Competitors covering | You covering |
+|-------|---------------------|--------------|
+| [topic] | Clay, Apollo | ❌ No |
+| [topic] | Nobody | ✅ Yes |
+
+## Recommended Actions
+1. [Specific content opportunity to act on this week]
+2. [Topic to consider writing a response/alternative take on]
+```
+
+Save digest to `clients/<client-name>/intelligence/competitor-content-[YYYY-MM-DD].md`.
+
+## Scheduling
+
+This skill is designed to run weekly (Mondays recommended). Set up a cron job:
+
+```bash
+# Every Monday at 8am
+0 8 * * 1 python3 run_skill.py competitor-content-tracker --client <client-name>
+```
+
+## Cost
+
+| Component | Cost |
+|-----------|------|
+| Blog scraping (RSS mode) | Free |
+| LinkedIn post scraping | ~$0.05-0.20/profile (Apify) |
+| Twitter scraping | ~$0.01-0.05 per run |
+| **Total per weekly run** | **~$0.10-0.50** depending on scope |
+
+## Tools Required
+
+- **Apify access** — via Gooseworks proxy by default (no key needed); set `APIFY_API_TOKEN` to BYO Apify
+- **Upstream skills:** `blog-feed-monitor`, `linkedin-profile-post-scraper`, `twitter-mention-tracker`
+
+## Trigger Phrases
+
+- "Run competitor content tracker for [client]"
+- "What did my competitors publish this week?"
+- "Give me a competitor content digest"
+- "What's [competitor] writing about?"

--- a/skills/composites/competitor-content-tracker/skill.meta.json
+++ b/skills/composites/competitor-content-tracker/skill.meta.json
@@ -1,0 +1,20 @@
+{
+  "slug": "competitor-content-tracker",
+  "category": "composites",
+  "tags": [
+    "competitive-intel"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install competitor-content-tracker",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "requires_skills": [
+    "blog-feed-monitor",
+    "linkedin-profile-post-scraper",
+    "twitter-mention-tracker"
+  ]
+}

--- a/skills/composites/customer-story-builder/SKILL.md
+++ b/skills/composites/customer-story-builder/SKILL.md
@@ -1,0 +1,241 @@
+---
+name: customer-story-builder
+description: >
+  Take raw customer inputs — interview transcripts, survey responses, Slack quotes,
+  support tickets, review excerpts — and generate a structured case study draft with
+  problem/solution/result narrative, pull-quotes, metric callouts, and multi-format
+  outputs (full case study, one-pager, social proof snippet, sales deck slide).
+  Pure reasoning skill. Use when a product marketing team has customer signal but no
+  time to write the story.
+tags: [content]
+---
+
+# Customer Story Builder
+
+Turn raw customer signal into a polished case study — plus every derivative format you need. One input (messy transcript or quote), all outputs (case study, one-pager, social snippet, deck slide).
+
+**Core principle:** The best customer stories already exist in your support tickets, Slack channels, and call recordings. You just need to extract and structure them.
+
+## When to Use
+
+- "Turn this customer interview into a case study"
+- "We have a great Slack quote from [customer] — help me build a story around it"
+- "Write a case study for [customer]"
+- "I need social proof assets from [customer win]"
+- "Package this customer result for the sales team"
+
+## Phase 0: Intake
+
+### Customer Context
+1. **Customer name** — Can we use their name publicly? (Named vs. anonymous)
+2. **Company description** — Industry, size, stage (1 sentence)
+3. **Customer role/title** — Who's the champion?
+4. **How long have they been a customer?**
+
+### Raw Input (provide any/all)
+5. **Interview transcript** — Full or partial transcript from a customer call
+6. **Slack/email quotes** — Specific messages where they praised the product
+7. **Survey responses** — NPS comments, CSAT feedback
+8. **Support ticket excerpts** — Before/after of a problem solved
+9. **Review excerpts** — G2, Capterra, Trustpilot quotes
+10. **Metrics** — Any numbers: time saved, revenue impact, efficiency gains, before/after
+
+### Story Angle
+11. **Primary use case** — What were they using the product for?
+12. **Key transformation** — What changed? (The "before → after" in one sentence)
+13. **Output formats needed** — Full case study, one-pager, social snippet, sales slide, or all?
+
+## Phase 1: Extract Story Elements
+
+From the raw inputs, identify and extract:
+
+### The Problem (Before)
+- What was the customer's situation before using the product?
+- What specific pain were they experiencing?
+- What had they tried before? (Manual process, competitor, nothing)
+- How bad was it? (Quantify if possible — hours wasted, money lost, deals missed)
+
+### The Decision (Why You)
+- Why did they choose your product?
+- What alternatives did they consider?
+- What was the deciding factor?
+
+### The Solution (How)
+- Which specific features/capabilities did they use?
+- How did they implement it? (Timeline, effort)
+- Any surprising use cases or creative applications?
+
+### The Result (After)
+- **Hard metrics** — numbers, percentages, time saved, revenue gained
+- **Soft outcomes** — confidence, team morale, process improvements
+- **Before/after comparison** — the transformation in concrete terms
+
+### Best Quotes
+Pull the 3-5 strongest verbatim quotes from the raw input:
+- **Hero quote** — the single most powerful statement (for headlines)
+- **Problem quote** — describes the pain vividly
+- **Result quote** — describes the outcome with specificity
+- **Recommendation quote** — would they recommend? Why?
+
+## Phase 2: Generate Story Outputs
+
+### Output 1: Full Case Study (800-1200 words)
+
+```markdown
+# [Headline: Outcome-driven, not product-driven]
+*[Subhead: Customer name + one-line result]*
+
+---
+
+## About [Customer]
+
+[2-3 sentences: company, industry, size, what they do]
+
+## The Challenge
+
+[2-3 paragraphs: What was the problem? Why did it matter? What had they tried?]
+
+> "[Problem quote]"
+> — [Name], [Title] at [Company]
+
+## Why [Your Product]
+
+[1-2 paragraphs: How did they find you? What made them choose you?]
+
+## The Solution
+
+[2-3 paragraphs: How did they use the product? Which capabilities mattered most?]
+
+> "[Solution/experience quote]"
+
+## The Results
+
+[Results summary with metric callouts]
+
+### Key Metrics
+- **[Metric 1]:** [Number + context]
+- **[Metric 2]:** [Number + context]
+- **[Metric 3]:** [Number + context]
+
+> "[Result quote]"
+
+## What's Next
+
+[1 paragraph: Future plans, expansion, what they're excited about]
+
+---
+
+**Industry:** [X] | **Company size:** [X] | **Use case:** [X] | **Product:** [X]
+```
+
+### Output 2: One-Pager (Sales Leave-Behind)
+
+```markdown
+# [Customer Name]: [Headline Result]
+
+**Challenge:** [2 sentences]
+**Solution:** [2 sentences — what they use and how]
+**Results:**
+- [Metric 1]
+- [Metric 2]
+- [Metric 3]
+
+> "[Hero quote]"
+> — [Name], [Title]
+
+[CTA: Learn more / Request a demo]
+```
+
+### Output 3: Social Proof Snippets
+
+**For website testimonial section:**
+```
+"[Short, punchy quote — max 2 sentences]"
+— [Name], [Title] at [Company]
+[Result: X% improvement in Y]
+```
+
+**For LinkedIn post:**
+```
+[Customer Name] just shared their results:
+
+→ [Metric 1]
+→ [Metric 2]
+→ [Metric 3]
+
+"[Quote]"
+
+Here's their story: [link]
+```
+
+**For cold email insert:**
+```
+[Company in their industry] saw [key metric] after switching to [Product].
+
+"[Short quote about the result]" — [Name], [Title]
+```
+
+### Output 4: Sales Deck Slide Content
+
+```
+Slide title: "[Customer] — [Key Result]"
+
+Left side:
+- Challenge: [1 line]
+- Solution: [1 line]
+- Result: [1 line with metric]
+
+Right side:
+> "[Hero quote]"
+— [Name], [Title]
+
+[Customer logo]
+```
+
+### Output 5: Metric Callout Cards
+
+For website or marketing collateral:
+```
+[BIG NUMBER]
+[Label — e.g., "hours saved per week"]
+— [Customer Name]
+```
+
+Generate 2-3 of these from the strongest metrics.
+
+## Phase 3: Story Quality Check
+
+Before finalizing, verify:
+
+- [ ] **Specificity** — Are results concrete, not vague? ("3x pipeline" > "improved results")
+- [ ] **Credibility** — Is the customer named? Is the metric believable?
+- [ ] **Relevance** — Does this story match your ICP? Will prospects see themselves?
+- [ ] **Permission** — Flag if customer approval is needed before publishing
+- [ ] **Freshness** — Are the results recent? (>12 months old = less impactful)
+
+## Phase 4: Output
+
+Save all assets to `clients/<client-name>/product-marketing/customer-stories/[customer-slug]/`:
+- `case-study-full.md` — Complete case study
+- `one-pager.md` — Sales leave-behind
+- `social-snippets.md` — All social proof formats
+- `slide-content.md` — Deck slide content
+- `raw-inputs.md` — Original source material (for reference)
+
+## Cost
+
+| Component | Cost |
+|-----------|------|
+| All story generation | Free (LLM reasoning) |
+| **Total** | **Free** |
+
+## Tools Required
+
+None. Pure reasoning skill. Takes raw text input and produces structured outputs.
+
+## Trigger Phrases
+
+- "Turn this transcript into a case study"
+- "Build a customer story for [customer]"
+- "Package [customer]'s results as social proof"
+- "Run customer story builder for [customer]"

--- a/skills/composites/customer-story-builder/skill.meta.json
+++ b/skills/composites/customer-story-builder/skill.meta.json
@@ -1,0 +1,15 @@
+{
+  "slug": "customer-story-builder",
+  "category": "composites",
+  "tags": [
+    "content"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install customer-story-builder",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Revive 5 skills that were swept up in PR #6 ("Clean up skills for open-source", commit `0fbe8cb`) along with the legitimate Crustdata/Supabase removals. Linear: [GOOSE-1506](https://linear.app/athina/issue/GOOSE-1506/revive-and-test-deleted-skills).

All 5 restored verbatim from `0fbe8cb^` with targeted edits where the surrounding repo had moved on.

### Restored

- **`skills/capabilities/icp-website-review`** — pure reasoning skill, no scripts. Replaced obsolete `icp-persona-builder` reference with `buyer-persona-generator` (the current persona-producing skill).
- **`skills/capabilities/newsletter-sponsorship-finder`** — fully unauthenticated (WebSearch + public Substack search API). Restored as-is.
- **`skills/capabilities/setup-outreach-campaign-smartlead`** — restored from `setup-outreach-campaign` and renamed (slug, frontmatter `name`, H1, meta). Does **not** use the Gooseworks proxy (no shared Smartlead account); SKILL.md now tells the user to bring their own `SMARTLEAD_API_KEY` from Smartlead → Settings → API Keys.
- **`skills/composites/competitor-content-tracker`** — restored. Updated stale chained-skill names (`blog-scraper` → `blog-feed-monitor`, `twitter-scraper` → `twitter-mention-tracker`) and updated script paths to the current `skills/capabilities/<slug>/scripts/...` layout. Added `requires_skills: [blog-feed-monitor, linkedin-profile-post-scraper, twitter-mention-tracker]` to `skill.meta.json` (matching `ad-angle-miner`, `battlecard-generator`, etc.).
- **`skills/composites/customer-story-builder`** — pure reasoning composite, no broken refs.

### Proxy notes

The Apify-using upstream skills (`blog-feed-monitor`, `linkedin-profile-post-scraper`, `twitter-mention-tracker`) already use the proxy-first / direct-fallback BASE_URL pattern, so no script edits were needed in this PR. `setup-outreach-campaign-smartlead` is the one explicit non-proxy case (BYO Smartlead key) called out in the ticket.

### Skipped per ticket

- `review-scraper` — already restored in GOOSE-1501 (commit `8b7c121`).
- "Maybe Later" set: `competitive-strategy-tracker`, `content-repurposer`, `search-ad-keyword-architect`.
- Sub-ticket [GOOSE-1507](https://linear.app/athina/issue/GOOSE-1507) — owned by @hbamoria.

## Test plan

- [x] `npm run validate:skills` — passes (193 skills validated)
- [x] `npm run build:index` — regenerated `skills-index.json` (204 skills, 2 packs)
- [x] `npm test` — 19/19 pass
- [x] Verified all referenced sibling skills exist on disk: `buyer-persona-generator`, `company-contact-finder`, `contact-cache`, `luma-event-attendees`, `conference-speaker-scraper`, `blog-feed-monitor`, `linkedin-profile-post-scraper`, `twitter-mention-tracker`
- [ ] Sync to local DB and exercise each skill in-app

🤖 Generated with [Claude Code](https://claude.com/claude-code)