### PR TITLE
Add job automation and skill promotion skills

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-04-29",
+  "generated": "2026-04-30",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -1473,6 +1473,40 @@
             "codex"
           ]
         }
+      }
+    },
+    {
+      "slug": "dice-easy-apply-automation",
+      "name": "dice-easy-apply-automation",
+      "category": "capabilities",
+      "description": "",
+      "tags": "lead-generation",
+      "path": "skills/capabilities/dice-easy-apply-automation",
+      "files": [
+        "skills/capabilities/dice-easy-apply-automation/SKILL.md",
+        "skills/capabilities/dice-easy-apply-automation/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "dice-easy-apply-automation",
+        "category": "capabilities",
+        "tags": [
+          "lead-generation"
+        ],
+        "installation": {
+          "base_command": "npx gooseworks install dice-easy-apply-automation",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Finds suitable remote technology roles on Dice",
+          "Uses conservative Easy Apply decision rules",
+          "Tracks prior submissions to avoid duplicates"
+        ],
+        "github_url": "https://github.com/ralyodio/dice-easy-apply-automation-skill",
+        "author": "Anthony Ettinger"
       }
     },
     {
@@ -3171,6 +3205,40 @@
       }
     },
     {
+      "slug": "linkedin-easy-apply-automation",
+      "name": "linkedin-easy-apply-automation",
+      "category": "capabilities",
+      "description": "",
+      "tags": "lead-generation",
+      "path": "skills/capabilities/linkedin-easy-apply-automation",
+      "files": [
+        "skills/capabilities/linkedin-easy-apply-automation/SKILL.md",
+        "skills/capabilities/linkedin-easy-apply-automation/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "linkedin-easy-apply-automation",
+        "category": "capabilities",
+        "tags": [
+          "lead-generation"
+        ],
+        "installation": {
+          "base_command": "npx gooseworks install linkedin-easy-apply-automation",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Finds relevant LinkedIn Easy Apply roles",
+          "Uploads the current resume when needed",
+          "Skips custom forms that require unverifiable answers"
+        ],
+        "github_url": "https://github.com/ralyodio/linkedin-easy-apply-automation-skill",
+        "author": "Anthony Ettinger"
+      }
+    },
+    {
       "slug": "linkedin-influencer-discovery",
       "name": "linkedin-influencer-discovery",
       "category": "capabilities",
@@ -4091,6 +4159,40 @@
           "seo-domain-analyzer",
           "site-content-catalog"
         ]
