### PR TITLE
Add three Meta Ads workflow skills (analyzer, lead-quality, policy-checker)

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-04-29",
+  "generated": "2026-05-04",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -54,6 +54,34 @@
         ],
         "installation": {
           "base_command": "npx goose-skills install ad-campaign-analyzer",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
+      }
+    },
+    {
+      "slug": "ad-lead-quality-analyzer",
+      "name": "ad-lead-quality-analyzer",
+      "category": "composites",
+      "description": ">",
+      "tags": "ads",
+      "path": "skills/composites/ad-lead-quality-analyzer",
+      "files": [
+        "skills/composites/ad-lead-quality-analyzer/SKILL.md",
+        "skills/composites/ad-lead-quality-analyzer/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "ad-lead-quality-analyzer",
+        "category": "composites",
+        "description": "For paid lead-gen and participant-recruitment ads, replaces vanity CPA with true CAC per qualified lead by joining ad-platform data with downstream funnel events stored in the advertiser's own database. Surfaces tracking gaps, classifies every creative into Scale / Keep / Investigate / Cut, and flags the 'dangerous winners' — low Platform CPA but high vanity-signup rate.",
+        "tags": [
+          "ads"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install ad-lead-quality-analyzer",
           "supports": [
             "claude",
             "cursor",
@@ -3491,6 +3519,34 @@
       }
     },
     {
+      "slug": "meta-ad-policy-checker",
+      "name": "meta-ad-policy-checker",
+      "category": "composites",
+      "description": ">",
+      "tags": "ads",
+      "path": "skills/composites/meta-ad-policy-checker",
+      "files": [
+        "skills/composites/meta-ad-policy-checker/SKILL.md",
+        "skills/composites/meta-ad-policy-checker/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "meta-ad-policy-checker",
+        "category": "composites",
+        "description": "Pre-flight policy check for Meta ads. Takes ad copy plus a short advertiser context, fetches the relevant policy pages from Meta's transparency center at runtime, and returns a verdict (Pass / Fix Required / Block) with cited findings and rewrites. Uses Meta's own published policies as source of truth, no hardcoded rule list. Designed to gate ad-write workflows or audit existing live ads.",
+        "tags": [
+          "ads"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install meta-ad-policy-checker",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
+      }
+    },
+    {
       "slug": "meta-ad-scraper",
       "name": "meta-ad-scraper",
       "category": "capabilities",
@@ -3510,6 +3566,34 @@
         ],
         "installation": {
           "base_command": "npx goose-skills install meta-ad-scraper",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
+      }
+    },
+    {
+      "slug": "meta-ads-analyzer",
+      "name": "meta-ads-analyzer",
+      "category": "composites",
+      "description": ">",
+      "tags": "ads",
+      "path": "skills/composites/meta-ads-analyzer",
+      "files": [
+        "skills/composites/meta-ads-analyzer/SKILL.md",
+        "skills/composites/meta-ads-analyzer/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "meta-ads-analyzer",
+        "category": "composites",
+        "description": "Diagnose Meta Ads campaigns using Meta's actual system mechanics — Breakdown Effect, Learning Phase, Auction Overlap, Pacing, and Creative Fatigue. Produces a structured diagnosis with root causes and testable hypotheses, designed to avoid the most common analysis mistake of judging segments by average CPA instead of marginal efficiency.",
+        "tags": [
+          "ads"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install meta-ads-analyzer",
           "supports": [
             "claude",
             "cursor",

--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-05-04",
+  "generated": "2026-05-07",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -66,7 +66,7 @@
       "slug": "ad-lead-quality-analyzer",
       "name": "ad-lead-quality-analyzer",
       "category": "composites",
-      "description": ">",
+      "description": "For paid lead-gen and participant-recruitment ads, replaces vanity CPA with true CAC per qualified lead by joining ad-platform data with downstream funnel events, surfaces tracking gaps, and classifies every creative into Scale / Keep / Investigate / Cut.",
       "tags": "ads",
       "path": "skills/composites/ad-lead-quality-analyzer",
       "files": [
@@ -3522,7 +3522,7 @@
       "slug": "meta-ad-policy-checker",
       "name": "meta-ad-policy-checker",
       "category": "composites",
-      "description": ">",
+      "description": "Pre-flight policy check for Meta ads. Takes ad copy plus advertiser context, resolves and fetches the relevant Meta transparency-center policy pages at runtime, and returns a Pass / Fix Required / Block verdict with cited findings and rewrites.",
       "tags": "ads",
       "path": "skills/composites/meta-ad-policy-checker",
       "files": [
@@ -3532,7 +3532,7 @@
       "metadata": {
         "slug": "meta-ad-policy-checker",
         "category": "composites",
-        "description": "Pre-flight policy check for Meta ads. Takes ad copy plus a short advertiser context, fetches the relevant policy pages from Meta's transparency center at runtime, and returns a verdict (Pass / Fix Required / Block) with cited findings and rewrites. Uses Meta's own published policies as source of truth, no hardcoded rule list. Designed to gate ad-write workflows or audit existing live ads.",
+        "description": "Pre-flight policy check for Meta ads. Takes ad copy plus a short advertiser context, resolves and fetches the relevant policy pages from Meta's transparency center at runtime, and returns a verdict (Pass / Fix Required / Block) with cited findings and rewrites. Uses Meta's own published policies as source of truth, no hardcoded rule list. Designed to gate ad-write workflows or audit existing live ads.",
         "tags": [
           "ads"
         ],
@@ -3578,7 +3578,7 @@
       "slug": "meta-ads-analyzer",
       "name": "meta-ads-analyzer",
       "category": "composites",
-      "description": ">",
+      "description": "Diagnose Meta Ads campaign performance using Meta's actual system mechanics — Breakdown Effect, Learning Phase, Auction Overlap, Pacing, and Creative Fatigue — and produce structured, testable recommendations that avoid judging segments by average CPA instead of marginal efficiency.",
       "tags": "ads",
       "path": "skills/composites/meta-ads-analyzer",
       "files": [

--- a/skills/composites/ad-lead-quality-analyzer/SKILL.md
+++ b/skills/composites/ad-lead-quality-analyzer/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: ad-lead-quality-analyzer
+description: >
+  For paid lead-gen and participant-recruitment ads, replaces vanity CPA with true
+  CAC per qualified lead by joining ad-platform data (signups) with downstream
+  funnel events (qualification, completion, payout) stored in the advertiser's
+  own database. Detects "winning" ads that are actually bringing in junk leads,
+  surfaces tracking gaps, and classifies every creative into Scale / Keep /
+  Investigate / Cut. Built for Meta first, channel-agnostic in design.
+tags: [ads]
+---
+
+# Ad Lead Quality Analyzer
+
+Meta optimizes for whatever conversion event you fire. For lead-gen and participant-recruitment campaigns that's almost always "signup" — but a signup is worthless if the lead never qualifies, never completes the requested action, or never gets paid out. The lowest-CPA campaign is often the one bringing in the *worst* leads.
+
+This skill joins what the ad platform knows (spend, signups) with what your own product knows (downstream funnel) and replaces vanity CPA with **true CAC per qualified lead**. It then classifies every creative into actionable buckets so you stop scaling the wrong winners.
+
+**Core principle:** The ad platform's CPA is a half-truth. Real optimization needs both halves of the funnel — pre-signup (the platform has it) and post-signup (you have it). Until they're joined, you're flying blind.
+
+## When to Use
+
+- "Which ads are bringing in real leads vs. junk?"
+- "True CAC per qualified contributor / customer / participant"
+- "Why is my lowest-CPA campaign performing worst downstream?"
+- "Audit lead quality across creatives / audiences / placements"
+- "Should I trust Meta's CPA when scaling?"
+- "Find the creatives that look like winners but aren't"
+
+## Pipeline Pattern Assumptions (Read First)
+
+This skill is opinionated about **what** to measure (true CAC per qualified lead, with cohort maturation, with vanity scoring) and agnostic about **how** the data is sourced.
+
+It assumes one of three standard attribution patterns:
+
+| Pattern | Setup | Join Key |
+|---|---|---|
+| **A. UTM-only** *(most common)* | UTM params captured on signup form, stored on lead/user record. Downstream events joined by user_id inside your DB. | `utm_content` (typically the ad ID) on both sides, or `fbclid` |
+| **B. UTM + CAPI send-back** *(best)* | Same as A, plus your app fires Conversions API events back to Meta when downstream stages hit. Meta then optimizes for quality, not signups. | `event_id` / `external_id` |
+| **C. Meta Lead Ads + CRM sync** | Meta-hosted lead form, `lead_id` syncs to CRM/DB, joined there. | `lead_id` |
+
+If none of these patterns is wired up, the skill switches to **`tracking-gap` mode** — it produces a fix-the-tracking report instead of an analysis.
+
+## Phase 0: Discovery Interview
+
+6 short questions. Don't proceed until each is answered (default = "I don't know — let's find out").
+
+1. **Where do downstream events live?** (Postgres / MySQL / Airtable / custom internal admin / spreadsheet / "no idea")
+2. **Can the agent query that source directly?** (DB credentials / API endpoint / CSV export / "needs a person to pull it")
+3. **Does the signup form capture `utm_*` params or `fbclid`?** ("I don't know" → inspect the signup form's HTML / network requests)
+4. **Is the app sending CAPI events back to Meta** for any downstream stage? (None / signup-only / signup + qualification / full funnel)
+5. **What is a "qualified lead"?** (Default: ≥1 unit of value-producing action completed within 14 days of signup. Examples: first purchase; demo attended; subscription activated; trial converted; first task completed and paid out)
+6. **Cost basis per qualified lead?** (Flat payout, variable, tiered by quality, or N/A — needed to compute margin)
+
+Output of Phase 0: a one-paragraph **Pipeline Brief** stating the assumed pattern (A/B/C), the join key, the qualification definition, and any unknowns.
+
+## Phase 1: Tracking Validation (Gating Step)
+
+Pull a sample of 10–20 recent signups from the downstream source. For each, check:
+
+- Is `utm_source` / `utm_campaign` / `utm_content` present? (Or `fbclid`? Or `lead_id`?)
+- Does the join key resolve back to a specific Meta ad?
+- Are there orphan signups (in your DB but no Meta join key)?
+- Are there orphan Meta signups (in Meta but no matching DB record)?
+
+**Coverage thresholds:**
+
+| Coverage | Action |
+|---|---|
+| ≥80% joinable | Proceed to Phase 2 (`analysis` mode) |
+| 50–80% joinable | Proceed with explicit confidence caveat on every finding |
+| <50% joinable | Switch to **`tracking-gap` mode**. Skip Phases 2–6. Output the gap report. |
+
+Output of Phase 1: a **Data Quality Report** with coverage %, sample of orphan records, and exact field-level findings.
+
+## Phase 2: Build the Per-Creative Funnel
+
+For every ad / ad set / campaign with statistical volume (default ≥30 signups in the window), construct:
+
+| Stage | Count | Conv. from prev. | What a drop here means |
+|---|---|---|---|
+| Impressions | n | — | — |
+| Link Clicks | n | CTR | Hook / placement issue |
+| Signups | n | Click → Signup | LP / form friction (use `ad-to-landing-page-auditor`) |
+| Qualified action started | n | Signup → Started | **Vanity signups** — wrong promise in the ad |
+| Qualified action approved | n | Started → Approved | Wrong audience or fraud |
+| Payout / value event | n | Approved → Paid | The "real" conversion |
+| Repeat action (configurable window) | n | Retention | One-and-done quality |
+
+The skill should pull Meta-side data via the existing Meta Marketing API connection (MCP, native API, or pasted CSV) and downstream-side data via whichever source Phase 0 identified.
+
+## Phase 3: Compute True CAC
+
+Per creative / ad set / campaign:
+
+- **Platform CPA** = spend ÷ signups *(what Meta reports)*
+- **True CAC** = spend ÷ qualified leads *(what actually matters)*
+- **Quality Multiplier** = True CAC ÷ Platform CPA *(how badly the platform is misleading you per ad — higher = worse vanity problem)*
+- **Margin per qualified lead** = (cost-basis or LTV-equivalent value) − True CAC
+
+## Phase 4: Score and Classify Each Creative
+
+Compute three quality scores per creative with sufficient volume:
+
+- **Vanity score** = 1 − (Started ÷ Signups). High = clicks but no work
+- **Audience-fit score** = Approved ÷ Started. Low = wrong people getting through
+- **Retention score** = Repeat ÷ Approved. Low = one-and-done
+
+Then classify into action buckets:
+
+| Bucket | Rule | Action |
+|---|---|---|
+| **Scale** | Low True CAC + good quality + sufficient volume | Increase budget, watch for diminishing returns |
+| **Keep** | Mid True CAC + acceptable quality | Hold |
+| **Investigate** | High True CAC but high quality (often low volume) | Give it more budget before deciding |
+| **Cut** | Low Platform CPA + high vanity score *(the dangerous one — looks like a winner)* | Pause and replace |
+| **Insufficient data** | Below volume threshold | Wait, do not act |
+
+Every classification cites the data and gets a confidence flag (sample size + CI on True CAC).
+
+## Phase 5: Cohort Maturation Handling
+
+The biggest analysis trap: judging signups before they've had time to complete the funnel.
+
+- **Exclude signups newer than the qualification window** (default 14 days) from "Cut" decisions
+- Show two parallel views in the report:
+  - **Mature cohort** (≥14 days old) — the basis for action
+  - **Recent cohort** (<14 days) — leading indicator only
+- If recent-cohort True CAC is diverging sharply from mature, flag a **creative-fatigue** or **audience-shift** hypothesis for investigation in `meta-ads-analyzer`
+
+## Phase 6: Generate Report
+
+Use this exact structure.
+
+```
+1. PIPELINE BRIEF
+   - Pattern (A/B/C), join key, qualification definition, unknowns
+
+2. DATA QUALITY
+   - Coverage %, orphan counts, confidence level
+
+3. HEADLINE
+   - Overall True CAC vs. Platform CPA
+   - Overall Quality Multiplier
+   - Period-over-period delta
+
+4. PER-CREATIVE TABLE
+   - Ad ID | Spend | Signups | Qualified | Platform CPA | True CAC | Quality Mult. | Vanity | Class
+
+5. ACTION LIST (prioritized)
+   - Cut (dangerous winners) → Scale (proven quality) → Investigate (low-vol promising) → Keep
+   - Each action: hypothesis + expected impact + rollback plan
+
+6. AUDIENCE / PLACEMENT PATTERNS
+   - Which interests / lookalikes / geos / placements correlate with qualified leads
+   - Which correlate with vanity signups
+
+7. TRACKING GAPS (if any from Phase 1)
+   - Specific fields, code locations, or events to wire up
+```
+
+## Tracking-Gap Mode (Output if Phase 1 Fails)
+
+If <50% of signups are joinable, the skill stops the analysis and outputs:
+
+```
+1. WHAT'S BROKEN
+   - Specific symptoms (e.g. "0 signups have utm_content; signup form's hidden fields are empty")
+
+2. WHAT TO ADD
+   - Code-level recommendations (e.g. "preserve URL params on form submit and POST to /signup as utm_source, utm_campaign, utm_content, fbclid")
+   - Schema changes (e.g. "add columns to leads table: utm_source, utm_campaign, utm_content, fbclid, signup_timestamp")
+   - CAPI event setup (recommended, not required)
+
+3. HOW TO VERIFY
+   - The 5-minute test: drop a tagged URL, complete signup, query DB, confirm fields populated
+
+4. EXPECTED IMPACT
+   - "Once fixed, re-run this skill in `analysis` mode in N days when you have enough signups for statistical volume"
+```
+
+## Output Standards (Mandatory)
+
+- **Every recommendation is a hypothesis with expected impact and rollback**, not a directive
+- **Never recommend cutting a creative purely on Platform CPA** — that's the bug this skill exists to fix
+- **Always show True CAC alongside Platform CPA** in any number reported back to the user
+- **Cohort-tag every figure** as Mature, Recent, or Combined — never let the reader confuse them
+- **Flag confidence level** on every per-creative recommendation (low / medium / high based on sample size + CI)
+- **Disambiguate "leads"** — define "signup", "qualified", "paid" clearly in the Pipeline Brief and use them consistently
+
+## What This Skill Will Not Do
+
+- **Will not write to ad accounts** — pure analysis. Action via Meta Ads Manager or whatever write tool the calling agent has available.
+- **Will not fix tracking for you** — it tells you what's broken and how to fix it; the fix is a code change in your app.
+- **Will not generate creative or copy variants** — use `messaging-ab-tester` and `ad-angle-miner`.
+- **Will not diagnose Meta system mechanics** (Breakdown Effect, Learning Phase) — pass the output to `meta-ads-analyzer` for that layer.
+- **Will not compute true LTV** — uses first-payout / first-value as proxy. Multi-touch LTV modeling is a different skill.
+
+## Related Skills
+
+- **`meta-ads-analyzer`** — Run after this skill to interpret *why* a creative's quality is low using Meta's system mechanics
+- **`ad-campaign-analyzer`** — Use for cross-channel budget reallocation once true CAC is known
+- **`ad-to-landing-page-auditor`** — Pair with this when "Click → Signup" drop-off is the leak
+- **`messaging-ab-tester`** — Use to generate replacement creatives for anything in the Cut bucket

--- a/skills/composites/ad-lead-quality-analyzer/SKILL.md
+++ b/skills/composites/ad-lead-quality-analyzer/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: ad-lead-quality-analyzer
-description: >
-  For paid lead-gen and participant-recruitment ads, replaces vanity CPA with true
-  CAC per qualified lead by joining ad-platform data (signups) with downstream
-  funnel events (qualification, completion, payout) stored in the advertiser's
-  own database. Detects "winning" ads that are actually bringing in junk leads,
-  surfaces tracking gaps, and classifies every creative into Scale / Keep /
-  Investigate / Cut. Built for Meta first, channel-agnostic in design.
+description: For paid lead-gen and participant-recruitment ads, replaces vanity CPA with true CAC per qualified lead by joining ad-platform data with downstream funnel events, surfaces tracking gaps, and classifies every creative into Scale / Keep / Investigate / Cut.
 tags: [ads]
 ---
 

--- a/skills/composites/ad-lead-quality-analyzer/skill.meta.json
+++ b/skills/composites/ad-lead-quality-analyzer/skill.meta.json
@@ -1,0 +1,16 @@
+{
+  "slug": "ad-lead-quality-analyzer",
+  "category": "composites",
+  "description": "For paid lead-gen and participant-recruitment ads, replaces vanity CPA with true CAC per qualified lead by joining ad-platform data with downstream funnel events stored in the advertiser's own database. Surfaces tracking gaps, classifies every creative into Scale / Keep / Investigate / Cut, and flags the 'dangerous winners' — low Platform CPA but high vanity-signup rate.",
+  "tags": [
+    "ads"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install ad-lead-quality-analyzer",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}

--- a/skills/composites/meta-ad-policy-checker/SKILL.md
+++ b/skills/composites/meta-ad-policy-checker/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: meta-ad-policy-checker
+description: >
+  Pre-flight policy check for Meta ads. Takes ad copy plus a short advertiser
+  context, fetches the relevant policy pages from Meta's transparency center
+  at runtime, and returns a verdict (Pass / Fix Required / Block) with cited
+  findings and rewrites. No hardcoded rule list — Meta's own published policies
+  are the source of truth. Designed to gate ad-write workflows or audit ads
+  already live.
+tags: [ads]
+---
+
+# Meta Ad Policy Checker
+
+Meta disapproves ads for policy reasons constantly, and most disapprovals are preventable. The pattern is almost always the same: an advertiser (or an AI agent generating variants) writes copy that uses a phrase or implies a claim that violates Meta's published advertising standards. The fix is cheap if you catch it before submission, expensive if you don't — repeated disapprovals on the same account can throttle delivery or trigger account-level restrictions.
+
+This skill is a pre-flight check. It reads ad copy, figures out which Meta policies apply, fetches the live policy text from Meta's transparency center, and returns a clear verdict with specific findings, citations, and rewrites. It does not hardcode policy rules — Meta updates those, and a static rule list goes stale. Instead, the skill uses Meta's own canonical policy pages as ground truth on every run.
+
+**Core principle:** The skill provides the methodology — what to check, how to reason, what severity to assign. Meta provides the source of truth — the actual policy text. This separation is what keeps the skill correct as Meta's standards evolve.
+
+## When to Use
+
+- Before launching any new Meta ad
+- After generating ad copy variants (call this on each variant before showing or submitting)
+- When auditing an existing live ad for policy risk
+- When troubleshooting a recently disapproved ad
+- Before pushing copy through any Meta MCP / API write tool
+
+## Phase 0: Intake
+
+1. **Advertiser context** *(1–2 sentences)*
+   - What the business does
+   - What product / service / offer is being advertised
+   - Primary conversion goal
+2. **Ad asset(s)**
+   - Headline(s)
+   - Primary text / body
+   - Description (if applicable)
+   - CTA button text
+   - Destination URL *(optional — enables a landing-page cross-check)*
+3. **Special Ad Category** — declared by user: `None` / `Employment` / `Credit` / `Housing` / `Social Issues, Elections or Politics` *(this changes the applicable rules significantly)*
+4. **Targeting summary** *(optional)* — useful for discrimination checks (age, gender, location exclusions)
+5. **Visual description** *(optional)* — text-in-image is policy-relevant
+6. **Mode** — `pre-flight` (block until clean) or `audit` (flag-only, used for already-live ads)
+
+## Phase 1: Determine Which Policies Apply
+
+Reason about the ad before fetching. Most ads need 3–6 policy pages, not all 25. Always include the **baseline set**, then add **content-driven** pages based on what the ad mentions, then add **category-driven** pages based on declared Special Ad Category.
+
+### Baseline (every ad)
+- Community Standards
+- Personal Attributes
+- Sensational Content
+- Misinformation
+- Engagement Bait / Spam
+- Grammar & Profanity
+- Non-Functional Landing Pages
+
+### Content-driven (add when present)
+
+| Triggers | Policies to fetch |
+|---|---|
+| Income, earnings, payouts, "make money", specific dollar amounts | `personal-financial-requirements`, `unrealistic-outcomes` |
+| Health, weight loss, supplements, wellness claims | `health-wellness`, `before-after-photos` |
+| Targeting by age, gender, race, religion, nationality | `discriminatory-practices` |
+| Crypto, weapons, adult, drugs, alcohol, gambling, tobacco | `restricted-content` |
+| Political, social-issue, election content | `social-issues-elections-politics` |
+| Profanity, slurs, sensitive language | `profanity`, `inflammatory-content` |
+| Anything that implies tracking / scraping / circumvention | `circumventing-systems` |
+
+### Category-driven (add based on declared Special Ad Category)
+
+| Special Ad Category | Add |
+|---|---|
+| Employment | `employment` |
+| Credit | `credit` |
+| Housing | `housing` |
+| Social Issues, Elections or Politics | `social-issues-elections-politics` |
+
+Output of Phase 1: an ordered list of policy slugs to fetch in Phase 2.
+
+## Phase 2: Fetch + Cache Live Policy Text
+
+For each slug from Phase 1, fetch from Meta's transparency center:
+
+```
+https://transparency.meta.com/policies/ad-standards/{slug}/
+```
+
+**Caching rule:** in-memory for the current session only. A batch check of 10 ad variants should produce 3–6 fetches total (one per relevant page), not 30–60. Skip persistent caching to avoid stale-cache bugs across sessions.
+
+**Fallback:** if a specific slug 404s (Meta occasionally renames policy pages), fetch the policy index at `https://transparency.meta.com/policies/ad-standards/` and let the agent navigate to the closest-matching policy. Log this as a "policy URL drift" note in the output so the slug list can be updated.
+
+## Phase 3: Reason — Ad vs. Policy
+
+For each fetched policy, walk through every element of the ad (headline, body, description, CTA, link, visual description if provided) and ask:
+
+1. **Does any phrase, implication, or pattern in the ad match a restricted pattern in this policy's text?**
+2. **What specific clause from the policy applies?** Pull the direct quote.
+3. **What is the severity?**
+
+Severity model — three levels:
+
+| Severity | Definition |
+|---|---|
+| **Block** | Clear violation. Ad will almost certainly be disapproved. Do not submit until fixed. |
+| **Fix Required** | Likely violation or explicit risk. Ad may pass but is at meaningful risk of disapproval or under-delivery. Fix recommended before submission. |
+| **Caution** | Edge case. Ambiguous wording or pattern Meta sometimes flags. Worth knowing about; not necessarily worth changing. |
+
+For each issue identified, produce:
+
+- **Issue** — exact phrase or pattern in the ad
+- **Policy** — name + URL
+- **Citation** — direct quote from Meta's policy page
+- **Severity** — one of the three above
+- **Why** — one-line explanation grounding the call in the cited policy text
+- **Suggested rewrite** — preserves the advertiser's intent, removes the risk
+
+## Phase 4: Landing-Page Cross-Check *(if URL provided)*
+
+Common disapproval reason: ad claims that aren't substantiated on the LP, or LP claims more aggressive than the ad. Run a brief cross-check:
+
+- Are the claims made in the ad reflected on the LP?
+- Are required disclosures present (terms, eligibility, conditions)?
+- Does the LP make any claim that, *if it were on the ad*, would be flagged?
+- Is the LP functional (load, render, no broken redirects)? — this is a separate Meta policy (`non-functional-landing-pages`)
+
+This is policy-specific cross-check — not message-match. For message-match (does the LP feel like a continuation of the ad?), use `ad-to-landing-page-auditor`.
+
+## Phase 5: Produce the Output
+
+Use this exact structure.
+
+```
+VERDICT: PASS | FIX REQUIRED | BLOCK
+
+ADVERTISER CONTEXT (echo back so the user knows what was assumed)
+SPECIAL AD CATEGORY: [declared]
+POLICIES CHECKED: [list of slugs fetched, with URLs]
+
+PER-ISSUE FINDINGS:
+  - Issue: [exact phrase or pattern from the ad]
+    Policy: [name] (URL)
+    Citation: "[direct quote from Meta's policy page]"
+    Severity: Block | Fix Required | Caution
+    Why: [one-line explanation grounded in the citation]
+    Suggested rewrite: [safer alternative preserving intent]
+
+RISK SCORE: Low | Medium | High
+  (factors: count of Block issues, count of Fix Required issues, special-category status)
+
+3 SAFER VARIANTS OF THE FULL AD:
+  (only generated if any Block or Fix Required issues exist)
+  - Variant A: [full ad rewrite — headline + body + CTA]
+  - Variant B: [full ad rewrite — different angle on the same offer]
+  - Variant C: [full ad rewrite — most conservative version]
+
+NOTES:
+  - Areas where Meta enforcement is known to vary (best-effort observation)
+  - LP-related findings (if URL was provided)
+  - Anything requiring human judgment beyond what this skill can verify
+  - Any "policy URL drift" notes from Phase 2 fallback handling
+```
+
+## Phase 6: Integration Hooks
+
+This skill is built to be both standalone-runnable and callable from other skills. Recommended chain patterns:
+
+- **Variant generation:** `messaging-ab-tester` produces N variants → `meta-ad-policy-checker` runs on each → only PASS / FIX REQUIRED variants surface to the user
+- **Campaign launch:** `meta-ads-campaign-builder` produces a brief with multiple ads → `meta-ad-policy-checker` runs on every ad → block launch if any return BLOCK
+- **Pre-write gate:** before any tool call that writes to Meta (via MCP, native API, or otherwise), the calling workflow checks the verdict and aborts on BLOCK
+- **Diagnostic on under-delivery:** `meta-ads-analyzer` flags an ad with near-zero delivery → suggest running `meta-ad-policy-checker` to rule out a silent disapproval
+
+The skill returns structured output (verdict + per-issue array) so calling code can gate on `verdict !== "BLOCK"` programmatically.
+
+## Output Standards (Mandatory)
+
+- **Cite, don't paraphrase.** Every finding includes a direct quote from Meta's policy page. If you can't quote, the finding isn't grounded — drop it.
+- **Severity is a calibration, not a guess.** A clear, specific match to a "you may not" clause in the policy = Block. An "ambiguous but risky" match = Fix Required. An edge case Meta sometimes flags but often doesn't = Caution.
+- **Rewrites preserve intent.** A rewrite that changes the offer or the audience is not a rewrite — it's a different ad. Rewrites change *how* the offer is expressed, not *what* it is.
+- **Don't replace Meta's review.** This is pre-flight; Meta is final gatekeeper. If a rewrite still gets disapproved, that's information for the next iteration — log it.
+- **Echo the advertiser context.** Always restate what was assumed, so the user can correct misinterpretation.
+
+## What This Skill Will Not Do
+
+- **Won't replace Meta's actual ad review.** Meta is the final gatekeeper. This catches the obvious and the well-documented; Meta enforcement evolves.
+- **Won't read images for text.** Text-in-image violations need a separate vision pass; out of scope for v1. The skill *will* reason about visual *descriptions* if provided.
+- **Won't determine Special Ad Category eligibility.** The user declares the category. Whether the ad *should* be in that category is a separate (legal/business) judgment.
+- **Won't enforce the BLOCK.** It produces a verdict; the calling skill, workflow, or human enforces the gate.
+- **Won't track historical disapprovals on your account.** Account-level history affects Meta's review, but isn't visible to this skill. Treat the verdict as the floor of risk, not the ceiling.
+
+## Maintenance Note
+
+The list of policy slugs in Phase 1 is the only mutable piece of this skill. Meta occasionally renames or restructures policy pages. The Phase 2 fallback handles individual page drift gracefully, but periodic review of the slug list (annually, or any time several "policy URL drift" notes appear in outputs) keeps the skill efficient. The slug list lives inline in this SKILL.md so updates are a single-file change.
+
+## Related Skills
+
+- **`messaging-ab-tester`** — runs *upstream*; generates variants this skill should check
+- **`meta-ads-campaign-builder`** — runs *upstream*; produces multi-ad briefs this skill should validate before launch
+- **`ad-to-landing-page-auditor`** — *paired pre-flight*; different concern (message-match vs. policy compliance), same checkpoint
+- **`meta-ads-analyzer`** — runs *downstream*; if a live campaign shows symptoms of a silent disapproval (near-zero delivery, throttling), this skill is the diagnostic step
+- **`ad-campaign-analyzer`** — *loose link*; disapprovals show up as underdelivery in performance data, so cross-reference when a creative shows zero delivery

--- a/skills/composites/meta-ad-policy-checker/SKILL.md
+++ b/skills/composites/meta-ad-policy-checker/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: meta-ad-policy-checker
-description: >
-  Pre-flight policy check for Meta ads. Takes ad copy plus a short advertiser
-  context, fetches the relevant policy pages from Meta's transparency center
-  at runtime, and returns a verdict (Pass / Fix Required / Block) with cited
-  findings and rewrites. No hardcoded rule list — Meta's own published policies
-  are the source of truth. Designed to gate ad-write workflows or audit ads
-  already live.
+description: Pre-flight policy check for Meta ads. Takes ad copy plus advertiser context, resolves and fetches the relevant Meta transparency-center policy pages at runtime, and returns a Pass / Fix Required / Block verdict with cited findings and rewrites.
 tags: [ads]
 ---
 
@@ -47,6 +41,8 @@ This skill is a pre-flight check. It reads ad copy, figures out which Meta polic
 
 Reason about the ad before fetching. Most ads need 3–6 policy pages, not all 25. Always include the **baseline set**, then add **content-driven** pages based on what the ad mentions, then add **category-driven** pages based on declared Special Ad Category.
 
+Treat the entries below as policy lookup keys, not URL slugs. Meta's Transparency Center URLs are nested under category paths and change over time, so never construct a flat policy URL directly from these labels.
+
 ### Baseline (every ad)
 - Community Standards
 - Personal Attributes
@@ -58,38 +54,44 @@ Reason about the ad before fetching. Most ads need 3–6 policy pages, not all 2
 
 ### Content-driven (add when present)
 
-| Triggers | Policies to fetch |
+| Triggers | Policy lookup keys |
 |---|---|
-| Income, earnings, payouts, "make money", specific dollar amounts | `personal-financial-requirements`, `unrealistic-outcomes` |
-| Health, weight loss, supplements, wellness claims | `health-wellness`, `before-after-photos` |
-| Targeting by age, gender, race, religion, nationality | `discriminatory-practices` |
-| Crypto, weapons, adult, drugs, alcohol, gambling, tobacco | `restricted-content` |
-| Political, social-issue, election content | `social-issues-elections-politics` |
-| Profanity, slurs, sensitive language | `profanity`, `inflammatory-content` |
-| Anything that implies tracking / scraping / circumvention | `circumventing-systems` |
+| Income, earnings, payouts, "make money", specific dollar amounts | Personal financial requirements; unrealistic outcomes |
+| Health, weight loss, supplements, wellness claims | Health and wellness; before-and-after photos |
+| Targeting by age, gender, race, religion, nationality | Discriminatory practices |
+| Crypto, weapons, adult, drugs, alcohol, gambling, tobacco | Restricted content |
+| Political, social-issue, election content | Social issues, elections or politics |
+| Profanity, slurs, sensitive language | Profanity; inflammatory content |
+| Anything that implies tracking / scraping / circumvention | Circumventing systems |
 
 ### Category-driven (add based on declared Special Ad Category)
 
 | Special Ad Category | Add |
 |---|---|
-| Employment | `employment` |
-| Credit | `credit` |
-| Housing | `housing` |
-| Social Issues, Elections or Politics | `social-issues-elections-politics` |
+| Employment | Employment |
+| Credit | Credit |
+| Housing | Housing |
+| Social Issues, Elections or Politics | Social issues, elections or politics |
 
-Output of Phase 1: an ordered list of policy slugs to fetch in Phase 2.
+Output of Phase 1: an ordered list of policy lookup keys to resolve and fetch in Phase 2.
 
 ## Phase 2: Fetch + Cache Live Policy Text
 
-For each slug from Phase 1, fetch from Meta's transparency center:
+Fetch Meta's ad-standards index first:
 
 ```
-https://transparency.meta.com/policies/ad-standards/{slug}/
+https://transparency.meta.com/policies/ad-standards/
 ```
 
-**Caching rule:** in-memory for the current session only. A batch check of 10 ad variants should produce 3–6 fetches total (one per relevant page), not 30–60. Skip persistent caching to avoid stale-cache bugs across sessions.
+For each lookup key from Phase 1:
 
-**Fallback:** if a specific slug 404s (Meta occasionally renames policy pages), fetch the policy index at `https://transparency.meta.com/policies/ad-standards/` and let the agent navigate to the closest-matching policy. Log this as a "policy URL drift" note in the output so the slug list can be updated.
+1. Resolve it from the index to Meta's canonical policy page URL. Prefer exact title matches, then closest title / category matches.
+2. Fetch the resolved canonical URL. Do not build a URL by appending the lookup key directly to the ad-standards base path; those flat URLs 404 for many current policies because Meta nests policy pages under category paths.
+3. Cache the lookup key → canonical URL → page text mapping.
+
+**Caching rule:** in-memory for the current session only. A batch check of 10 ad variants should produce 3–6 policy-page fetches total, not 30–60. Skip persistent caching to avoid stale-cache bugs across sessions.
+
+**Fallback:** if the index cannot be parsed or a resolved page 404s, use a site-restricted web search for the policy title on Meta's transparency domain and navigate to the closest-matching current policy. Log this as a "policy URL drift" note in the output so the lookup list can be updated.
 
 ## Phase 3: Reason — Ad vs. Policy
 

--- a/skills/composites/meta-ad-policy-checker/skill.meta.json
+++ b/skills/composites/meta-ad-policy-checker/skill.meta.json
@@ -1,0 +1,16 @@
+{
+  "slug": "meta-ad-policy-checker",
+  "category": "composites",
+  "description": "Pre-flight policy check for Meta ads. Takes ad copy plus a short advertiser context, fetches the relevant policy pages from Meta's transparency center at runtime, and returns a verdict (Pass / Fix Required / Block) with cited findings and rewrites. Uses Meta's own published policies as source of truth, no hardcoded rule list. Designed to gate ad-write workflows or audit existing live ads.",
+  "tags": [
+    "ads"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install meta-ad-policy-checker",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}

--- a/skills/composites/meta-ad-policy-checker/skill.meta.json
+++ b/skills/composites/meta-ad-policy-checker/skill.meta.json
@@ -1,7 +1,7 @@
 {
   "slug": "meta-ad-policy-checker",
   "category": "composites",
-  "description": "Pre-flight policy check for Meta ads. Takes ad copy plus a short advertiser context, fetches the relevant policy pages from Meta's transparency center at runtime, and returns a verdict (Pass / Fix Required / Block) with cited findings and rewrites. Uses Meta's own published policies as source of truth, no hardcoded rule list. Designed to gate ad-write workflows or audit existing live ads.",
+  "description": "Pre-flight policy check for Meta ads. Takes ad copy plus a short advertiser context, resolves and fetches the relevant policy pages from Meta's transparency center at runtime, and returns a verdict (Pass / Fix Required / Block) with cited findings and rewrites. Uses Meta's own published policies as source of truth, no hardcoded rule list. Designed to gate ad-write workflows or audit existing live ads.",
   "tags": [
     "ads"
   ],

--- a/skills/composites/meta-ads-analyzer/SKILL.md
+++ b/skills/composites/meta-ads-analyzer/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: meta-ads-analyzer
+description: >
+  Diagnose Meta Ads campaign performance using Meta's actual system mechanics —
+  Breakdown Effect, Learning Phase, Auction Overlap, Pacing, and Creative Fatigue.
+  Takes CSV exports, pasted tables, or live API data and produces a structured
+  diagnosis with root causes and testable recommendations. Built to avoid the
+  most common analysis mistake: judging segments by average CPA instead of
+  marginal efficiency.
+tags: [ads]
+---
+
+# Meta Ads Analyzer
+
+Most "Meta Ads analysis" stops at "this CPA is high, pause it." That's wrong more often than it's right. Meta's delivery system optimizes for **marginal efficiency** — the cost of the *next* conversion — not average efficiency across a snapshot. A segment with a higher average CPA is often the one keeping your overall campaign cheap. Pausing it makes things worse.
+
+This skill diagnoses Meta campaigns the way a senior media buyer would: at the right evaluation level, accounting for learning state, separating noise from signal, and explaining *why* the system is making the decisions it's making before recommending any change.
+
+**Core principle:** Holistic first, then drill down. Marginal over average. Dynamic over static. Every recommendation is a testable hypothesis with expected impact, not a directive.
+
+## When to Use
+
+- "Analyze my Meta Ads campaign performance"
+- "Why is the system spending more on the higher-CPA placement?"
+- "Diagnose what's wrong with this ad set"
+- "Should I pause this audience / placement / ad?"
+- "My CPA jumped — is this normal or a real problem?"
+- "Audit this campaign before I scale budget"
+- "I exported my Meta data — what does it actually mean?"
+
+## Phase 0: Intake
+
+1. **Campaign data** — One of:
+   - CSV export from Meta Ads Manager (Campaign / Ad Set / Ad level + breakdowns)
+   - Pasted performance table
+   - Screenshots (we'll extract the metrics)
+   - Live data via your existing Meta Marketing API connection
+2. **Campaign setup**:
+   - Objective (Awareness / Traffic / Engagement / Lead Gen / Conversions / Sales / App Installs)
+   - Budget type (Advantage+ Campaign Budget = CBO, or Ad Set Budget = ABO)
+   - Placements (Automatic vs. manual)
+   - Number of ad sets and ads
+3. **Time period** — Date range covered, with any known events (creative refresh, budget change, audience edit, account issue)
+4. **Target metrics** — CPA target, ROAS target, or "no target — benchmark me"
+5. **Funnel context** (if relevant) — On-platform conversion vs. website event vs. downstream qualification rate
+6. **What's making you ask?** — Specific concern ("CPA up 40%"), routine review, or pre-scale audit
+
+## Phase 1: Identify the Correct Evaluation Level
+
+This is the most important step. **Evaluating at the wrong level is the #1 source of wrong recommendations.**
+
+| Campaign Setup | Correct Evaluation Level | Why |
+|---|---|---|
+| Advantage+ Campaign Budget (CBO) | **Campaign level** | System pools budget across ad sets — only campaign totals reflect reality |
+| Automatic placements (no CBO) | **Ad Set level** | System pools budget across placements within the ad set |
+| Multiple ads in 1 ad set | **Ad Set level** | System pools delivery across ads |
+| Manual placements + ABO | Placement / Ad Set level | Each is independent |
+
+**Output for this phase:** State the evaluation level explicitly and explain why before any metric is interpreted.
+
+> If asked "is this Meta placement underperforming?" on a CBO campaign, the answer is "wrong question — at CBO the placement-level CPA is misleading. Here's the campaign total..."
+
+## Phase 2: Check Learning Phase Status
+
+Before judging anything, check delivery state per ad set.
+
+**Learning state checklist:**
+- Status is `Learning` (delivery less stable, CPA typically higher, results not predictive)
+- Exits after ~50 optimization events within 7 days of last significant edit
+- Shops ads exception: 17 website purchases + 5 Meta purchases
+- Status `Learning Limited` = can't get enough events → flag as a structural issue, not a performance issue
+
+**Significant edits that reset learning:**
+- Targeting changes
+- Optimization event change
+- Creative changes (large)
+- Bid strategy / amount changes
+- Budget changes >20%
+
+**Output for this phase:** Per ad set, mark `Active` / `Learning` / `Learning Limited`. Caveat all conclusions for anything in learning. **Do not recommend pausing a Learning ad set based on CPA alone.**
+
+## Phase 3: Diagnose with Meta-Specific Lenses
+
+Run the diagnosis through these five lenses. Each one explains a different class of "weird" behavior.
+
+### 3A: Marginal Efficiency Analysis (Breakdown Effect)
+
+The Breakdown Effect: the system shifts budget toward segments where the *next* conversion is cheapest, not where the *average* conversion is cheapest. A segment can have a high average CPA in a breakdown report and still be the right place for budget.
+
+**How to spot it:**
+- Time-series the segment's CPA. If marginal CPA is rising sharply, expect the system to shift budget out — even if average looks fine.
+- A breakdown row with high average CPA + high spend usually means the system found cheap marginal conversions there earlier in the period.
+
+**Mandatory framing in the report:** Never recommend pausing a segment based solely on higher average CPA/CPM in a breakdown report. Removing it will often *raise* total cost. Frame any cut as a hypothesis to test with a holdout, not an instruction.
+
+### 3B: Ad Relevance Diagnostics
+
+For each ad with sufficient impressions (~500+), check the three rankings:
+
+| Ranking | Below Average → | Action |
+|---|---|---|
+| **Quality Ranking** | Creative is the problem | Test new creative formats / hooks |
+| **Engagement Rate Ranking** | Hook isn't pulling | Test new opener / first 3 seconds |
+| **Conversion Rate Ranking** | Post-click is leaking | Audit landing page (use `ad-to-landing-page-auditor`) |
+
+Two below average + one average = creative refresh. All three below average = scrap and rebuild.
+
+### 3C: Auction Overlap Check
+
+Symptoms: ad sets in the same campaign chronically `Learning Limited`, underspending budget, or showing erratic delivery.
+
+**Causes:** Overlapping audiences within the same ad account / Page mean only one of your ads enters each auction (Meta picks the highest-value one; the others are excluded — you don't bid against yourself, but the suppressed ad sets can't learn).
+
+**Action:**
+- Run Account Overview → Opportunity Score for explicit overlap flags
+- Combine similar ad sets (consolidate learning) or pause the weaker overlapping ones
+
+### 3D: Pacing Analysis
+
+Pacing = the system smoothing budget across the day/period to capture the best opportunities. Daily snapshots will look uneven *by design*.
+
+**How to read it:**
+- Evaluate spend over the full campaign window, not single days
+- If the system is consistently underspending budget, that's a pacing/learning issue, not a "good thrift" — usually points to overlap, narrow audience, or bid-strategy mismatch
+- Ignore "$X budget unspent today" alarms unless sustained over 3+ days
+
+### 3E: Performance Fluctuation Assessment
+
+Distinguish noise from trend before recommending anything.
+
+| Signal | Verdict |
+|---|---|
+| Day-to-day CPA swing within 20–30% | Normal — ignore |
+| Weekend vs. weekday delta | Normal — control for it |
+| Gradual change over weeks | Trend — investigate |
+| Sudden ≥50% cost increase sustained 3+ days | Real problem — diagnose |
+| Delivery near zero | Account/asset/policy issue — check first |
+| Conv rate dropping while spend rises | Creative fatigue or LP regression |
+
+Always check sample size. A 1-conversion difference at low volume is meaningless.
+
+## Phase 4: Synthesize Through the Breakdown Effect Lens
+
+Before writing the report, restate every finding from Phase 3 in terms of *what the system is trying to do*:
+
+> "Placement A shows $10 average CPA vs Placement B's $15. Time-series shows A's CPA rising. The system is correctly shifting toward B because B's marginal CPA is now lower. Recommendation: do nothing on placements; test new creative in A to lower its marginal CPA."
+
+If a finding can't be restated in marginal/system-mechanics terms, it's probably noise — drop it.
+
+## Phase 5: Generate the Report
+
+Use this exact structure. No deviation.
+
+```
+1. EXECUTIVE SUMMARY
+   - 2–3 sentences on overall health
+   - Top 1 thing to do, top 1 thing NOT to do
+
+2. EVALUATION LEVEL
+   - Stated explicitly with the reason
+
+3. LEARNING STATUS
+   - Per-ad-set table: Active / Learning / Learning Limited
+   - Caveats applied to any in-learning analysis
+
+4. PERFORMANCE OVERVIEW
+   - Standardized metric naming (see table below)
+   - Aggregate first, then drill-down
+   - Compare to target where given, benchmarks otherwise
+
+5. DIAGNOSIS
+   - Findings from Phase 3, each tagged to its lens
+     (Marginal / Relevance / Overlap / Pacing / Fluctuation)
+   - Each finding cites specific data
+
+6. RECOMMENDATIONS
+   - Each = hypothesis + expected impact + how to test
+   - Marked Critical / High / Medium / Low priority
+   - Anything paused/scaled has a rollback plan
+
+7. BREAKDOWN EFFECT NOTES
+   - Explicit callouts where average ≠ marginal
+   - "Do not do X" warnings if the data tempts a wrong move
+```
+
+## Output Standards (Mandatory)
+
+These are not style suggestions. Violating them produces wrong analysis.
+
+- **Never recommend pausing or reducing budget on a segment based solely on higher average CPA/CPM in a breakdown report.** Removing it often raises total cost. State this explicitly when the data tempts a wrong move.
+- **Every recommendation includes:** evidence cited from the data + the system mechanic that explains it + expected impact + a rollback plan if it doesn't work.
+- **Every recommendation is a hypothesis,** not a directive. Use "test", "try", "hypothesize" — not "do this".
+- **Disambiguate clicks.** Never use bare "clicks". Use **Clicks (all)** for total interactions or **Link Clicks** for offsite clicks.
+- **Audience size language.** Use "Accounts Center accounts" or a bare number. Never "people". If quoting a specific count, use "person" as the noun (e.g., "17,000 person").
+- **Check `get_recommendations` first** if you have live API access. If your recommendation diverges from Meta's, explicitly explain why.
+
+## Metric Naming Standard
+
+Always rename raw metric names to these standardized display names in any output:
+
+| Raw | Display |
+|---|---|
+| `impressions` | Impressions |
+| `reach` | Reach (Accounts Center accounts) |
+| `frequency` | Frequency |
+| `spend` | Amount Spent |
+| `cpm` | CPM |
+| `clicks` | Clicks (all) |
+| `cpc` | CPC (all) |
+| `ctr` | CTR (all) |
+| `cost_per_action_type:link_click` | CPC (Link Click) |
+| `outbound_clicks_ctr` | Outbound CTR |
+| `actions:purchase` | Purchases |
+| `action_values:purchase` | Purchase Value |
+| `cost_per_action_type:purchase` | Cost per Purchase |
+| `purchase_roas` | Purchase ROAS (return on ad spend) |
+| `video_thruplay_watched_actions` | ThruPlays |
+
+## Reference: Domain Concepts
+
+### The Breakdown Effect
+
+The misinterpretation that Meta's system shifts budget into "underperforming" segments. In reality the system maximizes total results by optimizing for **marginal efficiency**. A breakdown report sliced by placement, demographic, or device shows averages — but the system optimizes for the next dollar, not the average. A segment with high average CPA may be protecting overall campaign efficiency by preventing even higher marginal cost elsewhere.
+
+### Learning Phase
+
+Delivery state where the system is exploring how to deliver a new or significantly edited ad set. Performance is less stable, CPA is typically higher, and results are not predictive of long-term performance. Exits after ~50 optimization events within 7 days of the last significant edit. **Don't edit during learning** (resets the clock). **Don't fragment** with too many ad sets (each needs its own 50 events). Use **realistic budgets** — too small or too large gives bad signal.
+
+### Auction Overlap
+
+When ad sets share overlapping audiences within the same ad account, only the highest-value ad from your portfolio enters each auction. The others are excluded. Symptoms: chronic `Learning Limited`, underspending, erratic delivery. Fix: consolidate ad sets, or pause the lower-performing overlapping ones to free up auction entries.
+
+### Pacing
+
+The system spreads spend across the day/period to capture best opportunities. Daily under/overspend is by design — only sustained underspend (3+ days) is a real signal.
+
+### Creative Fatigue
+
+Effectiveness decreases as the same audience sees the same creative repeatedly. Watch frequency (>3–4 in a 7-day window for prospecting) and conversion-rate decline while spend stays flat. Refresh creative on a rotation rather than waiting for fatigue to show in CPA.
+
+### Performance Fluctuations
+
+Day-to-day CPA variation within 20–30% is normal. Weekend/weekday differences are normal. Sudden ≥50% sustained cost increases over 3+ days, near-zero delivery, or conv-rate drops while spend rises are the only patterns worth diagnosing as "problems."
+
+## What This Skill Will Not Do
+
+- **Will not write to your ad account.** Pure analysis. Use Meta Ads Manager or whatever write tool the calling agent has available for execution.
+- **Will not generate creative.** Use `messaging-ab-tester` for variants and `ad-angle-miner` for source material.
+- **Will not analyze landing pages.** Use `ad-to-landing-page-auditor` — and use it whenever Conversion Rate Ranking is below average.
+- **Will not multi-platform compare.** Use `ad-campaign-analyzer` for cross-channel budget reallocation.
+
+## Related Skills
+
+- **`ad-campaign-analyzer`** — Multi-platform performance review and budget reallocation. Run this first if you have multiple channels; run `meta-ads-analyzer` after for the Meta-specific deep dive.
+- **`ad-to-landing-page-auditor`** — Always pair with this when Conversion Rate Ranking is below average.
+- **`messaging-ab-tester`** — Generate variants when creative fatigue is the diagnosis.
+- **`meta-ads-campaign-builder`** — Architect a new campaign when the diagnosis points to "rebuild, don't fix".
+
+## Credit
+
+Meta system-mechanics framing (Breakdown Effect, Learning Phase, Auction Overlap reference content) adapted from [mathiaschu/meta-ads-analyzer](https://github.com/mathiaschu/meta-ads-analyzer) (MIT).

--- a/skills/composites/meta-ads-analyzer/SKILL.md
+++ b/skills/composites/meta-ads-analyzer/SKILL.md
@@ -1,12 +1,6 @@
 ---
 name: meta-ads-analyzer
-description: >
-  Diagnose Meta Ads campaign performance using Meta's actual system mechanics —
-  Breakdown Effect, Learning Phase, Auction Overlap, Pacing, and Creative Fatigue.
-  Takes CSV exports, pasted tables, or live API data and produces a structured
-  diagnosis with root causes and testable recommendations. Built to avoid the
-  most common analysis mistake: judging segments by average CPA instead of
-  marginal efficiency.
+description: Diagnose Meta Ads campaign performance using Meta's actual system mechanics — Breakdown Effect, Learning Phase, Auction Overlap, Pacing, and Creative Fatigue — and produce structured, testable recommendations that avoid judging segments by average CPA instead of marginal efficiency.
 tags: [ads]
 ---
 
@@ -258,4 +252,4 @@ Day-to-day CPA variation within 20–30% is normal. Weekend/weekday differences 
 
 ## Credit
 
-Meta system-mechanics framing (Breakdown Effect, Learning Phase, Auction Overlap reference content) adapted from [mathiaschu/meta-ads-analyzer](https://github.com/mathiaschu/meta-ads-analyzer) (MIT).
+Meta system-mechanics framing (Breakdown Effect, Learning Phase, Auction Overlap reference content) adapted from an MIT-licensed Meta ads analyzer project by Mathias Chu.

--- a/skills/composites/meta-ads-analyzer/skill.meta.json
+++ b/skills/composites/meta-ads-analyzer/skill.meta.json
@@ -1,0 +1,16 @@
+{
+  "slug": "meta-ads-analyzer",
+  "category": "composites",
+  "description": "Diagnose Meta Ads campaigns using Meta's actual system mechanics — Breakdown Effect, Learning Phase, Auction Overlap, Pacing, and Creative Fatigue. Produces a structured diagnosis with root causes and testable hypotheses, designed to avoid the most common analysis mistake of judging segments by average CPA instead of marginal efficiency.",
+  "tags": [
+    "ads"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install meta-ads-analyzer",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds three new composite skills under the `ads` tag, designed to chain together as a Meta Ads workflow on top of the existing `ad-campaign-analyzer`, `ad-to-landing-page-auditor`, and `messaging-ab-tester` skills.

### `meta-ads-analyzer`
Diagnoses Meta campaigns using Meta's actual delivery mechanics — Breakdown Effect, Learning Phase, Auction Overlap, Pacing, and Creative Fatigue. Adapted from [mathiaschu/meta-ads-analyzer](https://github.com/mathiaschu/meta-ads-analyzer) (MIT) and restructured to match this repo's skill format. Read-only analysis; works against CSV exports, pasted tables, screenshots, or live API data.

### `ad-lead-quality-analyzer`
Replaces vanity CPA with true CAC per qualified lead by joining ad-platform data (signups) with downstream funnel events (qualification, completion, payout). Channel-agnostic in design (Meta-first). Classifies every creative into Scale / Keep / Investigate / Cut and explicitly flags "dangerous winners" — ads with low platform CPA but high vanity-signup rates. Falls back to a `tracking-gap` mode when attribution coverage is too low for analysis.

### `meta-ad-policy-checker`
Pre-flight policy check that fetches Meta's transparency-center policy pages at runtime — no hardcoded rule list, so the skill stays correct as Meta updates standards. Returns a `Pass` / `Fix Required` / `Block` verdict with cited findings and 3 safer rewrites. Designed to gate ad-write workflows or audit ads already live.

## Design principles across all three

- **Standalone**: no `requires_skills` dependencies, each runs independently with user-provided inputs
- **Generic / publishable**: no company-specific references, examples, env vars, or paths
- **Cross-agent**: works in Claude Code, Cursor, Codex, Goose, or any agent that reads SKILL.md
- **Cross-linked**: each skill's `Related Skills` section references the existing ad-workflow skills (`ad-campaign-analyzer`, `ad-to-landing-page-auditor`, `messaging-ab-tester`, `meta-ads-campaign-builder`)
- **Read-only**: none write to ad accounts; analysis and verdicts only

## Test plan

- [x] `npm run validate:skills` passes
- [x] `npm run build:index` regenerates `skills-index.json` cleanly
- [x] `npm test` (13/13 tests pass)
- [x] Manual structure audit against existing ad-tagged composites (`ad-campaign-analyzer`, `competitor-ad-intelligence`, `meta-ads-campaign-builder`)
- [x] Schema conformance verified against `schemas/skill-meta.schema.json`
- [ ] Reviewer spot-check on tone / scope vs. existing composites

🤖 Generated with [Claude Code](https://claude.com/claude-code)