### PR TITLE
Add six Google Ads optimization skills (audit, check-in, keyword/RSA/search-terms/gap-analysis)

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-04-29",
+  "generated": "2026-05-04",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -2090,6 +2090,183 @@
         ],
         "installation": {
           "base_command": "npx goose-skills install google-ad-scraper",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
+      }
+    },
+    {
+      "slug": "google-ads-account-audit",
+      "name": "google-ads-account-audit",
+      "category": "composites",
+      "description": ">",
+      "tags": "ads",
+      "path": "skills/composites/google-ads-account-audit",
+      "files": [
+        "skills/composites/google-ads-account-audit/SKILL.md",
+        "skills/composites/google-ads-account-audit/scripts/ngram_analyzer.py",
+        "skills/composites/google-ads-account-audit/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "google-ads-account-audit",
+        "category": "composites",
+        "description": "Comprehensive live-API audit of an existing Google Search Ads account. Pulls raw data via the Google Ads API, runs N-gram analysis on search terms, audits conversion tracking, RSA pinning, impression-share losses, and landing-page message-match. Output: raw metrics + specific findings + numbered immediate-actions list. No composite letter grades. Suggestion-only — user prioritizes which findings to act on.",
+        "tags": [
+          "ads"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install google-ads-account-audit",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
+      }
+    },
+    {
+      "slug": "google-ads-checkin",
+      "name": "google-ads-checkin",
+      "category": "composites",
+      "description": ">",
+      "tags": "ads",
+      "path": "skills/composites/google-ads-checkin",
+      "files": [
+        "skills/composites/google-ads-checkin/SKILL.md",
+        "skills/composites/google-ads-checkin/checkin-cadence.md",
+        "skills/composites/google-ads-checkin/daily-ops-loop.md",
+        "skills/composites/google-ads-checkin/skill.meta.json",
+        "skills/composites/google-ads-checkin/templates/checkin-report.template.md"
+      ],
+      "metadata": {
+        "slug": "google-ads-checkin",
+        "category": "composites",
+        "description": "Adaptive-cadence performance check-in for a Google Ads account being iteratively optimized. Pulls recent performance via the Google Ads API, measures lift on past suggestions, surfaces anomalies, and proposes the next round of optimizations. Cadence adapts to campaign maturity. Suggestion-only.",
+        "tags": [
+          "ads"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install google-ads-checkin",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
+      }
+    },
+    {
+      "slug": "google-ads-competitor-gap-analysis",
+      "name": "google-ads-competitor-gap-analysis",
+      "category": "composites",
+      "description": ">",
+      "tags": "ads",
+      "path": "skills/composites/google-ads-competitor-gap-analysis",
+      "files": [
+        "skills/composites/google-ads-competitor-gap-analysis/SKILL.md",
+        "skills/composites/google-ads-competitor-gap-analysis/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "google-ads-competitor-gap-analysis",
+        "category": "composites",
+        "description": "Unified competitive position report for a Google Search ad account. Pulls Auction Insights via Google Ads API, scrapes currently-running competitor ads, audits competitor landing pages, and surfaces specific gaps (auction position, angle gaps, keyword theme gaps, LP gaps). Maps each finding to a specific follow-up skill. Free stack only. Suggestion-only.",
+        "tags": [
+          "ads"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install google-ads-competitor-gap-analysis",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "requires_skills": [
+          "competitor-ad-intelligence"
+        ]
+      }
+    },
+    {
+      "slug": "google-ads-keyword-optimizer",
+      "name": "google-ads-keyword-optimizer",
+      "category": "composites",
+      "description": ">",
+      "tags": "ads",
+      "path": "skills/composites/google-ads-keyword-optimizer",
+      "files": [
+        "skills/composites/google-ads-keyword-optimizer/SKILL.md",
+        "skills/composites/google-ads-keyword-optimizer/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "google-ads-keyword-optimizer",
+        "category": "composites",
+        "description": "Analyze the keywords currently bidding in a live Google Ads account and propose per-keyword optimizations: pause underperformers, bid up/down, change match type, deduplicate cannibalizing keywords, fix Quality Score clusters. Per-item user approval; approved actions saved as drafts in the Google Ads UI for manual activation.",
+        "tags": [
+          "ads"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install google-ads-keyword-optimizer",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
+      }
+    },
+    {
+      "slug": "google-ads-rsa-optimizer",
+      "name": "google-ads-rsa-optimizer",
+      "category": "composites",
+      "description": ">",
+      "tags": "ads",
+      "path": "skills/composites/google-ads-rsa-optimizer",
+      "files": [
+        "skills/composites/google-ads-rsa-optimizer/SKILL.md",
+        "skills/composites/google-ads-rsa-optimizer/ads-copywriting-principles.md",
+        "skills/composites/google-ads-rsa-optimizer/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "google-ads-rsa-optimizer",
+        "category": "composites",
+        "description": "Find weak RSA assets (headlines + descriptions) in a live Google Ads account and propose replacements grounded in brand voice, ad group keyword theme, landing page copy, and competitor ad angles. Generates 3 candidate variants per weak slot, validates length + keyword-mirror + brand-don't list, presents per-asset approvals, saves approved variants as drafts in the Google Ads UI for manual activation.",
+        "tags": [
+          "ads"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install google-ads-rsa-optimizer",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
+      }
+    },
+    {
+      "slug": "google-ads-search-terms-miner",
+      "name": "google-ads-search-terms-miner",
+      "category": "composites",
+      "description": ">",
+      "tags": "ads",
+      "path": "skills/composites/google-ads-search-terms-miner",
+      "files": [
+        "skills/composites/google-ads-search-terms-miner/SKILL.md",
+        "skills/composites/google-ads-search-terms-miner/scripts/ngram_analyzer.py",
+        "skills/composites/google-ads-search-terms-miner/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "google-ads-search-terms-miner",
+        "category": "composites",
+        "description": "Mine the Google Ads search terms report. Runs N-gram analysis (1/2/3-word) by cost + ROAS, classifies n-gram themes into negative / scale / expand buckets, and proposes specific actions: negative keywords to add, keyword themes to expand, ad groups to investigate. Per-item user approval; approved actions saved as drafts in the Google Ads UI for manual activation.",
+        "tags": [
+          "ads"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install google-ads-search-terms-miner",
           "supports": [
             "claude",
             "cursor",

--- a/skills/composites/google-ads-account-audit/SKILL.md
+++ b/skills/composites/google-ads-account-audit/SKILL.md
@@ -1,0 +1,318 @@
+---
+name: google-ads-account-audit
+description: >
+  Comprehensive live-API audit of an existing Google Search Ads account. Pulls raw
+  data via the Google Ads API, runs N-gram analysis on search terms (1/2/3-word
+  by cost + ROAS), audits conversion tracking, RSA pinning, impression-share losses,
+  and landing-page message-match. Composes ad-campaign-analyzer and
+  ad-to-landing-page-auditor. Output: raw metrics + specific findings + numbered
+  immediate-actions list. No composite letter grades. Suggestion-only — user
+  prioritizes which findings to act on.
+tags: [ads]
+---
+
+# Google Ads Account Audit
+
+A diagnostic-grade audit of a live Google Ads account. Pulls real data through the API, finds waste and opportunities through specific analytics (not generic AI summaries), and produces a numbered list of actions for the user to prioritize.
+
+**Core principle:** Don't fabricate composite scores. Real performance marketers don't grade accounts A/B/C — they look at specific metrics and call out specific issues. Every finding ties back to a raw number the user can verify, and a specific action they can take.
+
+**Universal pattern:** Suggestion-only. The audit identifies issues and proposes priorities. The user decides what gets fixed and in what order. Downstream skills (`google-ads-rsa-optimizer`, `google-ads-search-terms-miner`, `google-ads-keyword-optimizer`) act on the priorities.
+
+## When to Use
+
+- "Audit my Google Ads account"
+- "What's wrong with my Google Ads?"
+- "Where am I wasting Google Ads spend?"
+- "Run a full account audit"
+- "Diagnose this Google Ads account"
+
+## Prerequisites
+
+- A working Google Ads API connection (MCP server, native client, or manual export). The audit reads heavily across multiple GAQL queries.
+- Optional: a web-fetch tool for the landing-page audit phase.
+
+## Phase 0: Intake
+
+Ask the user for these inputs at the start of the run:
+
+1. **Account ID** — the Google Ads customer ID
+2. **Primary conversion goal** — what conversion event is being optimized for (Demos / Trials / Purchases / Leads)
+3. **Target CPA / ROAS** — explicit numbers, or LTV × margin to back-calculate, or "no target — benchmark me"
+4. **Top competitors** *(optional)* — used for Auction Insights in Phase 6
+5. **Geographic markets** *(optional)* — used to scope analysis if geo segmentation matters
+6. **Time window** — 180 days default for deep audit; 56 days for tactical
+
+## Phase 1: Confirm Audit Scope
+
+Before pulling any data, confirm scope with the user:
+
+| Parameter | Default | User can override |
+|---|---|---|
+| Time window | **180 days** (deep audit) — switch to **56 days** for tactical | Yes |
+| Campaign scope | All active Search campaigns | Yes — can scope to specific campaigns |
+| Include paused campaigns | No | Yes |
+| Include experiments / drafts | No | Yes |
+
+### Approval Gate 1
+
+> "I'm about to audit your account over the last 180 days across all active Search campaigns. Want me to adjust the window or scope before I pull data?"
+
+Wait for confirmation. Update parameters if the user redirects.
+
+## Phase 2: Account Snapshot
+
+Run **parallel GAQL queries** for speed. Pull:
+
+1. **Account-level metrics** — total spend, impressions, clicks, conversions, conv value, CTR, conv rate, CPA, ROAS over the audit window
+2. **Campaign-level breakdown** — same metrics per active Search campaign
+3. **Ad group-level breakdown** — same metrics per ad group within each campaign
+4. **Day-by-day spend trend** — 30-day rolling
+5. **Account-level settings** — bid strategies in use, daily budgets per campaign, conversion actions configured
+
+Output the account snapshot as a structured table. **Do not fabricate a "health score."** Just show the numbers.
+
+```markdown
+## Account Snapshot ({date range})
+
+| Metric | Value |
+|---|---|
+| Total spend | ${X} |
+| Impressions | {N} |
+| Clicks | {N} |
+| CTR | {X%} |
+| Conversions | {N} |
+| Conversion rate | {X%} |
+| CPA | ${X} |
+| Conv value | ${X} |
+| ROAS | {X} |
+
+### Campaigns
+| Campaign | Spend | Conv | CPA | ROAS | Bid strategy | Status |
+|---|---|---|---|---|---|---|
+| ... | | | | | | |
+```
+
+## Phase 3: Conversion Tracking Audit
+
+Tracking is broken in a large fraction of audits — check this before anything else, since every other finding depends on conversions being measured correctly.
+
+For each configured conversion action:
+
+| Check | Method | Failure mode |
+|---|---|---|
+| Is the action firing? | Pull conversions over last 7 / 30 days, compare to expected volume | Drops to 0 = pixel broken |
+| Are values set? | Check if `value_settings.default_value` and `default_currency_code` are populated | Missing = can't compute ROAS |
+| Is it imported into Google Ads bidding? | Check `category` and `include_in_conversions_metric` | Excluded = bid strategies are blind to it |
+| Is attribution sane? | Check `attribution_model` (last-click vs data-driven) | Wrong model can mis-allocate credit |
+| Counting (one vs every)? | Check `counting_type` | Wrong setting inflates lead-form-style conversions |
+
+Output specific findings:
+
+```markdown
+## Tracking Findings
+
+- ✗ Conversion action "Demo booked" has 0 firings in last 7 days (had 24 in prior 30 days). Likely broken — check pixel install on /demo-thank-you page.
+- ⚠ Conversion action "Free trial signup" is set to count "Every" — this inflates conversion count. Should be "One" for trials.
+- ✓ "Purchase" tracking is firing correctly with values populated.
+```
+
+## Phase 4: N-gram Search Terms Analysis
+
+Pull the search terms report for the audit window (filter to terms with material spend, default ≥$5).
+
+Use `scripts/ngram_analyzer.py` (in this skill folder) for tokenization, aggregation, ranking, and anomaly detection. Pure Python, standard library only — no dependencies. The script's `aggregate()`, `rank()`, and `find_anomalies()` functions cover Phase 4 needs.
+
+For each search term, tokenize into:
+- 1-word phrases
+- 2-word phrases
+- 3-word phrases
+
+Aggregate by n-gram: total cost, total clicks, total conversions, total conv value. Compute CPA + ROAS per n-gram.
+
+Produce four ranked tables:
+
+```markdown
+### Top spenders — 2-word n-grams
+| 2-word phrase | Spend | Conv | CPA | ROAS | Sample terms |
+|---|---|---|---|---|---|
+| "free trial" | $4,200 | 18 | $233 | 2.1 | "free trial software", "free trial signup", ... |
+| ... | | | | | |
+
+### Biggest waste — 2-word n-grams (high spend, 0 or low conv)
+| 2-word phrase | Spend | Conv | CPA | Sample terms |
+|---|---|---|---|---|
+| ... | | | | |
+
+### Top performers — 2-word n-grams (high ROAS at meaningful spend)
+| 2-word phrase | Spend | Conv | ROAS | Sample terms |
+|---|---|---|---|---|
+| ... | | | | |
+
+### Same tables for 3-word n-grams
+```
+
+Surface specific anomalies:
+- **Seasonal/temporal mismatches** — terms tied to specific dates/seasons running outside window (e.g. "Halloween rave" in March)
+- **Competitor brand bleed** — competitor names showing up in spend without a competitor campaign
+- **Job-seeker/researcher bleed** — "jobs", "salary", "tutorial", "course", "review" terms
+
+## Phase 5: RSA Pinning + Asset Audit
+
+For each ad group with active RSAs:
+
+| Check | What it surfaces |
+|---|---|
+| Asset performance ratings | Count of headlines/descriptions marked **Best / Good / Low / Pending** per ad |
+| Pinning density | % of headlines pinned to specific positions (excessive pinning kills RSA optimization) |
+| Keyword-mirror coverage | Does at least 1 headline + 1 description literally contain the ad group's primary keyword? |
+| Length compliance | Any headlines >30 chars or descriptions >90 chars? (shouldn't happen in live ads but verify) |
+| RSA strength | Google's reported "Ad strength" rating per RSA |
+
+Output:
+
+```markdown
+## RSA Asset Findings
+
+- Ad group "Brand defense" has 12 of 15 headlines marked Low — heavy refresh needed
+- 8 ad groups have all headlines pinned to position 1, blocking Google's optimization
+- Ad group "Solution-aware" has no headline or description containing the keyword theme — message-match weak
+- 3 RSAs flagged as "Poor" Ad strength
+```
+
+The deep RSA replacement work happens in `google-ads-rsa-optimizer` — this audit just surfaces *which* ad groups need attention.
+
+## Phase 6: Impression Share + Auction Insights
+
+Pull impression-share metrics per campaign:
+
+| Metric | What it tells us |
+|---|---|
+| `search_impression_share` | What % of available impressions you're capturing |
+| `search_budget_lost_impression_share` | % lost because budget runs out — you'd benefit from more spend here |
+| `search_rank_lost_impression_share` | % lost to bid/quality — bid up or improve QS |
+| `search_top_impression_share` | % of impressions that were top-of-page |
+| `search_absolute_top_impression_share` | % that were position 1 |
+
+Pull **Auction Insights** for each campaign with material spend. This shows competitors in the auction and their relative position.
+
+### Approval Gate 2
+
+Before pulling Auction Insights, confirm the competitor list with the user:
+
+> "Which competitors should I benchmark against in Auction Insights? (You can list domains, brand names, or 'just show me whoever Google reports back.')"
+
+Wait for confirmation.
+
+Output:
+
+```markdown
+## Impression Share Findings
+
+- Campaign "Brand" — 100% IS, 98% abs top: brand defense is solid
+- Campaign "Solution-aware" — 34% IS, 41% lost to budget, 25% lost to rank: increasing budget here could capture meaningful additional volume
+- Campaign "Competitor" — 22% IS, 78% lost to rank: bidding too low or QS too low
+
+## Auction Insights ({date range})
+| Competitor | Impression share | Avg position vs you | Above us % | Top of page % |
+|---|---|---|---|---|
+| ... | | | | |
+```
+
+## Phase 7: Landing Page Message-Match Audit
+
+Compose the existing [`ad-to-landing-page-auditor`](https://github.com/gooseworks-ai/goose-skills/tree/main/skills/composites/ad-to-landing-page-auditor) skill.
+
+Inputs to pass through:
+- Each unique landing page URL in active campaigns
+- For each LP, the ads that point to it (headlines + descriptions)
+
+The skill will produce per-LP scores on:
+- Promise continuity (does the LP deliver on the ad's promise?)
+- Language match (does the LP use the same words/phrases as the ad?)
+- CTA alignment
+- Specificity match
+
+Surface only the LPs scoring poorly — don't pad the report with fine LPs.
+
+## Phase 8: Synthesize Findings + Immediate Actions
+
+Combine findings from Phases 3–7 into a numbered priority list. **Do not fabricate a letter grade.** Just rank by estimated impact (rough categories: high / medium / low) and let the user pick what to tackle first.
+
+```markdown
+## Immediate Actions to Review
+
+### High impact
+1. Fix conversion tracking for "Demo booked" (Phase 3) — 0 conversions firing means bid strategies are blind. Recommend: check pixel install on /demo-thank-you, run real-time conv check.
+2. Add "free + jobs + careers + tutorial" to negative keyword list (Phase 4) — currently bleeding $1,200/mo on these themes.
+3. Increase budget on "Solution-aware" campaign (Phase 6) — 41% IS lost to budget at strong CPA.
+
+### Medium impact
+4. RSA refresh on "Brand defense" ad group (Phase 5) — 12 of 15 headlines marked Low. Run google-ads-rsa-optimizer.
+5. Fix LP message-match on "competitor-alternative" ads (Phase 7) — sending traffic to homepage, ad promised comparison.
+
+### Low impact
+6. ...
+```
+
+### Approval Gate 3
+
+Present the immediate-actions list to the user. Ask:
+
+> "Here are the findings, ranked by impact. Which do you want to tackle first? Some can be addressed by other skills in this suite (RSA optimizer, search terms miner, keyword optimizer), others need your input."
+
+Map approved actions to follow-up skills:
+- Negative keyword work → `google-ads-search-terms-miner`
+- RSA refresh work → `google-ads-rsa-optimizer`
+- Keyword performance issues (pauses / bid changes / QS clusters / duplicates) → `google-ads-keyword-optimizer`
+- Competitive position concerns (auction loss, angle gaps, LP gaps) → `google-ads-competitor-gap-analysis`
+- Tracking fixes → user action with the skill's specific instructions
+- Budget reallocation → user action with the skill's rationale
+- LP fixes → user action with the audit findings as input
+
+## Phase 9: Output
+
+The skill returns the full audit inline. End with these structured blocks the user can persist (anywhere they want):
+
+### Decisions log entry (suggested to save for future reference)
+
+```
+{YYYY-MM-DD} | google-ads-account-audit | Audit completed for window {date range}. Top findings: tracking break on "Demo booked", $1,200/mo bleed on free/jobs/careers/tutorial themes, 41% IS lost to budget on Solution-aware. User prioritized: 1, 2, 3.
+```
+
+### Suggested filename for full audit report
+
+`google-ads-audit-{YYYY-MM-DD}.md` — the user can save the inline audit wherever fits their workflow.
+
+## Output Summary
+
+- **Inline:** Full audit report with all phases, snapshot tables, findings, and immediate-actions list
+- **Decisions log:** Structured text block at end of report for the user to save
+- **Triggers:** Specific follow-up skills the user can invoke based on approved actions
+
+## Tools Required
+
+- **Google Ads API connection** (MCP server, native client, or manual export) — for parallel GAQL queries
+- **Web-fetch capability** — for LP audits (via the composed skill)
+- Composes skill: [`ad-campaign-analyzer`](https://github.com/gooseworks-ai/goose-skills/tree/main/skills/composites/ad-campaign-analyzer) for analytic logic
+- Composes skill: [`ad-to-landing-page-auditor`](https://github.com/gooseworks-ai/goose-skills/tree/main/skills/composites/ad-to-landing-page-auditor) for Phase 7
+
+## Cost
+
+Free. Google Ads API read ops within free quota. Web fetches for LP audit are free.
+
+## Universal Patterns
+
+- **Suggestion-only:** No mutations. The audit produces findings; the user picks priorities.
+- **Raw metrics, not letter grades:** Every finding cites specific numbers. No "B+ overall account health" framing.
+- **Parallel GAQL:** Pull data in parallel for speed.
+- **Anti-laziness:** Pull data first, only ask the user when something can't be derived from the API.
+- **Self-healing:** Retry transient API errors with backoff. Don't escalate on first failure.
+
+## Trigger Phrases
+
+- "Audit my Google Ads account"
+- "What's wrong with my Google Ads?"
+- "Where am I wasting Google Ads spend?"
+- "Diagnose this account"
+- "Run a full audit"

--- a/skills/composites/google-ads-account-audit/scripts/ngram_analyzer.py
+++ b/skills/composites/google-ads-account-audit/scripts/ngram_analyzer.py
@@ -1,0 +1,190 @@
+"""
+N-gram analyzer for Google Ads search terms reports.
+
+Takes a list of search terms with cost / click / conversion data and produces
+aggregated 1/2/3-word n-gram tables with cost, conversions, CPA, and ROAS.
+
+Used by:
+- google-ads-account-audit (Phase 4)
+- google-ads-search-terms-miner (Phase 3)
+
+Standard library only — no external dependencies.
+"""
+
+from collections import defaultdict
+from typing import Iterable, Literal, TypedDict
+
+
+NGramSize = Literal[1, 2, 3]
+
+
+class SearchTermRow(TypedDict, total=False):
+    search_term: str
+    cost: float
+    clicks: int
+    conversions: float
+    conv_value: float
+
+
+class NGramMetrics(TypedDict):
+    cost: float
+    clicks: int
+    conversions: float
+    conv_value: float
+    cpa: float | None
+    roas: float | None
+    sample_terms: list[str]
+
+
+def tokenize(text: str) -> list[str]:
+    """Lowercase + whitespace-split. No stemming, no punctuation stripping
+    beyond what the Google Ads API already returns."""
+    return [t.lower() for t in text.split() if t.strip()]
+
+
+def ngrams(tokens: list[str], n: int) -> list[str]:
+    """Sliding window of size n over tokens, joined with spaces."""
+    if n <= 0 or n > len(tokens):
+        return []
+    return [" ".join(tokens[i : i + n]) for i in range(len(tokens) - n + 1)]
+
+
+def aggregate(
+    rows: Iterable[SearchTermRow],
+    sizes: Iterable[NGramSize] = (1, 2, 3),
+    sample_term_cap: int = 5,
+) -> dict[int, dict[str, NGramMetrics]]:
+    """
+    Aggregate search-term rows into n-gram metrics.
+
+    rows: iterable of dicts with keys (search_term, cost, clicks, conversions, conv_value)
+    sizes: which n-gram sizes to compute (default 1, 2, 3)
+    sample_term_cap: max sample search terms to keep per n-gram (default 5)
+
+    Returns: {n: {ngram: NGramMetrics}}
+    """
+    accumulators: dict[int, dict[str, dict]] = {
+        n: defaultdict(
+            lambda: {
+                "cost": 0.0,
+                "clicks": 0,
+                "conversions": 0.0,
+                "conv_value": 0.0,
+                "_terms": set(),
+            }
+        )
+        for n in sizes
+    }
+
+    for row in rows:
+        term = row.get("search_term", "")
+        if not term:
+            continue
+        tokens = tokenize(term)
+        for n in sizes:
+            for ng in ngrams(tokens, n):
+                bucket = accumulators[n][ng]
+                bucket["cost"] += float(row.get("cost", 0))
+                bucket["clicks"] += int(row.get("clicks", 0))
+                bucket["conversions"] += float(row.get("conversions", 0))
+                bucket["conv_value"] += float(row.get("conv_value", 0))
+                bucket["_terms"].add(term)
+
+    result: dict[int, dict[str, NGramMetrics]] = {}
+    for n, ngram_dict in accumulators.items():
+        result[n] = {}
+        for ng, m in ngram_dict.items():
+            conv = m["conversions"]
+            cost = m["cost"]
+            value = m["conv_value"]
+            result[n][ng] = {
+                "cost": round(cost, 2),
+                "clicks": m["clicks"],
+                "conversions": round(conv, 2),
+                "conv_value": round(value, 2),
+                "cpa": round(cost / conv, 2) if conv > 0 else None,
+                "roas": round(value / cost, 3) if cost > 0 else None,
+                "sample_terms": sorted(m["_terms"])[:sample_term_cap],
+            }
+    return result
+
+
+def rank(
+    aggregates: dict[str, NGramMetrics],
+    by: Literal["cost", "roas", "waste"],
+    min_spend: float = 5.0,
+    min_clicks: int = 0,
+    limit: int = 30,
+) -> list[tuple[str, NGramMetrics]]:
+    """
+    Rank n-grams by cost / roas / waste.
+
+    by="cost": top spenders, sorted by cost desc
+    by="roas": top performers, sorted by roas desc, requires roas not None
+    by="waste": high cost + zero conversions, sorted by cost desc
+    """
+    items = [
+        (ng, m)
+        for ng, m in aggregates.items()
+        if m["cost"] >= min_spend and m["clicks"] >= min_clicks
+    ]
+    if by == "cost":
+        items.sort(key=lambda x: x[1]["cost"], reverse=True)
+    elif by == "roas":
+        items = [x for x in items if x[1]["roas"] is not None]
+        items.sort(key=lambda x: x[1]["roas"], reverse=True)
+    elif by == "waste":
+        items = [x for x in items if x[1]["conversions"] == 0]
+        items.sort(key=lambda x: x[1]["cost"], reverse=True)
+    return items[:limit]
+
+
+def find_anomalies(
+    aggregates: dict[str, NGramMetrics],
+    seasonal_terms: Iterable[str] = (
+        "halloween",
+        "christmas",
+        "thanksgiving",
+        "easter",
+        "valentine",
+        "new year",
+        "black friday",
+        "cyber monday",
+    ),
+    intent_mismatch_terms: Iterable[str] = (
+        "free download",
+        "salary",
+        "jobs",
+        "careers",
+        "tutorial",
+        "course",
+        "review",
+        "wikipedia",
+        "reddit",
+        "quora",
+    ),
+    min_spend: float = 10.0,
+) -> dict[str, list[tuple[str, NGramMetrics]]]:
+    """
+    Surface n-grams matching anomaly patterns at material spend.
+
+    Returns: {category: [(ngram, metrics)]} for "seasonal" and "intent_mismatch".
+    Caller is responsible for date-aware seasonal filtering — this function
+    just flags presence at spend threshold.
+    """
+    seasonal_set = {t.lower() for t in seasonal_terms}
+    mismatch_set = {t.lower() for t in intent_mismatch_terms}
+
+    out = {"seasonal": [], "intent_mismatch": []}
+    for ng, m in aggregates.items():
+        if m["cost"] < min_spend:
+            continue
+        ng_lower = ng.lower()
+        if any(s in ng_lower for s in seasonal_set):
+            out["seasonal"].append((ng, m))
+        if any(s in ng_lower for s in mismatch_set):
+            out["intent_mismatch"].append((ng, m))
+
+    out["seasonal"].sort(key=lambda x: x[1]["cost"], reverse=True)
+    out["intent_mismatch"].sort(key=lambda x: x[1]["cost"], reverse=True)
+    return out

--- a/skills/composites/google-ads-account-audit/skill.meta.json
+++ b/skills/composites/google-ads-account-audit/skill.meta.json
@@ -1,0 +1,16 @@
+{
+  "slug": "google-ads-account-audit",
+  "category": "composites",
+  "description": "Comprehensive live-API audit of an existing Google Search Ads account. Pulls raw data via the Google Ads API, runs N-gram analysis on search terms, audits conversion tracking, RSA pinning, impression-share losses, and landing-page message-match. Output: raw metrics + specific findings + numbered immediate-actions list. No composite letter grades. Suggestion-only — user prioritizes which findings to act on.",
+  "tags": [
+    "ads"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install google-ads-account-audit",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}

--- a/skills/composites/google-ads-checkin/SKILL.md
+++ b/skills/composites/google-ads-checkin/SKILL.md
@@ -1,0 +1,223 @@
+---
+name: google-ads-checkin
+description: >
+  Adaptive-cadence performance check-in for a Google Ads account being
+  iteratively optimized. Pulls recent performance via the Google Ads API,
+  measures lift on past suggestions (did approved RSA replacements improve
+  asset ratings? did new negatives reduce waste?), surfaces anomalies,
+  proposes the next round of optimizations, and outputs structured logs
+  the user can persist for the next run. Cadence adapts to campaign maturity
+  (every 4-6hr right after launch, daily during learning phase, every 2-5
+  days when mature). Suggestion-only.
+tags: [ads]
+---
+
+# Google Ads Check-in
+
+The ongoing pulse on a Google Ads account being iteratively optimized. Replaces "weekly digest" cadence — adapts cadence to where each campaign is in its lifecycle, measures whether past suggestions worked, and proposes the next optimization round.
+
+**Core principle:** A check-in is not a report. A report tells you what happened; a check-in measures whether past suggestions worked, surfaces what's drifting, and proposes specific next actions for approval.
+
+**Universal pattern:** Suggestion-only, draft-first. The check-in surfaces findings + proposed next actions. The user approves per-item. Approved actions are executed by other skills (this skill never mutates the ad account itself).
+
+## When to Use
+
+- "Run a check-in on the account"
+- "How are we doing?"
+- "What's changed since last time?"
+- "Did the RSA replacements work?"
+- "What should I optimize next?"
+
+Also intended to be **scheduled** as a recurring run (manual trigger, or via whatever scheduling mechanism the calling agent supports):
+
+| Account state | Suggested cadence |
+|---|---|
+| Just launched / first 3 days | Every 4–6 hours |
+| Learning phase / first 14 days | Daily |
+| Early maturity / days 15–30 | Every 2 days |
+| Mature / 30+ days | Every 3–5 days |
+
+The skill itself recommends a cadence based on account age + recent volatility. The user (or scheduling layer) decides the actual cadence.
+
+## Prerequisites
+
+- A working Google Ads API connection (MCP server, native client, or manual export). The skill reads heavily across multiple GAQL queries.
+- Optional but high-value: at least one prior run of `google-ads-rsa-optimizer`, `google-ads-search-terms-miner`, or `google-ads-keyword-optimizer` — without past suggestions to measure lift on, the check-in degrades to a generic performance report.
+
+## Phase 0: Intake
+
+Ask the user for these inputs at the start of the run:
+
+1. **Account ID** — the Google Ads customer ID
+2. **Time since last check-in** — date of last check-in, or "first run"
+3. **Decisions log since last check-in** *(optional but high-value)* — paste any prior decisions log entries (from earlier `google-ads-rsa-optimizer`, `google-ads-search-terms-miner`, `google-ads-keyword-optimizer`, or `google-ads-account-audit` runs) so this skill can measure lift
+4. **Top competitors** *(optional)* — used to track Auction Insights changes
+5. **Target CPA / ROAS** — explicit, or "no target — benchmark me"
+6. **Recent learnings** *(optional)* — paste any prior learnings entries so the skill can sharpen future proposals
+
+If no prior decisions log is provided, the skill runs in "first check-in" mode: lift measurement is skipped, and the output focuses on performance snapshot + anomalies + next-round proposals based on the data alone.
+
+## Phase 1: Determine Cadence Recommendation
+
+Look at account age (oldest active campaign) + recent volatility:
+
+```
+Days since first active campaign:    {N}
+Days since last optimization applied: {N}
+Recent ±20% spend / CTR / conv-rate volatility (last 7d): {Y/N}
+
+Recommended cadence: every {X} hours/days
+```
+
+If the user is running this skill manually, just note the cadence recommendation. If running on a schedule, the cadence is whatever the schedule fires at. See `checkin-cadence.md` (in this skill folder) for the full pseudo-logic.
+
+## Phase 2: Pull Current Performance
+
+Run via the Google Ads API, in parallel:
+
+1. Account-level metrics over the period since last check-in
+2. Campaign-level + ad group-level breakdowns
+3. Asset performance ratings (RSA Best/Good/Low/Pending) — diff vs prior check-in if any
+4. Day-by-day conversion + spend trend
+5. Impression share metrics + Auction Insights diff
+
+## Phase 3: Measure Lift on Past Suggestions
+
+For each item in the decisions log provided at intake (skip this phase if no prior decisions):
+
+| Past action | What to measure |
+|---|---|
+| RSA replacement | Did the new asset get a Best/Good rating? Has CTR or conv rate moved on the ad group? |
+| Negative keyword added | Did wasted spend on that n-gram drop? |
+| Keyword expansion | Is the new keyword getting impressions, clicks, conversions? |
+| Budget reallocation | Did IS-lost-to-budget drop on the under-funded campaign? |
+| LP fix (user-applied) | Has conv rate moved on that LP? |
+
+Output specific findings:
+
+```markdown
+## Lift on past suggestions
+
+### RSA optimizer (last run: 2026-04-15)
+- ✓ Brand-defense ad group: 6 of 8 replacements now rated Good (was 0 Good before). CTR up from 4.1% → 5.6%.
+- ⚠ Solution-aware ad group: 3 replacements still Pending (only 9 days impressions — not yet reliable).
+- ✗ Competitor-alt ad group: 2 replacements rated Low. Note for next RSA run: candidates B and C didn't land — pattern was differentiation, may not fit this ad group's intent.
+
+### Search terms miner (last run: 2026-04-18)
+- ✓ Negative "free download" added 2026-04-18: wasted spend on n-gram dropped from $487 → $0 in 11 days.
+- ✓ New keyword "ai sdr" exact: 14 conv at $58 CPA (target: $80). Promote to higher bid.
+```
+
+## Phase 4: Surface Anomalies
+
+Detect anomalies relative to baseline:
+
+| Anomaly | Trigger |
+|---|---|
+| Spend spike or crash | ±30% vs 7-day baseline |
+| CTR drop | -25% vs 7-day baseline at material impressions |
+| Conversion rate drop | -25% vs 7-day baseline at material clicks |
+| Conversion volume drop to zero | Tracking probably broken — flag urgently |
+| Impression share crash | IS dropped >15 percentage points |
+| Auction Insights: new competitor entered top 5 | Track |
+| RSA strength rating drop | One or more RSAs dropped to "Poor" |
+| Quality Score drop on top keywords | Avg QS down ≥1 on keywords with material spend |
+
+Don't fabricate composite scores. Just surface the specific anomaly with the metric.
+
+```markdown
+## Anomalies
+
+- 🚨 Conversions dropped to 0 on 2026-04-27 — tracking may be broken. Verify pixel on /demo-thank-you immediately.
+- ⚠ Brand-defense IS dropped from 100% → 78% over last 3 days. Possible competitor outbidding or budget cap hit.
+- ⚠ "Acme Corp" appeared in Auction Insights top 5 (wasn't there last check-in) — new competitor.
+```
+
+## Phase 5: Propose Next Round
+
+Combine lift findings + anomalies + new opportunities into a concrete next-round proposal. Don't propose generic "do more optimization" — propose specific actions tied to specific findings.
+
+```markdown
+## Proposed next actions
+
+### Investigate / fix (high priority — user action)
+1. Conversion tracking on /demo-thank-you — verify pixel firing. Requires manual user action.
+2. Investigate brand-defense IS drop — check Auction Insights detail, consider bid increase if competitor pressure.
+
+### AI agent can run (with your approval)
+3. RSA optimizer rerun on Competitor-alt ad group — past replacements rated Low, try different patterns (urgency, scarcity instead of differentiation). Run `google-ads-rsa-optimizer`.
+4. Search terms mining on "Acme Corp" — new competitor showing up, check if their brand terms are in your search queries. Run `google-ads-search-terms-miner` with focus on brand bleed.
+5. Bid up on "ai sdr" — past run promoted at standard bid, performance is well below CPA target with IS lost to rank > 30%. Run `google-ads-keyword-optimizer` Phase 3 (Bid up bucket) on this keyword.
+6. Pause underperformers in Solution-aware — 5 keywords with $300+ spend and 0 conv over 21+ days. Run `google-ads-keyword-optimizer`.
+7. Competitive gap analysis — Acme Corp's IS up 12pp in Solution-aware over 30 days. Run `google-ads-competitor-gap-analysis` to see if their angles/keywords have shifted.
+
+### Watch list (no action yet)
+8. Solution-aware ad group RSAs still Pending — re-check next check-in (target: 14+ days impressions).
+```
+
+### Approval Gate
+
+Present findings + proposed next actions to user. Ask:
+
+> "Here's the check-in. Lift on past suggestions, anomalies, and proposed next actions. Which next actions do you want to run? Some are user-only (tracking fixes), some are skills you'd approve me to trigger."
+
+For agent-runnable actions: user picks which to trigger. The agent chains directly into the relevant skill (`google-ads-rsa-optimizer`, `google-ads-search-terms-miner`, `google-ads-keyword-optimizer`, `google-ads-competitor-gap-analysis`) or schedules it for later.
+
+For user-only actions: the skill provides specific instructions (e.g. "open Google Tag Assistant on /demo-thank-you, verify the conversion event fires when the form submits").
+
+## Phase 6: Output
+
+The skill returns the full check-in inline, ending with these structured blocks the user can persist (anywhere they want):
+
+### Decisions log entry (suggested to save for the next check-in)
+
+```
+{YYYY-MM-DD} | google-ads-checkin | Reviewed since last check-in {prior date}. Approved: rerun RSA optimizer on Competitor-alt; mine search terms for Acme Corp brand bleed. User-only: fix /demo-thank-you tracking.
+```
+
+### Learnings to capture
+
+```
+{YYYY-MM-DD} — Differentiation-pattern RSA replacements landed in Brand-defense (6/8 → Good) but didn't land in Competitor-alt (2/3 → Low). Hypothesis: Competitor-alt intent rewards urgency/scarcity, not differentiation. Try those patterns on next RSA run.
+```
+
+These notes can be passed back into this skill (or `google-ads-rsa-optimizer`, `google-ads-search-terms-miner`, etc.) on the next run to inform future proposals.
+
+### Suggested filename for the check-in report
+
+`google-ads-checkin-{YYYY-MM-DD-HHMM}.md` — the user can save the inline check-in wherever fits their workflow.
+
+## Output Summary
+
+- **Inline:** Full check-in: cadence recommendation, performance snapshot, lift on past suggestions, anomalies, proposed next actions
+- **Decisions log + Learnings:** Structured text blocks at end of report for the user to save
+- **Optional follow-up triggers:** Specific skills the user approved to run next
+
+## Tools Required
+
+- **Google Ads API connection** (MCP server, native client, or manual export) — for performance pulls, asset ratings, IS / Auction Insights data
+- Anomaly detection logic (built into this skill's Phase 4)
+- Check-in report template at `templates/checkin-report.template.md` in this skill folder
+- Cross-references other skills in this Google Ads suite as user-approved next actions
+
+## Cost
+
+Free.
+
+## Universal Patterns
+
+- **Suggestion-only:** Findings + proposed next actions. User picks what runs.
+- **Draft-first:** No mutations from the check-in itself. If the user approves a follow-up skill, that skill drafts.
+- **Adaptive cadence:** Every 4–6hr fresh → daily learning → 2–3 day mature.
+- **No composite scores:** Raw metrics + specific findings. No "B+ overall."
+- **Lift-first framing:** Always measure whether past suggestions worked before proposing new ones.
+- **Anti-laziness:** Cadence recommendation derived from account age + volatility, not asked of user.
+- **End-of-session ritual:** Output decisions log + learnings entries on every run for the user to persist.
+
+## Trigger Phrases
+
+- "Run a check-in on the account"
+- "How are we doing?"
+- "What's changed since last time?"
+- "Did the optimizations work?"
+- "What should I optimize next?"

--- a/skills/composites/google-ads-checkin/checkin-cadence.md
+++ b/skills/composites/google-ads-checkin/checkin-cadence.md
@@ -1,0 +1,65 @@
+# Workflow: Check-in Cadence Logic
+
+How `google-ads-checkin` decides the recommended cadence for a given account. This logic lives in the skill itself — this doc is the human-readable spec for how it works.
+
+## Why adaptive cadence
+
+Adaptive cadence beats fixed weekly digests for three reasons:
+
+- A new account or a freshly-changed account needs near-constant attention (tracking can break, search terms surface fast, learning phase is fragile)
+- A mature, stable account checked daily generates noise and approval fatigue
+- Real performance marketers naturally adjust attention based on lifecycle — automation should match that
+
+## Cadence levels
+
+| Level | Cadence | When it applies |
+|---|---|---|
+| **Hot** | Every 4–6 hours | Days 0–3 after a new campaign launch OR a major change (e.g. bid strategy switch, large budget increase, RSA replacement batch >5 ad groups) |
+| **Warm** | Daily | Days 4–14 (learning phase) |
+| **Steady** | Every 2 days | Days 15–30 (early maturity) |
+| **Cool** | Every 3–5 days | Days 30+ (mature, stable) |
+
+Plus override: **on-demand** — user manually invokes `google-ads-checkin` whenever they want a fresh pulse.
+
+## How the skill picks a cadence
+
+Pseudo-logic:
+
+```
+days_since_launch = days since the oldest active campaign was created
+days_since_change = days since last optimization (RSA replacement, negatives added, etc.)
+recent_volatility = any of these in last 7 days:
+  - ±20% spend swing day-over-day
+  - ±20% CTR swing
+  - ±20% conversion-rate swing
+  - new anomaly fired
+
+if days_since_change <= 3:
+  cadence = HOT
+elif days_since_launch <= 14 or days_since_change <= 14:
+  cadence = WARM
+elif days_since_launch <= 30:
+  cadence = STEADY
+elif recent_volatility:
+  cadence = WARM  # promote when stable accounts go volatile
+else:
+  cadence = COOL
+```
+
+## Override rules
+
+The skill **recommends** a cadence and surfaces the reasoning. The user (or whatever scheduling layer the calling agent uses) sets the actual schedule. Don't auto-schedule without user approval.
+
+Common override patterns:
+
+| User wants | Set cadence to |
+|---|---|
+| Tighter monitoring during a critical period | Hot or Warm regardless of recommendation |
+| Less interruption during a stable stretch | Cool regardless of recommendation |
+| Off entirely for X days (e.g. on PTO) | Pause the schedule |
+
+## What "cadence" actually means
+
+A check-in run does not mean making changes — it means generating a check-in report and surfacing proposed next actions. Whether anything happens depends on the user approving proposed actions in the report.
+
+So a Hot cadence (every 4–6 hours) does NOT mean changes every 4–6 hours. It means the skill pulls fresh data and proposes actions every 4–6 hours; whether the user approves any is up to them.

--- a/skills/composites/google-ads-checkin/daily-ops-loop.md
+++ b/skills/composites/google-ads-checkin/daily-ops-loop.md
@@ -1,0 +1,57 @@
+# Workflow: Daily Ops Loop
+
+SOP for ongoing Google Ads optimization once an initial audit has been run and prioritized actions have been taken. This is the steady-state cadence the optimization work settles into after the first round of changes.
+
+## Cadence
+
+| Account state | Skills to run | Frequency |
+|---|---|---|
+| Days 0–14 (post-launch / fresh changes) | `google-ads-checkin` | Daily |
+| Days 0–14 | `google-ads-search-terms-miner` | Every 2–3 days |
+| Days 15–30 | `google-ads-checkin` | Every 2 days |
+| Days 15–30 | `google-ads-search-terms-miner` | Weekly |
+| Days 30+ (mature) | `google-ads-checkin` | Every 3–5 days |
+| Days 30+ | `google-ads-search-terms-miner` | Bi-weekly |
+| When asset ratings drift | `google-ads-rsa-optimizer` | As triggered by check-in's lift findings |
+
+## The loop, abstractly
+
+```
+1. CHECKIN runs (adaptive cadence)
+   ├─ Pulls performance + lift on past suggestions
+   ├─ Surfaces anomalies
+   ├─ Proposes next actions
+   └─ User approves which actions to run
+       │
+       ├─ If RSA refresh needed → trigger RSA OPTIMIZER
+       ├─ If search terms drift → trigger SEARCH TERMS MINER
+       ├─ If user-fixable issue (tracking, LP) → user does manually
+       └─ If watch-list → wait for next check-in
+2. Approved skills run, save drafts to Google Ads UI
+3. User reviews drafts in Google Ads UI, activates manually
+4. Activated changes accumulate in decisions log
+5. Next CHECKIN measures lift on those decisions → repeat
+```
+
+## Approval discipline
+
+Every skill requires per-item user approval before drafts are saved. If the user is going to be unavailable for a stretch:
+
+- ✗ Do **not** lower the approval bar. Drafts pile up unsaved; that's the design.
+- ✓ Do queue runs to fire when the user returns — `google-ads-checkin` can be scheduled.
+- ✓ Do surface escalations clearly when the user does come back ("3 anomalies and 18 unactioned drafts since 2026-04-22").
+
+## What this loop does NOT do
+
+- ❌ No autonomous mutations — ever. Always drafts.
+- ❌ No "set bid strategy to X" without explicit user approval.
+- ❌ No new-campaign creation. This loop is for optimizing an existing account, not greenfield setup.
+
+## When to break the loop
+
+The loop is the steady state. Break it for:
+
+- **New product launch** → Run a full account audit again. The optimization picture has shifted enough that prior decisions may not apply.
+- **Major budget change** (>50%) → Run audit before resuming the loop. The whole optimization picture shifts.
+- **New competitor entered** → Run search terms miner with focus on competitor brand bleed. Maybe RSA optimizer with new competitor angles.
+- **Tracking broke** → Stop the loop until tracking is verified. Search terms miner is unreliable without conversions.

--- a/skills/composites/google-ads-checkin/skill.meta.json
+++ b/skills/composites/google-ads-checkin/skill.meta.json
@@ -1,0 +1,16 @@
+{
+  "slug": "google-ads-checkin",
+  "category": "composites",
+  "description": "Adaptive-cadence performance check-in for a Google Ads account being iteratively optimized. Pulls recent performance via the Google Ads API, measures lift on past suggestions, surfaces anomalies, and proposes the next round of optimizations. Cadence adapts to campaign maturity. Suggestion-only.",
+  "tags": [
+    "ads"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install google-ads-checkin",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}

--- a/skills/composites/google-ads-checkin/templates/checkin-report.template.md
+++ b/skills/composites/google-ads-checkin/templates/checkin-report.template.md
@@ -1,0 +1,52 @@
+# Check-in {YYYY-MM-DD HH:MM}
+
+**Account:** {Account ID}
+**Period since last check-in:** {N days}
+**Recommended cadence:** every {X} {hours/days}
+**Cadence reasoning:** {account age + recent volatility}
+
+## Performance snapshot ({date range})
+
+| Metric | This period | Prior period | Δ |
+|---|---|---|---|
+| Spend | ${X} | ${X} | {±X%} |
+| Impressions | {N} | {N} | {±X%} |
+| Clicks | {N} | {N} | {±X%} |
+| CTR | {X%} | {X%} | {±X pp} |
+| Conversions | {N} | {N} | {±X%} |
+| Conversion rate | {X%} | {X%} | {±X pp} |
+| CPA | ${X} | ${X} | {±X%} |
+| Conversion value | ${X} | ${X} | {±X%} |
+| ROAS | {X} | {X} | {±X%} |
+
+## Lift on past suggestions
+
+(For each item in the prior decisions log, did it work?)
+
+### {Skill name} (last run: {YYYY-MM-DD})
+- {✓/⚠/✗} {Specific past action} — {what we measured, what changed}
+
+## Anomalies
+
+(Specific findings, not letter grades. 🚨 urgent, ⚠ watch.)
+
+- {🚨/⚠} {Specific anomaly with metric}
+
+## Proposed next actions
+
+### Investigate / fix (high priority — user action required)
+1. {Action — requires manual user action, with specific instructions}
+
+### AI agent can run (with your approval)
+2. {Action — which skill to run, why, approval requested}
+
+### Watch list (no action yet)
+3. {Item to revisit next check-in}
+
+## Decisions log entry to save
+
+(Suggested text for the user to keep for the next check-in.)
+
+## Learnings entry to save
+
+(Suggested text for the user to keep for the next check-in.)

--- a/skills/composites/google-ads-competitor-gap-analysis/SKILL.md
+++ b/skills/composites/google-ads-competitor-gap-analysis/SKILL.md
@@ -1,0 +1,310 @@
+---
+name: google-ads-competitor-gap-analysis
+description: >
+  Produce a unified competitive position report for a Google Search ad account.
+  Pulls Auction Insights via Google Ads API, scrapes currently-running competitor
+  ads via competitor-ad-intelligence, scrapes competitor landing pages, then
+  cross-references against the user's own keywords/RSAs/LPs to surface specific
+  gaps: auction position diff, outranking share, ad angle gaps, keyword theme
+  gaps, LP/offer gaps. Maps each finding to a specific follow-up skill (RSA
+  optimizer / search terms miner / manual LP work). Free stack only — no paid
+  competitor intel tools. Suggestion-only.
+tags: [ads]
+---
+
+# Google Ads Competitor Gap Analysis
+
+The unified "where you're lacking vs competitors" view. Pulls competitive context from multiple free sources and synthesizes it into a single report with specific, actionable findings.
+
+**Core principle:** Most competitive intelligence in Search Ads sits scattered across Auction Insights, the Transparency Center, and competitor landing pages. None of these alone is actionable — combined, they reveal specific gaps tied to specific actions. This skill does the synthesis.
+
+**What this skill does NOT do (free-stack honesty):** It does not estimate competitor CTR, conversion rate, or spend. Free data doesn't expose competitor performance metrics. Findings are positional ("you're outranked 47% of the time on `crm software`"), structural ("3 of 5 competitors lead with 'no credit card required', you don't"), and qualitative ("competitor X's LP has 5 trust badges, yours has 0") — not performance-comparative.
+
+**Universal pattern:** Suggestion-only, draft-first. The skill proposes findings + actions; user approves which to act on; approved actions chain to other skills (`google-ads-rsa-optimizer`, `google-ads-search-terms-miner`, `google-ads-keyword-optimizer`). This skill itself doesn't push drafts to the Google Ads UI — it produces a report and queues follow-up skill runs.
+
+## When to Use
+
+- "How am I doing vs competitors?"
+- "Where am I lacking vs competitors?"
+- "What angles are competitors using that I'm not?"
+- "Run a competitive gap analysis"
+- "Show me where competitors are winning"
+
+## Prerequisites
+
+- A working Google Ads API connection (MCP server, native client, or manual export). The skill queries Auction Insights via the Google Ads API.
+- The [`competitor-ad-intelligence`](https://github.com/gooseworks-ai/goose-skills/tree/main/skills/composites/competitor-ad-intelligence) skill installed (composed in Phase 3).
+- A web-fetch capability for competitor landing-page scraping (optional but recommended).
+
+## Phase 0: Intake
+
+Ask the user for these inputs at the start of the run:
+
+1. **Account ID** — the Google Ads customer ID
+2. **Top competitors** — names + URLs (ideally 3–5)
+3. **Brand voice profile** *(optional)* — short description used for "what angles fit our brand"
+4. **Brand-don't list** *(optional)* — words/phrases that should never appear in the user's ad copy
+5. **Recent decisions** *(optional)* — paste any prior decisions log entries so the skill avoids re-proposing the same gap-fixes
+
+## Phase 1: Confirm Scope
+
+Before pulling data, confirm with user:
+
+| Parameter | Default | User can override |
+|---|---|---|
+| Competitor list | List from Phase 0 | Yes — can add/remove |
+| Campaigns to analyze | All active Search campaigns | Yes |
+| Time window for Auction Insights | Last 30 days | Yes |
+| Include LP scraping | Yes | Yes — can skip if competitor LPs are well-known |
+| Auction Insights granularity | Per campaign | Yes — can drill to ad group |
+
+### Approval Gate 1
+
+> "I'll analyze competitive position vs these competitors: {list}. Pull Auction Insights from the last 30 days, scrape currently-running ads via the Transparency Center, and audit their landing pages. Want to adjust the competitor list or scope before I pull data?"
+
+Wait for confirmation. Apply overrides.
+
+## Phase 2: Auction Position Pull
+
+Run **parallel GAQL queries** on `auction_insight_view` for each in-scope campaign:
+
+```sql
+SELECT
+  campaign.name,
+  ad_group.name,
+  auction_insight_domain.domain,
+  metrics.search_impression_share,
+  metrics.search_absolute_top_impression_share,
+  metrics.search_top_impression_share,
+  metrics.search_outranking_share,
+  metrics.search_rank_lost_impression_share,
+  segments.date
+FROM auction_insight_view
+WHERE
+  segments.date BETWEEN '{start}' AND '{end}'
+  AND campaign.status = 'ENABLED'
+```
+
+Aggregate per (campaign, competitor_domain). For each competitor:
+- Their IS in your auctions
+- Their abs top % vs yours
+- How often they outrank you (`outranking_share`)
+- Trend: improving / stable / declining over the window
+
+Output:
+
+```markdown
+## Auction Position vs Competitors
+
+### Campaign: Solution-aware
+| Competitor | Their IS | Your IS | Their abs top % | Your abs top % | Outranks you | Trend |
+|---|---|---|---|---|---|---|
+| acme.com | 42% | 28% | 18% | 12% | 51% | ⬆ improving |
+| beta.io | 31% | 28% | 14% | 12% | 44% | ➡ stable |
+| ... |
+
+### Campaign: Competitor-alt
+[same]
+```
+
+Surface specific findings:
+- Competitors with growing IS share (entering the auction more aggressively)
+- Competitors with high abs top % vs yours (winning premium placements)
+- New competitors not in the user-provided list (auto-suggest adding for future analyses)
+
+## Phase 3: Competitor Ad Copy Pull
+
+Compose [`competitor-ad-intelligence`](https://github.com/gooseworks-ai/goose-skills/tree/main/skills/composites/competitor-ad-intelligence). Pass:
+- Competitor names + URLs from Phase 1
+- Channel: Google Ads (Transparency Center) — Meta Ad Library is auxiliary
+- Time window: currently-running ads
+
+The skill returns currently-running competitor ads with:
+- Headline / description text
+- Sitelinks / callouts they use
+- Ad variants per competitor
+
+## Phase 4: Angle / Hook Categorization
+
+For each competitor, categorize their ads against the headline pattern library:
+
+| Pattern | Examples (from competitor ads) | Competitors using |
+|---|---|---|
+| Urgency / scarcity | "Q2 dates booking fast", "Limited spots" | acme.com, beta.io |
+| Numeric proof | "500+ teams", "Trusted by Fortune 500" | acme.com, gamma.co |
+| Friction-remover | "No credit card required", "Free 14-day trial" | beta.io, gamma.co, delta.io |
+| Differentiation | "Built for B2B SaaS, not generic" | acme.com |
+| Trust signal | "SOC2 Compliant", "GDPR Ready" | gamma.co, delta.io |
+
+For each pattern, note:
+- **Competitors using it** (count + names)
+- **User using it?** (cross-reference active RSAs in their account)
+
+Then surface gaps:
+
+```markdown
+## Angle Gaps
+
+**Angles 3+ competitors use that you don't:**
+1. **Friction-remover (no credit card / free trial)** — used by acme.com, beta.io, gamma.co, delta.io. You don't reference this in any active RSA.
+   → Suggested: chain to `google-ads-rsa-optimizer` to test friction-remover variants.
+
+2. **SOC2 / Compliance trust signal** — used by gamma.co, delta.io. You have SOC2 compliance per Phase 0 intake but don't surface in ads.
+   → Suggested: chain to `google-ads-rsa-optimizer` to add trust-signal variants.
+
+**Angles you use that competitors don't (your differentiation):**
+- "AI-native" framing — only you. Keep using this.
+- Specific integration call-outs — only you. Keep using this.
+```
+
+## Phase 5: Keyword Theme Gap Analysis
+
+Cross-reference the language in competitor ads against the user's active keyword themes (pulled fresh from the Google Ads API).
+
+Identify keyword themes that:
+- **Competitors clearly target** (multiple competitors run ads for it) AND
+- **You don't target** (no active keyword in your account contains the theme)
+
+```markdown
+## Keyword Theme Gaps
+
+| Theme competitors target | Competitors using it | You target? | Action |
+|---|---|---|---|
+| "automation" | acme.com, beta.io, gamma.co | No | Chain to `google-ads-search-terms-miner` Phase 6 to evaluate adding |
+| "for sales teams" | acme.com, gamma.co | Partially (only "Solution-aware" ad group) | Chain to `google-ads-search-terms-miner` to evaluate expansion across more ad groups |
+```
+
+Don't propose blind keyword expansion — the search-terms-miner skill validates volume + intent before adding. This skill just surfaces the theme.
+
+## Phase 6: Landing Page Comparison
+
+For each competitor, fetch their primary LP via whatever web-fetch tool the agent has available. Compare to user's LPs (referenced in active campaigns).
+
+Score competitor LPs on:
+- Hero headline pattern
+- Trust signals (logos, badges, customer counts, security/compliance)
+- Social proof (testimonials, reviews, ratings)
+- CTA (text + position)
+- Offer (free trial / demo / pricing transparency)
+- Risk reversal (no CC, money back, etc.)
+
+Compare side-by-side with user's LPs:
+
+```markdown
+## Landing Page Gaps
+
+**Trust signals present on most competitor LPs, missing from yours:**
+- Customer logos: 4 of 5 competitors show logo strip above fold. Your /pricing has none.
+- Security badges: 3 of 5 competitors show SOC2 / GDPR badges. You don't.
+- Customer count: 4 of 5 competitors prominently show "X+ teams trust us". You don't.
+
+**CTAs:**
+- Competitors all use "Start free trial" or "Book a demo". You use "Get started" — vaguer.
+
+**Risk reversal:**
+- 4 of 5 competitors say "No credit card required" above the fold. You don't.
+
+→ Suggested: manual LP improvements with this gap list as input. Re-run `google-ads-account-audit` Phase 7 (LP audit) after fixes.
+```
+
+## Phase 7: Synthesize Action Plan
+
+Combine findings from Phases 2–6 into a numbered action plan, ranked by estimated impact and tied to specific follow-up skills.
+
+```markdown
+## Competitive Action Plan
+
+### High impact
+1. **Add friction-remover angle to RSAs** — 4 of 5 competitors use it; you don't. Chain to `google-ads-rsa-optimizer` for Solution-aware + Brand-defense ad groups.
+2. **Surface SOC2 compliance in trust-signal headlines** — your intake says you're SOC2 but ads don't mention it. Chain to `google-ads-rsa-optimizer`.
+3. **Investigate "automation" keyword theme** — 3 competitors target, you don't. Chain to `google-ads-search-terms-miner` Phase 6 for keyword evaluation.
+
+### Medium impact
+4. **Auction position decline on Solution-aware** — acme.com's IS up 12pp in 30 days. Investigate if they raised bids. Chain to `google-ads-keyword-optimizer` for bid review.
+5. **Add customer logo strip to /pricing** — 4 of 5 competitors do this. User action.
+6. **Add "no credit card required" to /pricing above fold** — competitor pattern. User action.
+
+### Watch list
+7. New competitor `delta.io` appeared in Auction Insights with 18% IS — wasn't in the input list. Add to monitoring.
+```
+
+### Approval Gate 2
+
+Present the action plan to the user. Ask:
+
+> "Here's the competitive gap analysis. Which actions do you want to act on? Some chain to other skills in this Google Ads suite (RSA optimizer, search terms miner, keyword optimizer); LP fixes need to be done manually with these findings as input."
+
+Map approved actions:
+- RSA changes → queue `google-ads-rsa-optimizer` run
+- Keyword theme expansion → queue `google-ads-search-terms-miner` run
+- Bid investigation → queue `google-ads-keyword-optimizer` run
+- LP changes → manual user action with findings as input
+- New competitor → propose adding to user's competitor list for future analyses
+
+## Phase 8: Output
+
+The skill returns the full gap-analysis report inline, ending with these structured blocks the user can persist (anywhere they want):
+
+### Decisions log entry (suggested to save for future reference)
+
+```
+{YYYY-MM-DD} | google-ads-competitor-gap-analysis | Identified 3 high-impact gaps (friction-remover angle, SOC2 trust signal, "automation" theme) + 3 medium-impact (auction decline, LP logos, LP risk reversal). User approved chaining to RSA optimizer + search-terms-miner. New competitor delta.io added to competitor list.
+```
+
+### Learnings to capture
+
+```
+{YYYY-MM-DD} — Competitor angle pattern: friction-remover ("no CC required") is used by 4 of 5 competitors. Likely category convention. Test in next RSA round.
+```
+
+### Suggested filename for the gap analysis report
+
+`google-ads-competitor-gap-{YYYY-MM-DD}.md` — the user can save the inline report wherever fits their workflow.
+
+If a new competitor was discovered, propose to the user:
+
+> "delta.io appeared in Auction Insights with 18% IS — they weren't in your input list. Recommend adding them to your competitor list for future analyses."
+
+## Output Summary
+
+- **Inline:** Full gap analysis report with auction position, angle gaps, keyword theme gaps, LP gaps, and action plan
+- **Decisions log + Learnings:** Structured text blocks at end of report for the user to save
+- **Optional follow-up triggers:** Specific skills the user approved to run next
+
+## Tools Required
+
+- **Google Ads API connection** (MCP server, native client, or manual export) — Auction Insights via `auction_insight_view` GAQL
+- **Web-fetch capability** — competitor LP scraping (any agent web-fetch tool)
+- Composes skill: [`competitor-ad-intelligence`](https://github.com/gooseworks-ai/goose-skills/tree/main/skills/composites/competitor-ad-intelligence) for currently-running competitor ad copy
+
+## Cost
+
+Free.
+
+## Universal Patterns
+
+- **Suggestion-only:** No mutations. Findings + proposed actions. User picks what runs.
+- **Free-stack honesty:** No fabricated performance benchmarks. We surface what we can measure (positional, structural, qualitative gaps), not what we can't (competitor CTR, CVR, spend).
+- **Cross-skill chaining:** Gaps map to specific follow-up skills with phase-level precision (e.g. "chain to `google-ads-search-terms-miner` Phase 6").
+- **No composite letter grades:** Each finding cites specific data — IS percentages, competitor counts, named competitors.
+- **Anti-laziness:** Pull all data first; only ask the user when something can't be derived from the API or competitor scraping.
+- **Self-healing:** Retry transient API errors with backoff. Note in learnings if competitor scraping fails for a specific domain.
+- **Findings drive prioritization, not noise:** Don't pad with every tiny gap. Threshold for inclusion: ≥3 competitors using a pattern OR ≥10 percentage points IS difference OR clear directional trend.
+
+## What's Out of Scope
+
+- **Estimated competitor CTR / CVR per keyword** — requires paid competitive-intelligence tools (e.g. AdGooroo). This skill stays free-only.
+- **Real-time competitor change alerts** (new keywords added, bid strategy shifts) — requires paid monitoring tools (e.g. Adthena Smart Monitor).
+- **Historical ad copy archive beyond what's currently running** — requires paid tools (e.g. SpyFu).
+
+If you need these capabilities, this skill won't deliver them — that's a different (paid) tool category.
+
+## Trigger Phrases
+
+- "How am I doing vs competitors?"
+- "Where am I lacking vs competitors?"
+- "What angles are competitors using that I'm not?"
+- "Run a competitive gap analysis"
+- "Show me where competitors are winning"
+- "Competitive analysis"
+- "Competitor benchmark"

--- a/skills/composites/google-ads-competitor-gap-analysis/skill.meta.json
+++ b/skills/composites/google-ads-competitor-gap-analysis/skill.meta.json
@@ -1,0 +1,19 @@
+{
+  "slug": "google-ads-competitor-gap-analysis",
+  "category": "composites",
+  "description": "Unified competitive position report for a Google Search ad account. Pulls Auction Insights via Google Ads API, scrapes currently-running competitor ads, audits competitor landing pages, and surfaces specific gaps (auction position, angle gaps, keyword theme gaps, LP gaps). Maps each finding to a specific follow-up skill. Free stack only. Suggestion-only.",
+  "tags": [
+    "ads"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install google-ads-competitor-gap-analysis",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "requires_skills": [
+    "competitor-ad-intelligence"
+  ]
+}

--- a/skills/composites/google-ads-keyword-optimizer/SKILL.md
+++ b/skills/composites/google-ads-keyword-optimizer/SKILL.md
@@ -1,0 +1,324 @@
+---
+name: google-ads-keyword-optimizer
+description: >
+  Analyze the keywords currently bidding in a live Google Ads account and propose
+  per-keyword optimizations — pause underperformers, bid up / bid down, change
+  match type, deduplicate cannibalizing keywords, improve Quality Score clusters.
+  Pulls per-keyword performance + Quality Score components via Google Ads API,
+  validates expansions against Keyword Planner. Per-item user approval; approved
+  actions saved as drafts in Google Ads UI. Pure free stack — no paid tools.
+tags: [ads]
+---
+
+# Google Ads Keyword Optimizer
+
+Analyze the keywords currently running in a live Google Ads account and propose specific optimizations: pause / bid up / bid down / match-type change / dedupe / Quality Score remediation. Complements [`google-ads-search-terms-miner`](https://github.com/gooseworks-ai/goose-skills/tree/main/skills/composites/google-ads-search-terms-miner) — that skill is *reactive* (mines what users searched), this skill is *proactive* (optimizes the keywords the user is currently bidding on).
+
+**Core principle:** Per-keyword performance + Quality Score data + IS metrics are rich enough to make smart optimization proposals without third-party tools. The user's own data is the right source.
+
+**Universal pattern:** Suggestion-only, draft-first. Per-item approval. Approved actions saved as drafts in Google Ads UI; user activates manually.
+
+## When to Use
+
+- "Optimize my Google Ads keywords"
+- "Which keywords should I pause?"
+- "Are my bids right?"
+- "Find my keyword duplicates"
+- "Improve my Quality Scores"
+- "Run keyword optimizer"
+
+## Prerequisites
+
+- A working Google Ads API connection (MCP server, native client, or manual export). The skill uses Google Ads API queries throughout.
+- Optional but recommended: a recent run of [`google-ads-account-audit`](https://github.com/gooseworks-ai/goose-skills/tree/main/skills/composites/google-ads-account-audit) — it identifies which campaigns / ad groups have keyword issues so this skill can focus on them.
+
+## Phase 0: Intake
+
+Ask the user for these inputs at the start of the run:
+
+1. **Account ID** — the Google Ads customer ID
+2. **Primary conversion goal** — what conversion event is being optimized for (Demos / Trials / Purchases / Leads)
+3. **Target CPA** — explicit, or "back-calculate from LTV × margin", or "no target — benchmark me"
+4. **Target ROAS** — if applicable
+5. **Recent decisions** *(optional)* — paste any prior decisions log entries so the skill avoids re-proposing actions on keywords already paused / bid-changed in the last 14 days (let prior changes mature)
+6. **Scope** — all active Search campaigns by default; user can override to specific campaigns
+7. **Time window** — 30 days default (tactical); 90 days for strategic review
+
+## Phase 1: Confirm Scope
+
+| Parameter | Default | User can override |
+|---|---|---|
+| Time window | **30 days** | Yes |
+| Campaign scope | All active Search campaigns | Yes — can scope to specific campaigns |
+| Keyword status | Active only (skip paused/removed) | Yes |
+| Pause threshold | High spend + 0 conv after **14+ days**, OR CPA > 2× target consistently | Yes |
+| Bid-up trigger | Below target CPA + IS lost to rank > 25% | Yes |
+| Bid-down trigger | CPA > 1.5× target consistently with adequate volume | Yes |
+
+### Approval Gate 1
+
+> "I'll analyze active keywords across all Search campaigns over the last 30 days. Surface underperformers, QS issues, match-type optimization opportunities, and duplicates. Want to adjust scope before I pull data?"
+
+Wait for confirmation. Apply overrides.
+
+## Phase 2: Pull Per-Keyword Data
+
+Run **parallel GAQL queries** via the Google Ads API:
+
+1. Active keywords across in-scope campaigns with metrics
+2. Quality Score per keyword + components (Landing page experience, Expected CTR, Ad relevance)
+3. Per-keyword IS metrics (search_impression_share, search_rank_lost_impression_share)
+4. First-page CPC + top-of-page CPC bid estimates per keyword
+5. Days since each keyword was added (for "give it time" check)
+
+Example GAQL:
+
+```sql
+SELECT
+  ad_group.name,
+  campaign.name,
+  ad_group_criterion.keyword.text,
+  ad_group_criterion.keyword.match_type,
+  ad_group_criterion.quality_info.quality_score,
+  ad_group_criterion.quality_info.creative_quality_score,
+  ad_group_criterion.quality_info.post_click_quality_score,
+  ad_group_criterion.quality_info.search_predicted_ctr,
+  ad_group_criterion.cpc_bid_micros,
+  ad_group_criterion.position_estimates.first_page_cpc_micros,
+  ad_group_criterion.position_estimates.top_of_page_cpc_micros,
+  metrics.clicks,
+  metrics.impressions,
+  metrics.cost_micros,
+  metrics.conversions,
+  metrics.conversions_value,
+  metrics.search_impression_share,
+  metrics.search_rank_lost_impression_share,
+  segments.date
+FROM keyword_view
+WHERE
+  ad_group_criterion.status = 'ENABLED'
+  AND campaign.status = 'ENABLED'
+  AND segments.date BETWEEN '{start}' AND '{end}'
+```
+
+## Phase 3: Classify Keywords (Bucket by Action)
+
+For each keyword, classify into one bucket:
+
+| Bucket | Trigger | Action |
+|---|---|---|
+| 🔴 **Pause candidate** | High spend + 0 conv after 14+ days, OR CPA consistently > 2× target | Propose pause |
+| 🟠 **Bid down** | CPA between 1.5× and 2× target with adequate conv volume | Propose lower bid |
+| 🟢 **Bid up** | CPA at or below target + IS lost to rank > 25% | Propose raise bid |
+| 🚫 **Bid floor** | Top-of-page CPC required exceeds your bid by >50%, AND you're not winning | Note: realistically can't compete here at current budget |
+| ⏸ **Hold** | Performing at target — no change | Skip |
+
+Surface specific findings, not generic guidance:
+
+```markdown
+### 🔴 Pause candidates
+| Keyword | Match | Spend | Conv | CPA | Days | QS | Reason |
+|---|---|---|---|---|---|---|---|
+| "enterprise crm software" | Phrase | $487 | 0 | — | 30 | 6 | 0 conv after 30 days at 4× expected click volume |
+| "best b2b saas tools" | Broad | $312 | 0 | — | 21 | 4 | High spend, 0 conv, low QS suggests poor relevance |
+
+### 🟢 Bid up
+| Keyword | Match | Spend | Conv | CPA | IS lost rank | Action |
+|---|---|---|---|---|---|---|
+| "ai sdr" | Exact | $210 | 6 | $35 | 47% | Bid up from $4.50 → $7.00 to capture more impressions |
+```
+
+## Phase 4: Quality Score Analysis
+
+Group keywords by QS:
+
+| QS bucket | Count | Spend share | Top issues |
+|---|---|---|---|
+| 9-10 (top) | N | X% | — |
+| 7-8 (good) | N | X% | — |
+| 4-6 (medium) | N | X% | LP exp gaps, CTR gaps |
+| 1-3 (poor) | N | X% | Major issues |
+
+For each QS cluster ≤ 6, drill into components:
+
+- **Landing page experience: below average** → surface specific LP URLs scoring poorly. Cross-reference with [`ad-to-landing-page-auditor`](https://github.com/gooseworks-ai/goose-skills/tree/main/skills/composites/ad-to-landing-page-auditor) findings if a recent audit was run. Action: review LP for message-match.
+- **Expected CTR: below average** → propose RSA refresh on the ad group (chain to [`google-ads-rsa-optimizer`](https://github.com/gooseworks-ai/goose-skills/tree/main/skills/composites/google-ads-rsa-optimizer)).
+- **Ad relevance: below average** → keyword theme mismatch with ad copy. Action: split keyword to a better-matched ad group, OR refresh ads to mention the keyword theme literally.
+
+Output specific QS improvement actions, not generic "improve your QS":
+
+```markdown
+### Quality Score remediation
+
+5 keywords in ad group "enterprise-crm" have LP experience "below average":
+- All point to /pricing
+- LP hero: "AI Outbound Tool" (mismatched with ad group keyword theme)
+- Action: review LP for message-match. Suggested chain: run google-ads-account-audit Phase 7 (LP audit) on /pricing for these keywords.
+
+3 keywords in "competitor-alt" have Expected CTR "below average":
+- Current RSA assets: 4 of 8 headlines marked Low
+- Action: chain to google-ads-rsa-optimizer for this ad group
+```
+
+## Phase 5: Match-Type Optimization
+
+For each keyword, evaluate match-type fit using its triggered search terms (cross-reference with `google-ads-search-terms-miner` output if recent run exists):
+
+| Current → Proposed | When |
+|---|---|
+| Broad → Phrase or Exact | High spend + low relevance search terms triggering it |
+| Phrase → Exact + add negatives | Many irrelevant variants triggering, exact match would tighten |
+| Exact → Phrase | Performing well, but many close-variant negatives suggest there's adjacent volume worth capturing |
+
+Output proposals with the search-term evidence:
+
+```markdown
+### Match-type changes
+
+"crm software" (Broad) → propose change to Phrase
+- Triggered 47 search queries over 30 days
+- 23 of 47 are clearly irrelevant ("free crm software tutorial", "crm software jobs")
+- Tightening to phrase would block ~$180/mo waste
+```
+
+## Phase 6: Duplicate / Cannibalization Detection
+
+For each unique (keyword text + match type) combination, check if it appears in multiple ad groups within the same campaign:
+
+- ❌ **Same keyword + same match type in 2+ ad groups** → cannibalization. Recommend: keep in highest-performing ad group (best CPA), pause in others.
+- ⚠️ **Same keyword text, different match types across ad groups** → may be intentional (different intent → different LP). Flag for review, don't auto-propose action.
+
+```markdown
+### Duplicates / cannibalization
+
+"ai sdr" (Exact) appears in 3 ad groups:
+- "Solution-aware" — $210 spend, 6 conv, $35 CPA ← **highest performer**
+- "Brand-defense" — $89 spend, 1 conv, $89 CPA
+- "Competitor-alt" — $44 spend, 0 conv, —
+
+Recommend: keep in "Solution-aware", pause in other two.
+```
+
+## Phase 7: Volume Sanity Check via Keyword Planner
+
+For Bid-up + Match-type-expansion proposals, validate against Google Keyword Planner:
+
+- Average monthly search volume
+- Forecast clicks at proposed bid
+- Top-of-page CPC range
+
+If a Bid-up proposal targets a low-volume keyword, deprioritize — bidding harder for nothing. If volume is high but you're at low IS, the bid-up case strengthens.
+
+If a Match-type-expansion (e.g. Exact → Phrase) targets a keyword with limited related-query volume, deprioritize.
+
+## Phase 8: Per-Item Approval
+
+Present proposals organized by bucket. Run through in this order (lowest risk first):
+
+1. **Pause candidates** (lowest risk — stops bleed)
+2. **Duplicates / cannibalization** (low risk — consolidates spend)
+3. **Bid down** (low risk — caps overspend)
+4. **Match-type changes** (medium — affects future query coverage)
+5. **Bid up** (medium — increases spend)
+6. **Quality Score remediation** (chains to other skills — chain proposals require explicit approval)
+
+For each item:
+- ✓ approve as proposed
+- edit (e.g. set a different bid amount, change scope)
+- ✗ reject
+
+### Approval Gate 2 (final summary before saving drafts)
+
+```markdown
+### Final summary
+
+**Pause: 8 keywords**
+- 5 in Solution-aware ad group
+- 3 in Competitor-alt ad group
+
+**Bid changes: 12 keywords**
+- 4 bid up (avg +$2.50 increase)
+- 8 bid down (avg -$1.20 decrease)
+
+**Match-type changes: 3 keywords**
+- 2 Broad → Phrase
+- 1 Phrase → Exact
+
+**Duplicates: 2 deduplications**
+- "ai sdr" pause in 2 ad groups
+- "saas crm" pause in 1 ad group
+
+**QS remediation actions queued:**
+- LP audit on /pricing (chain to google-ads-account-audit Phase 7)
+- RSA refresh on "competitor-alt" ad group (chain to google-ads-rsa-optimizer)
+
+Ready to save these as drafts in your Google Ads account?
+```
+
+Wait for explicit confirmation.
+
+## Phase 9: Save as Drafts
+
+For each approved action, save via the Google Ads API:
+
+| Action | Draft type |
+|---|---|
+| Pause | Paused-keyword draft |
+| Bid change | Bid-update draft |
+| Match-type change | New keyword (new match type) + pause original (combined draft) |
+| Dedupe | Pause-in-ad-group draft for non-winning copies |
+
+If draft creation isn't available via the connected API, output a **copy-paste-ready document** the user can apply manually in the Google Ads UI. Suggested filename: `google-ads-keyword-changes-{YYYY-MM-DD}.md`.
+
+For QS remediation actions: don't save these as drafts (they trigger other skills). Just log them and queue the chained skill runs for the user's next session.
+
+## Phase 10: Output
+
+The skill returns the analysis inline, ending with these structured blocks the user can persist (anywhere they want):
+
+### Decisions log entry (suggested to save for future reference)
+
+```
+{YYYY-MM-DD} | google-ads-keyword-optimizer | Paused 8 keywords, bid-changed 12, match-type-changed 3, deduped 2. QS remediation queued: LP audit on /pricing, RSA refresh on competitor-alt. | Top patterns: pause for high-spend-zero-conv (5 of 8); bid-up triggered by IS-lost-to-rank > 30%.
+```
+
+### Learnings to capture
+
+- Which keyword patterns the user approves vs. rejects (e.g. "user consistently rejects pauses on competitor brand terms — keep them as defensive even at 0 conv")
+- Which match-type changes the user edits (signal for what's actually relevant in their account)
+
+These notes can be passed back into this skill (or `google-ads-checkin`) on the next run to inform future proposals.
+
+## Output Summary
+
+- **Inline:** Full analysis report with proposals and approvals
+- **In Google Ads:** Drafts for each approved action (or fallback markdown if drafts API unavailable)
+- **Decisions log + Learnings:** Structured text blocks at end of report for the user to save
+
+## Tools Required
+
+- **Google Ads API connection** (MCP server, native client, or manual data export) — keyword data, QS components, IS metrics, draft creation
+- **Google Keyword Planner access** (typically via the same Google Ads API connection) — volume validation for bid-up + expansion proposals
+
+## Cost
+
+Free.
+
+## Universal Patterns
+
+- **Suggestion-only:** Per-item approval gate.
+- **Draft-first:** Approved actions saved as drafts. User activates from Google Ads UI.
+- **Anti-laziness:** Pull all keyword + QS + IS data first; never ask the user something derivable from the API.
+- **Self-healing:** Log API errors, retry with backoff. Output markdown fallback if draft creation fails.
+- **No autonomous actions:** Even "obvious" pauses (e.g. $500 spend, 0 conv, 60 days) require user approval per item.
+- **Cross-skill chaining:** When findings warrant deeper work (LP issues, RSA issues), propose chaining to `google-ads-account-audit` Phase 7 or `google-ads-rsa-optimizer` rather than trying to do everything in this skill.
+
+## Trigger Phrases
+
+- "Optimize my keywords"
+- "Which keywords should I pause?"
+- "Are my bids right?"
+- "Find keyword duplicates"
+- "Improve my Quality Scores"
+- "Run keyword optimizer"
+- "Audit my keyword performance"

--- a/skills/composites/google-ads-keyword-optimizer/skill.meta.json
+++ b/skills/composites/google-ads-keyword-optimizer/skill.meta.json
@@ -1,0 +1,16 @@
+{
+  "slug": "google-ads-keyword-optimizer",
+  "category": "composites",
+  "description": "Analyze the keywords currently bidding in a live Google Ads account and propose per-keyword optimizations: pause underperformers, bid up/down, change match type, deduplicate cannibalizing keywords, fix Quality Score clusters. Per-item user approval; approved actions saved as drafts in the Google Ads UI for manual activation.",
+  "tags": [
+    "ads"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install google-ads-keyword-optimizer",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}

--- a/skills/composites/google-ads-rsa-optimizer/SKILL.md
+++ b/skills/composites/google-ads-rsa-optimizer/SKILL.md
@@ -1,0 +1,325 @@
+---
+name: google-ads-rsa-optimizer
+description: >
+  Find weak RSA assets (headlines + descriptions) in a live Google Ads account
+  and propose replacements grounded in brand voice, ad group keyword theme,
+  landing page copy, and competitor ad angles. Composes competitor-ad-intelligence
+  for category-specific creative direction. Generates 3 candidate variants per
+  weak slot, validates length (30/90) + keyword-mirror rule + brand-don't list,
+  presents per-asset approvals to user, saves approved variants as drafts in the
+  Google Ads UI for the user to manually review and activate. No live mutations.
+tags: [ads]
+---
+
+# Google Ads RSA Optimizer
+
+Find every weak RSA asset in a live Google Ads account and propose replacements grounded in the user's brand voice, the ad group's keyword theme, landing page copy, and what competitors are doing. Outputs drafts in the Google Ads UI — the user reviews and activates manually.
+
+**Core principle:** Most ad accounts have RSA assets running on autopilot for months — half rated **Low** by Google, never refreshed. Replacing them is the single highest-leverage creative optimization in Search ads. AI is genuinely good at this if you give it the right context (brand voice, ad group theme, LP, competitor angles) and validate hard (30/90 chars, keyword-mirror, brand-don't list).
+
+**Universal pattern:** Suggestion-only, draft-first. Every replacement is approved per-asset by the user. Approved variants are saved as drafts in Google Ads — the skill never activates them.
+
+## When to Use
+
+- "Optimize my RSAs"
+- "Refresh my Google Ads headlines"
+- "Find and replace weak ad assets"
+- "Improve my Google Ads creative"
+- "Run RSA optimizer on [campaign]"
+
+## Prerequisites
+
+- A working Google Ads API connection (MCP server, native client, or manual export). The skill reads RSAs and asset performance ratings.
+- Optional: a recent run of [`google-ads-account-audit`](https://github.com/gooseworks-ai/goose-skills/tree/main/skills/composites/google-ads-account-audit) — it identifies which ad groups have weak assets so this skill can focus on them.
+
+## Phase 0: Intake
+
+Ask the user for these inputs at the start of the run:
+
+1. **Account ID** — the Google Ads customer ID
+2. **Brand voice profile** — short description (e.g. "technical, plain-language, no superlatives, never use 'best-in-class'")
+3. **Brand-don't list** — words / phrases that should never appear in the user's ad copy (off-brand vocabulary, regulated terms, banned superlatives)
+4. **Top competitors** *(optional)* — used to inform Phase 5 angle scan
+5. **Primary conversion goal** — what conversion event is being optimized for (Demos / Trials / Purchases / Leads)
+6. **Recent decisions** *(optional)* — paste any prior decisions log entries so the skill avoids re-proposing the same variants
+
+## Phase 1: Confirm Scope
+
+| Parameter | Default | User can override |
+|---|---|---|
+| Asset performance bar | **Low + Pending (≥14 days impressions)** | Yes — can include Good for refresh |
+| Ad groups to optimize | Top 3 ad groups by spend with weak assets | Yes — can pick specific ad groups, or "all" |
+| Candidates per weak slot | **3** | Yes |
+| Time window for performance ratings | Last 30 days | Yes |
+
+### Approval Gate 1
+
+> "I'll find weak RSA assets (Low + Pending) in your top 3 ad groups by spend, generate 3 replacement candidates for each weak slot, and present them for your approval. Want me to adjust scope?"
+
+Wait for confirmation. Apply overrides.
+
+## Phase 2: Pull RSAs + Asset Performance
+
+Run via the Google Ads API, in parallel:
+
+1. All active RSAs in scope, with their headlines + descriptions
+2. Asset performance ratings (**Best / Good / Low / Pending**) per individual headline + description
+3. Days each asset has been running
+4. Pinning configuration per asset
+5. Ad group context: name, primary keyword theme, landing page URL
+6. Recent ad group performance (impressions, clicks, conv) for context
+
+For each ad group in scope, build:
+
+```markdown
+### Ad group: {name}
+- Primary keyword theme: {theme}
+- Landing page: {URL}
+- Spend (last 30d): ${X}
+- Active RSAs: {N}
+
+| RSA | Asset | Type | Text | Rating | Days running | Pinned? |
+|---|---|---|---|---|---|---|
+| RSA-1 | H1 | Headline | "AI Outbound Tool" | Low | 47 | No |
+| RSA-1 | H2 | Headline | "10x Your Pipeline" | Best | 47 | No |
+| ... | | | | | | |
+```
+
+## Phase 3: Identify Weak Assets
+
+Filter to weak assets per the configured threshold.
+
+**Pending exclusion rule:** Pending assets only count as weak if they have **≥14 days of impressions** — under that, they're still in Google's learning phase and the rating isn't reliable yet.
+
+Output the weak-asset queue per ad group:
+
+```markdown
+### Ad group: {name} — weak assets to replace
+| Asset | Type | Current text | Rating | Why flagged |
+|---|---|---|---|---|
+| H1 | Headline | "AI Outbound Tool" | Low | Marked Low for 47 days |
+| H4 | Headline | "Save Time Today" | Pending | 21 days impressions, no signal |
+| D2 | Description | "Boost your sales..." | Low | Marked Low for 47 days |
+```
+
+If an ad group has zero weak assets, skip it. If all 3 in-scope ad groups have zero weak assets, surface to user and stop.
+
+## Phase 4: Pull Landing Page Copy
+
+For each unique LP referenced by weak-asset ad groups, fetch with whatever web-fetch tool the agent has available. Extract:
+- Hero headline + subheadline
+- Primary CTA
+- 3-5 key benefit bullets / value props
+- Any trust signals (logos, testimonials, metrics)
+
+This LP copy becomes input to the generator — replacement headlines need to message-match what the user lands on.
+
+## Phase 5: Pull Competitor Ad Angles
+
+Compose [`competitor-ad-intelligence`](https://github.com/gooseworks-ai/goose-skills/tree/main/skills/composites/competitor-ad-intelligence) on the top competitors from Phase 0 intake. Pull from Google Ads Transparency Center and Meta Ad Library.
+
+Synthesize: what creative angles are competitors using that we're not?
+
+```markdown
+### Competitor angle scan
+
+**Common across competitors:**
+- "14-day free trial" framing (3 of 5 competitors)
+- Compliance/SOC2 trust signals (4 of 5 competitors)
+- Founder-led testimonials (3 of 5 competitors)
+
+**Angles competitors use that you don't:**
+1. Risk reversal — "no credit card required" (4 competitors)
+2. Speed — "set up in 5 minutes" (3 competitors)
+3. Specificity — "for B2B SaaS sales teams" rather than generic (5 competitors)
+
+**Angles you use that competitors don't:**
+- "AI-native" framing (only you)
+- Specific integration call-outs (only you)
+```
+
+### Approval Gate 2
+
+Show the user the competitor angle scan and ask:
+
+> "Here are angles competitors are using that you're not. Which of these would you want me to incorporate into the replacement variants? Pick any combination, or none."
+
+User picks angles to use. These become explicit prompt inputs to the variant generator. If the user says "none," generator runs without competitor input.
+
+## Phase 6: Generate Replacement Variants
+
+For each weak asset, generate **3 candidate replacements**.
+
+### Generator inputs
+
+| Input | Source |
+|---|---|
+| Weak asset being replaced (text + rating) | Phase 3 |
+| Asset type (headline / description / sitelink / callout) | Phase 3 |
+| Ad group's primary keyword theme | Phase 2 |
+| Landing page key copy (hero, CTA, benefits) | Phase 4 |
+| Brand voice profile + tone descriptors | Phase 0 intake |
+| Brand-don't list | Phase 0 intake |
+| Approved competitor angles | Phase 5 |
+| Headline pattern library (rotated) | See `ads-copywriting-principles.md` in this skill folder |
+
+### Headline pattern library
+
+Rotate through these patterns to avoid generating 3 same-feeling candidates. Each candidate uses a different pattern (see `ads-copywriting-principles.md` for the full reference):
+
+| Pattern | Example |
+|---|---|
+| **Urgency** | "2026 Dates Booking Fast" |
+| **Scarcity** | "Limited Spots — 14-Day Free Trial" |
+| **Differentiation** | "Built for B2B SaaS, Not Generic" |
+| **Friction-remover** | "No Credit Card Required" |
+| **Numeric proof** | "Trusted by 500+ Sales Teams" |
+| **Date / seasonality** | "Q2 2026 Setup in 5 Minutes" |
+| **Star reviews** | "4.8★ on G2 — Read Reviews" |
+| **Trust signal** | "SOC2 Compliant — Enterprise-Ready" |
+
+For descriptions, expand to longer-form versions of the same patterns plus pain-agitate, feature-benefit, social-proof-CTA, differentiator-CTA structures.
+
+### Generator output
+
+For each weak slot, produce 3 candidates:
+
+```markdown
+**Replacing: H1 "AI Outbound Tool" (Low rating, 47 days)**
+
+Candidate A (Differentiation):
+"AI SDR for B2B SaaS"
+— 19 chars. Mirrors keyword theme. Differentiation pattern.
+
+Candidate B (Numeric proof):
+"500+ Teams Pick [Brand]"
+— 23 chars. Trust signal. Brand insertion.
+
+Candidate C (Friction-remover):
+"Free 14-Day Trial — No CC"
+— 26 chars. Risk reversal. Competitor angle.
+```
+
+## Phase 7: Hard Validation (Reject Before User Sees)
+
+Before presenting candidates, validate:
+
+| Check | Action if fails |
+|---|---|
+| Headline ≤30 chars | Regenerate that candidate |
+| Description ≤90 chars | Regenerate that candidate |
+| Keyword-mirror rule per ad group: at least 1 headline + 1 description across the **full RSA after replacements** literally contains the ad group's primary keyword | Force keyword inclusion in next generation pass |
+| No words from brand-don't list | Regenerate, surface why to user in trace |
+| No duplicate text across candidates for the same slot | Regenerate the duplicate |
+| No identical text to existing strong assets in the same RSA | Regenerate (we want diversity, not repetition) |
+
+If a slot fails validation 3 times, surface to user: "I couldn't generate 3 valid candidates for {slot}. Want me to relax {constraint}?"
+
+## Phase 8: Per-Asset User Approval
+
+Present candidates to the user, one ad group at a time, one weak slot at a time:
+
+```markdown
+### Ad group: {name}
+
+#### Replacing H1 "AI Outbound Tool" (Low, 47 days)
+
+**A. AI SDR for B2B SaaS** (19 chars, differentiation)
+**B. 500+ Teams Pick {Brand}** (23 chars, numeric proof)
+**C. Free 14-Day Trial — No CC** (26 chars, friction-remover)
+
+Pick: A / B / C / edit / skip / write your own
+```
+
+For each weak slot, the user can:
+- **A/B/C** — accept that candidate
+- **edit** — accept a candidate but tweak the text
+- **skip** — leave the existing weak asset in place
+- **write your own** — replace with custom text
+
+Track all approvals + edits + skips per ad group.
+
+### Approval Gate 3 (final summary before saving drafts)
+
+After the user has worked through all weak slots in scope:
+
+```markdown
+### Final replacement summary
+
+**Ad group: {name}**
+- H1: "AI Outbound Tool" → "AI SDR for B2B SaaS" ✓
+- H4: "Save Time Today" → SKIPPED
+- D2: "Boost your sales..." → "Built for B2B SaaS sales teams. Set up in 5 minutes — no credit card required." ✓ (edited)
+
+[2 more ad groups...]
+
+Total: 8 replacements approved across 3 ad groups.
+```
+
+Ask:
+
+> "Ready to save these as drafts in your Google Ads account? You'll review them in the Google Ads UI and activate manually. I won't activate anything."
+
+Wait for explicit confirmation.
+
+## Phase 9: Save as Drafts
+
+Push approved replacements to Google Ads as **drafts** via the Google Ads API:
+
+- Create new RSA draft variants in each ad group with the replacement assets
+- Original RSA stays running unchanged
+- New draft is **not active** until the user activates it from the Google Ads UI
+
+If draft creation isn't available via the connected API, output a **copy-paste-ready document** the user can apply manually in the Google Ads UI. Suggested filename: `google-ads-rsa-changes-{YYYY-MM-DD}.md`.
+
+## Phase 10: Output
+
+The skill returns the analysis inline, ending with these structured blocks the user can persist (anywhere they want):
+
+### Decisions log entry (suggested to save for future reference)
+
+```
+{YYYY-MM-DD} | google-ads-rsa-optimizer | Replaced 8 weak assets across 3 ad groups | Patterns used: differentiation, numeric proof, friction-remover. Competitor angles incorporated: 14-day trial, no CC.
+```
+
+### Learnings to capture
+
+- Which patterns the user picked most often (signal for next run)
+- Which candidates the user edited (we missed something — log what was added/removed)
+- Which slots the user skipped (asset wasn't actually weak, or generation didn't fit)
+
+These notes can be passed back into this skill (or `google-ads-checkin`) on the next run to inform future proposals.
+
+## Output Summary
+
+- **Inline:** Full analysis report with weak-asset queue, candidates, approvals, and final summary
+- **In Google Ads:** Drafts for each approved replacement (or fallback markdown if drafts API unavailable)
+- **Decisions log + Learnings:** Structured text blocks at end of report for the user to save
+
+## Tools Required
+
+- **Google Ads API connection** (MCP server, native client, or manual data export) — read RSAs, asset performance, ad group context, draft creation
+- **Web-fetch capability** — for landing page copy (any agent web-fetch tool)
+- Composes skill: [`competitor-ad-intelligence`](https://github.com/gooseworks-ai/goose-skills/tree/main/skills/composites/competitor-ad-intelligence)
+- Headline pattern library + ad copywriting principles in `ads-copywriting-principles.md` (in this skill folder)
+
+## Cost
+
+Free. Google Ads API + Meta Ad Library + Google Ads Transparency Center are all free at this scale.
+
+## Universal Patterns
+
+- **Suggestion-only:** Per-asset approval gate. The skill never auto-applies a variant.
+- **Draft-first:** Approved variants are saved as drafts in Google Ads UI. User activates manually.
+- **Hard validation:** 30/90 char + keyword-mirror + brand-don't list checks happen before user sees candidates.
+- **Anti-laziness:** LP copy and competitor angles are pulled from API/web before asking the user — only confirmation gates are on outputs, never on inputs the agent could derive.
+- **Self-healing:** If draft API call fails, output markdown fallback and surface the error.
+- **Pattern rotation:** Generator rotates through 8+ headline patterns to avoid 3 same-feeling candidates per slot.
+
+## Trigger Phrases
+
+- "Optimize my RSAs"
+- "Refresh my Google Ads headlines"
+- "Replace weak ad assets"
+- "Improve my Google Ads creative"
+- "Run RSA optimizer"

--- a/skills/composites/google-ads-rsa-optimizer/ads-copywriting-principles.md
+++ b/skills/composites/google-ads-rsa-optimizer/ads-copywriting-principles.md
@@ -1,0 +1,87 @@
+# Ads Copywriting Principles
+
+Reference guide for the Google Ads skills that generate or audit ad copy (`google-ads-rsa-optimizer`, `google-ads-account-audit`). Synthesized from common patterns shared by experienced Google Ads practitioners. Re-read this before drafting any RSA variant.
+
+## Hard rules (validators reject before user sees output)
+
+| Rule | Constraint |
+|---|---|
+| Headline length | ≤30 characters |
+| Description length | ≤90 characters |
+| Sitelink length | ≤25 characters per text portion |
+| Callout length | ≤25 characters |
+| Keyword-mirror rule | At least 1 headline + 1 description per RSA must literally contain the ad group's primary keyword theme |
+| Brand-don't list | No words from the brand-don't list provided at intake |
+| No duplicate text | No two candidates for the same slot can be identical |
+| No identical to existing strong assets | New variants must differ from current Best/Good assets in the same RSA |
+
+If a candidate fails validation, regenerate before showing the user. After 3 failed regenerations, surface the failure and ask the user to relax a constraint.
+
+## Headline pattern library (8 patterns)
+
+Generators rotate through these to avoid producing 3 same-feeling candidates. Each candidate for a slot uses a different pattern.
+
+| Pattern | When to use | Example |
+|---|---|---|
+| **Urgency** | Time-bound offers, deadline framing | "2026 Dates Booking Fast" |
+| **Scarcity** | Limited availability | "Limited Spots — 14-Day Trial" |
+| **Differentiation** | When clearly different from category norm | "Built for B2B SaaS, Not Generic" |
+| **Friction-remover** | Risk reversal, removing buying objections | "No Credit Card Required" |
+| **Numeric proof** | Specific scale, customer count, revenue moved | "Trusted by 500+ Sales Teams" |
+| **Date / seasonality** | Time-bound relevance | "Q2 2026 Setup in 5 Minutes" |
+| **Star reviews** | Established review presence | "4.8★ on G2 — Read Reviews" |
+| **Trust signal** | Compliance, certification, enterprise readiness | "SOC2 Compliant — Enterprise-Ready" |
+
+## Description patterns (4 patterns)
+
+Each RSA needs 4 descriptions. Use one of each pattern.
+
+| Pattern | Structure | Example |
+|---|---|---|
+| **Feature-benefit** | What it does + why it matters | "Automate personalized outbound so your team closes more deals without manual prospecting work." |
+| **Pain-agitate-solution** | Frame the pain, then the resolution | "Tired of reps spending 4 hours on prospecting? Our AI handles it in minutes." |
+| **Social-proof + CTA** | Numeric proof + action | "Join 500+ growth teams. Start your free trial — no credit card needed." |
+| **Differentiator + CTA** | What makes you different + action | "Unlike legacy tools, [Brand] works out of the box. See it in action — book a 15-min demo." |
+
+## RSA structural rules
+
+- Default ad group structure: **single-keyword ad groups (SKAG)** for AI-generated campaigns
+- Default match type: **exact** for AI-generated SKAGs (tightest control over what triggers the ad)
+- Per ad group, **3 RSAs max** — diverse enough for Google to optimize, tight enough to monitor
+- Per RSA: **15 headlines × 4 descriptions × 4+ sitelinks × 4+ callouts**
+- **Avoid heavy pinning** — pinning blocks Google's optimization. Only pin when there's a compliance reason (e.g. legal disclaimer must be in H1).
+
+## Anti-patterns (don't do these)
+
+- ❌ Generic claims with no specificity ("Best in class", "Industry-leading", "Cutting-edge")
+- ❌ Same hook reused across all 15 headlines (rotate patterns)
+- ❌ Length over 30/90 chars — Google truncates and rejects, never trust the LLM
+- ❌ Promising outcomes the LP doesn't deliver on (message-match break)
+- ❌ Branded competitor mentions without legal sign-off
+- ❌ Using superlatives ("#1", "Best", "Top") without specific evidence
+- ❌ Composite letter grades on output ("A+ ad copy") — meaningless and erodes user trust
+
+## Brand voice integration
+
+Every generation pass takes the brand voice profile provided at intake as input:
+
+- **Tone descriptors** — formal / conversational / technical / playful
+- **Vocabulary level** — technical jargon ok / plain language only
+- **Sentence structure** — short and punchy / nuanced and qualified
+- **CTA patterns** — what types of CTAs the brand actually uses ("Book a demo" vs "Get started" vs "Try it free")
+- **Phrases that fit** — list of phrases known to work for this brand
+- **Phrases that don't fit** — phrases that violate brand voice
+
+Generators must produce candidates that respect these dimensions. If you can't find a way to honor brand voice within a chosen pattern, drop the pattern, don't break voice.
+
+## Validation order
+
+When generating a candidate:
+
+1. Generate text using one specific pattern + brand voice
+2. Run hard validators (length, brand-don't list, duplicates)
+3. If fail, regenerate (max 3 attempts per slot)
+4. If pass, add to candidate set
+5. After 3 valid candidates, present to user
+
+Never bypass validators to ship a candidate. If you can't get 3 valid candidates, surface the constraint that's blocking and ask the user to relax it.

--- a/skills/composites/google-ads-rsa-optimizer/skill.meta.json
+++ b/skills/composites/google-ads-rsa-optimizer/skill.meta.json
@@ -1,0 +1,16 @@
+{
+  "slug": "google-ads-rsa-optimizer",
+  "category": "composites",
+  "description": "Find weak RSA assets (headlines + descriptions) in a live Google Ads account and propose replacements grounded in brand voice, ad group keyword theme, landing page copy, and competitor ad angles. Generates 3 candidate variants per weak slot, validates length + keyword-mirror + brand-don't list, presents per-asset approvals, saves approved variants as drafts in the Google Ads UI for manual activation.",
+  "tags": [
+    "ads"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install google-ads-rsa-optimizer",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}

--- a/skills/composites/google-ads-search-terms-miner/SKILL.md
+++ b/skills/composites/google-ads-search-terms-miner/SKILL.md
@@ -1,0 +1,287 @@
+---
+name: google-ads-search-terms-miner
+description: >
+  Mine the Google Ads search terms report for a live account. Runs N-gram
+  analysis (1/2/3-word) by cost + ROAS, classifies n-gram themes into three
+  buckets (scale / negative / expand), and proposes specific actions:
+  negative keywords to add, keyword themes to expand, ad groups to investigate.
+  Composes competitor-ad-intelligence for expansion ideas. Validates expansion
+  proposals against Google Keyword Planner volume data. Per-item user approval;
+  approved actions saved as drafts in Google Ads UI. No live mutations.
+tags: [ads]
+---
+
+# Google Ads Search Terms Miner
+
+The single highest-leverage ongoing optimization in Google Search Ads: mining the search terms report for waste (negative keyword candidates), winners (expansion candidates), and seasonal/intent mismatches.
+
+**Core principle:** N-gram analysis (1/2/3-word phrases by cost + ROAS) reveals patterns invisible at the raw search-term level. A single search term spending $20 looks like noise; the 2-word n-gram "free download" spending $1,200 across 60 search terms is a screaming signal.
+
+**Universal pattern:** Suggestion-only, draft-first. The skill proposes negatives + expansions, the user approves per-item, approved actions are saved as drafts in the Google Ads UI for the user to activate manually.
+
+## When to Use
+
+- "Mine search terms"
+- "Find negative keywords I should add"
+- "What keywords am I wasting money on?"
+- "What new keywords should I add?"
+- "Run search terms analysis"
+- "Optimize my Google Ads keywords"
+
+## Prerequisites
+
+- A working Google Ads API connection (MCP server, native client, or manual export). The skill uses Google Ads API queries throughout.
+
+## Phase 0: Intake
+
+Ask the user for these inputs at the start of the run:
+
+1. **Account ID** — the Google Ads customer ID
+2. **Primary conversion goal** — what conversion event is being optimized for
+3. **Target CPA** — explicit, back-calculated from LTV × margin, or "no target — benchmark me"
+4. **Brand-don't list** *(optional)* — words/phrases that should never appear in the user's ad copy or expansion keywords (sensitive language, regulated terms, off-brand topics)
+5. **Top competitors** *(optional)* — used to recognize competitor brand bleed in search terms
+6. **Recent decisions** *(optional)* — paste any prior decisions log entries so the skill avoids re-proposing negatives the user already added
+7. **Scope** — all active Search campaigns by default; user can override
+
+## Phase 1: Confirm Scope
+
+| Parameter | Default | User can override |
+|---|---|---|
+| Time window | Last **30 days** | Yes — 14d for fresh accounts, 90d for mature |
+| Spend threshold per term | ≥**$5** (filter noise) | Yes |
+| Campaign scope | All active Search campaigns | Yes |
+| N-gram window | **1, 2, and 3-word** phrases | Yes |
+| Bucket thresholds | See Phase 3 | Yes |
+
+### Approval Gate 1
+
+> "I'll mine the last 30 days of search terms across all active Search campaigns. Filter noise below $5 per term. Run N-gram analysis on 1/2/3-word phrases. Want me to adjust before pulling data?"
+
+Wait for confirmation.
+
+## Phase 2: Pull Search Terms Report
+
+Run via the Google Ads API:
+
+```sql
+SELECT
+  search_term_view.search_term,
+  campaign.name,
+  ad_group.name,
+  metrics.clicks,
+  metrics.impressions,
+  metrics.cost_micros,
+  metrics.conversions,
+  metrics.conversions_value,
+  search_term_view.status
+FROM search_term_view
+WHERE
+  segments.date BETWEEN '{start}' AND '{end}'
+  AND metrics.cost_micros >= {threshold_micros}
+  AND campaign.status = 'ENABLED'
+```
+
+Pull also: list of currently-active negative keywords per campaign + ad group (so we don't propose duplicates).
+
+## Phase 3: N-gram Analysis
+
+Use `scripts/ngram_analyzer.py` (in this skill folder) for tokenization, aggregation, ranking, and anomaly detection. Pure Python, standard library only — no dependencies to install.
+
+For each search term, tokenize into 1-word, 2-word, and 3-word phrases (lowercase, strip punctuation). Aggregate by n-gram:
+
+```
+n-gram → {
+  total_cost,
+  total_clicks,
+  total_impressions,
+  total_conversions,
+  total_conv_value,
+  cpa = total_cost / total_conversions,  # null if 0 conv
+  roas = total_conv_value / total_cost,  # null if no value tracking
+  sample_terms: [list of 3-5 representative search terms],
+  campaigns: [where this n-gram appears]
+}
+```
+
+Produce four ranked tables per n-gram window (1/2/3):
+
+| Table | Sort | Filter |
+|---|---|---|
+| Top spenders | by cost desc | top 30 |
+| Biggest waste | by cost desc, conv = 0 OR CPA > 2× target | top 20 |
+| Top performers | by ROAS desc, min spend | top 20 |
+| Anomalies | seasonal/intent mismatches | flagged |
+
+### Anomaly detection
+
+Surface n-grams that look out of place:
+
+- **Seasonal/temporal** — terms tied to specific dates/seasons running outside window (e.g. "halloween" in March)
+- **Job-seeker / researcher / student bleed** — "jobs", "salary", "tutorial", "course", "review", "wikipedia", "reddit", "quora"
+- **Competitor brand bleed** — competitor names showing up in spend without a competitor campaign (or with weak performance)
+- **Free / unrelated bleed** — "free download" for paid SaaS, "open source" for closed product, etc.
+
+## Phase 4: 3-Bucket Classification
+
+For each meaningful n-gram (above noise threshold), classify into one of three buckets via intent reasoning:
+
+| Bucket | Signal | Suggested action |
+|---|---|---|
+| **🔴 Negative** | High spend + 0 or near-0 conversions, OR high CPA, OR clear intent mismatch | Add as negative keyword |
+| **🟢 Scale** | High spend + good performance (CPA at or below target, ROAS at or above target) | Expand: add as exact-match keyword in dedicated ad group, raise bid |
+| **🟡 Expand** | Low spend + good performance | Lower-priority expansion: add to existing ad group as exact match, monitor |
+
+Plus **anomaly bucket** from Phase 3 — these get treated as negatives unless the user redirects.
+
+For each n-gram in each bucket, draft the specific proposed action with reasoning.
+
+```markdown
+### 🔴 Negative — proposed
+| N-gram | Spend | Conv | Sample terms | Why | Match type | Scope |
+|---|---|---|---|---|---|---|
+| "free download" | $487 | 0 | "free download crm", "free download tool", ... | Free intent, no commercial signal. 0 conv across 31 search terms. | Phrase | Campaign-level |
+| "salary" | $213 | 0 | "saas product manager salary", ... | Job-seeker bleed | Phrase | Account-level |
+| "halloween" | $89 | 0 | (in March) | Seasonal mismatch | Phrase | Campaign-level |
+```
+
+```markdown
+### 🟢 Scale — proposed
+| N-gram | Spend | Conv | CPA | ROAS | Sample terms | Why | Action |
+|---|---|---|---|---|---|---|---|
+| "ai sdr" | $1,240 | 18 | $69 | 3.1 | "ai sdr tool", "ai sdr platform", ... | Below target CPA at meaningful volume | Promote to dedicated ad group with exact match keywords |
+```
+
+```markdown
+### 🟡 Expand — proposed
+| N-gram | Spend | Conv | Sample terms | Why | Action |
+|---|---|---|---|---|---|
+| "for b2b saas" | $124 | 4 | "lead gen for b2b saas", ... | Specificity matches ICP, low spend, good conv rate | Add as exact-match keyword in Solution-aware ad group |
+```
+
+## Phase 5: Validate Expansion Candidates Against Keyword Planner
+
+For each proposed Scale + Expand keyword, query Google Keyword Planner API for:
+- Average monthly search volume
+- Competition level
+- Estimated bid range
+
+If a proposed expansion has near-zero search volume, deprioritize it — it's a long-tail with no scale potential. Surface in the report but mark "low volume, monitor only."
+
+## Phase 6: Optional — Competitor-Inspired Expansion
+
+If the user wants competitor-inspired expansion, compose [`competitor-ad-intelligence`](https://github.com/gooseworks-ai/goose-skills/tree/main/skills/composites/competitor-ad-intelligence) on top competitors and surface keyword themes competitors are bidding on that the user isn't. This is opt-in (extra approval gate) because it's a different type of expansion than the in-account-data-driven proposals.
+
+### Approval Gate 2 (optional)
+
+> "Want me to also pull competitor ad data and surface keyword themes they're bidding on that you're not?"
+
+If yes, run competitor-ad-intelligence and add findings as a separate "Competitor-inspired expansion" section.
+
+## Phase 7: Per-Item User Approval
+
+Present the full proposal to the user, organized by bucket. For each item, the user can:
+
+- **✓** approve as proposed
+- **edit** approve with edits (e.g. change match type, scope to specific ad group)
+- **✗** reject (don't add)
+
+Run through Negatives first (lowest risk, highest hygiene impact), then Scale, then Expand, then optional Competitor-inspired.
+
+```markdown
+### 🔴 Negative — review
+
+1. "free download" — Phrase, Campaign-level — $487 wasted, 0 conv → ✓ / edit / ✗
+2. "salary" — Phrase, Account-level → ✓ / edit / ✗
+3. "halloween" — Phrase, Campaign-level → ✓ / edit / ✗
+[...]
+
+### 🟢 Scale — review
+
+1. "ai sdr" — Promote to dedicated ad group, exact match → ✓ / edit / ✗
+[...]
+```
+
+### Approval Gate 3 (final summary)
+
+After per-item review:
+
+```markdown
+### Final summary
+
+**Negatives to add: 12**
+- 8 at campaign level, 3 at ad group level, 1 at account level
+
+**Keywords to add (Scale): 4**
+- 2 in new ad group "AI SDR — Exact"
+- 2 in existing "Solution-aware" ad group
+
+**Keywords to add (Expand): 6**
+- All in existing ad groups as exact match
+
+**Skipped: 5**
+
+Ready to save these as drafts in your Google Ads account? You'll review and apply them from the Google Ads UI. I won't apply anything.
+```
+
+Wait for explicit confirmation.
+
+## Phase 8: Save as Drafts
+
+Push approved actions to Google Ads as drafts via the Google Ads API:
+
+- **Negatives** → save as draft negative keyword changes (campaign / ad group / account level as configured)
+- **Scale + Expand keywords** → save as draft new keywords in the specified ad groups (new ad groups created as drafts if needed)
+
+If draft creation isn't available via the connected API, output a **copy-paste-ready document** the user can apply manually in the Google Ads UI. Suggested filename: `google-ads-keyword-changes-{YYYY-MM-DD}.md`.
+
+## Phase 9: Output
+
+The skill returns the analysis inline, ending with these structured blocks the user can persist (anywhere they want):
+
+### Decisions log entry (suggested to save for future reference)
+
+```
+{YYYY-MM-DD} | google-ads-search-terms-miner | Approved 12 negatives, 4 scale keywords, 6 expand keywords. Skipped 5. | Top waste themes: "free download", "salary", "tutorial". Top expansion: "ai sdr".
+```
+
+### Learnings to capture
+
+- Patterns of negatives the user approves vs. skips (next run, prioritize the patterns they like)
+- Expansion keywords the user edits or rejects (signal for what's actually relevant)
+
+These notes can be passed back into this skill (or `google-ads-checkin`) on the next run to inform future proposals.
+
+## Output Summary
+
+- **Inline:** Full N-gram tables, bucket classifications, and proposals
+- **In Google Ads:** Drafts for each approved action (or fallback markdown if drafts API unavailable)
+- **Decisions log + Learnings:** Structured text blocks at end of report for the user to save
+
+## Tools Required
+
+- **Google Ads API connection** (MCP server, native client, or manual data export) — search terms report, current negatives, draft creation
+- **Google Keyword Planner access** (typically via the same Google Ads API connection) — volume validation
+- Composes skill: [`competitor-ad-intelligence`](https://github.com/gooseworks-ai/goose-skills/tree/main/skills/composites/competitor-ad-intelligence) (optional, Phase 6)
+
+## Cost
+
+Free. All data sources are free at this scale.
+
+## Universal Patterns
+
+- **Suggestion-only:** Per-item approval gate.
+- **Draft-first:** Approved actions saved as drafts. User activates from Google Ads UI.
+- **Anti-laziness:** Pull data first, only ask user for things we can't derive.
+- **Self-healing:** Log API errors, retry with backoff. Output markdown fallback if draft creation fails.
+- **N-gram rigor:** Every classification ties back to specific n-gram metrics, not gut feel. User can always audit the math.
+- **No autonomous additions:** Even "obvious" negatives like "salary" or "jobs" require user approval.
+
+## Trigger Phrases
+
+- "Mine search terms"
+- "Find negative keywords I should add"
+- "What keywords am I wasting money on?"
+- "What new keywords should I add?"
+- "Optimize my Google Ads keywords"
+- "Run search terms analysis"

--- a/skills/composites/google-ads-search-terms-miner/scripts/ngram_analyzer.py
+++ b/skills/composites/google-ads-search-terms-miner/scripts/ngram_analyzer.py
@@ -1,0 +1,190 @@
+"""
+N-gram analyzer for Google Ads search terms reports.
+
+Takes a list of search terms with cost / click / conversion data and produces
+aggregated 1/2/3-word n-gram tables with cost, conversions, CPA, and ROAS.
+
+Used by:
+- google-ads-account-audit (Phase 4)
+- google-ads-search-terms-miner (Phase 3)
+
+Standard library only — no external dependencies.
+"""
+
+from collections import defaultdict
+from typing import Iterable, Literal, TypedDict
+
+
+NGramSize = Literal[1, 2, 3]
+
+
+class SearchTermRow(TypedDict, total=False):
+    search_term: str
+    cost: float
+    clicks: int
+    conversions: float
+    conv_value: float
+
+
+class NGramMetrics(TypedDict):
+    cost: float
+    clicks: int
+    conversions: float
+    conv_value: float
+    cpa: float | None
+    roas: float | None
+    sample_terms: list[str]
+
+
+def tokenize(text: str) -> list[str]:
+    """Lowercase + whitespace-split. No stemming, no punctuation stripping
+    beyond what the Google Ads API already returns."""
+    return [t.lower() for t in text.split() if t.strip()]
+
+
+def ngrams(tokens: list[str], n: int) -> list[str]:
+    """Sliding window of size n over tokens, joined with spaces."""
+    if n <= 0 or n > len(tokens):
+        return []
+    return [" ".join(tokens[i : i + n]) for i in range(len(tokens) - n + 1)]
+
+
+def aggregate(
+    rows: Iterable[SearchTermRow],
+    sizes: Iterable[NGramSize] = (1, 2, 3),
+    sample_term_cap: int = 5,
+) -> dict[int, dict[str, NGramMetrics]]:
+    """
+    Aggregate search-term rows into n-gram metrics.
+
+    rows: iterable of dicts with keys (search_term, cost, clicks, conversions, conv_value)
+    sizes: which n-gram sizes to compute (default 1, 2, 3)
+    sample_term_cap: max sample search terms to keep per n-gram (default 5)
+
+    Returns: {n: {ngram: NGramMetrics}}
+    """
+    accumulators: dict[int, dict[str, dict]] = {
+        n: defaultdict(
+            lambda: {
+                "cost": 0.0,
+                "clicks": 0,
+                "conversions": 0.0,
+                "conv_value": 0.0,
+                "_terms": set(),
+            }
+        )
+        for n in sizes
+    }
+
+    for row in rows:
+        term = row.get("search_term", "")
+        if not term:
+            continue
+        tokens = tokenize(term)
+        for n in sizes:
+            for ng in ngrams(tokens, n):
+                bucket = accumulators[n][ng]
+                bucket["cost"] += float(row.get("cost", 0))
+                bucket["clicks"] += int(row.get("clicks", 0))
+                bucket["conversions"] += float(row.get("conversions", 0))
+                bucket["conv_value"] += float(row.get("conv_value", 0))
+                bucket["_terms"].add(term)
+
+    result: dict[int, dict[str, NGramMetrics]] = {}
+    for n, ngram_dict in accumulators.items():
+        result[n] = {}
+        for ng, m in ngram_dict.items():
+            conv = m["conversions"]
+            cost = m["cost"]
+            value = m["conv_value"]
+            result[n][ng] = {
+                "cost": round(cost, 2),
+                "clicks": m["clicks"],
+                "conversions": round(conv, 2),
+                "conv_value": round(value, 2),
+                "cpa": round(cost / conv, 2) if conv > 0 else None,
+                "roas": round(value / cost, 3) if cost > 0 else None,
+                "sample_terms": sorted(m["_terms"])[:sample_term_cap],
+            }
+    return result
+
+
+def rank(
+    aggregates: dict[str, NGramMetrics],
+    by: Literal["cost", "roas", "waste"],
+    min_spend: float = 5.0,
+    min_clicks: int = 0,
+    limit: int = 30,
+) -> list[tuple[str, NGramMetrics]]:
+    """
+    Rank n-grams by cost / roas / waste.
+
+    by="cost": top spenders, sorted by cost desc
+    by="roas": top performers, sorted by roas desc, requires roas not None
+    by="waste": high cost + zero conversions, sorted by cost desc
+    """
+    items = [
+        (ng, m)
+        for ng, m in aggregates.items()
+        if m["cost"] >= min_spend and m["clicks"] >= min_clicks
+    ]
+    if by == "cost":
+        items.sort(key=lambda x: x[1]["cost"], reverse=True)
+    elif by == "roas":
+        items = [x for x in items if x[1]["roas"] is not None]
+        items.sort(key=lambda x: x[1]["roas"], reverse=True)
+    elif by == "waste":
+        items = [x for x in items if x[1]["conversions"] == 0]
+        items.sort(key=lambda x: x[1]["cost"], reverse=True)
+    return items[:limit]
+
+
+def find_anomalies(
+    aggregates: dict[str, NGramMetrics],
+    seasonal_terms: Iterable[str] = (
+        "halloween",
+        "christmas",
+        "thanksgiving",
+        "easter",
+        "valentine",
+        "new year",
+        "black friday",
+        "cyber monday",
+    ),
+    intent_mismatch_terms: Iterable[str] = (
+        "free download",
+        "salary",
+        "jobs",
+        "careers",
+        "tutorial",
+        "course",
+        "review",
+        "wikipedia",
+        "reddit",
+        "quora",
+    ),
+    min_spend: float = 10.0,
+) -> dict[str, list[tuple[str, NGramMetrics]]]:
+    """
+    Surface n-grams matching anomaly patterns at material spend.
+
+    Returns: {category: [(ngram, metrics)]} for "seasonal" and "intent_mismatch".
+    Caller is responsible for date-aware seasonal filtering — this function
+    just flags presence at spend threshold.
+    """
+    seasonal_set = {t.lower() for t in seasonal_terms}
+    mismatch_set = {t.lower() for t in intent_mismatch_terms}
+
+    out = {"seasonal": [], "intent_mismatch": []}
+    for ng, m in aggregates.items():
+        if m["cost"] < min_spend:
+            continue
+        ng_lower = ng.lower()
+        if any(s in ng_lower for s in seasonal_set):
+            out["seasonal"].append((ng, m))
+        if any(s in ng_lower for s in mismatch_set):
+            out["intent_mismatch"].append((ng, m))
+
+    out["seasonal"].sort(key=lambda x: x[1]["cost"], reverse=True)
+    out["intent_mismatch"].sort(key=lambda x: x[1]["cost"], reverse=True)
+    return out

--- a/skills/composites/google-ads-search-terms-miner/skill.meta.json
+++ b/skills/composites/google-ads-search-terms-miner/skill.meta.json
@@ -1,0 +1,16 @@
+{
+  "slug": "google-ads-search-terms-miner",
+  "category": "composites",
+  "description": "Mine the Google Ads search terms report. Runs N-gram analysis (1/2/3-word) by cost + ROAS, classifies n-gram themes into negative / scale / expand buckets, and proposes specific actions: negative keywords to add, keyword themes to expand, ad groups to investigate. Per-item user approval; approved actions saved as drafts in the Google Ads UI for manual activation.",
+  "tags": [
+    "ads"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install google-ads-search-terms-miner",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds six new composite skills under the `ads` tag for optimizing an existing Google Search Ads account. All six are **suggestion-only** and **draft-first** — they read from the Google Ads API and propose changes, but never mutate the account. Approved actions are saved as drafts in the Google Ads UI for the user to activate manually.

The six skills compose into a Google Ads optimization workflow on top of the existing `ad-campaign-analyzer`, `ad-to-landing-page-auditor`, and `competitor-ad-intelligence` skills.

### Skills added

| Skill | Purpose |
|---|---|
| `google-ads-account-audit` | Comprehensive live-API audit. N-gram search-terms analysis, conversion-tracking audit, RSA pinning, impression-share losses, LP message-match. |
| `google-ads-checkin` | Adaptive-cadence performance check-in. Measures lift on past suggestions and proposes the next round. Cadence adapts to campaign maturity (every 4-6hr right after launch → every 3-5 days when mature). |
| `google-ads-competitor-gap-analysis` | Unified competitive position report combining Auction Insights, currently-running competitor ads, and competitor LPs. Maps each gap to a specific follow-up skill. |
| `google-ads-keyword-optimizer` | Per-keyword optimization proposals: pause / bid up / bid down / match-type change / dedupe / Quality Score remediation. |
| `google-ads-rsa-optimizer` | Finds weak RSA assets and proposes replacements grounded in brand voice, ad group keyword theme, LP copy, and competitor angles. |
| `google-ads-search-terms-miner` | N-gram analysis of the search terms report. Classifies into negative / scale / expand buckets. |

### Design principles across all six

- **Standalone** — each skill takes its context at intake (account ID, goals, brand voice, etc.). No `clients/{slug}/context.md` filesystem dependency.
- **Generic / publishable** — no company-specific references, examples, or paths. Works for any advertiser.
- **Cross-agent** — works in Claude Code, Cursor, Codex, Goose, or any agent that reads SKILL.md.
- **Cross-linked** — each skill's `Tools Required` and inline references point to other skills in this suite (and existing repo skills like `ad-campaign-analyzer`, `competitor-ad-intelligence`) where relevant.
- **Suggestion-only, draft-first** — never mutates the ad account. Approved actions are drafted in Google Ads UI for manual activation.
- **Free-stack** — all six rely on Google Ads API + Keyword Planner + Transparency Center + Meta Ad Library, all free at standard usage.

### Prerequisites

- A working Google Ads API connection (MCP server, native client, or manual export). Each skill calls this out in its Prerequisites section.
- `google-ads-competitor-gap-analysis` declares `requires_skills: ["competitor-ad-intelligence"]` (already published in this repo).
- The other five have no `requires_skills` — they're independent.

### Extras included (where useful)

- `google-ads-account-audit/scripts/ngram_analyzer.py` — pure-Python (stdlib only) n-gram analyzer
- `google-ads-search-terms-miner/scripts/ngram_analyzer.py` — same script
- `google-ads-rsa-optimizer/ads-copywriting-principles.md` — reference doc for headline/description patterns + validation rules
- `google-ads-checkin/checkin-cadence.md` + `daily-ops-loop.md` — workflow specs for the check-in skill
- `google-ads-checkin/templates/checkin-report.template.md` — output template

### Test plan

- [x] `npm run validate:skills` passes (199 skills total)
- [x] `npm run build:index` regenerates `skills-index.json` cleanly
- [x] All six conform to `schemas/skill-meta.schema.json`
- [x] Manual structure audit against existing `ad-campaign-analyzer` and `google-search-ads-builder`
- [x] Leak scan for client/identity/path/env-var references — clean
- [ ] Reviewer spot-check on tone / scope vs. existing composites

🤖 Generated with [Claude Code](https://claude.com/claude-code)