+      }
+    },
+    {
+      "slug": "promote-skill",
+      "name": "promote-skill",
+      "category": "composites",
+      "description": "",
+      "tags": "content",
+      "path": "skills/composites/promote-skill",
+      "files": [
+        "skills/composites/promote-skill/SKILL.md",
+        "skills/composites/promote-skill/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "promote-skill",
+        "category": "composites",
+        "tags": [
+          "content"
+        ],
+        "installation": {
+          "base_command": "npx gooseworks install promote-skill",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Prepares public safe agent skills",
+          "Publishes source repositories and listings",
+          "Generates marketplace specific submission checklists"
+        ],
+        "github_url": "https://github.com/ralyodio/promote-skill",
+        "author": "Anthony Ettinger"
       }
     },
     {

--- a/skills/capabilities/dice-easy-apply-automation/SKILL.md
+++ b/skills/capabilities/dice-easy-apply-automation/SKILL.md
@@ -1,0 +1,11 @@
+# Dice Easy Apply Automation
+
+Use this skill when a user wants an agent to find relevant remote technology roles on Dice and submit Easy Apply applications with conservative rules.
+
+The agent should prefer remote software engineering, web engineering, full stack, frontend, backend, JavaScript, TypeScript, React, Node, generative AI, LLM, and agentic AI roles. It should avoid roles that clearly require hybrid attendance, local office presence, relocation, unverifiable custom answers, or unrelated seniority and domain requirements.
+
+Before applying, the agent should verify that the resume and optional cover letter are current, confirm work authorization answers are consistent with the user profile, and keep an idempotent record of jobs already submitted. It should treat unclear questions as a skip condition rather than guessing.
+
+Use a persistent browser profile when login is required. Never store credentials in the skill file, source repository, logs, screenshots, or final report. If credentials are needed, the agent should request them through the active secure task channel or rely on an existing authenticated session.
+
+Report submitted roles with company, title, and job page. Report skipped roles only when the skip reason is useful for future tuning.

--- a/skills/capabilities/dice-easy-apply-automation/skill.meta.json
+++ b/skills/capabilities/dice-easy-apply-automation/skill.meta.json
@@ -1,0 +1,22 @@
+{
+  "slug": "dice-easy-apply-automation",
+  "category": "capabilities",
+  "tags": [
+    "lead-generation"
+  ],
+  "installation": {
+    "base_command": "npx gooseworks install dice-easy-apply-automation",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Finds suitable remote technology roles on Dice",
+    "Uses conservative Easy Apply decision rules",
+    "Tracks prior submissions to avoid duplicates"
+  ],
+  "github_url": "https://github.com/ralyodio/dice-easy-apply-automation-skill",
+  "author": "Anthony Ettinger"
+}

--- a/skills/capabilities/linkedin-easy-apply-automation/SKILL.md
+++ b/skills/capabilities/linkedin-easy-apply-automation/SKILL.md
@@ -1,0 +1,9 @@
+# LinkedIn Easy Apply Automation
+
+Use this skill when a user wants an agent to search LinkedIn for relevant software engineering roles and submit Easy Apply applications with the current resume.
+
+The agent should focus on remote or clearly acceptable software engineering roles, including web, full stack, frontend, backend, JavaScript, TypeScript, React, Node, generative AI, LLM, and agentic AI roles. It should skip roles that require local office attendance, hybrid attendance when the user wants remote, relocation, unclear compensation commitments, or custom screening questions that cannot be answered from known facts.
+
+The agent should use a persistent browser profile for login, keep submission state so repeated runs are safe, and upload the current resume when the flow asks for one. It should answer only stable known facts and avoid inventing employment history, credentials, salary numbers, or location commitments.
+
+Never store or print credentials. Use an already authenticated browser session or task scoped secrets only. The final report should include submitted title, company, and page when available, plus concise skip reasons for anything important.

--- a/skills/capabilities/linkedin-easy-apply-automation/skill.meta.json
+++ b/skills/capabilities/linkedin-easy-apply-automation/skill.meta.json
@@ -1,0 +1,22 @@
+{
+  "slug": "linkedin-easy-apply-automation",
+  "category": "capabilities",
+  "tags": [
+    "lead-generation"
+  ],
+  "installation": {
+    "base_command": "npx gooseworks install linkedin-easy-apply-automation",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Finds relevant LinkedIn Easy Apply roles",
+    "Uploads the current resume when needed",
+    "Skips custom forms that require unverifiable answers"
+  ],
+  "github_url": "https://github.com/ralyodio/linkedin-easy-apply-automation-skill",
+  "author": "Anthony Ettinger"
+}

--- a/skills/composites/promote-skill/SKILL.md
+++ b/skills/composites/promote-skill/SKILL.md
@@ -1,0 +1,9 @@
+# Promote Skill
+
+Use this skill when a user wants to publish a public agent skill across source hosts and skill marketplaces.
+
+The agent should start by validating that the skill source is safe for public release. It should remove credentials, cookies, private paths, personal secrets, one off session details, and any private operational data. Environment variable names and setup descriptions are acceptable when they do not include real values.
+
+Next, create a public source location and marketplace listing where authenticated access is available. Prefer a repository when a marketplace indexes repositories, and a direct raw skill file when a marketplace imports a file. For marketplaces that require review, account approval, wallet connection, or a pull request, prepare the submission package and complete the account or review flow when the user has authorized it.
+
+The final report should separate published pages from submitted for review pages and blocked destinations. Do not claim worldwide publication when a platform still needs account approval or manual review.

--- a/skills/composites/promote-skill/skill.meta.json
+++ b/skills/composites/promote-skill/skill.meta.json
@@ -1,0 +1,22 @@
+{
+  "slug": "promote-skill",
+  "category": "composites",
+  "tags": [
+    "content"
+  ],
+  "installation": {
+    "base_command": "npx gooseworks install promote-skill",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Prepares public safe agent skills",
+    "Publishes source repositories and listings",
+    "Generates marketplace specific submission checklists"
+  ],
+  "github_url": "https://github.com/ralyodio/promote-skill",
+  "author": "Anthony Ettinger"
+}


### PR DESCRIPTION
Adds three public SKILL.md entries:\n\n- dice-easy-apply-automation\n- linkedin-easy-apply-automation\n- promote-skill\n\nValidation run:\n- npm run build:index\n- npm run validate:skills\n- npm test