### PR TITLE
Add webinar repurposing engine skill

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-05-07",
+  "generated": "2026-05-14",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -5788,6 +5788,47 @@
             "codex"
           ]
         }
+      }
+    },
+    {
+      "slug": "webinar-repurposing-engine",
+      "name": "webinar-repurposing-engine",
+      "category": "composites",
+      "description": "Turns webinars, podcasts, demo calls, customer interviews, and recorded events into a complete multi-channel content pack with LinkedIn posts, X threads, email follow-ups, blog angles, clip briefs, and sales enablement snippets.",
+      "tags": "content, social, outreach",
+      "path": "skills/composites/webinar-repurposing-engine",
+      "files": [
+        "skills/composites/webinar-repurposing-engine/SKILL.md",
+        "skills/composites/webinar-repurposing-engine/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "webinar-repurposing-engine",
+        "category": "composites",
+        "tags": [
+          "content",
+          "social",
+          "outreach"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install webinar-repurposing-engine",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "requires_skills": [
+          "youtube-apify-transcript",
+          "brand-voice-extractor",
+          "create-linkedin-content",
+          "create-x-content",
+          "email-drafting"
+        ],
+        "features": [
+          "Repurpose webinar, podcast, demo, and event transcripts into channel-specific content packs",
+          "Extract audience pain points, proof points, objections, quotes, and follow-up angles",
+          "Produce LinkedIn posts, X threads, email follow-ups, blog outlines, and short clip briefs"
+        ]
       }
     },
     {

--- a/skills/composites/webinar-repurposing-engine/SKILL.md
+++ b/skills/composites/webinar-repurposing-engine/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: webinar-repurposing-engine
+description: Turns webinars, podcasts, demo calls, customer interviews, and recorded events into a complete multi-channel content pack with LinkedIn posts, X threads, email follow-ups, blog angles, clip briefs, and sales enablement snippets.
+tags: [content, social, outreach]
+---
+
+# Webinar Repurposing Engine
+
+Use this skill when the user wants to turn a long-form recording or transcript into publish-ready assets across social, email, blog, and sales follow-up channels.
+
+Start by identifying the source material. It can be a video link, audio link, transcript, event notes, webinar deck summary, customer interview, demo recording, or rough recap. If a transcript is not available, fetch one when possible. If no transcript can be fetched, work from the user's notes and clearly state that the output is based on partial source material.
+
+## Intake
+
+Collect or infer the following:
+
+- Source title and format
+- Target audience
+- Speaker or brand voice
+- Primary offer, product, or campaign
+- Desired channels
+- Any claims that require careful wording
+- Call to action
+
+If the user does not provide a target audience or campaign goal, infer the most likely audience from the source and label it as an assumption.
+
+## Extraction
+
+Read the source once for structure, then extract reusable content units:
+
+- Main thesis
+- Three to seven audience pains
+- Three to seven concrete takeaways
+- Proof points, metrics, customer examples, or demos
+- Memorable quotes
+- Objections or risks raised by the audience
+- Before and after transformation
+- Terms, phrases, and metaphors that reveal brand voice
+- Follow-up questions a buyer would naturally ask
+
+Do not manufacture claims, numbers, customer names, or results. If the source is vague, keep the asset language grounded and use softer phrasing.
+
+## Content Strategy
+
+Choose the asset mix based on the source:
+
+- For educational webinars, prioritize thought leadership posts, tactical checklists, and newsletter content.
+- For product demos, prioritize problem-solution posts, objection handling, feature benefit snippets, and follow-up email.
+- For customer interviews, prioritize proof-led stories, quote cards, case-study outlines, and sales enablement.
+- For podcasts, prioritize narrative posts, quote-led threads, and short clip briefs.
+- For live events, prioritize recap posts, attendee follow-up, and the best unanswered questions.
+
+Preserve the difference between channels. LinkedIn should feel complete and self-contained. X should move quickly and reward sharp sequence. Email should feel personal and action-oriented. Blog outlines should carry search intent and structure. Sales snippets should be concise enough to paste into follow-up.
+
+## Output Package
+
+Produce a structured pack with the sections that fit the user's requested channels:
+
+1. Source Brief
+2. Audience and Positioning
+3. Reusable Content Angles
+4. LinkedIn Post Set
+5. X Thread Set
+6. Email Follow-Up Set
+7. Blog or Newsletter Outline
+8. Short Clip Briefs
+9. Sales Enablement Snippets
+10. Repurposing Calendar
+
+For each asset, include:
+
+- Hook or subject line
+- Draft copy
+- Intended audience
+- Source moment or supporting idea
+- Call to action
+- Risk note if the claim needs validation
+
+## Quality Bar
+
+Every asset should tie back to the source. Avoid generic inspirational posts that could have been written without the recording. Keep the speaker's language where it is strong, but rewrite for clarity and channel fit. Remove filler, repeated setup, throat-clearing, and weak transitions.
+
+Use concise labels and practical formatting. Do not bury the useful draft copy inside long explanations. If a source has too little substance for a full pack, produce fewer stronger assets and explain what extra source material would unlock the rest.
+
+## Final Checks
+
+Before returning the pack, verify:
+
+- No unsupported statistics or fabricated customer claims
+- No duplicate hooks across channels
+- Each channel has a distinct job
+- Calls to action match the user's campaign
+- Tone is consistent with the brand or speaker
+- The highest value clips or quotes are easy to find

--- a/skills/composites/webinar-repurposing-engine/skill.meta.json
+++ b/skills/composites/webinar-repurposing-engine/skill.meta.json
@@ -1,0 +1,29 @@
+{
+  "slug": "webinar-repurposing-engine",
+  "category": "composites",
+  "tags": [
+    "content",
+    "social",
+    "outreach"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install webinar-repurposing-engine",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "requires_skills": [
+    "youtube-apify-transcript",
+    "brand-voice-extractor",
+    "create-linkedin-content",
+    "create-x-content",
+    "email-drafting"
+  ],
+  "features": [
+    "Repurpose webinar, podcast, demo, and event transcripts into channel-specific content packs",
+    "Extract audience pain points, proof points, objections, quotes, and follow-up angles",
+    "Produce LinkedIn posts, X threads, email follow-ups, blog outlines, and short clip briefs"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a composite skill for turning webinars, podcasts, demos, and customer interviews into multi-channel content packs.
- Include channel-specific workflow guidance for LinkedIn, X, email follow-up, blog outlines, short clip briefs, and sales enablement snippets.
- Regenerate the skills index so the new skill is discoverable.

## Verification
- npm run build:index
- node scripts/validate-skills.js
- git diff --check
- npm test -- --runInBand