### PR TITLE
Add partner program finder skill

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-05-07",
+  "generated": "2026-05-12",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -3869,6 +3869,40 @@
             "codex"
           ]
         }
+      }
+    },
+    {
+      "slug": "partner-program-finder",
+      "name": "partner-program-finder",
+      "category": "capabilities",
+      "description": "Find and qualify affiliate, referral, reseller, and partner programs for a company, niche, or competitor set.",
+      "tags": "lead-generation, research",
+      "path": "skills/capabilities/partner-program-finder",
+      "files": [
+        "skills/capabilities/partner-program-finder/SKILL.md",
+        "skills/capabilities/partner-program-finder/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "partner-program-finder",
+        "category": "capabilities",
+        "tags": [
+          "lead-generation",
+          "research"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install partner-program-finder",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "official-source-first",
+          "partner-fit-scoring",
+          "program-terms-comparison",
+          "outreach-next-steps"
+        ]
       }
     },
     {

--- a/skills/capabilities/partner-program-finder/SKILL.md
+++ b/skills/capabilities/partner-program-finder/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: partner-program-finder
+description: Find and qualify affiliate, referral, reseller, and partner programs for a company, niche, or competitor set.
+tags: [lead-generation, research]
+---
+
+# Partner Program Finder
+
+Find public partner, affiliate, referral, reseller, and marketplace programs that could create pipeline for a product or client. The skill turns broad partnership research into a ranked, source-backed shortlist that a GTM team can act on.
+
+## When To Use
+
+Use this skill when the user asks for any of these:
+
+- Find affiliate programs in a niche.
+- Find partner programs for competitors or adjacent tools.
+- Build a referral or reseller partner shortlist.
+- Identify marketplaces, directories, agencies, creators, or integration partners worth approaching.
+- Compare commission terms, approval requirements, or partner restrictions across programs.
+
+Do not use this skill for sending outreach, signing up for programs, using affiliate links, or making claims that are not backed by public sources.
+
+## Inputs
+
+Collect only what is needed for the search:
+
+| Input | Required | Notes |
+|-------|----------|-------|
+| Product or client | Yes | Name, website, and one-line value proposition if available. |
+| Target market | Yes | Industry, customer segment, geography, and buyer type. |
+| Partner goal | Yes | Affiliate revenue, referral pipeline, reseller channel, integrations, co-marketing, marketplace distribution, or competitive intelligence. |
+| Competitors or adjacent tools | No | Use these to seed discovery. |
+| Constraints | No | Excluded categories, minimum commission, preferred regions, regulated-industry limits, brand safety rules. |
+| Output depth | No | Quick shortlist, full landscape scan, or competitor comparison. |
+
+If the user provides only a niche, infer a reasonable market definition and state it before proceeding.
+
+## Discovery Procedure
+
+### Step 1: Frame The Partner Hypothesis
+
+Write one short hypothesis before searching:
+
+- Who would influence or distribute this product?
+- What partner type is most likely to work?
+- What proof would make a program worth pursuing?
+
+Example partner types include affiliates, agencies, consultants, creators, communities, app marketplaces, integration partners, newsletters, resellers, implementation partners, and referral programs.
+
+### Step 2: Search Official Sources First
+
+Prefer official company pages and program terms over blog summaries or directories. Search for combinations of:
+
+- Company name plus affiliate program, referral program, partner program, reseller program, agency partner, marketplace, integrations, ecosystem, ambassador, creator program.
+- Niche terms plus affiliate program, partner program, reseller program, commission, referral terms.
+- Competitor names plus partner, affiliate, referral, integrations, marketplace, or agency.
+
+For each candidate, capture the source URL, page title, observed program type, and the date you accessed it. If a directory lists a program but the official page is missing, mark the candidate as unverified.
+
+### Step 3: Extract Commercial Terms
+
+For every candidate, extract only terms that are visible in the source:
+
+- Program type.
+- Payout or commission model.
+- Cookie or attribution window.
+- Payout threshold or schedule.
+- Approval requirements.
+- Geographic restrictions.
+- Prohibited promotion methods.
+- Partner support or assets.
+- Marketplace or integration requirements.
+- Contact path or application path.
+
+If a term is not visible, write Not stated. Do not fill gaps from memory.
+
+### Step 4: Score Fit
+
+Score each candidate from 1 to 5 on these dimensions:
+
+| Dimension | What To Check |
+|-----------|---------------|
+| Audience fit | Their audience overlaps the target buyer. |
+| Commercial upside | Commission, deal size, or referral economics justify effort. |
+| Activation ease | Application, approval, and onboarding are realistic. |
+| Brand safety | Terms and category fit do not create obvious reputational risk. |
+| Evidence quality | Official terms are public and specific enough to trust. |
+
+Calculate an overall fit score as the rounded average. If evidence quality is below 3, cap the overall score at 3 even if the program looks attractive.
+
+### Step 5: Rank And Segment
+
+Group candidates by route:
+
+- Start now: official terms are clear, fit is strong, and the contact or application path is available.
+- Validate first: promising, but missing terms or requiring relationship confirmation.
+- Watch list: useful intelligence, but weak immediate fit.
+- Reject: low fit, unclear legitimacy, restricted category, or poor evidence.
+
+For each Start now candidate, add one next action. This can be apply, research the partner manager, map overlap with ICP, draft outreach, or compare against a competitor program.
+
+## Output Format
+
+Start with a concise verdict:
+
+- Best route: one sentence.
+- Number of candidates found.
+- Number ready to act on.
+- Main constraint or risk.
+
+Then provide the table:
+
+| Rank | Candidate | Program type | Terms summary | Fit | Evidence | Next action |
+|------|-----------|--------------|---------------|-----|----------|-------------|
+| 1 | Company or program | Affiliate, referral, reseller, marketplace, agency, creator | Commission, requirements, restrictions, or Not stated | 1-5 | Official URL or Unverified directory | Specific next step |
+
+After the table, include:
+
+- Top three recommendations.
+- Programs rejected and why.
+- Unknowns to verify before committing resources.
+- Optional outreach angles, only as drafts. Do not send messages.
+
+## Quality Bar
+
+Every included candidate must have evidence. Official source beats directories, directories beat unsourced blog posts, and unsourced claims should not be used.
+
+Do not inflate weak programs. A shortlist of five strong candidates is better than a long table of low-confidence links.
+
+Do not recommend restricted or deceptive tactics. Respect program terms, disclosure requirements, trademark rules, bidding restrictions, and regional compliance constraints.
+
+Do not take externally visible actions. The skill can prepare application notes or outreach drafts, but the user must approve before anything is submitted or sent.
+
+## Troubleshooting
+
+If few programs are found, broaden from direct competitors to adjacent products, marketplaces, agencies, creator programs, and newsletters in the same buyer ecosystem.
+
+If terms are hidden behind forms, list the candidate under Validate first and write the exact missing terms to ask about.
+
+If the niche is regulated, add a brand safety note and prioritize official partner ecosystems over open affiliate directories.

--- a/skills/capabilities/partner-program-finder/skill.meta.json
+++ b/skills/capabilities/partner-program-finder/skill.meta.json
@@ -1,0 +1,22 @@
+{
+  "slug": "partner-program-finder",
+  "category": "capabilities",
+  "tags": [
+    "lead-generation",
+    "research"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install partner-program-finder",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "official-source-first",
+    "partner-fit-scoring",
+    "program-terms-comparison",
+    "outreach-next-steps"
+  ]
+}


### PR DESCRIPTION
## Summary
- add `partner-program-finder`, a GTM capability for finding and qualifying affiliate, referral, reseller, marketplace, and partner programs
- include official-source-first evidence rules, program term extraction, fit scoring, and next-action output format
- regenerate `skills-index.json` so the new skill is discoverable

## Validation
- `npm run build:index`
- `npm run validate:skills`
- `npm test`

Note: the test suite intentionally prints expected error output for regression cases; final TAP result is 19/19 passing.