### PR TITLE
Lock goose-graphics formats to seven canvas dimensions

### DIFF
--- a/skills/composites/goose-graphics-create-format/SKILL.md
+++ b/skills/composites/goose-graphics-create-format/SKILL.md
@@ -19,9 +19,18 @@ with an existing style.
 
 ## When to use this skill
 
-Use when the existing community-published formats don't fit the user's canvas
-needs — e.g., LinkedIn banner (1584×396), story cover (1080×1920), event flyer
-(8.5×11in / 2550×3300px @ 300dpi), TikTok cover, podcast cover, blog hero, etc.
+Use when the user wants a new named format with its own content rules —
+a story cover, a podcast cover, a square testimonial — that maps to one
+of the seven built-in canvas sizes (carousel, infographic, slides,
+poster, story, chart, tweet). The new format defines new rules and a
+new slug; it inherits dimensions from one of those canvases.
+
+**Custom canvas dimensions are not supported.** If the user wants a
+canvas size that isn't in the seven built-ins (e.g. LinkedIn banner
+1584×396, US Letter 2550×3300), tell them honestly — that requires a
+code change to the `goose-graphics` skill pack's `FORMAT_CONFIGS` and is
+out of scope for this skill. Suggest the closest existing canvas
+instead.
 
 **Always check first:** run `npx gooseworks formats list` (or `formats search
 "banner"` etc.) to see whether a community-published format already covers the
@@ -29,9 +38,16 @@ use case. If one fits, just use it via the regular `goose-graphics` flow.
 
 ## Prerequisites
 
-- The `goose-graphics` skill must be installed in the same workspace. This skill
-  uses `goose-graphics/screenshot/screenshot.js` to render examples and pulls
-  style specs via `npx gooseworks styles get <slug>`.
+- The `goose-graphics` skill must be installed in the same workspace —
+  this skill uses `goose-graphics/screenshot/screenshot.js` to render
+  examples and pulls style specs via `npx gooseworks styles get <slug>`.
+  Install via:
+  ```bash
+  npx gooseworks install --claude --with goose-graphics
+  ```
+  (Swap `--claude` for `--cursor` or `--codex` as needed.) See the install
+  page on the hub for the canonical command:
+  https://skills.gooseworks.ai/skills/goose-graphics
 - The screenshot tool's dependencies must be installed
   (`goose-graphics/screenshot/node_modules/` must exist). If not:
   ```bash
@@ -61,20 +77,43 @@ rendered example is mandatory.
 
 ## Workflow
 
-### Step 1 — Confirm dimensions and intent
+### Step 1 — Pick a canvas (from the fixed allow-list) and confirm intent
 
-Ask the user:
+A new format is **a new slug + new content rules over one of the seven
+built-in canvas sizes** — *not* a new canvas. Custom dimensions are not
+supported: every renderer in the system (CLI screenshot tool, hub, other
+agents) is locked to this allow-list, and creating a format with custom
+`width`/`height` would produce something nobody can render.
 
-- What are the exact pixel dimensions? (Width × height. Be precise — formats
-  are immutable once published.)
+Pick the canvas the new format should use:
+
+| Canvas slug   | Dimensions | Best for                                   |
+|---------------|------------|--------------------------------------------|
+| `poster`      | 1080×1350  | Vertical hero composition, single panel    |
+| `infographic` | 1080×var.  | Tall vertical scroll, multi-section        |
+| `carousel`    | 1080×1080  | Square single panel / multi-slide          |
+| `slides`      | 1920×1080  | Widescreen / presentation                  |
+| `story`       | 1080×1920  | Vertical full-screen (IG/TikTok stories)   |
+| `chart`       | 1080×1080  | Square data viz                            |
+| `tweet`       | 1080×1080  | Square testimonial / social card           |
+
+Then ask the user:
+
+- Which canvas best fits the use case? (Pick from the table above.)
 - What is this format for? (Surface, platform, audience.)
-- What is the maximum content density? (Title length, body length, item counts,
-  whether it's single-panel or multi-panel.)
+- What is the maximum content density? (Title length, body length, item
+  counts, whether it's single-panel or multi-panel.)
 
-Sanity-check the dimensions against the spec constraint: width and height are
-integers in `[64, 8192]`. If the user says "8.5×11 inches," translate to pixels
-(typically 2550×3300 at 300dpi or 850×1100 at 100dpi — clarify the resolution
-before committing).
+The new format inherits the canvas's `width`/`height` exactly. Set the
+manifest's `width`/`height` fields to the canvas's dimensions verbatim
+(e.g. 1080/1350 for a poster-canvas format). Do not invent new
+dimensions — the publish step will reject anything that doesn't match
+one of the seven canvases.
+
+If the user wants a canvas that isn't in the list (e.g. LinkedIn banner
+1584×396), tell them honestly: that's a code change to the
+`goose-graphics` skill pack's `FORMAT_CONFIGS` and is out of scope for
+this skill. Suggest the closest existing canvas instead.
 
 ### Step 2 — Pick a name and slug
 
@@ -127,18 +166,18 @@ For each example:
    - Fixed pixel sizes only — no `vw`/`vh`/`%`/`rem`/`em`/`clamp()`.
    - Outer dimensions match exactly:
      `html, body { width: <W>px; height: <H>px; overflow: hidden; }`.
-4. Render via the screenshot tool from the `goose-graphics` skill pack:
+4. Render via the screenshot tool from the `goose-graphics` skill pack,
+   passing the **canvas slug** (carousel/infographic/slides/poster/story/
+   chart/tweet — the one chosen in Step 1), not the new format's slug:
    ```bash
    node <path-to>/goose-graphics/screenshot/screenshot.js \
