### PR TITLE
Add changelog launch kit skill

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-05-07",
+  "generated": "2026-05-14",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -562,6 +562,47 @@
             "codex"
           ]
         }
+      }
+    },
+    {
+      "slug": "changelog-launch-kit",
+      "name": "changelog-launch-kit",
+      "category": "composites",
+      "description": "Turn a product changelog, release note draft, pull request summary, or shipped feature list into a complete launch kit for customers, sales, support, social, and internal stakeholders. Use when a team needs to announce shipped work clearly without overpromising or losing technical nuance.",
+      "tags": "content, outreach, social",
+      "path": "skills/composites/changelog-launch-kit",
+      "files": [
+        "skills/composites/changelog-launch-kit/SKILL.md",
+        "skills/composites/changelog-launch-kit/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "changelog-launch-kit",
+        "category": "composites",
+        "tags": [
+          "content",
+          "outreach",
+          "social"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install changelog-launch-kit",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Turns product changes into a segmented launch kit",
+          "Creates customer announcements, sales enablement, and social copy",
+          "Adds rollout risk checks, metrics, and follow-up actions"
+        ],
+        "requires_skills": [
+          "feature-launch-playbook",
+          "help-center-article-generator",
+          "create-x-content",
+          "create-linkedin-content",
+          "email-drafting"
+        ]
       }
     },
     {

--- a/skills/composites/changelog-launch-kit/SKILL.md
+++ b/skills/composites/changelog-launch-kit/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: changelog-launch-kit
+description: Turn a product changelog, release note draft, pull request summary, or shipped feature list into a complete launch kit for customers, sales, support, social, and internal stakeholders. Use when a team needs to announce shipped work clearly without overpromising or losing technical nuance.
+---
+
+# Changelog Launch Kit
+
+Use this skill when the user has shipped or is about to ship product changes and needs a launch-ready communication package. The input can be a rough changelog, a set of merged changes, a release note draft, product screenshots, customer feedback, or a short description of what changed.
+
+The core job is to preserve the product truth, translate it for each audience, and leave the user with publishable assets plus a rollout checklist.
+
+## Intake
+
+Start by identifying the release shape:
+
+- Product area and release date or target window
+- Source material: changelog, feature list, issue summaries, customer requests, screenshots, docs, or sales notes
+- Primary audience: current customers, trial users, prospects, partners, internal teams, or developers
+- Desired tone: technical, executive, friendly, founder-led, enterprise, playful, or minimal
+- Distribution channels: email, in-app announcement, blog, help center, LinkedIn, X, sales notes, support macros, community post
+- Constraints: regulated claims, availability limits, beta status, pricing changes, migration requirements, breaking changes, or security sensitivity
+
+If the source material is vague, create a conservative assumption list and mark anything that needs confirmation before publishing.
+
+## Product Truth Pass
+
+Before writing copy, extract a factual release brief:
+
+- What changed
+- Who benefits
+- What job or pain it addresses
+- What is new versus previously available
+- What users need to do next
+- What limitations, rollout caveats, or known gaps remain
+- Proof points, metrics, customer quotes, or usage examples
+
+Do not inflate the release. Avoid vague superlatives unless the source material supports them. If the release includes fixes or reliability work, frame the customer value without pretending it is a net-new feature.
+
+## Message Architecture
+
+Build a single messaging spine before creating assets:
+
+- One plain-language headline
+- One technical headline if developers or admins are an audience
+- Three value bullets tied to user outcomes
+- One concise before-and-after explanation
+- One specific call to action
+- One risk-safe caveat when needed
+
+When there are multiple features, group them by audience need rather than by internal component names.
+
+## Asset Package
+
+Produce only the assets relevant to the requested channels. When the user does not specify channels, create this default package:
+
+- Customer email announcement with subject line options and preview text
+- In-app or modal announcement copy
+- Help center article outline with setup steps and troubleshooting notes
+- Sales enablement note with objection handling and discovery prompts
+- Support macro for common questions
+- LinkedIn post in a professional product-launch voice
+- X post variants: concise, technical, and founder-style
+- Internal launch note for customer-facing teams
+
+Each asset should stand alone and be ready to paste into the destination channel after final factual review.
+
+## Audience Adaptation
+
+Adapt the same release to each audience:
+
+- Customers need benefits, eligibility, what changes for them, and what to do next
+- Prospects need a crisp problem-to-outcome story and credibility
+- Developers need exact behavior, integration impact, and migration details
+- Sales needs discovery prompts, competitive angle, and common objections
+- Support needs likely questions, escalation triggers, and safe language
+- Executives need business outcome, adoption signal, and risk posture
+
+Avoid sending every audience the same copy with only light wording changes.
+
+## Rollout Checklist
+
+Finish with a launch operations checklist:
+
+- Final factual review items
+- Links or screenshots still needed
+- Docs and support dependencies
+- Customer segments to notify
+- Metrics to watch in the first day, first week, and first month
+- Rollback or correction plan if the release has risk
+- Follow-up content ideas based on likely customer questions
+
+If the release includes a breaking change, include a migration notice sequence and support escalation plan.
+
+## Quality Bar
+
+The final output should be specific, sober, and useful. It should not sound like a generic launch template.
+
+Before finalizing, check:
+
+- Claims match the source material
+- Each channel has a clear next action
+- Technical details remain accurate
+- Support and sales copy does not overpromise
+- Social posts are distinct rather than trimmed versions of the same paragraph
+- The launch checklist includes measurable follow-up
+
+When uncertain, choose precise language over hype.

--- a/skills/composites/changelog-launch-kit/skill.meta.json
+++ b/skills/composites/changelog-launch-kit/skill.meta.json
@@ -1,0 +1,29 @@
+{
+  "slug": "changelog-launch-kit",
+  "category": "composites",
+  "tags": [
+    "content",
+    "outreach",
+    "social"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install changelog-launch-kit",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Turns product changes into a segmented launch kit",
+    "Creates customer announcements, sales enablement, and social copy",
+    "Adds rollout risk checks, metrics, and follow-up actions"
+  ],
+  "requires_skills": [
+    "feature-launch-playbook",
+    "help-center-article-generator",
+    "create-x-content",
+    "create-linkedin-content",
+    "email-drafting"
+  ]
+}


### PR DESCRIPTION
Summary:
- Add a new changelog-launch-kit composite skill for turning product changes into launch-ready GTM assets.
- Include metadata, related skill references, and generated skills-index entry.

Tests:
- npm run build:index
- npm run validate:skills
- npm test