### PR TITLE
Add graphic ebook, gif, and case study skills

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -2250,6 +2250,217 @@
       }
     },
     {
+      "slug": "graphic-case-study",
+      "name": "graphic-case-study",
+      "category": "composites",
+      "description": "Create professionally designed B2B SaaS case study PDFs as HTML + CSS, then export them to PDF. Use when the user needs a polished customer story for sales, marketing, website, email, or enablement use, wants a challenge-to-solution-to-results narrative, and needs structured 1 to 4 page layouts with Gooseworks-compatible styling and print-ready output.",
+      "tags": "content, design",
+      "path": "skills/composites/graphic-case-study",
+      "files": [
+        "skills/composites/graphic-case-study/SKILL.md",
+        "skills/composites/graphic-case-study/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "graphic-case-study",
+        "category": "composites",
+        "tags": [
+          "content",
+          "design"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install graphic-case-study",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "requires_skills": [
+          "goose-graphics"
+        ],
+        "recommends_skills": [
+          "visual-brand-extractor",
+          "goose-graphics-create-style",
+          "graphic-chart"
+        ],
+        "features": [
+          "Creates professionally designed B2B SaaS case study PDFs from customer-story inputs",
+          "Supports 1-page, 2-page, and 4-page structures built around challenge, solution, results, testimonial, and CTA flows",
+          "Uses Gooseworks style themes with validated recommendations for enterprise-safe and premium proof assets",
+          "Outputs one HTML file per page with optional preview and print files",
+          "Includes guidance for anonymized customers, stat-led proof, testimonial handling, and print-ready PDF export"
+        ]
+      }
+    },
+    {
+      "slug": "graphic-chart",
+      "name": "graphic-chart",
+      "category": "composites",
+      "description": "Generate polished chart graphics from structured data as HTML first, then screenshot to PNG. Use when the user needs a bar, line, pie, doughnut, scatter, area, radar, or treemap chart for social posts, reports, blog posts, or decks, wants Gooseworks-compatible styling, and can provide JSON or CSV data plus an explicit chart type.",
+      "tags": "content, design",
+      "path": "skills/composites/graphic-chart",
+      "files": [
+        "skills/composites/graphic-chart/SKILL.md",
+        "skills/composites/graphic-chart/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "graphic-chart",
+        "category": "composites",
+        "tags": [
+          "content",
+          "design"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install graphic-chart",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "requires_skills": [
+          "goose-graphics"
+        ],
+        "recommends_skills": [
+          "goose-graphics-create-style"
+        ],
+        "features": [
+          "Generates HTML-based charts, then screenshots them to PNG",
+          "Uses Chart.js for standard charts and D3.js for treemaps or custom layouts",
+          "Supports titles, subtitles, source attribution, and highlighted data points",
+          "Uses Gooseworks-compatible style themes for presentation-ready chart graphics",
+          "Optimized for social posts, reports, blog charts, and slide-deck visuals"
+        ]
+      }
+    },
+    {
+      "slug": "graphic-ebook",
+      "name": "graphic-ebook",
+      "category": "composites",
+      "description": "Create professionally designed B2B SaaS e-books as HTML + CSS, then export them to PDF. Use when the user needs a lead magnet, gated content asset, nurture guide, or thought-leadership e-book from a brief or existing content, wants Gooseworks-compatible style themes, and needs structured portrait page layouts with print-ready output.",
+      "tags": "content, design",
+      "path": "skills/composites/graphic-ebook",
+      "files": [
+        "skills/composites/graphic-ebook/SKILL.md",
+        "skills/composites/graphic-ebook/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "graphic-ebook",
+        "category": "composites",
+        "tags": [
+          "content",
+          "design"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install graphic-ebook",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "requires_skills": [
+          "goose-graphics"
+        ],
+        "recommends_skills": [
+          "visual-brand-extractor",
+          "goose-graphics-create-style",
+          "graphic-chart",
+          "technical-blog-graphics"
+        ],
+        "features": [
+          "Creates professionally designed B2B SaaS e-books as HTML + CSS with PDF export",
+          "Supports a 9-layout page library including cover, TOC, chapter, sidebar, stat, visual, and CTA pages",
+          "Uses Gooseworks style themes with validated recommendations for lead magnets and thought-leadership assets",
+          "Outputs one HTML file per page with optional preview and print files",
+          "Optimized for portrait, print-ready gated content and nurture assets"
+        ]
+      }
+    },
+    {
+      "slug": "graphic-gif",
+      "name": "graphic-gif",
+      "category": "composites",
+      "description": "Generate looping animated GIFs from a prompt by rendering HTML + CSS animations to frames and compiling them into a `.gif`, or by using an optional image-to-video workflow when external APIs are available. Use when the user needs animated text, icons, counters, tickers, or motion graphics for social posts, blog embeds, lightweight ads, or product marketing, and the final deliverable should be a GIF rather than a static PNG.",
+      "tags": "content, design",
+      "path": "skills/composites/graphic-gif",
+      "files": [
+        "skills/composites/graphic-gif/SKILL.md",
+        "skills/composites/graphic-gif/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "graphic-gif",
+        "category": "composites",
+        "tags": [
+          "content",
+          "design"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install graphic-gif",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "requires_skills": [
+          "goose-graphics"
+        ],
+        "recommends_skills": [
+          "goose-graphics-create-style"
+        ],
+        "features": [
+          "Generates looping GIFs from HTML and CSS animations, then compiles captured frames into a .gif",
+          "Supports fade, slide, typewriter, counter, pulse, and loop-scroll animation patterns",
+          "Includes an optional AI-generated motion path when external image-to-video tooling is available",
+          "Uses Gooseworks-compatible style themes with guidance for GIF-safe color and background choices",
+          "Optimized for social loops, blog embeds, lightweight ads, and other compact animated graphics"
+        ]
+      }
+    },
+    {
+      "slug": "graphic-slide-deck",
+      "name": "graphic-slide-deck",
+      "category": "composites",
+      "description": "Create professionally designed HTML + CSS slide decks for sales, pitch, work, conference, and onboarding presentations, with optional PDF export. Use when the user needs a polished slide deck from a brief, outline, or existing content, wants goose-graphics-compatible style themes, and needs structured slide layouts, browser-previewable HTML, or print-ready PDF output.",
+      "tags": "content, design",
+      "path": "skills/composites/graphic-slide-deck",
+      "files": [
+        "skills/composites/graphic-slide-deck/SKILL.md",
+        "skills/composites/graphic-slide-deck/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "graphic-slide-deck",
+        "category": "composites",
+        "tags": [
+          "content",
+          "design"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install graphic-slide-deck",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "requires_skills": [
+          "goose-graphics"
+        ],
+        "recommends_skills": [
+          "visual-brand-extractor",
+          "goose-graphics-create-style"
+        ],
+        "features": [
+          "Creates structured HTML + CSS slide decks for pitch, sales, work, conference, and onboarding use cases",
+          "Supports a 13-layout slide library including title, section, stats, comparison, timeline, and CTA slides",
+          "Uses Gooseworks style themes with validated presentation-friendly style recommendations",
+          "Outputs one HTML file per slide with optional preview and print files",
+          "Supports print-safe PDF export after HTML generation"
+        ]
+      }
+    },
+    {
       "slug": "gtm-enrichment-deep",
       "name": "gtm-enrichment-deep",
       "category": "capabilities",

--- a/skills/composites/graphic-case-study/SKILL.md
+++ b/skills/composites/graphic-case-study/SKILL.md
@@ -1,0 +1,435 @@
+---
+name: graphic-case-study
+description: Create professionally designed B2B SaaS case study PDFs as HTML + CSS, then export them to PDF. Use when the user needs a polished customer story for sales, marketing, website, email, or enablement use, wants a challenge-to-solution-to-results narrative, and needs structured 1 to 4 page layouts with Gooseworks-compatible styling and print-ready output.
+tags: [content, design]
+---
+
+# Graphic Case Study
+
+Create professionally designed B2B SaaS case studies as HTML + CSS first, then export to PDF.
+
+This skill is for one of the most important B2B proof assets: a polished customer success story that can be used in sales follow-up, website resources, outbound collateral, decks, and nurture campaigns. The output should feel credible, specific, and conversion-oriented, not like a generic marketing flyer.
+
+## Core Promise
+
+1. Extract or clarify the customer story details
+2. Shape the narrative into a classic proof arc
+3. Design each page with a consistent visual system
+4. Keep the document tight, measurable, and scannable
+5. Export a print-ready PDF
+
+## Best Fit
+
+- Sales-ready customer proof assets
+- Website case study downloads
+- Outbound follow-up PDFs
+- Customer success spotlights
+- Product ROI stories
+- Enablement collateral for reps and partners
+
+## Use Something Else
+
+- If the user needs a broader multi-topic lead magnet, use `graphic-ebook`.
+- If the user needs a slide presentation, use `graphic-slide-deck`.
+- If the user only needs a chart or metric visual, use `graphic-chart`.
+- If the user needs architecture or workflow diagrams inside the case study, use `technical-blog-graphics`.
+
+## Required Intake
+
+Ask only for what is missing, but always resolve these fields before full generation:
+
+1. Customer name or anonymized label
+2. Customer context: size, industry, or use case
+3. Core challenge
+4. Solution or implementation story
+5. Measurable results
+6. Testimonial, if available
+7. Page count target
+8. Style choice
+9. Customer logo inclusion, if available
+10. Your brand/logo for closing or footer treatment
+
+Suggested question phrasing:
+
+- Who is the customer? If needed, should I anonymize them?
+- What was the core challenge before using your product?
+- What specifically did your product or service do to solve it?
+- What measurable results can we include: time saved, efficiency gains, revenue lift, cost reduction, or error reduction?
+- Do you have a customer quote or testimonial to include?
+- Should this be a 1-page summary, a 2-page standard case study, or a 4-page detailed version?
+- Which style should I use? I can list Gooseworks styles, use a validated case-study style, or match your brand.
+- Should I include the customer logo and your logo? If yes, provide the assets or URLs.
+
+## Default Length Guidance
+
+| Format | Recommended Use |
+|--------|-----------------|
+| `1` page | Summary card for quick follow-up or website download |
+| `2` pages | Standard sales-ready case study |
+| `4` pages | Detailed proof asset with richer context and visuals |
+
+If the user wants depth but only one page, compress to the strongest story beats and three proof points. Do not cram.
+
+## Story Structure
+
+The default narrative arc should be:
+
+1. Customer context
+2. Challenge
+3. Solution
+4. Results
+5. Testimonial
+6. CTA or next step
+
+This flow is proven because it moves from credibility to pain to action to proof.
+
+## Style Selection
+
+Use the Gooseworks style ecosystem rather than inventing a disconnected case-study design language.
+
+### Preferred Style Flow
+
+1. If the user names a style, verify it exists:
+
+```bash
+npx gooseworks styles list
+npx gooseworks styles search "clean slate"
+npx gooseworks styles get <slug>
+```
+
+2. If the user says "match our brand":
+
+- If they provide brand references or an existing one-pager, use `goose-graphics-create-style` first
+- If they provide a company website, use `visual-brand-extractor`
+
+3. If the user has no style preference, recommend from the validated case-study styles below.
+
+### Validated Case-Study Styles
+
+These styles are especially suitable for B2B SaaS case studies:
+
+- `clean-slate` - white, professional, enterprise-safe
+- `midnight-editorial` - dark, premium, strong for AI and tech brands
+- `matt-gray` - neutral, credible, classic B2B
+- `product-minimal` - whitespace-heavy, good for product screenshots
+- `mint-pixel-corporate` - modern corporate, fresh but polished
+- `warm-earth` - approachable, good for services and consulting
+- `brutalist` - bold, differentiating, startup-forward
+- `magazine-red` - editorial, strong for agencies or creative positioning
+
+### Style Matching Heuristics
+
+| Case Study Need | Good Style Direction |
+|-----------------|----------------------|
+| Enterprise credibility | `clean-slate`, `matt-gray` |
+| Premium AI or technical brand | `midnight-editorial`, `product-minimal` |
+| Warm customer success story | `warm-earth`, `soft-cloud` |
+| Bold startup proof asset | `brutalist`, `magazine-red` |
+| Product-led story with screenshots | `product-minimal`, `clean-slate` |
+
+## Output Structure
+
+Required output:
+
+```text
+case-study/[customer-name]-pages/
+  page-01.html
+  page-02.html
+  ...
+```
+
+Optional but recommended support files:
+
+```text
+case-study/[customer-name]-pages/
+  index.html
+  print.html
+  assets/
+```
+
+Required PDF output:
+
+```text
+case-study/[customer-name].pdf
+```
+
+## Page Layout Library
+
+Use these layouts intentionally. Do not force every page into the same template.
+
+| Layout | Purpose |
+|--------|---------|
+| `cover` | Customer name, headline result, logo, hook |
+| `overview` | Customer profile, industry, use case, implementation summary |
+| `challenge` | Problem context and pain |
+| `solution` | Product or service response with feature callouts |
+| `results` | Metrics, ROI, stat blocks, supporting proof |
+| `testimonial` | Pull quote from the customer |
+| `closing-cta` | Brand, contact, next step, or product follow-up |
+
+## Layout Mapping Heuristics
+
+Choose layouts based on page intent:
+
+- Strong opening claim -> `cover`
+- Reader orientation -> `overview`
+- Before-state pain -> `challenge`
+- How it worked -> `solution`
+- Proof and ROI -> `results`
+- Customer voice -> `testimonial`
+- Conversion prompt -> `closing-cta`
+
+Results pages should usually be visually heavier than challenge pages. The proof is the hero.
+
+## Standard Page Structures
+
+### 1-Pager
+
+Typical sequence:
+
+1. Cover
+2. Short challenge block
+3. Short solution block
+4. Three key stats
+5. Quote or testimonial
+
+This should feel like a sharp summary card, not a compressed brochure.
+
+### 2-Pager
+
+Typical sequence:
+
+1. Cover plus overview
+2. Challenge plus solution
+3. Results
+4. Testimonial plus CTA
+
+This is the default format for most B2B use.
+
+### 4-Pager
+
+Typical sequence:
+
+1. Cover
+2. Overview
+3. Challenge
+4. Solution
+5. Results
+6. Testimonial
+7. Supporting visuals or proof
+8. Closing CTA
+
+Use the longer format only when the story truly supports more context, screenshots, or charts.
+
+## Case Study Workflow
+
+### Step 1 - Understand the Proof Asset
+
+Before designing anything, understand:
+
+- who the audience is
+- what sales or marketing job the case study is meant to do
+- how specific the claims can be
+- whether the customer should be named or anonymized
+- what proof is strongest: metrics, quote, implementation complexity, or brand recognition
+
+This determines the tone and structure more than the raw notes do.
+
+### Step 2 - Normalize the Story
+
+Always convert raw notes into a clear story table before rendering pages.
+
+Use a planning table like:
+
+| Section | Core Message | Proof Element | Layout |
+|---------|--------------|---------------|--------|
+| Cover | Big outcome for this customer | headline stat | cover |
+| Challenge | Manual work or risk before the product | problem summary | challenge |
+| Solution | What changed operationally | feature or workflow callouts | solution |
+| Results | Tangible lift after adoption | metrics or chart | results |
+| Testimonial | Customer validation in their voice | quote | testimonial |
+
+Do not start page design until the story is coherent and evidence-backed.
+
+### Step 3 - Tighten for Credibility
+
+Case studies win on specificity.
+
+Rules:
+
+- prefer concrete numbers over vague claims
+- keep the customer context concise but real
+- use three standout metrics when possible
+- avoid inflated marketing language
+- keep quotes believable and not over-edited
+
+If the user does not provide measurable results, push the story toward concrete operational outcomes instead of inventing metrics.
+
+### Step 4 - Build the Visual System
+
+Once style is chosen, apply it consistently across the whole asset:
+
+- cover hierarchy
+- stat block styling
+- quote treatment
+- logo placement
+- caption and metadata treatment
+- footer or page number system
+- screenshot or chart framing
+
+The case study should feel like one unified proof document.
+
+### Step 5 - Generate HTML Pages
+
+Each page should be its own HTML file sized for the selected export format.
+
+Recommended default size:
+
+- `1200x1697` for portrait
+
+Acceptable alternate size:
+
+- `1200x900` for landscape `4:3`
+
+Choose portrait unless the user explicitly wants landscape or the story is more visual than narrative.
+
+For each page:
+
+- use a fixed pixel artboard
+- keep content fully within the page bounds
+- preserve generous margins
+- use the chosen style's palette, type, spacing, and component logic
+- add comments only when helpful for future edits
+
+Recommended additional files:
+
+- `index.html` for browser preview
+- `print.html` to assemble all pages for PDF generation
+
+## Rendering Rules
+
+### HTML Rules
+
+- HTML first, then PDF
+- one page per file
+- inline or local CSS is fine, but keep the design system consistent
+- prefer self-contained page files where practical
+- use local `assets/` for logos, screenshots, charts, and diagrams
+
+### Page Safety Rules
+
+- never let content overflow the page
+- never rely on scrolling
+- never shrink text until the proof becomes hard to read
+- keep stats and quotes visually prominent
+- leave enough whitespace to make the story feel premium
+
+### Content Rules
+
+- write for skimmability and trust
+- emphasize business outcomes, not empty adjectives
+- keep jargon under control
+- make the before and after state obvious
+- keep CTA language direct and sales-appropriate
+
+## Testimonial Rules
+
+If a testimonial is provided:
+
+- preserve the customer's meaning
+- trim only for clarity and layout
+- attribute it clearly when allowed
+- make it visually distinct from body copy
+
+If no testimonial is provided:
+
+- do not fabricate one
+- use a stronger results page or customer overview instead
+
+## Anonymization Rules
+
+If the customer must be anonymized:
+
+- replace the name with a credible descriptor like `Fortune 500 Retailer` or `Series B Fintech Platform`
+- remove logos and overly identifying context
+- keep industry, scale, and use case if they help the story
+- preserve the proof, even when the brand is hidden
+
+An anonymized case study should still feel specific, not vague.
+
+## Results Presentation
+
+Results should usually carry the visual center of gravity.
+
+Use:
+
+- large stat blocks
+- concise narrative explanation
+- a chart only when it genuinely clarifies the improvement
+- one to three metrics as the hero proof points
+
+If a chart would materially improve the story, use `graphic-chart` for the supporting visual rather than faking one in prose.
+
+## PDF Export
+
+This skill should output a PDF after the HTML pages are complete.
+
+Preferred method:
+
+- generate a `print.html` with one page per printed sheet
+- use a browser or Playwright print-to-PDF flow
+
+Print requirements:
+
+- one case-study page per PDF page
+- no browser chrome
+- zero accidental page breaks
+- preserve background colors and images
+- maintain the intended portrait or landscape sizing
+
+If exporting via Playwright or Chromium, ensure print CSS forces clean page boundaries.
+
+## Recommended Print CSS
+
+Use print rules like:
+
+- fixed page width and height
+- `page-break-after: always` on each page wrapper
+- final page wrapper `page-break-after: auto`
+- `print-color-adjust: exact`
+
+The goal is a merged PDF that looks like a designed sales asset, not a web article.
+
+## Success Criteria
+
+A strong output from this skill should feel:
+
+- sales-ready without manual redesign
+- specific and credible
+- visually consistent across pages
+- easy to skim in PDF form
+- strong enough to send directly to prospects or publish on a site
+
+## Dependencies
+
+Required skill:
+
+- `goose-graphics`
+
+Recommended skills:
+
+- `visual-brand-extractor`
+- `goose-graphics-create-style`
+- `graphic-chart`
+
+## Example Request
+
+```text
+Create a 2-page case study for Acme Corp. They were spending 20 hours per week on manual reporting. We automated it. They saved 80% of that time and reduced errors by 95%. Use midnight-editorial style.
+```
+
+Expected result:
+
+- a planned case study structure
+- HTML pages in `case-study/[customer-name]-pages/`
+- a matching print-ready PDF in `case-study/[customer-name].pdf`

--- a/skills/composites/graphic-case-study/skill.meta.json
+++ b/skills/composites/graphic-case-study/skill.meta.json
@@ -1,0 +1,31 @@
+{
+  "slug": "graphic-case-study",
+  "category": "composites",
+  "tags": [
+    "content",
+    "design"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install graphic-case-study",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "requires_skills": [
+    "goose-graphics"
+  ],
+  "recommends_skills": [
+    "visual-brand-extractor",
+    "goose-graphics-create-style",
+    "graphic-chart"
+  ],
+  "features": [
+    "Creates professionally designed B2B SaaS case study PDFs from customer-story inputs",
+    "Supports 1-page, 2-page, and 4-page structures built around challenge, solution, results, testimonial, and CTA flows",
+    "Uses Gooseworks style themes with validated recommendations for enterprise-safe and premium proof assets",
+    "Outputs one HTML file per page with optional preview and print files",
+    "Includes guidance for anonymized customers, stat-led proof, testimonial handling, and print-ready PDF export"
+  ]
+}

--- a/skills/composites/graphic-ebook/SKILL.md
+++ b/skills/composites/graphic-ebook/SKILL.md
@@ -1,0 +1,396 @@
+---
+name: graphic-ebook
+description: Create professionally designed B2B SaaS e-books as HTML + CSS, then export them to PDF. Use when the user needs a lead magnet, gated content asset, nurture guide, or thought-leadership e-book from a brief or existing content, wants Gooseworks-compatible style themes, and needs structured portrait page layouts with print-ready output.
+tags: [content, design]
+---
+
+# Graphic Ebook
+
+Create professionally designed B2B SaaS e-books as HTML + CSS first, then export to PDF.
+
+This skill is for serious marketing collateral: lead magnets, gated guides, executive primers, mini-reports, and nurture assets that should feel editorial, branded, and polished. The output should read like a designed publishing asset, not a long web page dumped into PDF.
+
+## Core Promise
+
+1. Clarify the e-book topic, audience, and desired outcome
+2. Plan the page structure before designing anything
+3. Draft or shape content into page-sized sections
+4. Generate one HTML file per page using a consistent visual system
+5. Export a clean, print-ready PDF
+
+## Best Fit
+
+- B2B SaaS lead magnets
+- Gated guides
+- Thought-leadership mini reports
+- Nurture content assets
+- Product education e-books
+- Research or benchmark summaries
+
+## Use Something Else
+
+- If the user needs a presentation deck, use `graphic-slide-deck`.
+- If the user only needs one infographic, hero visual, or social graphic, use `goose-graphics`.
+- If the user needs supporting charts or data visuals, use `graphic-chart`.
+- If the user needs technical diagrams or architecture visuals inside the e-book, use `technical-blog-graphics`.
+
+## Required Intake
+
+Ask only for what is missing, but always resolve these fields before full generation:
+
+1. Topic
+2. Audience
+3. Desired action or CTA
+4. Page count target
+5. Source content: existing content or draft-from-scratch brief
+6. Style choice
+7. Brand name
+8. Logo inclusion, if available
+
+Suggested question phrasing:
+
+- What is the e-book topic? Be specific about the promise or angle.
+- Who is the target audience: role, company type, company size, and main pain point?
+- What should the reader do after reading: book a demo, download a template, share the content, or something else?
+- How many pages do you want? If you are unsure, suggest a range based on depth.
+- Do you already have content, or should I draft it from scratch?
+- Which style should I use? I can list Gooseworks styles, use one of the validated e-book styles, or match your brand.
+- What brand name and logo, if any, should appear on the cover and footer?
+
+## Default Page Count Guidance
+
+| Ebook Type | Recommended Count |
+|------------|-------------------|
+| Quick guide | 3-5 |
+| Standard lead magnet | 5-7 |
+| Thought-leadership report | 6-10 |
+| Research summary | 6-10 |
+
+If the user tries to fit too much into too few pages, increase the page count or simplify the scope. A readable asset converts better than a cramped one.
+
+## Style Selection
+
+Use the Gooseworks style ecosystem instead of inventing a disconnected e-book aesthetic.
+
+### Preferred Style Flow
+
+1. If the user names a style, verify it exists:
+
+```bash
+npx gooseworks styles list
+npx gooseworks styles search "clean slate"
+npx gooseworks styles get <slug>
+```
+
+2. If the user says "match our brand":
+
+- If they provide a reference image, existing PDF, or visual sample, use `goose-graphics-create-style` first
+- If they provide a website and want a brand-derived system, use `visual-brand-extractor`
+
+3. If the user has no style preference, recommend from the validated e-book styles below.
+
+### Validated Ebook Styles
+
+These styles are especially suitable for B2B SaaS e-books:
+
+- `clean-slate` - white background, professional, B2B-safe
+- `midnight-editorial` - dark, premium, thought-leadership feel
+- `matt-gray` - neutral, clean, timeless
+- `product-minimal` - whitespace-heavy, ideal for product-led guides
+- `warm-earth` - approachable, startup-friendly
+- `soft-cloud` - light, airy, SaaS-forward
+- `brutalist` - bold, disruptive, high-energy positioning
+- `magazine-red` - editorial punch for trend or research reports
+
+### Style Matching Heuristics
+
+| Ebook Need | Good Style Direction |
+|------------|----------------------|
+| Executive thought leadership | `midnight-editorial`, `matt-gray` |
+| Product education | `product-minimal`, `clean-slate` |
+| Demand generation guide | `clean-slate`, `soft-cloud`, `warm-earth` |
+| Category creation or bold POV | `brutalist`, `magazine-red` |
+| Benchmark or research report | `matt-gray`, `midnight-editorial`, `magazine-red` |
+
+## Output Structure
+
+Required output:
+
+```text
+ebook/[name]-pages/
+  page-01.html
+  page-02.html
+  page-03.html
+  ...
+```
+
+Optional but recommended support files:
+
+```text
+ebook/[name]-pages/
+  index.html
+  print.html
+  assets/
+```
+
+Required PDF output:
+
+```text
+ebook/[name].pdf
+```
+
+## Page Layout Library
+
+Use these layouts intentionally. Do not force every page into the same template.
+
+| Layout | Purpose |
+|--------|---------|
+| `cover` | Title, subtitle, brand, hero visual |
+| `toc` | Table of contents with numbered sections |
+| `chapter-intro` | Section opener with short summary |
+| `text-column` | Dense content in one or two columns |
+| `text-sidebar` | Main copy with sidebar for stats, tips, or quotes |
+| `full-image` | Full-page visual, illustration, product shot, or diagram |
+| `quote-callout` | Pull quote or strong point-of-view statement |
+| `stat-grid` | Metrics, benchmark figures, or proof points |
+| `closing-cta` | Summary, next step, contact, or conversion prompt |
+
+## Layout Mapping Heuristics
+
+Choose layouts based on page intent:
+
+- First impression -> `cover`
+- Reader navigation -> `toc`
+- New section -> `chapter-intro`
+- Educational explanation -> `text-column`
+- Main narrative plus proof or aside -> `text-sidebar`
+- Visual break or conceptual diagram -> `full-image`
+- Memorable takeaway -> `quote-callout`
+- Data-backed proof -> `stat-grid`
+- Final conversion push -> `closing-cta`
+
+Avoid long runs of dense text pages. Break rhythm with visuals, stats, or chapter openers.
+
+## Ebook Workflow
+
+### Step 1 - Understand the Content Job
+
+Before building pages, understand:
+
+- What the reader is trying to learn or solve
+- What level of sophistication the audience has
+- What credibility signals are needed
+- What action the asset is meant to drive
+- Whether the e-book is educational, opinionated, research-driven, or product-adjacent
+
+This determines the page flow more than the topic name alone.
+
+### Step 2 - Build the Page Outline First
+
+Always outline the e-book before rendering pages.
+
+Use a planning table like:
+
+| Page | Purpose | Core Message | Layout |
+|------|---------|--------------|--------|
+| 1 | Hook the reader | Why this guide matters | cover |
+| 2 | Orient | What is inside | toc |
+| 3 | Section open | Frame the first major idea | chapter-intro |
+| 4 | Teach | Main guidance or framework | text-column |
+| 5 | Prove | Metrics or examples | stat-grid |
+| 6 | Convert | Summary + CTA | closing-cta |
+
+Do not start page design until the outline feels coherent and proportional.
+
+### Step 3 - Shape Content for Page Density
+
+E-book pages should feel designed, not stuffed.
+
+Rules:
+
+- One core idea per page
+- Prefer short paragraphs over walls of copy
+- Use sidebars for tips, stats, and standout points
+- Turn abstract ideas into frameworks, charts, diagrams, or pull quotes where possible
+- Split pages before shrinking text to make everything fit
+
+If the user provides too much content, redistribute it across more pages or tighten the writing.
+
+### Step 4 - Build the Visual System
+
+Once style is chosen, apply it consistently across the full e-book:
+
+- Cover treatment
+- Heading scale
+- Body-copy rhythm
+- Sidebar styling
+- Accent color usage
+- Page numbers or footer system
+- Diagram and chart framing
+- CTA treatment
+
+The e-book should feel like one designed publication, not unrelated pages.
+
+### Step 5 - Generate HTML Pages
+
+Each page should be its own HTML file sized for portrait export.
+
+Default page size:
+
+- `1200x1697`
+
+For each page:
+
+- Use a fixed pixel artboard
+- Keep all content fully within the page bounds
+- Preserve generous margins
+- Use the chosen style's palette, type, spacing, and component behavior
+- Add comments only where helpful for future edits
+
+Recommended additional files:
+
+- `index.html` for browser preview
+- `print.html` to assemble all pages in print order for PDF generation
+
+## Rendering Rules
+
+### HTML Rules
+
+- HTML first, then PDF
+- One page per file
+- Inline or local CSS is fine, but keep the system consistent
+- Prefer self-contained page files where practical
+- Use local `assets/` for logos, screenshots, charts, and diagrams
+
+### Page Safety Rules
+
+- Never let content overflow the page
+- Never rely on scrolling
+- Never reduce type until the page becomes hard to read
+- Keep clear hierarchy between title, section labels, body, and footnotes
+- Leave breathing room around visuals and sidebars
+
+### Content Rules
+
+- Write for skim-readability and conversion, not academic density
+- Keep claims specific and credible
+- Use charts, proof blocks, and frameworks when they clarify the message
+- Make the CTA explicit on the closing page
+
+## PDF Export
+
+This skill should output a PDF after the HTML pages are complete.
+
+Preferred method:
+
+- Generate a `print.html` with one page per printed sheet
+- Use a browser or Playwright print-to-PDF flow
+
+Print requirements:
+
+- One e-book page per PDF page
+- No browser chrome
+- Zero accidental page breaks
+- Preserve background colors and images
+- Keep portrait sizing consistent across the document
+
+If exporting via Playwright or Chromium, ensure print CSS forces exact page boundaries cleanly.
+
+## Recommended Print CSS
+
+Use print rules like:
+
+- fixed portrait page width and height
+- `page-break-after: always` on each page wrapper
+- final page wrapper `page-break-after: auto`
+- `print-color-adjust: exact`
+
+The goal is a merged PDF that looks like a designed publication, not a scrolling web article.
+
+## Suggested Ebook Shapes
+
+### Quick Guide
+
+Typical sequence:
+
+1. Cover
+2. TOC
+3. Problem or context
+4. Framework or playbook
+5. Example or proof
+6. CTA
+
+### Thought-Leadership Ebook
+
+Typical sequence:
+
+1. Cover
+2. TOC
+3. Thesis or trend framing
+4. Section intro
+5. Core argument
+6. Supporting proof
+7. Framework or model
+8. Implications
+9. Recommendation
+10. CTA
+
+### Product-Education Ebook
+
+Typical sequence:
+
+1. Cover
+2. TOC
+3. Problem framing
+4. Best-practice framework
+5. Common mistakes
+6. Product-supported approach
+7. Results or case proof
+8. CTA
+
+## If Content Must Be Drafted
+
+If the user asks you to draft from scratch:
+
+1. Build the page outline first
+2. Draft concise page copy per page
+3. Keep the tone aligned with the target reader
+4. Favor clarity, specificity, and B2B usefulness
+5. Avoid sounding generic, inflated, or obviously AI-written
+
+Write for a polished lead magnet, not a blog post pasted into PDF.
+
+## Success Criteria
+
+A strong output from this skill should feel:
+
+- Print-ready without manual redesign
+- Structured around audience and CTA
+- Visually consistent across all pages
+- Readable in PDF on desktop and tablet
+- Polished enough to use as a real gated asset
+
+## Dependencies
+
+Required skill:
+
+- `goose-graphics`
+
+Recommended skills:
+
+- `visual-brand-extractor`
+- `goose-graphics-create-style`
+- `graphic-chart`
+- `technical-blog-graphics`
+
+## Example Request
+
+```text
+Create a 6-page e-book titled "The B2B SaaS Guide to Reducing Churn." Audience: Customer Success Managers at 50-500 person SaaS companies. Use clean-slate style. CTA: book a demo of our platform.
+```
+
+Expected result:
+
+- A planned 6-page e-book
+- HTML pages in `ebook/[name]-pages/`
+- Matching print-ready PDF in `ebook/[name].pdf`

--- a/skills/composites/graphic-ebook/skill.meta.json
+++ b/skills/composites/graphic-ebook/skill.meta.json
@@ -1,0 +1,32 @@
+{
+  "slug": "graphic-ebook",
+  "category": "composites",
+  "tags": [
+    "content",
+    "design"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install graphic-ebook",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "requires_skills": [
+    "goose-graphics"
+  ],
+  "recommends_skills": [
+    "visual-brand-extractor",
+    "goose-graphics-create-style",
+    "graphic-chart",
+    "technical-blog-graphics"
+  ],
+  "features": [
+    "Creates professionally designed B2B SaaS e-books as HTML + CSS with PDF export",
+    "Supports a 9-layout page library including cover, TOC, chapter, sidebar, stat, visual, and CTA pages",
+    "Uses Gooseworks style themes with validated recommendations for lead magnets and thought-leadership assets",
+    "Outputs one HTML file per page with optional preview and print files",
+    "Optimized for portrait, print-ready gated content and nurture assets"
+  ]
+}

--- a/skills/composites/graphic-gif/SKILL.md
+++ b/skills/composites/graphic-gif/SKILL.md
@@ -1,0 +1,344 @@
+---
+name: graphic-gif
+description: Generate looping animated GIFs from a prompt by rendering HTML + CSS animations to frames and compiling them into a `.gif`, or by using an optional image-to-video workflow when external APIs are available. Use when the user needs animated text, icons, counters, tickers, or motion graphics for social posts, blog embeds, lightweight ads, or product marketing, and the final deliverable should be a GIF rather than a static PNG.
+tags: [content, design]
+---
+
+# Graphic GIF
+
+Generate looping animated GIFs with a default HTML + CSS animation workflow, then compile the frames into a `.gif`.
+
+This skill is for motion-light graphics: animated quotes, stat reveals, typewriter hooks, CTA pulses, simple loops, and compact social graphics that should feel designed but not like a full video production. The output should be a real GIF, optimized for looping and shareability.
+
+## Core Promise
+
+1. Accept a prompt plus motion parameters
+2. Choose the safest animation workflow
+3. Render an HTML animation or optional AI-driven short motion source
+4. Capture or convert frames into a looping GIF
+5. Optimize the result for quality, smoothness, and file size
+
+## Best Fit
+
+- Animated social media graphics
+- Looping stat reveals
+- Typewriter hooks
+- Pulsing CTAs
+- Simple text-and-shape motion graphics
+- Lightweight blog or newsletter embeds
+
+## Use Something Else
+
+- If the user needs a static chart or diagram, use `graphic-chart` or `technical-blog-graphics`.
+- If the user needs a static branded visual instead of animation, use `goose-graphics`.
+- If the user needs a longer, non-looping video deliverable, use a motion-video skill instead of a GIF workflow.
+
+## Accepted Inputs
+
+Required:
+
+- `prompt`
+
+Optional:
+
+- `animation_type`
+- `duration`
+- `fps`
+- `loop`
+- `style`
+- `dimensions`
+- `optimization`
+
+## Input Defaults
+
+If the user does not specify values, use:
+
+- `animation_type`: `css-animated`
+- `duration`: `3.0`
+- `fps`: `12`
+- `loop`: `true`
+- `style`: `clean-slate`
+- `dimensions`: `800x800`
+- `optimization`: `balanced`
+
+## Animation Workflow Choice
+
+### Default to CSS Animated
+
+Use the CSS workflow for almost all requests involving:
+
+- text reveal
+- counters
+- fades
+- slides
+- pulses
+- looped icon or shape motion
+- terminal-style typing
+
+This is the preferred path because it is more controllable, more reproducible, and does not rely on external image-to-video credentials.
+
+### Use AI Generated Only When Justified
+
+Use an AI-generated path only when:
+
+- the user explicitly asks for painterly or cinematic motion
+- the requested animation depends on complex image motion that CSS cannot fake well
+- an image-to-video API is actually available in the current environment
+
+If no external API or conversion path is available, stay on the CSS route rather than pretending the AI path exists.
+
+## Supported Animation Types
+
+| Animation | Description | Best Use |
+|-----------|-------------|----------|
+| `fade-in` | Content fades in from transparent | Quotes, announcements |
+| `slide-in` | Elements move in from an edge | Headlines, icons, stats |
+| `typewriter` | Text appears character by character | Hooks, claims, terminal motifs |
+| `counter` | Numbers count up to a target | Metrics, KPI reveals |
+| `pulse` | Repeating scale or glow pulse | CTAs, buttons, icons |
+| `loop-scroll` | Infinite ticker or marquee motion | Feeds, logos, lists |
+
+If the user describes motion in prose, map it to one or two of these patterns instead of inventing a chaotic multi-effect sequence.
+
+## Style Guidance
+
+Simpler palettes and backgrounds usually produce better GIFs.
+
+Recommended styles:
+
+- `clean-slate`
+- `terminal`
+- `electric-burst`
+- `brutalist`
+
+Avoid heavy photographic backgrounds, dense gradients, and tiny decorative details. Too many colors increase file size and can create banding or muddy loops.
+
+If the user names a style, verify it exists first:
+
+```bash
+npx gooseworks styles list
+npx gooseworks styles search "clean slate"
+npx gooseworks styles get <slug>
+```
+
+If the user provides no style, default to `clean-slate`.
+
+## Output Defaults
+
+- Output file: `animation.gif`
+- Default canvas: `800x800`
+- Default duration: `3.0` seconds
+- Default FPS: `12`
+- Default loop: `true`
+
+Typical output size:
+
+- `500 KB` to `3 MB` depending on duration, color complexity, dimensions, and optimization mode
+
+## Output Structure
+
+Recommended output structure:
+
+```text
+gif/[name]/
+  animation.html
+  animation.gif
+```
+
+Optional support files:
+
+```text
+gif/[name]/
+  frames/
+  animation.mp4
+  source.png
+  assets/
+```
+
+## Optimization Modes
+
+| Mode | Priority | Behavior |
+|------|----------|----------|
+| `quality` | visual fidelity | more frames, more colors, larger file |
+| `balanced` | default tradeoff | moderate frame rate and palette control |
+| `filesize` | lightweight sharing | fewer frames, reduced colors, simpler motion |
+
+If the user cares about email embeds, docs, or lightweight social sharing, bias toward `filesize` or `balanced`.
+
+## Workflow
+
+### Step 1 - Understand the Motion Job
+
+Before rendering anything, resolve:
+
+1. What should move
+2. What should stay static
+3. What the viewer should notice first
+4. Whether the loop should feel seamless or deliberately restart
+5. Whether the asset is for social, blog, internal doc, or ad use
+
+If the user only says "make a GIF," clarify the visual concept and motion pattern before proceeding.
+
+### Step 2 - Choose the Animation Path
+
+#### CSS Path
+
+Use HTML + CSS when:
+
+- the motion is shape-based or text-based
+- timing matters
+- the user needs clean, branded, deterministic output
+- you need a small, repeatable loop
+
+#### AI Path
+
+Use an external image-to-video path only when:
+
+- the concept depends on richer visual motion
+- a base still frame can be prepared first
+- API access and a video-to-GIF conversion path are available
+
+If using the AI path, create the still frame first with `goose-graphics` or another approved graphic generation path, then animate from that source.
+
+### Step 3 - Design for the Loop
+
+Good GIF loops are planned, not improvised.
+
+Rules:
+
+- keep motion simple
+- animate only one to three focal elements when possible
+- avoid jump cuts unless intentionally punchy
+- make the last frame connect naturally back to the first
+- prefer stable backgrounds
+
+For typewriter and counter loops, consider a short hold at the end before the restart.
+
+### Step 4 - Build the HTML Animation
+
+For the CSS route, generate a self-contained HTML file that:
+
+- creates a fixed-size artboard
+- applies the chosen style
+- uses `@keyframes` for motion
+- times each element intentionally
+- renders cleanly in a headless browser at the requested dimensions
+
+Recommended output:
+
+```text
+gif/[name]/animation.html
+```
+
+Keep the DOM simple. GIFs do not benefit from elaborate page structure.
+
+### Step 5 - Capture Frames
+
+Capture frames via headless Chromium or the Gooseworks screenshot flow at the requested FPS.
+
+Frame-capture rules:
+
+- render at exact target dimensions
+- preserve background colors
+- capture enough frames for smoothness, but not so many that the GIF becomes wasteful
+- keep timing consistent
+
+As a starting point:
+
+- `8-10 fps` for simple pulsing or fading
+- `12 fps` for most social loops
+- `15-18 fps` only when motion really benefits from it
+
+### Step 6 - Assemble the GIF
+
+Compile the frames into a looping GIF using a frame assembly or image processing library.
+
+Requirements:
+
+- preserve frame order
+- honor the loop setting
+- honor optimization priority
+- avoid visible palette collapse on highlighted elements
+
+If the source path produces a short video, convert the final video to GIF only after trimming and sizing it to the intended loop.
+
+## Animation-Specific Guidance
+
+### Typewriter
+
+- keep lines short
+- use a monospaced or display-safe font if the style allows
+- time pauses so the statement is readable before reset
+- avoid too much text for the duration
+
+### Counter
+
+- make the final number the star
+- keep supporting labels static or lightly animated
+- ensure the count speed matches the duration
+
+### Pulse
+
+- use subtle scale or glow changes
+- avoid harsh flashing
+- keep the background stable
+
+### Loop Scroll
+
+- ensure the ticker loops seamlessly
+- duplicate content as needed to hide the seam
+- keep the speed readable
+
+## Legibility Rules
+
+- Text must remain readable frame by frame
+- Motion must not obscure the main message
+- Keep one primary focus area
+- Avoid more than necessary colors and micro-details
+- If the GIF is too busy, reduce elements before increasing duration
+
+Never trade comprehension for novelty.
+
+## Quality Checks
+
+Before delivery, verify:
+
+- the loop is smooth
+- the key message is understandable within one cycle
+- the first and last frames connect cleanly
+- the style remains readable after GIF color reduction
+- the file size matches the likely delivery context
+
+If the GIF feels jittery or bloated, simplify the motion or lower FPS before shipping.
+
+## Success Criteria
+
+A strong output from this skill should feel:
+
+- loop-ready
+- visually intentional
+- small enough to share comfortably
+- clear even without sound
+- stronger than a static graphic, but lighter than a full video
+
+## Dependencies
+
+Required skill:
+
+- `goose-graphics`
+
+Recommended skills:
+
+- `goose-graphics-create-style`
+
+## Example Request
+
+```text
+Create an animated GIF with a typewriter effect. Text: "73% of B2B buyers read 3+ pieces of content before contacting sales." Style: terminal. Duration: 3 seconds. FPS: 12. Loop: true.
+```
+
+Expected result:
+
+- animation HTML
+- captured frames
+- a looping `animation.gif` with readable typewriter timing

--- a/skills/composites/graphic-gif/skill.meta.json
+++ b/skills/composites/graphic-gif/skill.meta.json
@@ -1,0 +1,29 @@
+{
+  "slug": "graphic-gif",
+  "category": "composites",
+  "tags": [
+    "content",
+    "design"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install graphic-gif",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "requires_skills": [
+    "goose-graphics"
+  ],
+  "recommends_skills": [
+    "goose-graphics-create-style"
+  ],
+  "features": [
+    "Generates looping GIFs from HTML and CSS animations, then compiles captured frames into a .gif",
+    "Supports fade, slide, typewriter, counter, pulse, and loop-scroll animation patterns",
+    "Includes an optional AI-generated motion path when external image-to-video tooling is available",
+    "Uses Gooseworks-compatible style themes with guidance for GIF-safe color and background choices",
+    "Optimized for social loops, blog embeds, lightweight ads, and other compact animated graphics"
+  ]
+}


### PR DESCRIPTION
## Summary
- add three new graphic composite skills under `skills/composites`
- include a clear `SKILL.md` description and matching `skill.meta.json` for each skill
- register all three skills in `skills-index.json`

## Added Skills
- `graphic-case-study`
  - adds a composite for sales- and marketing-ready B2B SaaS case study PDFs
  - supports 1-page, 2-page, and 4-page structures built around challenge, solution, results, testimonial, and CTA
  - includes anonymization guidance, stat-led proof handling, and Gooseworks style selection

- `graphic-ebook`
  - adds a composite for B2B SaaS e-books and lead magnets designed in HTML + CSS with PDF export
  - supports structured portrait page layouts, CTA-driven content planning, and validated Gooseworks style recommendations
  - includes routing guidance for supporting charts and technical diagrams when the asset needs richer visuals

- `graphic-gif`
  - adds a composite for looping animated GIF generation with a CSS-to-frames default workflow
  - supports typewriter, counter, pulse, fade, slide, and ticker-style motion patterns
  - includes an optional AI motion path when external image-to-video tooling is available, without making that path a hard dependency

## Notes
- all three skills follow the existing graphics composite conventions in this repo
- each skill includes installation metadata and is indexed for discovery
