### PR TITLE
Add video generation composite skills

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -5335,6 +5335,363 @@
       }
     },
     {
+      "slug": "vid-animated-explainer-2d",
+      "name": "vid-animated-explainer-2d",
+      "category": "composites",
+      "description": "Create 2D animated explainer videos from a scene-based script, character notes, and narration plan. Use when the user needs onboarding, product-page, investor, educational, or process-explainer video that should feel more polished than whiteboard animation but lighter and cheaper than live action.",
+      "tags": "content, design",
+      "path": "skills/composites/vid-animated-explainer-2d",
+      "files": [
+        "skills/composites/vid-animated-explainer-2d/SKILL.md",
+        "skills/composites/vid-animated-explainer-2d/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "vid-animated-explainer-2d",
+        "category": "composites",
+        "tags": [
+          "content",
+          "design"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install vid-animated-explainer-2d",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Creates 2D animated explainer videos from scene-based scripts and character notes",
+          "Supports flat, cartoon, corporate, and sketch animation directions",
+          "Uses a structured problem, solution, how-it-works, proof, and CTA flow",
+          "Optimized for onboarding, product-page, investor, and educational explainer use cases",
+          "Outputs a polished MP4 with narration, scene transitions, and optional captions"
+        ]
+      }
+    },
+    {
+      "slug": "vid-customer-testimonial",
+      "name": "vid-customer-testimonial",
+      "category": "composites",
+      "description": "Create customer testimonial videos from verbatim quotes, customer identity details, and format choice. Use when the user needs social proof video for landing pages, sales decks, email follow-up, paid social, or website trust sections, and can provide the real customer words instead of a paraphrased marketing summary.",
+      "tags": "content, design, social",
+      "path": "skills/composites/vid-customer-testimonial",
+      "files": [
+        "skills/composites/vid-customer-testimonial/SKILL.md",
+        "skills/composites/vid-customer-testimonial/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "vid-customer-testimonial",
+        "category": "composites",
+        "tags": [
+          "content",
+          "design",
+          "social"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install vid-customer-testimonial",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Creates customer testimonial videos from verbatim quotes, customer identity details, and result highlights",
+          "Supports talking-head, text-on-video, and split-screen testimonial formats",
+          "Preserves customer voice while tightening for short-form trust-building delivery",
+          "Works for landing pages, paid social, sales decks, email follow-up, and website proof sections",
+          "Outputs a testimonial MP4 with optional photo-based animation, identity overlays, and result-stat callouts"
+        ]
+      }
+    },
+    {
+      "slug": "vid-faq",
+      "name": "vid-faq",
+      "category": "composites",
+      "description": "Create FAQ videos from real question-and-answer pairs as talking-head, text-on-video, or animated MP4s. Use when the user needs support-deflection, pre-purchase objection handling, onboarding help, help-center explainers, or sales follow-up video content, and can provide the actual FAQs rather than a vague topic.",
+      "tags": "content, design, social",
+      "path": "skills/composites/vid-faq",
+      "files": [
+        "skills/composites/vid-faq/SKILL.md",
+        "skills/composites/vid-faq/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "vid-faq",
+        "category": "composites",
+        "tags": [
+          "content",
+          "design",
+          "social"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install vid-faq",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Creates FAQ videos from real question-and-answer pairs in talking-head, text-on-video, or animated formats",
+          "Supports long-form chapterized FAQ videos and short-form social FAQ clips",
+          "Includes sequencing guidance so the most important customer questions lead the video",
+          "Optimizes answers for concise, trust-building video delivery without inventing new claims",
+          "Outputs a clean MP4 with optional captions, chapters, and branded visual treatment"
+        ]
+      }
+    },
+    {
+      "slug": "vid-product-demo-screencast",
+      "name": "vid-product-demo-screencast",
+      "category": "composites",
+      "description": "Create product demo and screencast walkthrough videos from a product URL or recording plus an ordered feature flow. Use when the user needs onboarding, sales-enablement, product-page, feature-release, or walkthrough video that shows the real interface in action instead of describing it abstractly.",
+      "tags": "content, design",
+      "path": "skills/composites/vid-product-demo-screencast",
+      "files": [
+        "skills/composites/vid-product-demo-screencast/SKILL.md",
+        "skills/composites/vid-product-demo-screencast/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "vid-product-demo-screencast",
+        "category": "composites",
+        "tags": [
+          "content",
+          "design"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install vid-product-demo-screencast",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Creates product demo and screencast walkthrough videos from a product URL or recording plus an ordered feature list",
+          "Supports narration generation, click annotations, cursor emphasis, and zoom-on-action behavior",
+          "Keeps feature order aligned to the real on-screen flow rather than marketing order",
+          "Optimized for sales enablement, onboarding, product pages, and feature-release walkthroughs",
+          "Outputs a clean MP4 showing the product in action and ending on the outcome"
+        ]
+      }
+    },
+    {
+      "slug": "vid-product-launch",
+      "name": "vid-product-launch",
+      "category": "composites",
+      "description": "Create cinematic or structured product launch videos from a launch brief, reveal timing, and CTA. Use when the user needs a launch-day announcement, teaser, landing-page hero, email-campaign reveal, or social launch asset with a clear build-to-reveal narrative rather than a generic hype reel.",
+      "tags": "content, design, social",
+      "path": "skills/composites/vid-product-launch",
+      "files": [
+        "skills/composites/vid-product-launch/SKILL.md",
+        "skills/composites/vid-product-launch/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "vid-product-launch",
+        "category": "composites",
+        "tags": [
+          "content",
+          "design",
+          "social"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install vid-product-launch",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Creates product launch videos with a clear tease, build, reveal, proof, and CTA structure",
+          "Supports cinematic, energetic, minimal, and emotional launch tones",
+          "Helps protect the reveal moment and compress feature overload into one strong proof beat",
+          "Works for landing-page heroes, social launch clips, email campaigns, and announcement videos",
+          "Outputs a launch-ready MP4 with product name, tagline, and end-card CTA"
+        ]
+      }
+    },
+    {
+      "slug": "vid-short-form-vertical",
+      "name": "vid-short-form-vertical",
+      "category": "composites",
+      "description": "Create short-form vertical videos from a hook, prompt, format, and platform choice. Use when the user needs Instagram Reels, TikToks, or YouTube Shorts that are mobile-native, hook-first, caption-friendly, and optimized for reach, watch-through, shares, or saves.",
+      "tags": "content, design, social",
+      "path": "skills/composites/vid-short-form-vertical",
+      "files": [
+        "skills/composites/vid-short-form-vertical/SKILL.md",
+        "skills/composites/vid-short-form-vertical/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "vid-short-form-vertical",
+        "category": "composites",
+        "tags": [
+          "content",
+          "design",
+          "social"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install vid-short-form-vertical",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Creates short-form vertical videos from a hook, prompt, and platform choice",
+          "Supports talking-points, list, storytime, POV, and tutorial short-form structures",
+          "Optimizes for Reels, TikTok, and YouTube Shorts with caption-first mobile-native pacing",
+          "Uses a strict hook, payoff, and CTA flow to protect watch-through performance",
+          "Outputs a vertical 9:16 MP4 ready for social distribution"
+        ]
+      }
+    },
+    {
+      "slug": "vid-sizzle-reel",
+      "name": "vid-sizzle-reel",
+      "category": "composites",
+      "description": "Create high-energy sizzle reels from key messages, brand assets, music direction, and end-card content. Use when the user needs a hype-first montage for launches, conference openers, investor decks, event promos, or campaign kickoffs where excitement and momentum matter more than explanation.",
+      "tags": "content, design, social",
+      "path": "skills/composites/vid-sizzle-reel",
+      "files": [
+        "skills/composites/vid-sizzle-reel/SKILL.md",
+        "skills/composites/vid-sizzle-reel/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "vid-sizzle-reel",
+        "category": "composites",
+        "tags": [
+          "content",
+          "design",
+          "social"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install vid-sizzle-reel",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Creates high-energy sizzle reels from key messages, music direction, brand assets, and end-card content",
+          "Supports energetic, cinematic, emotional, and professional montage directions",
+          "Uses a cold-open, build, peak, and brand-land structure for hype-first video",
+          "Works for launches, investor decks, conference openers, event promos, and campaign kickoffs",
+          "Outputs a montage-style MP4 optimized for momentum rather than explanation"
+        ]
+      }
+    },
+    {
+      "slug": "vid-talking-head",
+      "name": "vid-talking-head",
+      "category": "composites",
+      "description": "Create talking-head videos from a word-for-word script, avatar or source face, voice, and background settings. Use when the user needs founder-style messaging, product explanation, educational content, thought leadership, or presenter-led video without filming a real person on camera.",
+      "tags": "content, design, social",
+      "path": "skills/composites/vid-talking-head",
+      "files": [
+        "skills/composites/vid-talking-head/SKILL.md",
+        "skills/composites/vid-talking-head/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "vid-talking-head",
+        "category": "composites",
+        "tags": [
+          "content",
+          "design",
+          "social"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install vid-talking-head",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Creates talking-head videos from exact scripts, avatars or source faces, voices, and background settings",
+          "Supports lip-synced avatar, animated-photo, and real-footage-based talking-head production paths",
+          "Optimizes scripts for spoken rhythm, pause control, captions, and presenter credibility overlays",
+          "Works for founder messaging, thought leadership, product explanation, and educational presenter video",
+          "Outputs a polished talking-head MP4 in horizontal or vertical aspect ratios"
+        ]
+      }
+    },
+    {
+      "slug": "vid-ugc-style",
+      "name": "vid-ugc-style",
+      "category": "composites",
+      "description": "Create UGC-style vertical videos from a product brief, hook, tone, and CTA. Use when the user needs creator-style paid social or organic short-form video that feels authentic, direct-to-camera, and high-retention, especially for Instagram, TikTok, Meta ads, and other scroll-first channels.",
+      "tags": "content, design, social",
+      "path": "skills/composites/vid-ugc-style",
+      "files": [
+        "skills/composites/vid-ugc-style/SKILL.md",
+        "skills/composites/vid-ugc-style/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "vid-ugc-style",
+        "category": "composites",
+        "tags": [
+          "content",
+          "design",
+          "social"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install vid-ugc-style",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Creates UGC-style vertical videos from a product brief, hook, tone, and CTA",
+          "Supports authentic, excited, and skeptical-convert creative directions",
+          "Uses a proven hook, pain, product, proof, and CTA structure for feed-native short-form video",
+          "Optimized for Instagram, TikTok, Facebook, and other scroll-first channels",
+          "Outputs a caption-friendly 9:16 MP4 ready for paid or organic distribution"
+        ]
+      }
+    },
+    {
+      "slug": "vid-whiteboard-animation",
+      "name": "vid-whiteboard-animation",
+      "category": "composites",
+      "description": "Create whiteboard-style explainer videos from narration and draw cues, then export them to MP4. Use when the user needs educational, training, onboarding, or conceptual B2B video that explains ideas step by step with synchronized hand-drawn visuals rather than a presenter or glossy promo treatment.",
+      "tags": "content, design",
+      "path": "skills/composites/vid-whiteboard-animation",
+      "files": [
+        "skills/composites/vid-whiteboard-animation/SKILL.md",
+        "skills/composites/vid-whiteboard-animation/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "vid-whiteboard-animation",
+        "category": "composites",
+        "tags": [
+          "content",
+          "design"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install vid-whiteboard-animation",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Creates whiteboard-style explainer videos from narration and draw cues",
+          "Supports whiteboard, blackboard, and glassboard visual treatments",
+          "Helps convert scripts into synchronized draw-and-narrate segments",
+          "Optimized for educational, onboarding, training, and conceptual B2B video",
+          "Outputs a paced MP4 with optional draw-hand, voiceover, music, and selective color highlights"
+        ]
+      }
+    },
+    {
       "slug": "voice-of-customer-synthesizer",
       "name": "voice-of-customer-synthesizer",
       "category": "composites",

--- a/skills/composites/vid-animated-explainer-2d/SKILL.md
+++ b/skills/composites/vid-animated-explainer-2d/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: vid-animated-explainer-2d
+description: Create 2D animated explainer videos from a scene-based script, character notes, and narration plan. Use when the user needs onboarding, product-page, investor, educational, or process-explainer video that should feel more polished than whiteboard animation but lighter and cheaper than live action.
+tags: [content, design]
+---
+
+# Vid Animated Explainer 2D
+
+Create 2D animated explainer videos with illustrated characters, scene transitions, narration, and music.
+
+This skill is for product explainers, onboarding videos, investor explainers, and educational walkthroughs where the user wants a structured, polished animation instead of a talking head or whiteboard sketch.
+
+## Best Fit
+
+- Product page hero explainers
+- Onboarding videos
+- Pitch or investor explainers
+- Educational process videos
+- Feature explainers with narrative scenes
+
+## Use Something Else
+
+- If the user wants a whiteboard hand-drawn look, use `vid-whiteboard-animation`.
+- If the user wants a direct-to-camera presenter, use `vid-talking-head`.
+- If the user wants a product walkthrough showing the real interface, use `vid-product-demo-screencast`.
+
+## Core Promise
+
+1. Accept a script and scene plan
+2. Break the script into animated scenes
+3. Match each scene to a simple character action or visual transition
+4. Choose a consistent 2D style
+5. Export a polished MP4
+
+## Inputs
+
+| Parameter | Required | Default | Notes |
+|-----------|----------|---------|-------|
+| `script` | Yes | - | Full narration script broken into scenes |
+| `animation_style` | No | `flat` | `flat`, `cartoon`, `corporate`, or `sketch` |
+| `characters` | No | `auto` | Character descriptions and roles |
+| `voiceover` | No | `default` | TTS voice or uploaded voice clone |
+| `music` | No | `auto` | Background music direction |
+| `duration` | No | `auto` | Usually 60 to 180 seconds |
+| `aspect_ratio` | No | `16:9` | `16:9`, `9:16`, or `1:1` |
+| `captions` | No | `false` | Burn captions into the final video |
+| `assets` | No | none | Logos, product screenshots, diagrams, brand references |
+
+## Animation Style Selection
+
+| Style | Best For | Notes |
+|-------|----------|-------|
+| `flat` | general SaaS and B2B explainer work | safest default |
+| `cartoon` | friendlier or more playful storytelling | use when approachability matters |
+| `corporate` | enterprise or professional explainer tone | cleaner and more restrained |
+| `sketch` | lighter illustrative feel | close cousin to whiteboard but more polished |
+
+Use `flat` by default unless the user wants a stronger aesthetic direction.
+
+## Provider Guidance
+
+| Tool | Best Use |
+|------|----------|
+| `Vyond` | professional 2D animation and corporate explainer style |
+| `Animaker` | broader character library and scene builder workflow |
+| `Steve.ai` | script-first AI-assisted animation assembly |
+| `Synthesia` | hybrid 2D plus avatar narration workflows |
+| `Runway` | stylized illustration-driven animated scenes |
+
+## Explainer Structure
+
+Use this structure unless the user gives a stronger one:
+
+| Section | Purpose | Typical Duration |
+|---------|---------|------------------|
+| Problem | Show the pain point | 15 to 20 sec |
+| Solution intro | Introduce what the product does | 10 to 15 sec |
+| How it works | Simple 3-step process | 30 to 60 sec |
+| Proof or outcome | One result or social proof point | 10 to 15 sec |
+| CTA | One next step | 5 to 10 sec |
+
+If the user tries to explain too much in one video, simplify the concept or split it.
+
+## Workflow
+
+### Step 1 - Intake
+
+Resolve these before building:
+
+1. The scene-based script
+2. Audience
+3. Product or concept being explained
+4. Animation style
+5. Character needs
+6. Voiceover and music direction
+7. Aspect ratio
+8. CTA
+
+If the script is not already scene-based, convert it before rendering.
+
+### Step 2 - Break the Script into Scenes
+
+Each scene should communicate one concept.
+
+Use a structure like:
+
+| Scene | Visual | Narration | Purpose |
+|-------|--------|-----------|---------|
+| 1 | marketer drowning in tabs | "Marketing teams waste hours finding information." | problem |
+| 2 | one workspace appears | "Gooseworks brings it into one AI workspace." | solution intro |
+| 3 | tasks complete automatically | "Research, content, and outreach happen in one flow." | how it works |
+
+Rules:
+
+- one concept per scene
+- one primary action per scene
+- narration should match the visual action
+- do not combine multiple product ideas into one visual beat
+
+### Step 3 - Choose the Production Path
+
+Use tools like:
+
+- Vyond
+- Animaker
+- Steve.ai
+- Synthesia for hybrid avatar-animation work
+- Runway for stylized illustration-driven scenes
+
+Choose based on the job:
+
+- Vyond for professional B2B animation
+- Animaker for wider character variety and easier scene assembly
+- Steve.ai for script-first automation
+
+### Step 4 - Direct Character and Motion
+
+Character instructions should be simple and readable:
+
+- who is on screen
+- what they are doing
+- what changes in the environment
+- what the viewer should notice
+
+Avoid overdirecting with live-action language. This is 2D animation, not a film set.
+
+### Step 5 - Keep the Narrative Tight
+
+Rules:
+
+- keep it under two minutes unless the user explicitly needs longer
+- favor clarity over visual complexity
+- keep every scene moving the explanation forward
+- use one clear proof point, not a laundry list
+
+## Prompt Tips
+
+- structure the script by scene before rendering
+- describe character actions, not just the narration
+- keep most explainers under `2 minutes`
+- never try to explain two separate ideas in the same scene
+
+## Delivery
+
+Default output:
+
+- `explainer-2d.mp4`
+
+Typical output:
+
+- 1080p MP4
+- 60 to 180 seconds
+
+When delivering, report:
+
+- animation style
+- aspect ratio
+- approximate scene count
+- whether captions were included
+
+## Guardrails
+
+- do not accept a vague brief in place of a real script
+- do not overload a scene with multiple concepts
+- do not let the explainer drift into feature-spam
+- do not use more characters than the story actually needs
+
+## Example Request
+
+```text
+Create a 90-second 2D explainer. Animation style: flat. Script: [Scene 1] Sarah, a marketer, stares at five open tabs. Narration: "Marketing teams spend hours just finding information." [Scene 2] Sarah discovers Gooseworks and her workflow collapses into one interface. Narration: "Gooseworks brings research, content, and outreach into one AI workspace." [Scene 3] Completed tasks fill the dashboard. Narration: "Get started free at gooseworks.ai." Voice: warm female. Music: upbeat corporate.
+```
+
+Expected result:
+
+- a scene-based animated explainer
+- a final `explainer-2d.mp4`

--- a/skills/composites/vid-animated-explainer-2d/skill.meta.json
+++ b/skills/composites/vid-animated-explainer-2d/skill.meta.json
@@ -1,0 +1,23 @@
+{
+  "slug": "vid-animated-explainer-2d",
+  "category": "composites",
+  "tags": [
+    "content",
+    "design"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install vid-animated-explainer-2d",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Creates 2D animated explainer videos from scene-based scripts and character notes",
+    "Supports flat, cartoon, corporate, and sketch animation directions",
+    "Uses a structured problem, solution, how-it-works, proof, and CTA flow",
+    "Optimized for onboarding, product-page, investor, and educational explainer use cases",
+    "Outputs a polished MP4 with narration, scene transitions, and optional captions"
+  ]
+}

--- a/skills/composites/vid-customer-testimonial/SKILL.md
+++ b/skills/composites/vid-customer-testimonial/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: vid-customer-testimonial
+description: Create customer testimonial videos from verbatim quotes, customer identity details, and format choice. Use when the user needs social proof video for landing pages, sales decks, email follow-up, paid social, or website trust sections, and can provide the real customer words instead of a paraphrased marketing summary.
+tags: [content, design, social]
+---
+
+# Vid Customer Testimonial
+
+Create customer testimonial videos that turn real customer words into a high-trust proof asset.
+
+This skill is for landing-page trust blocks, sales collateral, paid social proof, and email follow-up assets. The strongest output feels credible and specific, not scripted or overly polished.
+
+## Best Fit
+
+- Customer proof videos for landing pages
+- Social proof clips for ads or social posts
+- Testimonial inserts for sales decks
+- Email follow-up trust assets
+- Customer outcome highlights
+
+## Use Something Else
+
+- If the user needs a general talking-head explainer, use `vid-talking-head`.
+- If the user needs product education or onboarding, use `vid-product-demo-screencast` or `vid-faq`.
+- If the user only has a result stat and no quote, use a static proof graphic or another format instead of inventing a testimonial.
+
+## Core Promise
+
+1. Accept a real customer quote
+2. Choose the right testimonial format
+3. Highlight the most credible proof point
+4. Add identity and result overlays
+5. Export a trust-building MP4
+
+## Non-Negotiable Input Rule
+
+Use verbatim customer words whenever possible.
+
+Do not rewrite the testimonial into polished brand copy. The authenticity of the quote is the asset.
+
+## Inputs
+
+| Parameter | Required | Default | Notes |
+|-----------|----------|---------|-------|
+| `customer_quote` | Yes | - | Real testimonial text |
+| `customer_name` | Yes | - | Full customer name or approved display name |
+| `customer_title` | No | none | Job title |
+| `customer_company` | No | none | Company name |
+| `customer_photo` | No | none | Headshot for AI animation |
+| `product` | No | none | Product or service being praised |
+| `format` | No | `text-on-video` | `talking-head`, `text-on-video`, or `split-screen` |
+| `result_stat` | No | none | Outcome to emphasize |
+| `aspect_ratio` | No | `16:9` | `16:9`, `9:16`, or `1:1` |
+| `style` | No | `clean-slate` | Visual direction |
+| `assets` | No | none | Logos, screenshots, supporting visuals |
+
+## Format Selection
+
+| Format | Best For | Notes |
+|--------|----------|-------|
+| `talking-head` | landing pages, email, sales decks | strongest when a customer photo exists |
+| `text-on-video` | paid social and organic social | fastest and safest path |
+| `split-screen` | before/after or problem/solution proof | useful when showing contrast or product visuals |
+
+Use `text-on-video` by default if there is no customer photo or if speed matters most.
+
+## Provider Guidance
+
+| Tool | Best Use |
+|------|----------|
+| `HeyGen` | AI avatar or customer-likeness testimonial from a real photo |
+| `D-ID` | animated customer headshot testimonial |
+| `Typeframes` | text-on-video testimonial with branded motion treatment |
+| `ElevenLabs` | voice cloning when the customer supplies usable audio |
+| `Synthesia` | enterprise-grade testimonial presentation workflows |
+
+## What Makes a Strong Testimonial
+
+Favor:
+
+- specific before-and-after language
+- named result or timeframe
+- role and company context
+- believable phrasing
+
+Avoid:
+
+- generic praise with no concrete outcome
+- heavy paraphrasing
+- identity-free quotes if identity is actually available
+
+## Workflow
+
+### Step 1 - Intake
+
+Resolve these before rendering:
+
+1. The exact quote
+2. Customer identity fields
+3. The strongest result or proof point
+4. Desired format
+5. Channel and aspect ratio
+6. Whether a customer photo exists
+7. Brand/style preferences
+
+If the user only gives a vague summary of what the customer felt, ask for the actual quote.
+
+### Step 2 - Tighten Without Changing Meaning
+
+You may trim for clarity and length, but do not alter the substance.
+
+Rules:
+
+- preserve the customer voice
+- remove only obvious filler when needed
+- keep the strongest proof line intact
+- highlight one result stat if available
+
+### Step 3 - Choose the Production Path
+
+Use tools like:
+
+- HeyGen
+- D-ID
+- Typeframes
+- ElevenLabs
+- Synthesia
+
+Choose based on the format:
+
+- talking-head when a customer photo and presenter-style trust matter
+- text-on-video when the quote itself should be the hero
+- split-screen when product visuals or contrast strengthen the story
+
+### Step 4 - Build the Sequence
+
+Use a structure like:
+
+| Segment | Purpose | Visual |
+|---------|---------|--------|
+| 1 | Hook the trust signal | name, title, company |
+| 2 | Main quote | quote body or first strong line |
+| 3 | Result | stat overlay or proof callout |
+| 4 | Brand close | logo or CTA if needed |
+
+Keep the testimonial short. The best versions are usually 30 to 45 seconds.
+
+## Output Defaults
+
+- File: `testimonial.mp4`
+- Resolution: `1080p`
+- Format: `MP4`
+- Typical duration: `30` to `90` seconds
+
+## Prompt Tips
+
+- use the customer quote verbatim whenever possible
+- elevate one result stat as an on-screen callout if the quote includes measurable proof
+- match format to placement: `text-on-video` for social, `talking-head` for landing pages, `split-screen` for contrast stories
+- keep most testimonial cuts under `60 seconds`
+
+## Delivery
+
+Default output:
+
+- `testimonial.mp4`
+
+Typical output:
+
+- 1080p MP4
+- 30 to 90 seconds
+
+When delivering, report:
+
+- selected format
+- result stat used
+- whether a customer photo was used
+- aspect ratio
+
+## Guardrails
+
+- do not fabricate quotes
+- do not paraphrase away the customer voice
+- do not overproduce the asset until it feels fake
+- do not hide the result if one is available
+
+## Example Request
+
+```text
+Customer testimonial video. Format: text-on-video. Quote: "Before Gooseworks, my team spent 4 hours a day just on research. Now we get the same output in 20 minutes. It changed how we operate." Customer: Sarah Kim, Head of Marketing, Acme Corp. Result stat: "95% reduction in research time." Style: midnight-editorial. Aspect ratio: 9:16.
+```
+
+Expected result:
+
+- a short social-proof video centered on the real quote
+- a final `testimonial.mp4`

--- a/skills/composites/vid-customer-testimonial/skill.meta.json
+++ b/skills/composites/vid-customer-testimonial/skill.meta.json
@@ -1,0 +1,24 @@
+{
+  "slug": "vid-customer-testimonial",
+  "category": "composites",
+  "tags": [
+    "content",
+    "design",
+    "social"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install vid-customer-testimonial",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Creates customer testimonial videos from verbatim quotes, customer identity details, and result highlights",
+    "Supports talking-head, text-on-video, and split-screen testimonial formats",
+    "Preserves customer voice while tightening for short-form trust-building delivery",
+    "Works for landing pages, paid social, sales decks, email follow-up, and website proof sections",
+    "Outputs a testimonial MP4 with optional photo-based animation, identity overlays, and result-stat callouts"
+  ]
+}

--- a/skills/composites/vid-faq/SKILL.md
+++ b/skills/composites/vid-faq/SKILL.md
@@ -1,0 +1,319 @@
+---
+name: vid-faq
+description: Create FAQ videos from real question-and-answer pairs as talking-head, text-on-video, or animated MP4s. Use when the user needs support-deflection, pre-purchase objection handling, onboarding help, help-center explainers, or sales follow-up video content, and can provide the actual FAQs rather than a vague topic.
+tags: [content, design, social]
+---
+
+# Vid FAQ
+
+Create FAQ videos from real question-and-answer pairs, then export a single MP4 that answers the most important customer questions clearly and quickly.
+
+This skill is for objection handling, support reduction, onboarding clarity, and buyer education. The end result should feel useful, specific, and easy to trust, not like a generic brand video.
+
+## Best Fit
+
+- Product FAQ videos for landing pages
+- Sales follow-up videos that answer common objections
+- Help-center or onboarding explainers
+- Social FAQ clips for LinkedIn, Reels, or TikTok
+- Multi-question YouTube or email-sequence FAQ assets
+
+## Use Something Else
+
+- If the user needs a creator-style paid social ad, use `vid-ugc-style`.
+- If the user needs a drawn educational explainer, use `vid-whiteboard-animation`.
+- If the user only needs static FAQ cards or screenshots, use `goose-graphics`.
+
+## Core Promise
+
+1. Accept a real list of questions and answers
+2. Choose the right FAQ format for the channel
+3. Tighten the answers for video pacing without changing meaning
+4. Build a clear question-to-answer structure with titles, captions, and transitions
+5. Export a clean MP4
+
+## Non-Negotiable Input Rule
+
+Do not generate the FAQ list from scratch unless the user explicitly asks for that upstream step elsewhere.
+
+This skill works best when the user provides the real FAQs:
+
+- actual customer objections
+- real support questions
+- real onboarding confusion points
+- real sales-call questions
+
+If the user says only "make an FAQ video about our product," stop and ask for the actual Q&A pairs.
+
+## Inputs
+
+| Parameter | Required | Default | Notes |
+|-----------|----------|---------|-------|
+| `faqs` | Yes | - | Array of `{ question, answer }` pairs |
+| `format` | No | `talking-head` | `talking-head`, `text-on-video`, or `animated` |
+| `avatar` | No | `default` | AI avatar ID if using talking-head |
+| `voice` | No | `default` | TTS voice or cloned voice |
+| `product` | No | none | Product name and brand context |
+| `num_questions` | No | `all` | Limit to N questions for short variants |
+| `aspect_ratio` | No | `16:9` | `16:9` or `9:16` |
+| `captions` | No | `true` | Burn captions into video |
+| `include_chapters` | No | `true` | Add chapter markers or visual separators |
+| `style` | No | `clean-slate` | Visual direction for overlays and backgrounds |
+| `assets` | No | none | Logos, screenshots, UI captures, diagrams, customer footage |
+
+## Format Selection
+
+Choose one path before scripting the video.
+
+| Format | Best For | Notes |
+|--------|----------|-------|
+| `talking-head` | Trust-building, product clarity, sales follow-up | Strongest when a human or avatar should answer directly |
+| `text-on-video` | Fast-turn social clips, branded FAQ cards, simple reels | Fastest to produce and easiest to localize |
+| `animated` | Complex answers, onboarding steps, conceptual product behavior | Best when the answer needs more than a face and subtitles |
+
+### Default Format Choice
+
+Use `talking-head` by default when:
+
+- the user wants trust and familiarity
+- the question is objection-heavy
+- the video is for landing pages, email follow-up, or sales enablement
+
+Use `text-on-video` by default when:
+
+- the video is short-form social
+- speed matters more than personality
+- the answer is short and benefits from big typography
+
+Use `animated` by default when:
+
+- the answer needs product visuals, diagrams, or motion overlays
+- the concept is harder to explain with a face alone
+
+## Workflow
+
+### Step 1 - Intake
+
+Resolve these before generating:
+
+1. The actual Q&A list
+2. Channel and audience
+3. Desired format
+4. Aspect ratio
+5. Number of questions to include
+6. Whether captions and chapters are needed
+7. Voice or avatar requirements
+8. Supporting assets and brand direction
+
+If the user has too many questions, ask which should be prioritized or split the output into multiple videos.
+
+### Step 2 - Order the Questions
+
+FAQ sequencing matters.
+
+Rules:
+
+- lead with the most frequently asked question, not the most strategic one
+- keep the strongest trust-building answer early
+- group related questions together
+- put setup or implementation questions after "what is it" and "is it safe"
+- if the audience is cold traffic, open with the question most likely to stop the scroll
+
+For long-form versions, use 5 to 10 questions.
+For short-form versions, use 1 to 3 questions.
+
+## FAQ Video Structures
+
+### Long-Form
+
+Use for:
+
+- YouTube
+- landing pages
+- help centers
+- sales email sequences
+
+Rules:
+
+- 5 to 10 questions
+- chapter markers between questions
+- consistent title card pattern
+- one answer at a time
+
+### Short-Form
+
+Use for:
+
+- Instagram Reels
+- TikTok
+- LinkedIn short video
+
+Rules:
+
+- 1 to 3 questions
+- `9:16` aspect ratio by default
+- lead with the question immediately
+- keep each answer fast and direct
+
+## Step 3 - Tighten the Answers
+
+Each answer should be concise enough for video, but still trustworthy.
+
+Answer rules:
+
+- answer in 1 to 2 sentences first
+- then add the minimum necessary context
+- end with reassurance, clarity, or next step when useful
+- avoid long disclaimers
+- never leave "it depends" hanging without explanation
+
+If an answer is too long, compress it rather than reading out a paragraph.
+
+## Step 4 - Build the Run of Show
+
+Before rendering, turn the FAQs into a scene list.
+
+Use a structure like:
+
+| Segment | Question | Answer Goal | Visual Treatment |
+|---------|----------|-------------|------------------|
+| 1 | "How is this different from X?" | Positioning | title card + direct answer |
+| 2 | "Is my data private?" | Trust | calm close-up + reassurance |
+| 3 | "How long does setup take?" | Simplicity | answer + UI screenshot |
+
+Rules:
+
+- one main question per segment
+- show the question text clearly
+- avoid stacking multiple objections inside one answer
+- keep transition style consistent
+- use chapters only when they actually help navigation
+
+## Step 5 - Choose the Production Path
+
+### Talking-Head Path
+
+Use tools like:
+
+- HeyGen
+- Synthesia
+- D-ID
+
+Use when:
+
+- a direct answer from a face builds trust
+- the user wants presenter energy
+- the FAQ is sales-facing or onboarding-facing
+
+Talking-head rules:
+
+- keep the framing simple
+- show the question as an on-screen header
+- use captions by default
+- insert screenshots only when they clarify the answer
+
+### Text-on-Video Path
+
+Use tools like:
+
+- Typeframes
+- motion-graphics or typography-based video tools
+- branded editor workflows for text-first social clips
+
+Use when:
+
+- the answer is short
+- speed matters
+- the channel is social-first
+
+Text-on-video rules:
+
+- keep text large and readable
+- never put the full answer on screen at once if it becomes a wall of text
+- use one visual pattern per question
+
+### Animated Path
+
+Use when:
+
+- diagrams, icons, or product flows improve comprehension
+- the answer needs more than a face and subtitles
+
+Animated rules:
+
+- use motion only to clarify
+- keep the question visible up front
+- avoid overproduced transitions that slow down the answer
+
+## Writing Strong FAQ Answers
+
+Use these defaults:
+
+- first line: direct answer
+- second line: context or explanation
+- final beat: reassurance, result, or next step
+
+Example pattern:
+
+- "Yes, Gooseworks works with any browser."
+- "It runs as a web app, so there is nothing to install."
+- "Most teams are set up in under five minutes."
+
+## Channel Rules
+
+### Sales and Landing Pages
+
+- favor `talking-head`
+- keep authority high and pacing calm
+- include trust and setup questions early
+
+### Help Center and Onboarding
+
+- favor `animated` or `text-on-video`
+- optimize for clarity over persuasion
+- include product screenshots when useful
+
+### Social
+
+- favor `text-on-video` or short `talking-head`
+- keep one objection or one question per clip
+- use `9:16` by default
+
+## Delivery
+
+Default output:
+
+- `faq-video.mp4`
+
+Typical output:
+
+- 1080p MP4
+- `16:9` for long-form
+- `9:16` for social
+
+When delivering, report:
+
+- number of questions used
+- selected format
+- aspect ratio
+- whether captions and chapter markers were included
+
+## Guardrails
+
+- do not invent FAQs unless explicitly asked to upstream
+- do not rewrite the product truth into marketing fluff
+- do not bury the answer under too much intro
+- do not overload one clip with too many questions
+- do not use a generic FAQ order when actual question frequency is known
+
+## Example Request
+
+```text
+FAQ video, format: talking-head. Product: Gooseworks. FAQs: [{ Q: "How is this different from ChatGPT?", A: "ChatGPT is a conversation. Gooseworks is a workspace with memory, execution, and tool connections." }, { Q: "Is my data private?", A: "Yes. Your workspace is isolated and we do not train on your data." }, { Q: "How long does setup take?", A: "Under 5 minutes. Connect your tools and your agent is ready." }]. Voice: confident and friendly. Captions: true. Aspect ratio: 16:9.
+```
+
+Expected result:
+
+- a structured FAQ video
+- one segment per question
+- a final `faq-video.mp4`

--- a/skills/composites/vid-faq/skill.meta.json
+++ b/skills/composites/vid-faq/skill.meta.json
@@ -1,0 +1,24 @@
+{
+  "slug": "vid-faq",
+  "category": "composites",
+  "tags": [
+    "content",
+    "design",
+    "social"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install vid-faq",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Creates FAQ videos from real question-and-answer pairs in talking-head, text-on-video, or animated formats",
+    "Supports long-form chapterized FAQ videos and short-form social FAQ clips",
+    "Includes sequencing guidance so the most important customer questions lead the video",
+    "Optimizes answers for concise, trust-building video delivery without inventing new claims",
+    "Outputs a clean MP4 with optional captions, chapters, and branded visual treatment"
+  ]
+}

--- a/skills/composites/vid-product-demo-screencast/SKILL.md
+++ b/skills/composites/vid-product-demo-screencast/SKILL.md
@@ -1,0 +1,221 @@
+---
+name: vid-product-demo-screencast
+description: Create product demo and screencast walkthrough videos from a product URL or recording plus an ordered feature flow. Use when the user needs onboarding, sales-enablement, product-page, feature-release, or walkthrough video that shows the real interface in action instead of describing it abstractly.
+tags: [content, design]
+---
+
+# Vid Product Demo Screencast
+
+Create product demo videos that show the product in action with narration, annotations, cursor guidance, and zoom effects.
+
+This skill is for real product walkthroughs. The output should show what the product does on screen, in a logical order, with a clear outcome. It should not feel like a generic pitch over random UI footage.
+
+## Best Fit
+
+- Sales-enablement demos
+- Product-page walkthroughs
+- Onboarding and training videos
+- Feature-release demos
+- Async demo assets for prospects
+
+## Use Something Else
+
+- If the user needs a conceptual explainer rather than the real product, use `vid-animated-explainer-2d`.
+- If the user wants a launch reveal, use `vid-product-launch`.
+- If the user wants a talking-head explanation with minimal screen share, use `vid-talking-head`.
+
+## Core Promise
+
+1. Accept a product URL or existing recording
+2. Sequence the features in the right order
+3. Build a narration flow around the on-screen actions
+4. Add helpful annotations, cursor cues, and zooms
+5. Export a clean MP4 walkthrough
+
+## Non-Negotiable Input Rule
+
+This skill needs either:
+
+- a real `product_url`, or
+- an existing recording,
+
+plus an ordered list of the features or flows to demonstrate.
+
+Do not accept "make a demo for our product" without the actual flow.
+
+## Inputs
+
+| Parameter | Required | Default | Notes |
+|-----------|----------|---------|-------|
+| `product_url` | Yes, unless recording provided | - | URL to record |
+| `key_features` | Yes | - | Ordered list of flows or features to show |
+| `narration` | No | `auto` | Script or auto-generated narration |
+| `voice` | No | `default` | TTS voice or uploaded voice clone |
+| `annotations` | No | `true` | Click highlights and attention effects |
+| `zoom_on_action` | No | `true` | Zoom when clicking key UI elements |
+| `duration` | No | `auto` | Usually 60 to 180 seconds |
+| `resolution` | No | `1080p` | `1080p` or `4K` |
+| `aspect_ratio` | No | `16:9` | `16:9` or `9:16` |
+| `show_cursor` | No | `true` | Show animated cursor movement |
+| `assets` | No | none | Existing recordings, logos, customer environment notes |
+
+## Provider Guidance
+
+| Tool | Best Use |
+|------|----------|
+| `Arcade` | interactive demos with click-through annotations |
+| `Loom AI` | fast screen recording with summaries and chapters |
+| `Descript` | screencast editing, overdub narration, and cleanup |
+| `Synthesia` | hybrid avatar plus screen demo workflows |
+| `Tella` | polished async sales demos with strong presentation framing |
+
+## Demo Logic
+
+A demo should show the product solving something in a logical sequence.
+
+That means:
+
+- feature order matters more than feature importance
+- the viewer should always know what is happening
+- the demo should end on the outcome, not another menu
+
+## Recommended Demo Structure
+
+| Section | Purpose | Typical Duration |
+|---------|---------|------------------|
+| Hook | Name the pain point or job | 5 to 10 sec |
+| Overview | One-sentence intro and roadmap | 10 to 15 sec |
+| Feature 1 | Show the most important flow first | 20 to 30 sec |
+| Feature 2 to 3 | Secondary supporting flows | 20 to 30 sec each |
+| Result | Show the completed state | 10 to 15 sec |
+| CTA | Trial, signup, or next step | 5 to 10 sec |
+
+## Workflow
+
+### Step 1 - Intake
+
+Resolve these before building:
+
+1. Product URL or existing recording
+2. Ordered feature list
+3. Target audience
+4. Narration style
+5. Duration target
+6. Whether annotations, zooms, and cursor should be shown
+7. CTA
+
+If the feature list is unordered, reorder it into a natural user flow before writing the script.
+
+### Step 2 - Lock the Demo Order
+
+Use the real on-screen order, not the marketing order.
+
+Good example:
+
+1. Create a workspace
+2. Run a research task
+3. See the output
+4. Export to Notion
+
+Bad example:
+
+1. Export
+2. Workspace setup
+3. Research
+4. Results
+
+### Step 3 - Choose the Production Path
+
+Use tools like:
+
+- Arcade
+- Loom AI
+- Descript
+- Synthesia for hybrid avatar-plus-screen work
+- Tella
+
+Choose based on the job:
+
+- Arcade for interactive click-through style demo work
+- Loom AI for fast screen-first walkthroughs
+- Descript for narration cleanup and post-production
+- Tella for polished async sales-style screencasts
+
+### Step 4 - Write the Narration
+
+Narration should support the on-screen action, not compete with it.
+
+Rules:
+
+- describe what the viewer is seeing
+- keep each action easy to follow
+- use one sentence per meaningful interaction
+- do not front-load long explanation before the product appears
+
+If narration is auto-generated, review it against the actual click flow.
+
+### Step 5 - Add Guidance Effects
+
+Use annotations only where they help.
+
+Good use:
+
+- click highlights
+- zoom on meaningful actions
+- cursor emphasis on important controls
+
+Bad use:
+
+- constant zooming
+- every click highlighted
+- distracting motion on trivial actions
+
+## Output Defaults
+
+- File: `product-demo.mp4`
+- Resolution: `1080p` or `4K`
+- Format: `MP4`
+- Typical duration: `60` to `180` seconds
+
+## Prompt Tips
+
+- list features in demo order, not importance order
+- specify exact on-screen actions like click, type, submit, and result states
+- keep most sales demos under `90 seconds` and onboarding demos under `3 minutes`
+- end on the finished outcome, not another configuration screen
+
+## Delivery
+
+Default output:
+
+- `product-demo.mp4`
+
+Typical output:
+
+- 1080p or 4K MP4
+- 60 to 180 seconds
+
+When delivering, report:
+
+- whether URL or recording path was used
+- feature order shown
+- whether narration was auto-generated or provided
+- annotation and zoom settings
+
+## Guardrails
+
+- do not make up UI steps the product does not have
+- do not order features by marketing importance if it breaks the flow
+- do not end on menus instead of results
+- do not overuse zooms and cursor effects
+
+## Example Request
+
+```text
+Product demo for Gooseworks. Key features: [1. Create a new workspace, 2. Run a web research task, 3. See the output in chat, 4. Export to Notion]. Narration: auto-generate from feature list. Annotations: true. Zoom on click: true. Voice: confident American male. Duration: 90 seconds. CTA: "Start your free trial at gooseworks.ai."
+```
+
+Expected result:
+
+- a logical product walkthrough
+- a final `product-demo.mp4`

--- a/skills/composites/vid-product-demo-screencast/skill.meta.json
+++ b/skills/composites/vid-product-demo-screencast/skill.meta.json
@@ -1,0 +1,23 @@
+{
+  "slug": "vid-product-demo-screencast",
+  "category": "composites",
+  "tags": [
+    "content",
+    "design"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install vid-product-demo-screencast",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Creates product demo and screencast walkthrough videos from a product URL or recording plus an ordered feature list",
+    "Supports narration generation, click annotations, cursor emphasis, and zoom-on-action behavior",
+    "Keeps feature order aligned to the real on-screen flow rather than marketing order",
+    "Optimized for sales enablement, onboarding, product pages, and feature-release walkthroughs",
+    "Outputs a clean MP4 showing the product in action and ending on the outcome"
+  ]
+}

--- a/skills/composites/vid-product-launch/SKILL.md
+++ b/skills/composites/vid-product-launch/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: vid-product-launch
+description: Create cinematic or structured product launch videos from a launch brief, reveal timing, and CTA. Use when the user needs a launch-day announcement, teaser, landing-page hero, email-campaign reveal, or social launch asset with a clear build-to-reveal narrative rather than a generic hype reel.
+tags: [content, design, social]
+---
+
+# Vid Product Launch
+
+Create product launch videos that build anticipation, reveal the product clearly, and end with one strong CTA.
+
+This skill is for launch moments: new product announcements, feature reveals, waitlist opens, launch-day landing pages, hero videos, and social rollout content. The video should feel deliberate and narrative, not like a generic montage of random product shots.
+
+## Best Fit
+
+- Product announcement videos
+- Launch-day hero videos for landing pages
+- Reveal videos for social channels
+- Email-campaign launch assets
+- Waitlist, beta, or release announcement videos
+
+## Use Something Else
+
+- If the user wants a creator-style paid social ad, use `vid-ugc-style`.
+- If the user wants a presenter-led FAQ or objection handling piece, use `vid-faq`.
+- If the user wants pure animated typography with no reveal narrative, use a motion-graphics-first video skill.
+
+## Core Promise
+
+1. Accept a product launch brief
+2. Turn it into a reveal narrative
+3. Choose the right tone and aspect ratio
+4. Build anticipation before the reveal
+5. Export a launch-ready MP4 with product name, tagline, and CTA
+
+## Inputs
+
+| Parameter | Required | Default | Notes |
+|-----------|----------|---------|-------|
+| `product_name` | Yes | - | Product or feature name |
+| `product_description` | Yes | - | What it does and who it is for |
+| `tagline` | No | `auto` | Prefer user-written 4 to 6 word headline |
+| `launch_date` | No | none | Use for countdown or urgency |
+| `cta` | No | `auto` | Final CTA line |
+| `tone` | No | `cinematic` | `cinematic`, `energetic`, `minimal`, or `emotional` |
+| `duration` | No | `60` | Usually `30`, `60`, or `90` seconds |
+| `aspect_ratio` | No | `16:9` | `16:9` or `9:16` |
+| `include_countdown` | No | `false` | Use sparingly |
+| `music` | No | `auto` | Music direction matched to tone |
+| `assets` | No | none | Logos, screenshots, UI captures, brand footage, renders |
+
+## Launch Video Logic
+
+This is not a sizzle reel. A launch video has:
+
+1. a tease
+2. a build
+3. a reveal
+4. one proof point
+5. a CTA
+
+If the user gives a list of five features, compress to one lead benefit or one strong proof point. Launch videos lose power when they try to explain everything.
+
+## Tone Selection
+
+| Tone | Best For | Reference Feel |
+|------|----------|----------------|
+| `cinematic` | premium, ambitious, launch-the-company energy | high-end reveal |
+| `energetic` | fast SaaS, developer tools, social-first launch | Product Hunt-style momentum |
+| `minimal` | design-forward software, calm confidence | clean modern announcement |
+| `emotional` | mission-driven or human-outcome product stories | narrative brand launch |
+
+### Tone Rules
+
+- `cinematic` works when the market expects drama or polish
+- `energetic` works when speed and momentum matter
+- `minimal` works when the product and promise are already strong
+- `emotional` works when the human impact matters more than interface flash
+
+Do not default to cinematic if the audience is technical and prefers clarity over spectacle.
+
+## Workflow
+
+### Step 1 - Intake
+
+Resolve these first:
+
+1. Product name
+2. Product description
+3. Target audience
+4. Channel and placement
+5. Tagline
+6. Reveal timing
+7. CTA
+8. Tone
+9. Assets and brand constraints
+
+If the user has not written the tagline, strongly encourage them to do it. The tagline is load-bearing.
+
+## Step 2 - Choose the Narrative Shape
+
+Use this default launch structure:
+
+| Time | Section | Purpose |
+|------|---------|---------|
+| 0-10 sec | Tease | Frame the problem or intrigue without naming the product yet |
+| 10-30 sec | Build | Raise tension and hint at the solution |
+| 30-45 sec | Reveal | Show product name, tagline, and first look |
+| 45-55 sec | Proof | One feature, metric, or outcome |
+| 55-60 sec | CTA | Availability, waitlist, or next step |
+
+For a 30-second cut, compress each section instead of deleting the reveal.
+
+## Step 3 - Lock the Reveal Moment
+
+The reveal moment is the center of gravity.
+
+Rules:
+
+- the audience should feel the build before the reveal
+- the product name and tagline must land clearly
+- use one unmistakable visual treatment at the reveal
+- do not reveal the product too early unless the user explicitly wants a fast open
+
+If the user says "reveal at 30 seconds," protect that timing.
+
+## Step 4 - Choose the Production Path
+
+### Cinematic AI Visual Path
+
+Use tools like:
+
+- Runway
+- Pika
+- Kling
+- Kaiber
+
+Use when:
+
+- the user wants cinematic product-world visuals
+- the launch is visual-first
+- the brand can support a more stylized treatment
+
+Rules:
+
+- pair AI visuals with deliberate text overlays
+- use the actual product name and tagline, not vague mood text
+- keep the proof section concrete
+
+### Structured Announcement Path
+
+Use tools like:
+
+- HeyGen Studio
+- structured template-based editors
+- hybrid launch packages with uploaded screenshots and motion titles
+
+Use when:
+
+- brand control matters more than visual experimentation
+- the user wants consistent product screenshots or presenter segments
+- the launch requires exact logo and text placement
+
+## Step 5 - Build the Asset List
+
+Preferred supporting assets:
+
+- logo lockup
+- product screenshots
+- UI recordings
+- feature render stills
+- headline and tagline copy
+- launch URL or CTA destination
+
+Do not make the video depend on assets the user has not actually provided.
+
+## Step 6 - Script the Launch
+
+Write the launch script in short beats, not paragraphs.
+
+Each beat should define:
+
+- what the viewer sees
+- what text appears
+- whether narration is present
+- what the music is doing
+
+Example structure:
+
+| Beat | Visual | On-Screen Text | Audio |
+|------|--------|----------------|-------|
+| 1 | dark tease, abstract motion | "Work changed. Tools did not." | low build |
+| 2 | hints of product UI | "Research. Content. Outreach." | rise |
+| 3 | full reveal | "Gooseworks" / "Work at AI speed." | lift |
+| 4 | proof card | "500+ growth teams. 10x output." | hold |
+| 5 | end card | "Join the waitlist" | resolve |
+
+## Proof Rules
+
+The proof section should carry one thing:
+
+- one feature
+- one result
+- one product outcome
+
+Do not turn the proof section into a feature checklist.
+
+## Aspect Ratio Rules
+
+- `16:9` by default for landing pages and hero use
+- `9:16` for social-first launch cuts
+- if the user needs both, design the main reveal logic once and adapt afterwards
+
+## Delivery
+
+Default output:
+
+- `product-launch.mp4`
+
+Typical output:
+
+- 1080p MP4
+- 30 to 90 seconds
+- product name, tagline, and CTA included
+
+When delivering, report:
+
+- chosen tone
+- reveal timing
+- aspect ratio
+- whether countdown was used
+
+## Guardrails
+
+- do not invent the tagline if the user can provide it
+- do not overload the launch with too many benefits
+- do not skip the reveal moment
+- do not use countdowns unless they actually support the launch
+- do not let music overwhelm the product name, tagline, or CTA
+
+## Example Request
+
+```text
+Product launch video, 60 seconds. Product: Gooseworks. Description: AI workspace that automates research, content creation, and outreach for growth teams. Tagline: "Work at AI speed." Tone: minimal. Reveal at 30 seconds. Proof: "500+ growth teams, 10x output." CTA: "Join the waitlist at gooseworks.ai." Music: ambient electronic build. Aspect ratio: 16:9.
+```
+
+Expected result:
+
+- a launch narrative with tease, build, reveal, proof, and CTA
+- a final `product-launch.mp4`

--- a/skills/composites/vid-product-launch/skill.meta.json
+++ b/skills/composites/vid-product-launch/skill.meta.json
@@ -1,0 +1,24 @@
+{
+  "slug": "vid-product-launch",
+  "category": "composites",
+  "tags": [
+    "content",
+    "design",
+    "social"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install vid-product-launch",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Creates product launch videos with a clear tease, build, reveal, proof, and CTA structure",
+    "Supports cinematic, energetic, minimal, and emotional launch tones",
+    "Helps protect the reveal moment and compress feature overload into one strong proof beat",
+    "Works for landing-page heroes, social launch clips, email campaigns, and announcement videos",
+    "Outputs a launch-ready MP4 with product name, tagline, and end-card CTA"
+  ]
+}

--- a/skills/composites/vid-short-form-vertical/SKILL.md
+++ b/skills/composites/vid-short-form-vertical/SKILL.md
@@ -1,0 +1,228 @@
+---
+name: vid-short-form-vertical
+description: Create short-form vertical videos from a hook, prompt, format, and platform choice. Use when the user needs Instagram Reels, TikToks, or YouTube Shorts that are mobile-native, hook-first, caption-friendly, and optimized for reach, watch-through, shares, or saves.
+tags: [content, design, social]
+---
+
+# Vid Short Form Vertical
+
+Create short-form vertical videos optimized for Reels, TikTok, and Shorts.
+
+This skill is for mobile-first, hook-first content. The output should feel fast, native to the platform, and easy to understand without relying on sound.
+
+## Best Fit
+
+- Instagram Reels
+- TikTok clips
+- YouTube Shorts
+- Hook-first educational video
+- Short list, POV, tutorial, and storytime formats
+
+## Use Something Else
+
+- If the user wants a creator-testimonial ad, use `vid-ugc-style`.
+- If the user wants a launch reveal, use `vid-product-launch`.
+- If the user wants a detailed product walkthrough, use `vid-product-demo-screencast`.
+
+## Core Promise
+
+1. Accept a hook and core content prompt
+2. Match the video to a short-form format
+3. Build a hook-payoff-CTA structure
+4. Add captions and platform-appropriate pacing
+5. Export a vertical MP4
+
+## Inputs
+
+| Parameter | Required | Default | Notes |
+|-----------|----------|---------|-------|
+| `hook` | Yes | - | Opening line or first visual |
+| `prompt` | Yes | - | Topic, script, or content direction |
+| `duration` | No | `30` | Usually `15`, `30`, or `60` |
+| `format` | No | `talking-points` | `talking-points`, `list`, `storytime`, `pov`, or `tutorial` |
+| `captions` | No | `true` | Captions should almost always stay on |
+| `music` | No | `trending` | Energy or music style |
+| `aspect_ratio` | No | `9:16` | Fixed default for this skill |
+| `platform` | No | `instagram` | `instagram`, `tiktok`, or `youtube-shorts` |
+| `style` | No | `auto` | Visual treatment or aesthetic |
+| `assets` | No | none | Existing clips, brand visuals, b-roll, screenshots |
+
+## Short-Form Formula
+
+Use this structure unless the user gives a stronger one:
+
+| Time | Purpose |
+|------|---------|
+| 0-3 sec | Hook |
+| 3-25 sec | Payoff |
+| 25-30 sec | CTA |
+
+The hook is the most important beat in the entire brief.
+
+## Format Selection
+
+| Format | Best For |
+|--------|----------|
+| `talking-points` | quick educational commentary |
+| `list` | numbered tips, examples, or formats |
+| `storytime` | narrative with a setup and payoff |
+| `pov` | immersive or scenario-driven framing |
+| `tutorial` | tactical step-by-step advice |
+
+If the user does not specify a format, choose the one that best matches the content type.
+
+## Platform Differences
+
+### Instagram Reels
+
+- ideal length: 15 to 30 seconds
+- captions should be large and center-readable
+- optimize for saves and shares
+
+### TikTok
+
+- ideal length: 30 to 60 seconds
+- conversational pacing works well
+- optimize for watch-through
+
+### YouTube Shorts
+
+- ideal length: 30 to 60 seconds
+- a stronger CTA to long-form or next action can make sense
+
+## Provider Guidance
+
+| Tool | Best Use |
+|------|----------|
+| `Runway` | AI-generated short-form video from text or image prompts |
+| `Pika` | fast visual generation for lightweight b-roll style clips |
+| `Kling` | higher-quality generated clips and longer short-form sequences |
+| `CapCut` | editing and repurposing existing assets into vertical short-form |
+| `Opus Clip` | auto-clipping long-form content into vertical cuts |
+
+## Hook Formulas
+
+Patterns that work:
+
+- "The [topic] tip nobody talks about..."
+- "I tested [X] so you do not have to. Here is what happened."
+- "[Number] signs that [problem you have]"
+- "POV: you just discovered [solution]"
+- "Stop doing [common mistake]. Do this instead."
+
+## Workflow
+
+### Step 1 - Intake
+
+Resolve these before generating:
+
+1. Hook
+2. Prompt or core content
+3. Format
+4. Platform
+5. Duration
+6. Captions
+7. Music energy
+8. CTA
+
+If the user has not written the hook, help them write that before anything else.
+
+### Step 2 - Lock the Hook
+
+The first 1 to 3 seconds decide whether the rest matters.
+
+Rules:
+
+- bold statement, surprise, pattern interrupt, or strong framing
+- no slow intro
+- no logo-first opening
+- no generic setup line
+
+### Step 3 - Build the Payoff
+
+The payoff should deliver exactly what the hook promised.
+
+Rules:
+
+- one insight, one list, one story, or one tutorial thread
+- no bait-and-switch
+- keep momentum high
+- cut anything that does not support the hook
+
+### Step 4 - Choose the Production Path
+
+Use tools like:
+
+- Runway
+- Pika
+- Kling
+- CapCut
+- Opus Clip
+
+Choose based on the job:
+
+- AI-generated path when creating from text or image prompts
+- repurposing/editing path when working from existing long-form or raw clips
+
+### Step 5 - Add Captions and Music
+
+Captions are effectively required for this skill.
+
+Rules:
+
+- keep captions readable
+- match music energy to the content
+- do not let music overpower the spoken message
+
+## Output Defaults
+
+- File: `short-form-vertical.mp4`
+- Dimensions: `1080x1920`
+- Format: `MP4`
+- Aspect ratio: `9:16`
+- Common durations: `15`, `30`, or `60` seconds
+
+## Prompt Tips
+
+- write the hook first before anything else
+- specify the format because `list`, `storytime`, `pov`, and `tutorial` produce very different pacing
+- keep captions on by default because most first-view consumption is silent
+- match music energy to the emotional shape of the content, not just the platform
+
+## Delivery
+
+Default output:
+
+- `short-form-vertical.mp4`
+
+Typical output:
+
+- `1080x1920`
+- `9:16`
+- 15, 30, or 60 seconds
+
+When delivering, report:
+
+- hook used
+- platform
+- format
+- duration
+- caption setting
+
+## Guardrails
+
+- do not start without a strong hook
+- do not let the payoff drift away from the promise
+- do not drop captions by default
+- do not use a static horizontal mindset inside a vertical format
+
+## Example Request
+
+```text
+Hook: "The LinkedIn post type that outperforms everything else and almost nobody uses." Format: list. Content: five overlooked LinkedIn post formats with 2x average engagement. Duration: 45 seconds. Captions: true. Music: lo-fi upbeat. Platform: instagram.
+```
+
+Expected result:
+
+- a hook-first short-form video
+- a final `short-form-vertical.mp4`

--- a/skills/composites/vid-short-form-vertical/skill.meta.json
+++ b/skills/composites/vid-short-form-vertical/skill.meta.json
@@ -1,0 +1,24 @@
+{
+  "slug": "vid-short-form-vertical",
+  "category": "composites",
+  "tags": [
+    "content",
+    "design",
+    "social"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install vid-short-form-vertical",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Creates short-form vertical videos from a hook, prompt, and platform choice",
+    "Supports talking-points, list, storytime, POV, and tutorial short-form structures",
+    "Optimizes for Reels, TikTok, and YouTube Shorts with caption-first mobile-native pacing",
+    "Uses a strict hook, payoff, and CTA flow to protect watch-through performance",
+    "Outputs a vertical 9:16 MP4 ready for social distribution"
+  ]
+}

--- a/skills/composites/vid-sizzle-reel/SKILL.md
+++ b/skills/composites/vid-sizzle-reel/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: vid-sizzle-reel
+description: Create high-energy sizzle reels from key messages, brand assets, music direction, and end-card content. Use when the user needs a hype-first montage for launches, conference openers, investor decks, event promos, or campaign kickoffs where excitement and momentum matter more than explanation.
+tags: [content, design, social]
+---
+
+# Vid Sizzle Reel
+
+Create high-energy sizzle reels that use fast montage, music, bold text, and brand visuals to build excitement.
+
+This skill is for momentum, not explanation. The output should feel punchy, emotional, and music-led, with a clean brand landing at the end.
+
+## Best Fit
+
+- Conference opener videos
+- Campaign kickoff videos
+- Investor pitch opener reels
+- Launch hype videos
+- Event promos
+- Brand momentum montages
+
+## Use Something Else
+
+- If the user needs a narrative launch reveal, use `vid-product-launch`.
+- If the user needs product education, use `vid-product-demo-screencast` or `vid-animated-explainer-2d`.
+- If the user needs a talking-head message, use `vid-talking-head`.
+
+## Core Promise
+
+1. Accept key messages, assets, tone, and music direction
+2. Turn them into a montage-friendly shot list
+3. Match the cut style to the tone
+4. Build to a brand land or end card
+5. Export a hype-forward MP4
+
+## Inputs
+
+| Parameter | Required | Default | Notes |
+|-----------|----------|---------|-------|
+| `brand_assets` | No | none | Logos, colors, imagery, screenshots, footage |
+| `key_messages` | Yes | - | 3 to 5 punchy on-screen messages |
+| `tone` | No | `energetic` | `energetic`, `cinematic`, `emotional`, or `professional` |
+| `music` | No | `auto` | Genre, BPM, or energy direction |
+| `duration` | No | `60` | Usually `30`, `60`, or `90` |
+| `aspect_ratio` | No | `16:9` | `16:9` or `9:16` |
+| `cut_style` | No | `fast` | `fast` or `cinematic` |
+| `end_card` | No | none | Final frame logo, tagline, and CTA |
+| `assets` | No | none | Additional b-roll, footage, or generated visual references |
+
+## Sizzle Reel Logic
+
+This format is music-first and excitement-first.
+
+That means:
+
+- visuals should move with the energy
+- messages should be short and bold
+- explanation should be minimal
+- the last few seconds should belong to the brand
+
+## Recommended Structure
+
+| Section | Purpose | Typical Duration |
+|---------|---------|------------------|
+| Cold open | boldest first impression | 0 to 5 sec |
+| Build | escalating montage and message flashes | 5 to 40 sec |
+| Peak | maximum visual and musical intensity | 40 to 55 sec |
+| Land | logo, tagline, CTA, and breathing room | 55 to 60 sec |
+
+For a 30-second cut, compress the build but still preserve the land.
+
+## Tone Guide
+
+| Tone | Cut Style | Text Style | Music |
+|------|-----------|------------|-------|
+| `energetic` | 1-second cuts | bold, all-caps, rapid entry | high-BPM electronic or hip-hop |
+| `cinematic` | 3-second cuts | elegant, slower motion | orchestral or ambient swell |
+| `emotional` | mixed pacing | softer or poetic | piano or acoustic |
+| `professional` | 2-second cuts | structured sans-serif | corporate instrumental |
+
+## Provider Guidance
+
+| Tool | Best Use |
+|------|----------|
+| `Runway` | AI-generated cinematic b-roll and mood shots |
+| `Pika` | fast visual generation for background or transition footage |
+| `Opus Clip` | auto-sizzle from existing long-form video |
+| `CapCut` | beat-sync editing and text overlay effects |
+| `Kaiber` | consistent stylized motion across a full reel |
+
+## Workflow
+
+### Step 1 - Intake
+
+Resolve these before generating:
+
+1. Key messages
+2. Tone
+3. Music direction
+4. Available brand assets
+5. End-card content
+6. Duration and aspect ratio
+
+If the user has not written the key messages, ask for them. They are the on-screen payload.
+
+### Step 2 - Build the Message Order
+
+Order messages for momentum, not information hierarchy.
+
+Rules:
+
+- strongest or broadest claim early
+- proof or traction in the middle
+- brand name and promise near the end
+- CTA only on the land or end card
+
+### Step 3 - Choose the Production Path
+
+Use tools like:
+
+- Runway
+- Pika
+- Opus Clip
+- CapCut
+- Kaiber
+
+Choose based on the job:
+
+- generated visuals path for cinematic b-roll and mood shots
+- editing path when existing footage already exists
+
+### Step 4 - Build the Shot List
+
+Use a structure like:
+
+| Beat | Visual | On-Screen Text | Music Energy |
+|------|--------|----------------|--------------|
+| 1 | bold opening image | first punch line | immediate hit |
+| 2 | montage | message 2 | rising |
+| 3 | faster sequence | message 3 | peak |
+| 4 | brand frame | logo, tagline, CTA | release |
+
+Keep text short. Sizzle reels are not meant for reading paragraphs.
+
+## Output Defaults
+
+- File: `sizzle-reel.mp4`
+- Resolution: `1080p`
+- Format: `MP4`
+- Typical duration: `30` to `90` seconds
+
+## Prompt Tips
+
+- give the `3` to `5` key messages as actual on-screen text, not topic labels
+- specify the feeling, not just the subject matter
+- choose the music energy or BPM before refining cut rhythm
+- keep the final few seconds focused on logo, tagline, and CTA only
+
+## Delivery
+
+Default output:
+
+- `sizzle-reel.mp4`
+
+Typical output:
+
+- 1080p MP4
+- 30 to 90 seconds
+
+When delivering, report:
+
+- tone
+- cut style
+- music direction
+- aspect ratio
+- end-card content used
+
+## Guardrails
+
+- do not turn the reel into an explainer
+- do not overload with too many messages
+- do not end on clutter instead of a clean brand land
+- do not ignore the music direction
+
+## Example Request
+
+```text
+Sizzle reel, 60 seconds. Tone: cinematic. Key messages: ["The future of work is autonomous", "AI that thinks, researches, and executes", "Used by 500+ growth teams", "Gooseworks"]. Music: orchestral swell building to crescendo. Cut style: cinematic. End card: Gooseworks logo + "Work at AI speed" + "gooseworks.ai". Aspect ratio: 16:9.
+```
+
+Expected result:
+
+- a music-led hype montage
+- a final `sizzle-reel.mp4`

--- a/skills/composites/vid-sizzle-reel/skill.meta.json
+++ b/skills/composites/vid-sizzle-reel/skill.meta.json
@@ -1,0 +1,24 @@
+{
+  "slug": "vid-sizzle-reel",
+  "category": "composites",
+  "tags": [
+    "content",
+    "design",
+    "social"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install vid-sizzle-reel",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Creates high-energy sizzle reels from key messages, music direction, brand assets, and end-card content",
+    "Supports energetic, cinematic, emotional, and professional montage directions",
+    "Uses a cold-open, build, peak, and brand-land structure for hype-first video",
+    "Works for launches, investor decks, conference openers, event promos, and campaign kickoffs",
+    "Outputs a montage-style MP4 optimized for momentum rather than explanation"
+  ]
+}

--- a/skills/composites/vid-talking-head/SKILL.md
+++ b/skills/composites/vid-talking-head/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: vid-talking-head
+description: Create talking-head videos from a word-for-word script, avatar or source face, voice, and background settings. Use when the user needs founder-style messaging, product explanation, educational content, thought leadership, or presenter-led video without filming a real person on camera.
+tags: [content, design, social]
+---
+
+# Vid Talking Head
+
+Create talking-head videos using an AI avatar or source face with lip-synced narration.
+
+This skill is for presenter-led explanation without on-camera recording. The result should feel clear, direct, and intentional, with good speech rhythm and strong framing.
+
+## Best Fit
+
+- Founder-style messaging
+- Educational explainers
+- Product explanation videos
+- Thought-leadership clips
+- LinkedIn talking-head posts
+
+## Use Something Else
+
+- If the user wants a customer-proof asset, use `vid-customer-testimonial`.
+- If the user wants FAQ-specific formatting, use `vid-faq`.
+- If the user wants creator-style social content, use `vid-ugc-style`.
+
+## Core Promise
+
+1. Accept a word-for-word script
+2. Choose avatar, voice, language, and background
+3. Tighten pacing for better lip-sync and speech rhythm
+4. Add captions and lower-third treatment when useful
+5. Export a polished MP4
+
+## Non-Negotiable Input Rule
+
+This skill needs the actual script, not a vague brief.
+
+If the user says "make a talking head video about our product," ask for the exact words or help draft the script first.
+
+## Inputs
+
+| Parameter | Required | Default | Notes |
+|-----------|----------|---------|-------|
+| `script` | Yes | - | Full spoken script |
+| `avatar` | No | `default` | AI avatar ID, photo URL, or source footage |
+| `voice` | No | `default` | TTS voice or uploaded voice clone |
+| `language` | No | `en` | Language code |
+| `background` | No | `office` | Virtual background or brand backdrop |
+| `captions` | No | `true` | Burn captions into the video |
+| `lower_third` | No | none | Name and title overlay |
+| `aspect_ratio` | No | `16:9` | `16:9` or `9:16` |
+| `assets` | No | none | Logos, title cards, supporting product visuals |
+
+## Provider Guidance
+
+| Tool | Best Use |
+|------|----------|
+| `HeyGen` | best avatar quality, studio backgrounds, multilingual delivery |
+| `Synthesia` | enterprise talking-head workflows and corporate presenter templates |
+| `D-ID` | animating a still photo into a talking head |
+| `ElevenLabs` | TTS quality and voice cloning |
+| `Runway` | lip-syncing onto real human footage |
+
+## Script Structure
+
+Use this simple pattern:
+
+| Section | Purpose |
+|---------|---------|
+| Hook | first 1 to 2 sentences |
+| Body | one idea per paragraph |
+| CTA | 1 to 2 sentences |
+
+Mark pauses with `[pause]` or `...` when natural rhythm matters.
+
+## Workflow
+
+### Step 1 - Intake
+
+Resolve these before rendering:
+
+1. The exact script
+2. Audience and channel
+3. Avatar or face source
+4. Voice and language
+5. Background
+6. Captions and lower-third
+7. Aspect ratio
+
+### Step 2 - Tighten for Speech
+
+TTS and lip-sync work better when the script is spoken language, not written prose.
+
+Rules:
+
+- short sentences
+- one idea per paragraph
+- natural pause markers
+- no stacked clauses unless necessary
+- CTA should be direct and singular
+
+### Step 3 - Choose the Production Path
+
+Use tools like:
+
+- HeyGen
+- Synthesia
+- D-ID
+- ElevenLabs
+- Runway for lip sync on real human footage
+
+Choose based on the job:
+
+- HeyGen for polished avatar quality and multilingual flexibility
+- Synthesia for enterprise presenter workflows
+- D-ID when animating a still photo into a talking head
+- Runway when syncing audio onto real footage
+
+### Step 4 - Frame the Presenter
+
+The talking head should feel intentional, not generic.
+
+Rules:
+
+- match background to the message
+- keep captions on by default
+- use lower-third only when it adds credibility
+- avoid cluttered or distracting visual treatment
+
+## Output Defaults
+
+- File: `talking-head.mp4`
+- Resolution: `1080p`
+- Format: `MP4`
+- Aspect ratio: `16:9` or `9:16`
+- Duration guide: roughly `150 words` is about `1 minute`
+
+## Prompt Tips
+
+- write the actual script, not a description of what the avatar should say
+- mark natural pauses with `[pause]` or `...` when delivery rhythm matters
+- specify delivery tone, such as conversational, keynote-style, direct, calm, or high-energy
+- keep social-facing versions under `90 seconds` when possible
+
+## Delivery
+
+Default output:
+
+- `talking-head.mp4`
+
+Typical output:
+
+- 1080p MP4
+- `16:9` or `9:16`
+- duration based on script length
+
+When delivering, report:
+
+- avatar path used
+- voice and language
+- caption status
+- lower-third status
+- aspect ratio
+
+## Guardrails
+
+- do not accept a topic in place of a real script
+- do not overstyle the background until it distracts from the speaker
+- do not leave long written-prose sentences untouched if they will sound unnatural
+
+## Example Request
+
+```text
+Script: "Most teams waste 3 hours a day on status updates. [pause] What if you could automate all of it? [pause] That is exactly what we built. Here is how it works in 60 seconds." Voice: confident American male. Avatar: professional, dark blazer. Background: modern office. Captions: true. Aspect ratio: 16:9.
+```
+
+Expected result:
+
+- a presenter-led explanation video
+- a final `talking-head.mp4`

--- a/skills/composites/vid-talking-head/skill.meta.json
+++ b/skills/composites/vid-talking-head/skill.meta.json
@@ -1,0 +1,24 @@
+{
+  "slug": "vid-talking-head",
+  "category": "composites",
+  "tags": [
+    "content",
+    "design",
+    "social"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install vid-talking-head",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Creates talking-head videos from exact scripts, avatars or source faces, voices, and background settings",
+    "Supports lip-synced avatar, animated-photo, and real-footage-based talking-head production paths",
+    "Optimizes scripts for spoken rhythm, pause control, captions, and presenter credibility overlays",
+    "Works for founder messaging, thought leadership, product explanation, and educational presenter video",
+    "Outputs a polished talking-head MP4 in horizontal or vertical aspect ratios"
+  ]
+}

--- a/skills/composites/vid-ugc-style/SKILL.md
+++ b/skills/composites/vid-ugc-style/SKILL.md
@@ -1,0 +1,277 @@
+---
+name: vid-ugc-style
+description: Create UGC-style vertical videos from a product brief, hook, tone, and CTA. Use when the user needs creator-style paid social or organic short-form video that feels authentic, direct-to-camera, and high-retention, especially for Instagram, TikTok, Meta ads, and other scroll-first channels.
+tags: [content, design, social]
+---
+
+# Vid UGC Style
+
+Create UGC-style videos that feel like creator content instead of polished brand advertising.
+
+This skill is for short-form social and paid acquisition. The result should feel native to the feed: casual, direct, specific, and convincing without sounding like a polished corporate ad.
+
+## Best Fit
+
+- Paid social ads on Meta
+- Instagram Reels
+- TikTok product videos
+- Casual product recommendation clips
+- Cold-traffic creative testing
+
+## Use Something Else
+
+- If the user needs a launch-day reveal or cinematic product announcement, use `vid-product-launch`.
+- If the user needs direct objection handling or support-style Q&A, use `vid-faq`.
+- If the user needs static ad cards or carousel creative, use `goose-graphics`.
+
+## Core Promise
+
+1. Accept a product brief, hook, tone, and CTA
+2. Turn the brief into a high-retention UGC script
+3. Match the script to a platform-native pacing model
+4. Render with a casual creator-style avatar or presenter workflow
+5. Export a vertical MP4 ready for short-form distribution
+
+## Inputs
+
+| Parameter | Required | Default | Notes |
+|-----------|----------|---------|-------|
+| `product_brief` | Yes | - | What the product is, what it does, and who it is for |
+| `hook` | No | `auto` | First 3-second opening line |
+| `avatar` | No | `default` | Casual creator avatar or presenter profile |
+| `tone` | No | `authentic` | `authentic`, `excited`, or `skeptical-convert` |
+| `platform` | No | `instagram` | `instagram`, `tiktok`, or `facebook` |
+| `duration` | No | `30` | Usually `15`, `30`, or `60` |
+| `captions` | No | `true` | Burn captions into the video |
+| `cta` | No | `auto` | Final call to action |
+| `proof` | No | none | One result, claim, demo insight, or testimonial point |
+| `assets` | No | none | Product screenshots, app recordings, brand marks, b-roll |
+
+## UGC Logic
+
+UGC converts because it does not feel like a formal ad.
+
+That means:
+
+- the hook matters more than the logo
+- the first sentence matters more than the brand intro
+- one believable benefit is better than a long feature list
+- casual pacing is good, but vagueness is not
+
+## Tone Selection
+
+| Tone | Best Use | Notes |
+|------|----------|-------|
+| `authentic` | broad default | sounds like genuine discovery or recommendation |
+| `excited` | louder consumer or impulse-friendly products | faster and more expressive |
+| `skeptical-convert` | cold traffic and stronger persuasion | starts doubtful, ends convinced |
+
+### Default Tone
+
+Use `skeptical-convert` when:
+
+- the audience is cold
+- the product makes a big claim
+- the ad needs to earn attention from skeptics
+
+Use `authentic` when:
+
+- the brand wants calm credibility
+- the product solves a known pain point directly
+
+## Platform Defaults
+
+### Instagram
+
+- default to 30 seconds
+- use a clean hook and visible captions
+- keep pacing fast but readable
+
+### TikTok
+
+- default to 15 to 30 seconds
+- lead with the strongest pattern interrupt
+- let the voice feel a little more conversational
+
+### Facebook
+
+- default to 30 seconds
+- keep the message clear even without sound
+- make the CTA explicit
+
+## UGC Script Formula
+
+Use this structure unless the user provides a stronger one:
+
+| Section | Purpose | Typical Timing |
+|---------|---------|----------------|
+| Hook | Stop the scroll | 0-3 sec |
+| Pain point | Name the problem | 3-8 sec |
+| Product intro | Introduce the solution naturally | 8-18 sec |
+| Proof | One concrete result or outcome | 18-25 sec |
+| CTA | One next action | 25-30 sec |
+
+For 15-second cuts, compress each beat.
+For 60-second cuts, add a little more proof, not more fluff.
+
+## Hook Rules
+
+Hooks are load-bearing. Prefer a real hook from the user if they have one.
+
+Patterns that work:
+
+- "I can't believe I've been doing X wrong for so long..."
+- "No one talks about this, but..."
+- "POV: you finally found a way to..."
+- "If you're struggling with X, watch this."
+
+Hook rules:
+
+- make the first line understandable in isolation
+- lead with the pain or curiosity
+- avoid "Hi guys, today I want to talk about..."
+- never spend the first 3 seconds on brand filler
+
+## Workflow
+
+### Step 1 - Intake
+
+Resolve these before scripting:
+
+1. Product brief
+2. Audience
+3. Hook
+4. Tone
+5. Platform
+6. Duration
+7. CTA
+8. Proof point
+
+If the user has not supplied a hook, generate one only after you understand the product, pain point, and audience.
+
+### Step 2 - Pick the Production Path
+
+Use tools like:
+
+- Creatify
+- Arcads
+- HeyGen
+- ElevenLabs for voice work
+
+Choose based on the job:
+
+- Creatify for stronger UGC avatar variety and ad-oriented output
+- Arcads for quick direct-response ad generation
+- HeyGen for multilingual or more structured avatar control
+
+Do not pretend all tools behave the same. Pick one path and keep the direction consistent.
+
+### Step 3 - Write the UGC Script
+
+Write like a creator speaking to one person.
+
+Rules:
+
+- short sentences
+- spoken cadence, not brochure copy
+- one claim at a time
+- natural transition into the product
+- one clear CTA
+
+Bad UGC copy sounds like:
+
+- mission statement language
+- feature overload
+- corporate adjectives with no concrete payoff
+
+Good UGC copy sounds like:
+
+- observed pain
+- direct reaction
+- simple explanation
+- one believable outcome
+
+### Step 4 - Build the Scene Plan
+
+Before rendering, define the beats.
+
+Use a structure like:
+
+| Beat | Visual | Spoken Line | On-Screen Text |
+|------|--------|-------------|----------------|
+| 1 | direct-to-camera | hook | short opening line |
+| 2 | creator reaction | pain point | problem keyword |
+| 3 | product mention | intro | product name |
+| 4 | screenshot or proof | result | one metric or outcome |
+| 5 | close | CTA | action line |
+
+Keep the visual rhythm simple. Too many cuts can make AI UGC feel fake.
+
+### Step 5 - Render for Feed Native Behavior
+
+Rules:
+
+- `9:16` by default
+- captions on by default
+- front-load the hook
+- show proof quickly
+- keep the CTA single and obvious
+
+If the user asks for multiple variants, vary:
+
+- hook
+- tone
+- CTA
+- proof framing
+
+Do not vary everything at once if the goal is creative testing.
+
+## Proof Rules
+
+The proof beat should contain one concrete thing:
+
+- one result
+- one before-and-after change
+- one testimonial line
+- one product behavior the viewer can understand instantly
+
+Do not stack five benefits into one proof section.
+
+## Delivery
+
+Default output:
+
+- `ugc-video.mp4`
+
+Typical output:
+
+- `1080x1920`
+- `9:16`
+- MP4 with captions
+
+When delivering, report:
+
+- selected platform
+- tone
+- duration
+- hook used
+- CTA used
+
+## Guardrails
+
+- do not write polished corporate ad copy and call it UGC
+- do not bury the hook
+- do not use generic product category language when the actual product is known
+- do not overload the script with too many benefits
+- do not let the CTA sound disconnected from the rest of the clip
+
+## Example Request
+
+```text
+Product: Gooseworks, an AI agent that automates research, content, and outreach workflows. Hook: "I used to spend 4 hours a day on research. Then I found this." Tone: authentic. Duration: 30 seconds. Platform: instagram. CTA: "Link in bio for a free trial."
+```
+
+Expected result:
+
+- a short-form UGC script with hook, pain, product intro, proof, and CTA
+- a final vertical `ugc-video.mp4`

--- a/skills/composites/vid-ugc-style/skill.meta.json
+++ b/skills/composites/vid-ugc-style/skill.meta.json
@@ -1,0 +1,24 @@
+{
+  "slug": "vid-ugc-style",
+  "category": "composites",
+  "tags": [
+    "content",
+    "design",
+    "social"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install vid-ugc-style",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Creates UGC-style vertical videos from a product brief, hook, tone, and CTA",
+    "Supports authentic, excited, and skeptical-convert creative directions",
+    "Uses a proven hook, pain, product, proof, and CTA structure for feed-native short-form video",
+    "Optimized for Instagram, TikTok, Facebook, and other scroll-first channels",
+    "Outputs a caption-friendly 9:16 MP4 ready for paid or organic distribution"
+  ]
+}

--- a/skills/composites/vid-whiteboard-animation/SKILL.md
+++ b/skills/composites/vid-whiteboard-animation/SKILL.md
@@ -1,0 +1,226 @@
+---
+name: vid-whiteboard-animation
+description: Create whiteboard-style explainer videos from narration and draw cues, then export them to MP4. Use when the user needs educational, training, onboarding, or conceptual B2B video that explains ideas step by step with synchronized hand-drawn visuals rather than a presenter or glossy promo treatment.
+tags: [content, design]
+---
+
+# Vid Whiteboard Animation
+
+Create whiteboard-style explainer videos where concepts are drawn out in sync with narration.
+
+This skill is for educational explainers, onboarding sequences, sales training, and conceptual B2B content. The result should feel clear, approachable, and sequential, not flashy or photorealistic.
+
+## Best Fit
+
+- Concept explainers
+- Product education
+- Internal training videos
+- Sales onboarding material
+- Thought-leadership explainers
+- LinkedIn educational video clips
+
+## Use Something Else
+
+- If the user needs a creator-style ad, use `vid-ugc-style`.
+- If the user needs an FAQ or objection-handling format, use `vid-faq`.
+- If the user needs a cinematic launch reveal, use `vid-product-launch`.
+
+## Core Promise
+
+1. Accept a script and concept list
+2. Break the script into draw-and-narrate segments
+3. Map each narration beat to a simple visual
+4. Choose the right board style and pacing
+5. Export a clean MP4 with synchronized draw timing
+
+## Inputs
+
+| Parameter | Required | Default | Notes |
+|-----------|----------|---------|-------|
+| `script` | Yes | - | Narration script broken into beats |
+| `concepts` | No | `auto` | Key concepts or visuals if not embedded in the script |
+| `board_style` | No | `whiteboard` | `whiteboard`, `blackboard`, or `glass` |
+| `draw_hand` | No | `true` | Show a drawing hand |
+| `voiceover` | No | `default` | TTS voice, uploaded voice, or clone |
+| `music` | No | `none` | Optional soft background music |
+| `duration` | No | `auto` | Usually 60 to 240 seconds |
+| `color_illustrations` | No | `false` | Color-fill after draw versus pure sketch |
+| `assets` | No | none | Logos, diagrams, screenshots, icon references |
+
+## Whiteboard Logic
+
+Whiteboard animation works because it reveals information in sequence.
+
+That means:
+
+- the narration should match the draw order
+- the visuals should stay simple
+- each beat should introduce one idea
+- pacing must allow the viewer to watch the drawing happen
+
+If the script moves too fast for the visuals, slow the script down or split the beat.
+
+## Board Style Selection
+
+| Style | Best For | Notes |
+|-------|----------|-------|
+| `whiteboard` | general B2B education | clean and familiar default |
+| `blackboard` | more dramatic or classroom-like tone | stronger contrast, more stylized |
+| `glass` | modern explainer aesthetic | use sparingly and keep visuals clean |
+
+### Default Style
+
+Use `whiteboard` unless the user explicitly wants a different feel.
+
+## Workflow
+
+### Step 1 - Intake
+
+Resolve these before building:
+
+1. The narration script
+2. Audience
+3. Educational goal
+4. Board style
+5. Voice and music direction
+6. Whether color fills should be used
+7. Any required concepts, icons, or diagrams
+
+If the user gives only a topic, ask for the real script or help them draft one before rendering.
+
+### Step 2 - Convert Script into Draw Beats
+
+Whiteboard scripts should be segmented, not written as a monologue.
+
+Use this structure:
+
+```text
+[DRAW: stick figure at desk]
+NARRATOR: "Imagine you spend 3 hours every morning just on email."
+
+[DRAW: inbox with 500 unread]
+NARRATOR: "Sound familiar?"
+```
+
+Rules:
+
+- every narration beat gets a visual cue
+- visuals should be icons, stick figures, arrows, diagrams, or simple scenes
+- avoid complex descriptions that need photorealism
+- if a narration line is too long, split it
+
+### Step 3 - Simplify the Visual Language
+
+Whiteboard is not the place for detailed UI polish or cinematic imagery.
+
+Prefer:
+
+- stick figures
+- icons
+- arrows
+- clocks
+- checkmarks
+- simple dashboards
+- process diagrams
+
+Avoid:
+
+- detailed character acting
+- dense interface recreation
+- visual clutter
+- more than one highlight color unless the user explicitly wants it
+
+## Step 4 - Choose the Production Path
+
+Use tools like:
+
+- VideoScribe
+- Doodly
+- Simpleshow
+- Vyond when a broader animation suite is needed
+
+Choose based on the job:
+
+- VideoScribe for classic whiteboard and large asset-library work
+- Doodly when blackboard or glassboard styles matter
+- Simpleshow when AI-assisted concept translation is useful
+- Vyond when the whiteboard look is part of a broader mixed-style piece
+
+## Step 5 - Pace the Narration
+
+Whiteboard pacing is slower than talking-head pacing.
+
+Rules:
+
+- use short sentences
+- leave room for the draw action
+- one idea per segment
+- allow a tiny pause before moving to the next visual
+
+If the user gives dense copy, trim it before rendering. Do not just speed up the voice.
+
+## Step 6 - Add Color Carefully
+
+By default, keep the video mostly black-and-white.
+
+Use color only for:
+
+- one important stat
+- a final highlight
+- a key problem area
+- a single brand accent
+
+Too much color defeats the whiteboard effect.
+
+## Step 7 - Build the Sequence
+
+Before rendering, create a simple storyboard.
+
+Use a structure like:
+
+| Segment | Draw Cue | Narration Goal |
+|---------|----------|----------------|
+| 1 | overwhelmed worker | introduce the problem |
+| 2 | clock and inbox | quantify the pain |
+| 3 | 3-step workflow | explain the solution |
+| 4 | checkmark and result | close with outcome |
+
+This makes the final animation easier to pace and revise.
+
+## Delivery
+
+Default output:
+
+- `whiteboard-animation.mp4`
+
+Typical output:
+
+- 1080p MP4
+- `1920x1080`
+- 60 to 240 seconds
+
+When delivering, report:
+
+- board style
+- whether draw hand is enabled
+- whether color fill is enabled
+- approximate duration
+
+## Guardrails
+
+- do not treat whiteboard like a cinematic ad format
+- do not use photorealistic visual instructions
+- do not write long narration blocks without draw segmentation
+- do not overload the board with too many simultaneous elements
+- do not use too much color
+
+## Example Request
+
+```text
+Whiteboard animation, 90 seconds. Board style: whiteboard. Draw hand: true. [DRAW: person looking overwhelmed at computer]. NARRATOR: "The average knowledge worker checks email 74 times a day." [DRAW: clock spinning fast]. NARRATOR: "That is hours of context switching every single day." [DRAW: simple 3-step workflow]. NARRATOR: "Here is a better system." Voice: calm. Music: none.
+```
+
+Expected result:
+
+- a segmented draw-and-narrate storyboard
+- a final `whiteboard-animation.mp4`

--- a/skills/composites/vid-whiteboard-animation/skill.meta.json
+++ b/skills/composites/vid-whiteboard-animation/skill.meta.json
@@ -1,0 +1,23 @@
+{
+  "slug": "vid-whiteboard-animation",
+  "category": "composites",
+  "tags": [
+    "content",
+    "design"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install vid-whiteboard-animation",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Creates whiteboard-style explainer videos from narration and draw cues",
+    "Supports whiteboard, blackboard, and glassboard visual treatments",
+    "Helps convert scripts into synchronized draw-and-narrate segments",
+    "Optimized for educational, onboarding, training, and conceptual B2B video",
+    "Outputs a paced MP4 with optional draw-hand, voiceover, music, and selective color highlights"
+  ]
+}


### PR DESCRIPTION
## Summary
- add 10 new video-generation composite skills under `skills/composites`
- include a clear `SKILL.md` and matching `skill.meta.json` for each skill
- register all 10 skills in `skills-index.json`
- align each skill to the provided Notion spec while tightening execution details for real agent use

## What Was Added

| Skill | What It Creates | Best For | Key Inputs | Output |
|---|---|---|---|---|
| `vid-faq` | FAQ videos in talking-head, text-on-video, or animated format | objection handling, support deflection, onboarding, sales follow-up | FAQ pairs, format, voice/avatar, aspect ratio | `faq-video.mp4` |
| `vid-whiteboard-animation` | Whiteboard-style narrated explainer videos | educational content, onboarding, training, conceptual B2B explainers | script, draw concepts, board style, voiceover | `whiteboard-animation.mp4` |
| `vid-ugc-style` | Creator-style vertical UGC videos | paid social, organic short-form, cold-traffic creative testing | product brief, hook, tone, platform, CTA | `ugc-video.mp4` |
| `vid-product-launch` | Narrative launch and reveal videos | launch-day announcements, landing-page hero videos, social launch assets | product brief, tagline, tone, reveal timing, CTA | `product-launch.mp4` |
| `vid-talking-head` | AI-avatar or source-face talking-head videos | founder messaging, thought leadership, product explanation, educational presenter video | exact script, avatar, voice, background, captions | `talking-head.mp4` |
| `vid-customer-testimonial` | Testimonial videos from verbatim customer quotes | landing-page trust sections, sales decks, email follow-up, paid social proof | customer quote, identity details, format, result stat | `testimonial.mp4` |
| `vid-short-form-vertical` | Hook-first vertical short-form videos | Reels, TikTok, Shorts, short educational clips | hook, prompt, format, platform, music | `short-form-vertical.mp4` |
| `vid-sizzle-reel` | High-energy montage/sizzle videos | campaign kickoffs, conference openers, investor deck openers, hype assets | key messages, tone, music, brand assets, end card | `sizzle-reel.mp4` |
| `vid-animated-explainer-2d` | Scene-based 2D animated explainer videos | onboarding, product-page, investor, and educational explainers | scene-based script, animation style, characters, voiceover | `explainer-2d.mp4` |
| `vid-product-demo-screencast` | Product demo and screencast walkthrough videos | onboarding, sales enablement, feature-release demos, product-page walkthroughs | product URL or recording, ordered feature list, narration, annotations | `product-demo.mp4` |

## Per-Skill Notes

### `vid-faq`
- implements explicit handling for long-form multi-question FAQ videos and short-form one-question social variants
- requires real Q&A pairs instead of allowing vague product-topic prompts
- includes format selection guidance across talking-head, text-on-video, and animated FAQ production

### `vid-whiteboard-animation`
- translates scripts into draw-and-narrate beats instead of treating whiteboard as a generic explainer format
- includes board-style selection (`whiteboard`, `blackboard`, `glass`) and sparse-color rules
- emphasizes synchronized visual pacing and simpler icon/diagram language for reliable execution

### `vid-ugc-style`
- adds a feed-native UGC workflow with hook, pain, product, proof, and CTA structure
- supports `authentic`, `excited`, and `skeptical-convert` tones with platform-aware defaults
- keeps outputs vertical and caption-friendly for Instagram, TikTok, and Meta-style short-form distribution

### `vid-product-launch`
- separates launch-reveal storytelling from generic hype or sizzle-reel behavior
- enforces tease, build, reveal, proof, and CTA structure with reveal timing as a protected moment
- supports cinematic, energetic, minimal, and emotional launch directions

### `vid-talking-head`
- requires a word-for-word script rather than a loose topic brief
- adds provider guidance for avatar, animated-photo, and real-footage lip-sync paths
- includes output defaults, pause handling, and presenter framing guidance for stronger delivery

### `vid-customer-testimonial`
- preserves verbatim customer voice instead of paraphrasing into marketing copy
- supports talking-head, text-on-video, and split-screen testimonial formats
- emphasizes identity, specificity, and measurable proof as the core trust-building elements

### `vid-short-form-vertical`
- formalizes hook-first, mobile-native structure for Reels, TikTok, and YouTube Shorts
- supports `talking-points`, `list`, `storytime`, `pov`, and `tutorial` short-form shapes
- adds hook formulas, platform differences, caption defaults, and music guidance

### `vid-sizzle-reel`
- defines the format as hype-first and music-led rather than explanatory
- structures the reel around cold open, build, peak, and brand land/end card
- includes tone/cut-style guidance for energetic, cinematic, emotional, and professional treatments

### `vid-animated-explainer-2d`
- adds scene-based 2D explainer planning with one concept per scene
- supports `flat`, `cartoon`, `corporate`, and `sketch` animation styles
- positions the format between whiteboard simplicity and heavier live-action production

### `vid-product-demo-screencast`
- requires a real product URL or recording plus an ordered feature flow
- centers the actual on-screen user journey instead of marketing-priority ordering
- includes narration, annotation, zoom, and cursor-guidance rules for more usable product walkthroughs

## Implementation Notes
- all 10 skills were added under `skills/composites/`
- each skill includes a matching `skill.meta.json`
- all 10 were added to `skills-index.json`
- the new `vid-*` entries are alphabetized in the index for discoverability and consistency
- the skill text was expanded beyond the raw Notion cards where needed to make execution more reliable inside this repo

## Validation
- confirmed the exact requested 10-skill set exists on disk
- confirmed all 10 have matching index entries
- ran a focused validation pass over frontmatter, metadata shape, install commands, and `vid-*` ordering in `skills-index.json`
- ran a follow-up audit pass after tightening weaker skills to ensure the whole family stayed consistent