-     --format <new-format-slug> \
+     --format <canvas-slug> \
      --input <path-to-html> \
      --output <working-dir>/example-N.png \
      --font-delay 1500
    ```
-   The `--format` flag tells the screenshot tool how to size the viewport. If
-   the screenshot tool doesn't yet recognize the new slug, fall back to
-   `--width <W> --height <H>` (or whatever the current screenshot tool's
-   override flags are — check `screenshot.js --help`).
+   This works out of the box — the new format inherits the canvas's
+   dimensions, so no code changes are needed anywhere.
 
 ### Step 5 — Write `gooseworks-format.json`
 
@@ -146,13 +185,13 @@ Match the shape documented in `goose-graphics/SKILL.md` §17.2. Required:
 
 ```json
 {
-  "name": "LinkedIn Banner",
-  "slug": "linkedin-banner",
-  "description": "1584×396 LinkedIn profile background. Single horizontal banner; minimal text (4 words max), abstract backdrop, optional small logo lower-right. Use for professional brand presence on LinkedIn company and personal pages.",
-  "width": 1584,
-  "height": 396,
-  "contentRulesMd": "## Rules\n\n- Title: 4 words max, large display, top-left or center\n- No body copy\n- One brand mark optional, lower-right, ≤8% of canvas\n…",
-  "tags": ["linkedin", "banner", "horizontal", "professional"],
+  "name": "Story Cover",
+  "slug": "story-cover",
+  "description": "1080×1920 vertical cover slide for Instagram and TikTok stories. Single hero panel, 5-word title max, optional brand mark in the lower 10%. Use for product launches and event reminders where the viewer scrolls past in 2 seconds.",
+  "width": 1080,
+  "height": 1920,
+  "contentRulesMd": "## Rules\n\n- Title: 5 words max, large display, centered or top-left\n- One hero element (image, stat, or large icon) in the upper 70% of the canvas\n- Optional brand mark in the lower 10%, ≤8% of canvas height\n…",
+  "tags": ["story", "vertical", "social", "instagram", "tiktok"],
   "examples": [
     { "file": "./example-1.png", "styleSlug": "matt-gray", "caption": "Paired with matt-gray" },
     { "file": "./example-2.png", "styleSlug": "neon-dashboard" }
@@ -164,7 +203,12 @@ Match the shape documented in `goose-graphics/SKILL.md` §17.2. Required:
 
 - `name`: 1–120 chars
 - `description`: 20–1000 chars (**required**). See guidelines below.
-- `width` / `height`: integers, 64–8192
+- `width` / `height`: **must match one of the seven built-in canvases
+  exactly** (1080×1080, 1080×1350, 1920×1080, 1080×1920, or
+  1080×variable for infographic). Custom dimensions will render fine
+  locally if you stretch the rules but will fail for any other agent that
+  pulls the format later, since their `screenshot.js` only accepts the
+  built-in canvas slugs.
 - `contentRulesMd`: minimum 50 chars (**required**)
 - `tags`: 3–10 lowercase strings. See guidelines below.
 - `examples`: minimum 1 (**required**); `styleSlug` is optional but recommended.
@@ -191,7 +235,7 @@ npx gooseworks formats publish --yes
 
 ```
 Published format: <slug>
-https://app.gooseworks.ai/formats/<slug>
+https://skills.gooseworks.ai/formats/<slug>
 ```
 
 **Exit codes:** `0` success, `1` transient/auth (network, 401, 5xx), `2` user
@@ -218,10 +262,11 @@ Tell the user:
 
 ## Description-writing guidelines
 
-Same shape as styles — 50–200 words, keyword-dense — but lead with **dimensions
+Same shape as styles — 50–200 words, keyword-dense — but lead with **canvas
 and content density** instead of mood.
 
-- Lead with dimensions + surface: `"1584×396 LinkedIn profile background."`
+- Lead with canvas + surface: `"1080×1080 square testimonial card for X
+  feed posts."`
 - Mention single-panel vs multi-panel and approximate text limits.
 - Mention intended platform / surface (`Instagram Stories`, `LinkedIn`,
   `print event flyer`, etc.).

--- a/skills/composites/goose-graphics-create-style/SKILL.md
+++ b/skills/composites/goose-graphics-create-style/SKILL.md
@@ -31,8 +31,15 @@ it via the regular `goose-graphics` flow.
 
 ## Prerequisites
 
-- The `goose-graphics` skill must be installed in the same workspace. This
-  skill uses its `screenshot/screenshot.js` to render examples.
+- The `goose-graphics` skill must be installed in the same workspace —
+  this skill uses its `screenshot/screenshot.js` to render examples.
+  Install via:
+  ```bash
+  npx gooseworks install --claude --with goose-graphics
+  ```
+  (Swap `--claude` for `--cursor` or `--codex` as needed.) See the install
+  page on the hub for the canonical command:
+  https://skills.gooseworks.ai/skills/goose-graphics
 - The screenshot tool's dependencies must be installed
   (`goose-graphics/screenshot/node_modules/` must exist). If not:
   ```bash
@@ -242,6 +249,14 @@ node <path-to>/goose-graphics/screenshot/screenshot.js \
   --font-delay 1500
 ```
 
+**Single-file vs directory input:** carousel, slides, and story are
+"multi-file" formats by default — if `--input` is a directory, the tool
+renders every `.html` file inside it to numbered `slide-NN.png` files in
+the `--output` directory. For the single representative slide we want
+here, pass a single `.html` file as `--input` and a single PNG path as
+`--output` — the tool detects the file input and writes one PNG. The
+other formats (poster, infographic, chart, tweet) are always single-file.
+
 Common failure modes:
 
 - Content overflows the fixed canvas → reduce font sizes or simplify
@@ -329,7 +344,7 @@ npx gooseworks styles publish --yes
 
 ```
 Published style: <slug>
-https://app.gooseworks.ai/styles/<slug>
+https://skills.gooseworks.ai/styles/<slug>
 ```
 
 **Exit codes:** `0` success, `1` transient/auth (network, 401, 5xx), `2`

--- a/skills/composites/goose-graphics/SKILL.md
+++ b/skills/composites/goose-graphics/SKILL.md
@@ -179,7 +179,7 @@ Ask the user what they want to create. Run `npx gooseworks formats list` to see 
 | **Chart** | 1080x1080px | Single data chart graphic |
 | **Tweet** | 1080x1080px | Tweet-sized square screenshot |
 
-The community library may publish additional formats (LinkedIn banners, story covers, etc.) — always run `list` first rather than assuming the seven above are exhaustive. If none of the available formats fit the user's needs, suggest the `/goose-graphics-create-format` skill.
+The community library may publish additional formats (story covers, podcast covers, square testimonials, etc.) — always run `list` first rather than assuming only the seven baseline slugs exist. Note that every community format must use one of the seven canvas sizes above (the renderer is locked to that allow-list); they differ from the baselines only in name, intent, and content rules. If no published format fits the user's needs, suggest the `/goose-graphics-create-format` skill.
 
 Once the user chooses a format, fetch its full spec:
 
@@ -246,14 +246,31 @@ Follow the chosen format spec's **HTML Generation** phase. When generating:
 Run the screenshot script to export HTML files to high-resolution PNGs:
 
 ```bash
-node [skill-pack-dir]/screenshot/screenshot.js --format FORMAT --input INPUT_PATH --output OUTPUT_PATH
+node [skill-pack-dir]/screenshot/screenshot.js --format CANVAS --input INPUT_PATH --output OUTPUT_PATH
 ```
 
 Where:
 - `[skill-pack-dir]` is the absolute path to this skill pack's directory.
-- `FORMAT` is the format slug (e.g., `carousel`, `story`, `poster`, or any community slug whose spec defines a renderer profile).
+- `CANVAS` is **always one of the seven built-in canvas slugs**, never the format's catalog slug. The renderer's allow-list is strict — passing a community format slug like `story-cover` or `linkedin-banner` will fail.
 - `INPUT_PATH` is the directory or file containing the generated HTML.
 - `OUTPUT_PATH` is the directory where PNG files should be saved.
+
+**Map the format's `width`/`height` (from `npx gooseworks formats get <slug>`) to a canvas slug using this table:**
+
+| width × height       | Canvas slug   |
+|----------------------|---------------|
+| 1080 × 1080          | `carousel`    |
+| 1080 × 1350          | `poster`      |
+| 1920 × 1080          | `slides`      |
+| 1080 × 1920          | `story`       |
+| 1080 × ≥1080 (variable) | `infographic` |
+
+Examples:
+- Built-in `poster` (1080×1350) → `--format poster`.
+- Community `story-cover` (1080×1920) → `--format story` (because the format inherits the `story` canvas).
+- Community `linkedin-quote-card` (1080×1080) → `--format carousel` (any 1080×1080 catalog format renders against the `carousel` canvas).
+
+If the format's `width`/`height` doesn't match any row above, the format was published incorrectly — report it to the user and stop. Don't try to render with custom dimensions; the tool can't.
 
 ## 15. Step 7: Deliver
 
@@ -313,13 +330,13 @@ Field constraints:
 
 ```json
 {
-  "name": "LinkedIn Banner",
-  "slug": "linkedin-banner",
-  "description": "1584×396 LinkedIn profile background. Single horizontal banner; minimal text (4 words max), abstract backdrop, optional small logo lower-right. Use for professional brand presence.",
-  "width": 1584,
-  "height": 396,
-  "contentRulesMd": "## Rules\n\n- Title: 4 words max, large display, top-left or center\n- No body copy\n- One brand mark optional, lower-right, ≤8% of canvas\n…",
-  "tags": ["linkedin", "banner", "horizontal", "professional"],
+  "name": "Story Cover",
+  "slug": "story-cover",
+  "description": "1080×1920 vertical cover slide for Instagram and TikTok stories. Single hero panel, 5-word title max, optional brand mark in the lower 10%. Use for product launches and event reminders where the viewer scrolls past in 2 seconds.",
+  "width": 1080,
+  "height": 1920,
+  "contentRulesMd": "## Rules\n\n- Title: 5 words max, large display, centered or top-left\n- One hero element (image, stat, or large icon) in the upper 70% of the canvas\n- Optional brand mark in the lower 10%, ≤8% of canvas height\n…",
+  "tags": ["story", "vertical", "social", "instagram", "tiktok"],
   "examples": [
     { "file": "./example-1.png", "styleSlug": "matt-gray", "caption": "Paired with matt-gray" },
     { "file": "./example-2.png", "styleSlug": "neon-dashboard" }
@@ -331,7 +348,7 @@ Field constraints:
 - `name`: 1–120 chars
 - `slug`: optional kebab-case
 - `description`: 20–1000 chars (**required**)
-- `width` / `height`: integers, 64–8192
+- `width` / `height`: **must match one of the seven built-in canvases**: 1080×1080 (carousel/chart/tweet), 1080×1350 (poster), 1920×1080 (slides), 1080×1920 (story), or 1080×≥1080 (infographic). Custom dimensions are rejected at publish time because the renderer's allow-list is strict.
 - `contentRulesMd`: minimum 50 chars (**required**)
 - `tags`: array of strings
 - `examples`: array, **minimum 1 entry** (**required** — the backend rejects empty)

--- a/skills/composites/goose-graphics/screenshot/screenshot.js
+++ b/skills/composites/goose-graphics/screenshot/screenshot.js
@@ -6,16 +6,29 @@
  * Captures HTML files as PNG images at format-specific dimensions.
  *
  * Usage:
- *   node screenshot.js --format <carousel|infographic|slides|poster|story|chart|tweet> --input <path> --output <path> [--font-delay <ms>]
+ *   node screenshot.js --format <slug> --input <path> --output <path> [--font-delay <ms>]
  *
- * Formats:
- *   carousel     1080x1080px per slide, directory of HTML files -> numbered PNGs
- *   infographic  1080px wide, variable height, single HTML file -> single PNG
- *   slides       1920x1080px per slide, directory of HTML files -> numbered PNGs
- *   poster       1080x1350px, single HTML file -> single PNG
- *   story        1080x1920px per slide, directory of HTML files -> numbered PNGs
- *   chart        1080x1080px, single HTML file -> single PNG
- *   tweet        1080x1080px, single HTML file -> single PNG
+ * Built-in formats (must be one of these — slug is a strict allow-list):
+ *   carousel     1080x1080px per slide
+ *   infographic  1080px wide, variable height (full-page)
+ *   slides       1920x1080px per slide
+ *   poster       1080x1350px
+ *   story        1080x1920px per slide
+ *   chart        1080x1080px
+ *   tweet        1080x1080px
+ *
+ * Input modes:
+ *   - If --input is a directory, every .html file is rendered to numbered
+ *     PNGs (slide-01.png, slide-02.png, …) in the --output directory. This
+ *     is the "multi-file" mode used for carousel/slides/story.
+ *   - If --input is a single .html file, one PNG is written to the --output
+ *     path (any format). For carousel/slides/story this captures a single
+ *     representative slide.
+ *
+ * To render a brand-new custom format (e.g. linkedin-banner 1584×396),
+ * extend FORMAT_CONFIGS below with the new slug + dimensions before running.
+ * The same allow-list is used by hub-side rendering, so unknown slugs are
+ * rejected on purpose.
  */
 
 const path = require('path');
@@ -101,11 +114,12 @@ function parseArgs(argv) {
 function validateArgs(args) {
     if (!args.format) {
         console.error('Error: Missing required --format flag.');
-        console.error('Usage: node screenshot.js --format <carousel|infographic|slides|poster|story|chart|tweet> --input <path> --output <path> [--font-delay <ms>]');
+        console.error('Usage: node screenshot.js --format <slug> --input <path> --output <path> [--font-delay <ms>]');
         process.exit(1);
     }
     if (!FORMAT_CONFIGS[args.format]) {
         console.error(`Error: Invalid format "${args.format}". Must be one of: ${Object.keys(FORMAT_CONFIGS).join(', ')}`);
+        console.error('To render a brand-new custom format, add the slug + dimensions to FORMAT_CONFIGS in this file first.');
         process.exit(1);
     }
     if (!args.input) {
@@ -123,11 +137,29 @@ function validateArgs(args) {
         process.exit(1);
     }
 
+    const config = { ...FORMAT_CONFIGS[args.format] };
+    const inputIsDirectory = fs.statSync(inputPath).isDirectory();
+
+    // A single-file input always runs in single-file mode regardless of the
+    // format's default multiFile setting. This lets carousel/slides/story
+    // render one representative slide when --input points at a single .html.
+    if (!inputIsDirectory) {
+        config.multiFile = false;
+    }
+    // The inverse — passing a directory to a single-file format — is a
+    // misuse and would otherwise fail deep inside the renderer with an
+    // unhelpful page.goto() error. Reject it up front.
+    if (inputIsDirectory && !config.multiFile) {
+        console.error(`Error: Format "${args.format}" expects a single HTML file as --input, not a directory.`);
+        process.exit(1);
+    }
+
     return {
         format: args.format,
         input: inputPath,
         output: path.resolve(args.output),
         fontDelay: args.fontDelay || 500,
+        config,
     };
 }
 
@@ -285,7 +317,7 @@ async function screenshotSingleFile(config, inputFile, outputPath, fontDelay) {
 async function main() {
     const rawArgs = parseArgs(process.argv);
     const args = validateArgs(rawArgs);
-    const config = FORMAT_CONFIGS[args.format];
+    const config = args.config;
 
     await ensureChromium();
 


### PR DESCRIPTION
## Summary

Audit-and-fix pass on `goose-graphics`, `goose-graphics-create-style`, and `goose-graphics-create-format`. The original first-run friction was a `carousel` ENOTDIR error, which surfaced a deeper asymmetry: `screenshot.js` ships a strict format allow-list while every doc and validator implied custom dimensions were allowed. Tightening everything to match the renderer (rather than the other way round) makes the catalog self-consistent end-to-end.

## What changed

- **`screenshot.js`** — single-file `--input` now triggers single-file mode for *any* format slug. Carousel/slides/story can render one representative slide instead of erroring with ENOTDIR. Directory input to non-multi-file formats now errors up front.
- **`goose-graphics-create-style/SKILL.md`** — adds the canonical install command (`npx gooseworks install --claude --with goose-graphics`) and hub link to Prerequisites; documents the single-file vs directory `--input` behavior; success URL corrected to `https://skills.gooseworks.ai/styles/<slug>`.
- **`goose-graphics-create-format/SKILL.md`** — locked to the seven built-in canvases. Authors render examples with the **canvas slug** (carousel/poster/etc.), not the new format slug. Removed the bogus `--width`/`--height` fallback that referenced flags `screenshot.js` doesn't expose. Manifest example refreshed off LinkedIn-banner; success URL corrected.
- **`goose-graphics/SKILL.md`** — consumer-side §14 Step 6 now documents the `width`×`height` → canvas-slug mapping table and explicitly says: pass the canvas slug to `screenshot.js`, never the catalog slug. §17.2 manifest reference scrubbed (canvas allow-list called out in field constraints).

## Why locked, not loosened

`screenshot.js`'s strict allow-list governs every render in the system. We had two ways to fix the asymmetry:
1. Loosen the renderer (add `--width`/`--height`) → would let authors render locally but break for any other agent that pulls the format later, since their `screenshot.js` still wouldn't know the slug.
2. Tighten everything else to match the renderer.

Picked (2). The "LinkedIn-banner" custom-canvas pitch in the original SKILL.md was vapor — there was no path that actually worked end-to-end. We removed the false advertising rather than a working capability.

Companion PR in `gooseworks-app` adds matching client+server validation (`FormatManifestSchema` rejects out-of-allow-list dimensions) so the catalog can't drift back into a state where a published format isn't renderable.

## Test plan

- [x] Author flow: `screenshot.js --format carousel --input <single.html> --output <pic.png>` produces a single PNG (was: ENOTDIR).
- [x] Existing callers that pass directories to multi-file formats still work.
- [x] `screenshot.js --format poster --input <dir>` now errors clearly instead of failing inside `page.goto`.
- [x] Companion gooseworks-app PR's tests pass: `FormatManifestSchema` rejects 1584×396 and accepts each of the seven canvases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)