### PR TITLE
Add developer-relations composite skills pack (10 skills)

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,17 +1,17 @@
 {
   "version": "1.2.0",
-  "generated": "2026-05-07",
+  "generated": "2026-05-15",
   "skills": [
     {
       "slug": "ad-angle-miner",
       "name": "ad-angle-miner",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "ads",
       "path": "skills/composites/ad-angle-miner",
       "files": [
-        "skills/composites/ad-angle-miner/SKILL.md",
-        "skills/composites/ad-angle-miner/skill.meta.json"
+        "skills\\composites\\ad-angle-miner\\SKILL.md",
+        "skills\\composites\\ad-angle-miner\\skill.meta.json"
       ],
       "metadata": {
         "slug": "ad-angle-miner",
@@ -38,12 +38,12 @@
       "slug": "ad-campaign-analyzer",
       "name": "ad-campaign-analyzer",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "ads",
       "path": "skills/composites/ad-campaign-analyzer",
       "files": [
-        "skills/composites/ad-campaign-analyzer/SKILL.md",
-        "skills/composites/ad-campaign-analyzer/skill.meta.json"
+        "skills\\composites\\ad-campaign-analyzer\\SKILL.md",
+        "skills\\composites\\ad-campaign-analyzer\\skill.meta.json"
       ],
       "metadata": {
         "slug": "ad-campaign-analyzer",
@@ -66,12 +66,12 @@
       "slug": "ad-lead-quality-analyzer",
       "name": "ad-lead-quality-analyzer",
       "category": "composites",
-      "description": "For paid lead-gen and participant-recruitment ads, replaces vanity CPA with true CAC per qualified lead by joining ad-platform data with downstream funnel events, surfaces tracking gaps, and classifies every creative into Scale / Keep / Investigate / Cut.",
+      "description": "",
       "tags": "ads",
       "path": "skills/composites/ad-lead-quality-analyzer",
       "files": [
-        "skills/composites/ad-lead-quality-analyzer/SKILL.md",
-        "skills/composites/ad-lead-quality-analyzer/skill.meta.json"
+        "skills\\composites\\ad-lead-quality-analyzer\\SKILL.md",
+        "skills\\composites\\ad-lead-quality-analyzer\\skill.meta.json"
       ],
       "metadata": {
         "slug": "ad-lead-quality-analyzer",
@@ -94,12 +94,12 @@
       "slug": "ad-to-landing-page-auditor",
       "name": "ad-to-landing-page-auditor",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "ads",
       "path": "skills/composites/ad-to-landing-page-auditor",
       "files": [
-        "skills/composites/ad-to-landing-page-auditor/SKILL.md",
-        "skills/composites/ad-to-landing-page-auditor/skill.meta.json"
+        "skills\\composites\\ad-to-landing-page-auditor\\SKILL.md",
+        "skills\\composites\\ad-to-landing-page-auditor\\skill.meta.json"
       ],
       "metadata": {
         "slug": "ad-to-landing-page-auditor",
@@ -124,12 +124,12 @@
       "slug": "aeo",
       "name": "aeo",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "seo",
       "path": "skills/capabilities/aeo",
       "files": [
-        "skills/capabilities/aeo/SKILL.md",
-        "skills/capabilities/aeo/skill.meta.json"
+        "skills\\capabilities\\aeo\\SKILL.md",
+        "skills\\capabilities\\aeo\\skill.meta.json"
       ],
       "metadata": {
         "slug": "aeo",
@@ -151,12 +151,12 @@
       "slug": "ai-video-calls-tavus",
       "name": "ai-video-calls-tavus",
       "category": "capabilities",
-      "description": "AI video conversations - create real-time video calls with AI personas",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/ai-video-calls-tavus",
       "files": [
-        "skills/capabilities/ai-video-calls-tavus/SKILL.md",
-        "skills/capabilities/ai-video-calls-tavus/skill.meta.json"
+        "skills\\capabilities\\ai-video-calls-tavus\\SKILL.md",
+        "skills\\capabilities\\ai-video-calls-tavus\\skill.meta.json"
       ],
       "metadata": {
         "slug": "ai-video-calls-tavus",
@@ -177,12 +177,12 @@
       "slug": "ai-web-scraping-scrapegraph",
       "name": "ai-web-scraping-scrapegraph",
       "category": "capabilities",
-      "description": "AI-powered web scraping - extract data using natural language prompts",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/ai-web-scraping-scrapegraph",
       "files": [
-        "skills/capabilities/ai-web-scraping-scrapegraph/SKILL.md",
-        "skills/capabilities/ai-web-scraping-scrapegraph/skill.meta.json"
+        "skills\\capabilities\\ai-web-scraping-scrapegraph\\SKILL.md",
+        "skills\\capabilities\\ai-web-scraping-scrapegraph\\skill.meta.json"
       ],
       "metadata": {
         "slug": "ai-web-scraping-scrapegraph",
@@ -203,12 +203,12 @@
       "slug": "amazon-search",
       "name": "amazon-search",
       "category": "capabilities",
-      "description": "Search Amazon products - find items, compare prices, read reviews",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/amazon-search",
       "files": [
-        "skills/capabilities/amazon-search/SKILL.md",
-        "skills/capabilities/amazon-search/skill.meta.json"
+        "skills\\capabilities\\amazon-search\\SKILL.md",
+        "skills\\capabilities\\amazon-search\\skill.meta.json"
       ],
       "metadata": {
         "slug": "amazon-search",
@@ -226,15 +226,88 @@
       }
     },
     {
+      "slug": "api-deprecation-sunset-planner",
+      "name": "api-deprecation-sunset-planner",
+      "category": "composites",
+      "description": "",
+      "tags": "content, research",
+      "path": "skills/composites/api-deprecation-sunset-planner",
+      "files": [
+        "skills\\composites\\api-deprecation-sunset-planner\\SKILL.md",
+        "skills\\composites\\api-deprecation-sunset-planner\\skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "api-deprecation-sunset-planner",
+        "category": "composites",
+        "tags": [
+          "content",
+          "research"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install api-deprecation-sunset-planner",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "requires_skills": [
+          "api-release-notes-composer"
+        ],
+        "features": [
+          "Assesses migration effort, consumer breadth, and detectable usage before building the plan",
+          "Validates the planned removal date against minimum runway guidelines by migration effort level",
+          "Produces HTTP Deprecation/Sunset header configuration with IETF RFC 9745 format and SDK deprecation markers",
+          "Builds a phased backward-planning timeline with action items from D-90 announcement through D+3 post-removal",
+          "Delivers all channel copy variants (email x3, docs banner x2, Discord, status page) and a day-of removal checklist"
+        ]
+      }
+    },
+    {
+      "slug": "api-release-notes-composer",
+      "name": "api-release-notes-composer",
+      "category": "composites",
+      "description": "",
+      "tags": "content, research",
+      "path": "skills/composites/api-release-notes-composer",
+      "files": [
+        "skills\\composites\\api-release-notes-composer\\SKILL.md",
+        "skills\\composites\\api-release-notes-composer\\skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "api-release-notes-composer",
+        "category": "composites",
+        "tags": [
+          "content",
+          "research"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install api-release-notes-composer",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Classifies PRs, tickets, and commits into Added, Breaking, Deprecated, Fixed, and Removed buckets before writing",
+          "Validates the declared semver version against the change set and flags mismatches",
+          "Writes structured developer-facing changelog prose with endpoint paths, field names, and active-voice copy",
+          "Appends before/after migration hints for every breaking change",
+          "Outputs a Slack/Discord-ready two-sentence TL;DR alongside the full changelog entry"
+        ]
+      }
+    },
+    {
       "slug": "api-tester",
       "name": "api-tester",
       "category": "capabilities",
-      "description": "Test and document API endpoints - validate responses, check status, generate examples",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/api-tester",
       "files": [
-        "skills/capabilities/api-tester/SKILL.md",
-        "skills/capabilities/api-tester/skill.meta.json"
+        "skills\\capabilities\\api-tester\\SKILL.md",
+        "skills\\capabilities\\api-tester\\skill.meta.json"
       ],
       "metadata": {
         "slug": "api-tester",
@@ -255,13 +328,13 @@
       "slug": "apollo-lead-finder",
       "name": "apollo-lead-finder",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/capabilities/apollo-lead-finder",
       "files": [
-        "skills/capabilities/apollo-lead-finder/SKILL.md",
-        "skills/capabilities/apollo-lead-finder/scripts/apollo_client.py",
-        "skills/capabilities/apollo-lead-finder/skill.meta.json"
+        "skills\\capabilities\\apollo-lead-finder\\scripts\\apollo_client.py",
+        "skills\\capabilities\\apollo-lead-finder\\SKILL.md",
+        "skills\\capabilities\\apollo-lead-finder\\skill.meta.json"
       ],
       "metadata": {
         "slug": "apollo-lead-finder",
@@ -283,12 +356,12 @@
       "slug": "battlecard-generator",
       "name": "battlecard-generator",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "competitive-intel",
       "path": "skills/composites/battlecard-generator",
       "files": [
-        "skills/composites/battlecard-generator/SKILL.md",
-        "skills/composites/battlecard-generator/skill.meta.json"
+        "skills\\composites\\battlecard-generator\\SKILL.md",
+        "skills\\composites\\battlecard-generator\\skill.meta.json"
       ],
       "metadata": {
         "slug": "battlecard-generator",
@@ -314,12 +387,12 @@
       "slug": "beat-sync-reel",
       "name": "beat-sync-reel",
       "category": "capabilities",
-      "description": "Generates Instagram Reels where product image cuts are synced to audio beats. Accepts audio as a local file, URL, or search query. Uses librosa for beat detection, FFmpeg Ken Burns for scene animation, and Pillow for text overlays. No AI video generation — fully free, fast, and scalable.",
+      "description": "",
       "tags": "content",
       "path": "skills/packs/video-production/beat-sync-reel",
       "files": [
-        "skills/packs/video-production/beat-sync-reel/SKILL.md",
-        "skills/packs/video-production/beat-sync-reel/skill.meta.json"
+        "skills\\packs\\video-production\\beat-sync-reel\\SKILL.md",
+        "skills\\packs\\video-production\\beat-sync-reel\\skill.meta.json"
       ],
       "metadata": {
         "slug": "beat-sync-reel",
@@ -342,13 +415,13 @@
       "slug": "blog-feed-monitor",
       "name": "blog-feed-monitor",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "content",
       "path": "skills/capabilities/blog-feed-monitor",
       "files": [
-        "skills/capabilities/blog-feed-monitor/SKILL.md",
-        "skills/capabilities/blog-feed-monitor/scripts/scrape_blogs.py",
-        "skills/capabilities/blog-feed-monitor/skill.meta.json"
+        "skills\\capabilities\\blog-feed-monitor\\scripts\\scrape_blogs.py",
+        "skills\\capabilities\\blog-feed-monitor\\SKILL.md",
+        "skills\\capabilities\\blog-feed-monitor\\skill.meta.json"
       ],
       "metadata": {
         "slug": "blog-feed-monitor",
@@ -370,12 +443,12 @@
       "slug": "brand-intel-branddev",
       "name": "brand-intel-branddev",
       "category": "capabilities",
-      "description": "Brand intelligence - logos, colors, fonts, styleguides, and company data from any domain",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/brand-intel-branddev",
       "files": [
-        "skills/capabilities/brand-intel-branddev/SKILL.md",
-        "skills/capabilities/brand-intel-branddev/skill.meta.json"
+        "skills\\capabilities\\brand-intel-branddev\\SKILL.md",
+        "skills\\capabilities\\brand-intel-branddev\\skill.meta.json"
       ],
       "metadata": {
         "slug": "brand-intel-branddev",
@@ -396,12 +469,12 @@
       "slug": "brand-voice-extractor",
       "name": "brand-voice-extractor",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "brand",
       "path": "skills/capabilities/brand-voice-extractor",
       "files": [
-        "skills/capabilities/brand-voice-extractor/SKILL.md",
-        "skills/capabilities/brand-voice-extractor/skill.meta.json"
+        "skills\\capabilities\\brand-voice-extractor\\SKILL.md",
+        "skills\\capabilities\\brand-voice-extractor\\skill.meta.json"
       ],
       "metadata": {
         "slug": "brand-voice-extractor",
@@ -420,15 +493,53 @@
       }
     },
     {
+      "slug": "breaking-change-comms-kit",
+      "name": "breaking-change-comms-kit",
+      "category": "composites",
+      "description": "",
+      "tags": "content, outreach",
+      "path": "skills/composites/breaking-change-comms-kit",
+      "files": [
+        "skills\\composites\\breaking-change-comms-kit\\SKILL.md",
+        "skills\\composites\\breaking-change-comms-kit\\skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "breaking-change-comms-kit",
+        "category": "composites",
+        "tags": [
+          "content",
+          "outreach"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install breaking-change-comms-kit",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "requires_skills": [
+          "api-release-notes-composer"
+        ],
+        "features": [
+          "Tiers the impact of a breaking change (Critical/High/Medium/Low) and selects channels accordingly",
+          "Generates a backward-planning rollout timeline from the hard cutoff date",
+          "Writes a step-by-step migration guide with before/after code examples",
+          "Produces per-channel copy for docs banner, email, in-product warning, status page, and Slack",
+          "Delivers a support-ready FAQ so the team can handle tickets verbatim"
+        ]
+      }
+    },
+    {
       "slug": "browser-automation-notte",
       "name": "browser-automation-notte",
       "category": "capabilities",
-      "description": "Browser automation - control browser sessions, scrape pages, and run AI agents",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/browser-automation-notte",
       "files": [
-        "skills/capabilities/browser-automation-notte/SKILL.md",
-        "skills/capabilities/browser-automation-notte/skill.meta.json"
+        "skills\\capabilities\\browser-automation-notte\\SKILL.md",
+        "skills\\capabilities\\browser-automation-notte\\skill.meta.json"
       ],
       "metadata": {
         "slug": "browser-automation-notte",
@@ -449,12 +560,12 @@
       "slug": "buyer-persona-generator",
       "name": "buyer-persona-generator",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "research",
       "path": "skills/capabilities/buyer-persona-generator",
       "files": [
-        "skills/capabilities/buyer-persona-generator/SKILL.md",
-        "skills/capabilities/buyer-persona-generator/skill.meta.json"
+        "skills\\capabilities\\buyer-persona-generator\\SKILL.md",
+        "skills\\capabilities\\buyer-persona-generator\\skill.meta.json"
       ],
       "metadata": {
         "slug": "buyer-persona-generator",
@@ -476,12 +587,12 @@
       "slug": "campaign-brief-generator",
       "name": "campaign-brief-generator",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "content",
       "path": "skills/composites/campaign-brief-generator",
       "files": [
-        "skills/composites/campaign-brief-generator/SKILL.md",
-        "skills/composites/campaign-brief-generator/skill.meta.json"
+        "skills\\composites\\campaign-brief-generator\\SKILL.md",
+        "skills\\composites\\campaign-brief-generator\\skill.meta.json"
       ],
       "metadata": {
         "slug": "campaign-brief-generator",
@@ -503,12 +614,12 @@
       "slug": "champion-move-outreach",
       "name": "champion-move-outreach",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "outreach",
       "path": "skills/composites/champion-move-outreach",
       "files": [
-        "skills/composites/champion-move-outreach/SKILL.md",
-        "skills/composites/champion-move-outreach/skill.meta.json"
+        "skills\\composites\\champion-move-outreach\\SKILL.md",
+        "skills\\composites\\champion-move-outreach\\skill.meta.json"
       ],
       "metadata": {
         "slug": "champion-move-outreach",
@@ -535,15 +646,15 @@
       "slug": "champion-tracker",
       "name": "champion-tracker",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/capabilities/champion-tracker",
       "files": [
-        "skills/capabilities/champion-tracker/SKILL.md",
-        "skills/capabilities/champion-tracker/input/champions.csv",
-        "skills/capabilities/champion-tracker/input/champions_template.csv",
-        "skills/capabilities/champion-tracker/scripts/champion_tracker.py",
-        "skills/capabilities/champion-tracker/skill.meta.json"
+        "skills\\capabilities\\champion-tracker\\input\\champions.csv",
+        "skills\\capabilities\\champion-tracker\\input\\champions_template.csv",
+        "skills\\capabilities\\champion-tracker\\scripts\\champion_tracker.py",
+        "skills\\capabilities\\champion-tracker\\SKILL.md",
+        "skills\\capabilities\\champion-tracker\\skill.meta.json"
       ],
       "metadata": {
         "slug": "champion-tracker",
@@ -568,12 +679,12 @@
       "slug": "churn-risk-detector",
       "name": "churn-risk-detector",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "research",
       "path": "skills/composites/churn-risk-detector",
       "files": [
-        "skills/composites/churn-risk-detector/SKILL.md",
-        "skills/composites/churn-risk-detector/skill.meta.json"
+        "skills\\composites\\churn-risk-detector\\SKILL.md",
+        "skills\\composites\\churn-risk-detector\\skill.meta.json"
       ],
       "metadata": {
         "slug": "churn-risk-detector",
@@ -595,12 +706,12 @@
       "slug": "cold-email-outreach",
       "name": "cold-email-outreach",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "outreach",
       "path": "skills/capabilities/cold-email-outreach",
       "files": [
-        "skills/capabilities/cold-email-outreach/SKILL.md",
-        "skills/capabilities/cold-email-outreach/skill.meta.json"
+        "skills\\capabilities\\cold-email-outreach\\SKILL.md",
+        "skills\\capabilities\\cold-email-outreach\\skill.meta.json"
       ],
       "metadata": {
         "slug": "cold-email-outreach",
@@ -622,12 +733,12 @@
       "slug": "community-signals",
       "name": "community-signals",
       "category": "capabilities",
-      "description": "Extract leads from developer forums (Hacker News, Reddit) by detecting intent signals — alternative seeking, competitor pain, scaling challenges, DIY solutions, and migration intent. Scores users by intent strength and cross-platform presence.",
+      "description": "",
       "tags": "lead-generation, research, competitive-intel",
       "path": "skills/packs/lead-gen-devtools/community-signals",
       "files": [
-        "skills/packs/lead-gen-devtools/community-signals/SKILL.md",
-        "skills/packs/lead-gen-devtools/community-signals/scripts/community_signals.py"
+        "skills\\packs\\lead-gen-devtools\\community-signals\\scripts\\community_signals.py",
+        "skills\\packs\\lead-gen-devtools\\community-signals\\SKILL.md"
       ],
       "metadata": {
         "slug": "community-signals",
@@ -652,12 +763,12 @@
       "slug": "company-contact-finder",
       "name": "company-contact-finder",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/capabilities/company-contact-finder",
       "files": [
-        "skills/capabilities/company-contact-finder/SKILL.md",
-        "skills/capabilities/company-contact-finder/skill.meta.json"
+        "skills\\capabilities\\company-contact-finder\\SKILL.md",
+        "skills\\capabilities\\company-contact-finder\\skill.meta.json"
       ],
       "metadata": {
         "slug": "company-contact-finder",
@@ -679,12 +790,12 @@
       "slug": "company-current-gtm-analysis",
       "name": "company-current-gtm-analysis",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "competitive-intel",
       "path": "skills/composites/company-current-gtm-analysis",
       "files": [
-        "skills/composites/company-current-gtm-analysis/SKILL.md",
-        "skills/composites/company-current-gtm-analysis/skill.meta.json"
+        "skills\\composites\\company-current-gtm-analysis\\SKILL.md",
+        "skills\\composites\\company-current-gtm-analysis\\skill.meta.json"
       ],
       "metadata": {
         "slug": "company-current-gtm-analysis",
@@ -711,12 +822,12 @@
       "slug": "company-domain-lookup-logodev",
       "name": "company-domain-lookup-logodev",
       "category": "capabilities",
-      "description": "Logo.dev - search for company domains by brand name",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/company-domain-lookup-logodev",
       "files": [
-        "skills/capabilities/company-domain-lookup-logodev/SKILL.md",
-        "skills/capabilities/company-domain-lookup-logodev/skill.meta.json"
+        "skills\\capabilities\\company-domain-lookup-logodev\\SKILL.md",
+        "skills\\capabilities\\company-domain-lookup-logodev\\skill.meta.json"
       ],
       "metadata": {
         "slug": "company-domain-lookup-logodev",
@@ -737,12 +848,12 @@
       "slug": "company-funding-search",
       "name": "company-funding-search",
       "category": "capabilities",
-      "description": "Find company funding history, investors, and investment details",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/company-funding-search",
       "files": [
-        "skills/capabilities/company-funding-search/SKILL.md",
-        "skills/capabilities/company-funding-search/skill.meta.json"
+        "skills\\capabilities\\company-funding-search\\SKILL.md",
+        "skills\\capabilities\\company-funding-search\\skill.meta.json"
       ],
       "metadata": {
         "slug": "company-funding-search",
@@ -763,12 +874,12 @@
       "slug": "company-intel",
       "name": "company-intel",
       "category": "capabilities",
-      "description": "Full company intelligence report - overview, team, funding, products, news",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/company-intel",
       "files": [
-        "skills/capabilities/company-intel/SKILL.md",
-        "skills/capabilities/company-intel/skill.meta.json"
+        "skills\\capabilities\\company-intel\\SKILL.md",
+        "skills\\capabilities\\company-intel\\skill.meta.json"
       ],
       "metadata": {
         "slug": "company-intel",
@@ -789,12 +900,12 @@
       "slug": "competitive-pricing-intel",
       "name": "competitive-pricing-intel",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "competitive-intel",
       "path": "skills/composites/competitive-pricing-intel",
       "files": [
-        "skills/composites/competitive-pricing-intel/SKILL.md",
-        "skills/composites/competitive-pricing-intel/skill.meta.json"
+        "skills\\composites\\competitive-pricing-intel\\SKILL.md",
+        "skills\\composites\\competitive-pricing-intel\\skill.meta.json"
       ],
       "metadata": {
         "slug": "competitive-pricing-intel",
@@ -816,12 +927,12 @@
       "slug": "competitor-ad-intelligence",
       "name": "competitor-ad-intelligence",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "ads",
       "path": "skills/composites/competitor-ad-intelligence",
       "files": [
-        "skills/composites/competitor-ad-intelligence/SKILL.md",
-        "skills/composites/competitor-ad-intelligence/skill.meta.json"
+        "skills\\composites\\competitor-ad-intelligence\\SKILL.md",
+        "skills\\composites\\competitor-ad-intelligence\\skill.meta.json"
       ],
       "metadata": {
         "slug": "competitor-ad-intelligence",
@@ -843,12 +954,12 @@
       "slug": "competitor-content-tracker",
       "name": "competitor-content-tracker",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "competitive-intel",
       "path": "skills/composites/competitor-content-tracker",
       "files": [
-        "skills/composites/competitor-content-tracker/SKILL.md",
-        "skills/composites/competitor-content-tracker/skill.meta.json"
+        "skills\\composites\\competitor-content-tracker\\SKILL.md",
+        "skills\\composites\\competitor-content-tracker\\skill.meta.json"
       ],
       "metadata": {
         "slug": "competitor-content-tracker",
@@ -875,12 +986,12 @@
       "slug": "competitor-intel",
       "name": "competitor-intel",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "competitive-intel",
       "path": "skills/composites/competitor-intel",
       "files": [
-        "skills/composites/competitor-intel/SKILL.md",
-        "skills/composites/competitor-intel/skill.meta.json"
+        "skills\\composites\\competitor-intel\\SKILL.md",
+        "skills\\composites\\competitor-intel\\skill.meta.json"
       ],
       "metadata": {
         "slug": "competitor-intel",
@@ -902,12 +1013,12 @@
       "slug": "competitor-monitoring-system",
       "name": "competitor-monitoring-system",
       "category": "playbooks",
-      "description": ">",
+      "description": "",
       "tags": "competitive-intel",
       "path": "skills/playbooks/competitor-monitoring-system",
       "files": [
-        "skills/playbooks/competitor-monitoring-system/SKILL.md",
-        "skills/playbooks/competitor-monitoring-system/skill.meta.json"
+        "skills\\playbooks\\competitor-monitoring-system\\SKILL.md",
+        "skills\\playbooks\\competitor-monitoring-system\\skill.meta.json"
       ],
       "metadata": {
         "slug": "competitor-monitoring-system",
@@ -929,13 +1040,13 @@
       "slug": "competitor-post-engagers",
       "name": "competitor-post-engagers",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/capabilities/competitor-post-engagers",
       "files": [
-        "skills/capabilities/competitor-post-engagers/SKILL.md",
-        "skills/capabilities/competitor-post-engagers/scripts/competitor_post_engagers.py",
-        "skills/capabilities/competitor-post-engagers/skill.meta.json"
+        "skills\\capabilities\\competitor-post-engagers\\scripts\\competitor_post_engagers.py",
+        "skills\\capabilities\\competitor-post-engagers\\SKILL.md",
+        "skills\\capabilities\\competitor-post-engagers\\skill.meta.json"
       ],
       "metadata": {
         "slug": "competitor-post-engagers",
@@ -960,12 +1071,12 @@
       "slug": "competitor-research",
       "name": "competitor-research",
       "category": "capabilities",
-      "description": "Research competitors - products, pricing, team, funding, and strategy",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/competitor-research",
       "files": [
-        "skills/capabilities/competitor-research/SKILL.md",
-        "skills/capabilities/competitor-research/skill.meta.json"
+        "skills\\capabilities\\competitor-research\\SKILL.md",
+        "skills\\capabilities\\competitor-research\\skill.meta.json"
       ],
       "metadata": {
         "slug": "competitor-research",
@@ -986,12 +1097,12 @@
       "slug": "competitor-signals",
       "name": "competitor-signals",
       "category": "capabilities",
-      "description": "Extract leads from competitor product activity — Product Hunt commenters/upvoters, HN posts about competitors, case studies, testimonials, tech press, and switching signals. Detects people actively switching from competitors as highest-priority leads.",
+      "description": "",
       "tags": "lead-generation, research, competitive-intel",
       "path": "skills/packs/lead-gen-devtools/competitor-signals",
       "files": [
-        "skills/packs/lead-gen-devtools/competitor-signals/SKILL.md",
-        "skills/packs/lead-gen-devtools/competitor-signals/scripts/competitor_signals.py"
+        "skills\\packs\\lead-gen-devtools\\competitor-signals\\scripts\\competitor_signals.py",
+        "skills\\packs\\lead-gen-devtools\\competitor-signals\\SKILL.md"
       ],
       "metadata": {
         "slug": "competitor-signals",
@@ -1016,12 +1127,12 @@
       "slug": "comprehensive-enrichment",
       "name": "comprehensive-enrichment",
       "category": "capabilities",
-      "description": "Enrich any person or company from any identifier — email, name, LinkedIn URL, domain, company name, Twitter/X handle. Use when asked to enrich, look up, or research a lead, contact, person, or company.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/comprehensive-enrichment",
       "files": [
-        "skills/capabilities/comprehensive-enrichment/SKILL.md",
-        "skills/capabilities/comprehensive-enrichment/skill.meta.json"
+        "skills\\capabilities\\comprehensive-enrichment\\SKILL.md",
+        "skills\\capabilities\\comprehensive-enrichment\\skill.meta.json"
       ],
       "metadata": {
         "slug": "comprehensive-enrichment",
@@ -1042,13 +1153,13 @@
       "slug": "conference-speaker-scraper",
       "name": "conference-speaker-scraper",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/capabilities/conference-speaker-scraper",
       "files": [
-        "skills/capabilities/conference-speaker-scraper/SKILL.md",
-        "skills/capabilities/conference-speaker-scraper/scripts/scrape_speakers.py",
-        "skills/capabilities/conference-speaker-scraper/skill.meta.json"
+        "skills\\capabilities\\conference-speaker-scraper\\scripts\\scrape_speakers.py",
+        "skills\\capabilities\\conference-speaker-scraper\\SKILL.md",
+        "skills\\capabilities\\conference-speaker-scraper\\skill.meta.json"
       ],
       "metadata": {
         "slug": "conference-speaker-scraper",
@@ -1070,13 +1181,13 @@
       "slug": "contact-cache",
       "name": "contact-cache",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/capabilities/contact-cache",
       "files": [
-        "skills/capabilities/contact-cache/SKILL.md",
-        "skills/capabilities/contact-cache/scripts/cache.py",
-        "skills/capabilities/contact-cache/skill.meta.json"
+        "skills\\capabilities\\contact-cache\\scripts\\cache.py",
+        "skills\\capabilities\\contact-cache\\SKILL.md",
+        "skills\\capabilities\\contact-cache\\skill.meta.json"
       ],
       "metadata": {
         "slug": "contact-cache",
@@ -1098,12 +1209,12 @@
       "slug": "contact-finder-contactout",
       "name": "contact-finder-contactout",
       "category": "capabilities",
-      "description": "Find emails, phone numbers, and enrich profiles using ContactOut. LinkedIn enrichment, people search, company enrichment, and batch operations.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/contact-finder-contactout",
       "files": [
-        "skills/capabilities/contact-finder-contactout/SKILL.md",
-        "skills/capabilities/contact-finder-contactout/skill.meta.json"
+        "skills\\capabilities\\contact-finder-contactout\\SKILL.md",
+        "skills\\capabilities\\contact-finder-contactout\\skill.meta.json"
       ],
       "metadata": {
         "slug": "contact-finder-contactout",
@@ -1124,12 +1235,12 @@
       "slug": "content-asset-creator",
       "name": "content-asset-creator",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "content",
       "path": "skills/capabilities/content-asset-creator",
       "files": [
-        "skills/capabilities/content-asset-creator/SKILL.md",
-        "skills/capabilities/content-asset-creator/skill.meta.json"
+        "skills\\capabilities\\content-asset-creator\\SKILL.md",
+        "skills\\capabilities\\content-asset-creator\\skill.meta.json"
       ],
       "metadata": {
         "slug": "content-asset-creator",
@@ -1151,12 +1262,12 @@
       "slug": "content-brief-factory",
       "name": "content-brief-factory",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "content",
       "path": "skills/composites/content-brief-factory",
       "files": [
-        "skills/composites/content-brief-factory/SKILL.md",
-        "skills/composites/content-brief-factory/skill.meta.json"
+        "skills\\composites\\content-brief-factory\\SKILL.md",
+        "skills\\composites\\content-brief-factory\\skill.meta.json"
       ],
       "metadata": {
         "slug": "content-brief-factory",
@@ -1184,12 +1295,12 @@
       "slug": "create-dashboard",
       "name": "create-dashboard",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "content, design",
       "path": "skills/capabilities/create-dashboard",
       "files": [
-        "skills/capabilities/create-dashboard/SKILL.md",
-        "skills/capabilities/create-dashboard/skill.meta.json"
+        "skills\\capabilities\\create-dashboard\\SKILL.md",
+        "skills\\capabilities\\create-dashboard\\skill.meta.json"
       ],
       "metadata": {
         "slug": "create-dashboard",
@@ -1212,16 +1323,16 @@
       "slug": "create-html-carousel",
       "name": "create-html-carousel",
       "category": "capabilities",
-      "description": "Create LinkedIn carousel posts as high-quality PNG images. Design informational multi-slide posts like \"5 AI GTM workflows\" with consistent styling, then automatically screenshot each slide at LinkedIn's optimal 1080x1080px format.",
+      "description": "",
       "tags": "content",
       "path": "skills/capabilities/create-html-carousel",
       "files": [
-        "skills/capabilities/create-html-carousel/README.md",
-        "skills/capabilities/create-html-carousel/SKILL.md",
-        "skills/capabilities/create-html-carousel/STYLE_PRESETS.md",
-        "skills/capabilities/create-html-carousel/package.json",
-        "skills/capabilities/create-html-carousel/screenshot-slides.js",
-        "skills/capabilities/create-html-carousel/skill.meta.json"
+        "skills\\capabilities\\create-html-carousel\\package.json",
+        "skills\\capabilities\\create-html-carousel\\README.md",
+        "skills\\capabilities\\create-html-carousel\\screenshot-slides.js",
+        "skills\\capabilities\\create-html-carousel\\SKILL.md",
+        "skills\\capabilities\\create-html-carousel\\skill.meta.json",
+        "skills\\capabilities\\create-html-carousel\\STYLE_PRESETS.md"
       ],
       "metadata": {
         "slug": "create-html-carousel",
@@ -1243,16 +1354,16 @@
     },
     {
       "slug": "create-html-slides",
-      "name": "frontend-slides",
+      "name": "create-html-slides",
       "category": "capabilities",
-      "description": "Create stunning, animation-rich HTML presentations from scratch or by converting PowerPoint files. Use when the user wants to build a presentation, convert a PPT/PPTX to web, or create slides for a talk/pitch. Helps non-designers discover their aesthetic through visual exploration rather than abstract choices.",
+      "description": "",
       "tags": "content",
       "path": "skills/capabilities/create-html-slides",
       "files": [
-        "skills/capabilities/create-html-slides/README.md",
-        "skills/capabilities/create-html-slides/SKILL.md",
-        "skills/capabilities/create-html-slides/STYLE_PRESETS.md",
-        "skills/capabilities/create-html-slides/skill.meta.json"
+        "skills\\capabilities\\create-html-slides\\README.md",
+        "skills\\capabilities\\create-html-slides\\SKILL.md",
+        "skills\\capabilities\\create-html-slides\\skill.meta.json",
+        "skills\\capabilities\\create-html-slides\\STYLE_PRESETS.md"
       ],
       "metadata": {
         "slug": "create-html-slides",
@@ -1276,12 +1387,12 @@
       "slug": "create-linkedin-content",
       "name": "create-linkedin-content",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "content, social",
       "path": "skills/capabilities/create-linkedin-content",
       "files": [
-        "skills/capabilities/create-linkedin-content/SKILL.md",
-        "skills/capabilities/create-linkedin-content/skill.meta.json"
+        "skills\\capabilities\\create-linkedin-content\\SKILL.md",
+        "skills\\capabilities\\create-linkedin-content\\skill.meta.json"
       ],
       "metadata": {
         "slug": "create-linkedin-content",
@@ -1304,16 +1415,16 @@
       "slug": "create-workflow-diagram",
       "name": "create-workflow-diagram",
       "category": "capabilities",
-      "description": "Create FigJam/Miro-style workflow diagrams as high-quality PNG images from plain-text workflow descriptions. Renders beautiful HTML diagrams with connected nodes, arrows, and labels, then screenshots them for sharing.",
+      "description": "",
       "tags": "content",
       "path": "skills/capabilities/create-workflow-diagram",
       "files": [
-        "skills/capabilities/create-workflow-diagram/README.md",
-        "skills/capabilities/create-workflow-diagram/SKILL.md",
-        "skills/capabilities/create-workflow-diagram/STYLE_PRESETS.md",
-        "skills/capabilities/create-workflow-diagram/package.json",
-        "skills/capabilities/create-workflow-diagram/screenshot-diagram.js",
-        "skills/capabilities/create-workflow-diagram/skill.meta.json"
+        "skills\\capabilities\\create-workflow-diagram\\package.json",
+        "skills\\capabilities\\create-workflow-diagram\\README.md",
+        "skills\\capabilities\\create-workflow-diagram\\screenshot-diagram.js",
+        "skills\\capabilities\\create-workflow-diagram\\SKILL.md",
+        "skills\\capabilities\\create-workflow-diagram\\skill.meta.json",
+        "skills\\capabilities\\create-workflow-diagram\\STYLE_PRESETS.md"
       ],
       "metadata": {
         "slug": "create-workflow-diagram",
@@ -1335,12 +1446,12 @@
       "slug": "create-x-content",
       "name": "create-x-content",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "content, social",
       "path": "skills/capabilities/create-x-content",
       "files": [
-        "skills/capabilities/create-x-content/SKILL.md",
-        "skills/capabilities/create-x-content/skill.meta.json"
+        "skills\\capabilities\\create-x-content\\SKILL.md",
+        "skills\\capabilities\\create-x-content\\skill.meta.json"
       ],
       "metadata": {
         "slug": "create-x-content",
@@ -1363,15 +1474,15 @@
       "slug": "customer-discovery",
       "name": "customer-discovery",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "competitive-intel, research",
       "path": "skills/capabilities/customer-discovery",
       "files": [
-        "skills/capabilities/customer-discovery/SKILL.md",
-        "skills/capabilities/customer-discovery/scripts/scrape_wayback_logos.py",
-        "skills/capabilities/customer-discovery/scripts/scrape_website_logos.py",
-        "skills/capabilities/customer-discovery/scripts/search_builtwith.py",
-        "skills/capabilities/customer-discovery/skill.meta.json"
+        "skills\\capabilities\\customer-discovery\\scripts\\scrape_wayback_logos.py",
+        "skills\\capabilities\\customer-discovery\\scripts\\scrape_website_logos.py",
+        "skills\\capabilities\\customer-discovery\\scripts\\search_builtwith.py",
+        "skills\\capabilities\\customer-discovery\\SKILL.md",
+        "skills\\capabilities\\customer-discovery\\skill.meta.json"
       ],
       "metadata": {
         "slug": "customer-discovery",
@@ -1394,12 +1505,12 @@
       "slug": "customer-story-builder",
       "name": "customer-story-builder",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "content",
       "path": "skills/composites/customer-story-builder",
       "files": [
-        "skills/composites/customer-story-builder/SKILL.md",
-        "skills/composites/customer-story-builder/skill.meta.json"
+        "skills\\composites\\customer-story-builder\\SKILL.md",
+        "skills\\composites\\customer-story-builder\\skill.meta.json"
       ],
       "metadata": {
         "slug": "customer-story-builder",
@@ -1421,12 +1532,12 @@
       "slug": "customer-win-back-sequencer",
       "name": "customer-win-back-sequencer",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "outreach",
       "path": "skills/composites/customer-win-back-sequencer",
       "files": [
-        "skills/composites/customer-win-back-sequencer/SKILL.md",
-        "skills/composites/customer-win-back-sequencer/skill.meta.json"
+        "skills\\composites\\customer-win-back-sequencer\\SKILL.md",
+        "skills\\composites\\customer-win-back-sequencer\\skill.meta.json"
       ],
       "metadata": {
         "slug": "customer-win-back-sequencer",
@@ -1452,12 +1563,12 @@
       "slug": "data-charts-tako",
       "name": "data-charts-tako",
       "category": "capabilities",
-      "description": "Search and visualize the world's data - get charts, insights, and embeddable knowledge cards for finance, economics, demographics, sports, and more",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/data-charts-tako",
       "files": [
-        "skills/capabilities/data-charts-tako/SKILL.md",
-        "skills/capabilities/data-charts-tako/skill.meta.json"
+        "skills\\capabilities\\data-charts-tako\\SKILL.md",
+        "skills\\capabilities\\data-charts-tako\\skill.meta.json"
       ],
       "metadata": {
         "slug": "data-charts-tako",
@@ -1478,11 +1589,11 @@
       "slug": "demo-builder",
       "name": "demo-builder",
       "category": "capabilities",
-      "description": "Builds personalized demo assets for top prospects using the founder's product API/MCP/SDK. Researches prospect, proposes demo concepts, builds working prototype, tests it, and generates comparison report with live demo link.",
+      "description": "",
       "tags": "lead-generation, research, competitive-intel",
       "path": "skills/packs/lead-gen-devtools/demo-builder",
       "files": [
-        "skills/packs/lead-gen-devtools/demo-builder/SKILL.md"
+        "skills\\packs\\lead-gen-devtools\\demo-builder\\SKILL.md"
       ],
       "metadata": {
         "slug": "demo-builder",
@@ -1504,15 +1615,50 @@
       }
     },
     {
+      "slug": "developer-newsletter-composer",
+      "name": "developer-newsletter-composer",
+      "category": "composites",
+      "description": "",
+      "tags": "content, social",
+      "path": "skills/composites/developer-newsletter-composer",
+      "files": [
+        "skills\\composites\\developer-newsletter-composer\\SKILL.md",
+        "skills\\composites\\developer-newsletter-composer\\skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "developer-newsletter-composer",
+        "category": "composites",
+        "tags": [
+          "content",
+          "social"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install developer-newsletter-composer",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Triages raw ship data into highlights, action-required, deprecations, fixes, and ecosystem buckets",
+          "Writes developer-voice prose with endpoint paths and field names, zero marketing language",
+          "Always surfaces action-required items first with deadline, one-sentence action, and migration link",
+          "Outputs email and Discord/GitHub Markdown variants with appropriate length constraints",
+          "Delivers subject line variants and flags any item that warrants its own standalone breaking-change email"
+        ]
+      }
+    },
+    {
       "slug": "disqualification-handling",
       "name": "disqualification-handling",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "outreach",
       "path": "skills/composites/disqualification-handling",
       "files": [
-        "skills/composites/disqualification-handling/SKILL.md",
-        "skills/composites/disqualification-handling/skill.meta.json"
+        "skills\\composites\\disqualification-handling\\SKILL.md",
+        "skills\\composites\\disqualification-handling\\skill.meta.json"
       ],
       "metadata": {
         "slug": "disqualification-handling",
@@ -1538,12 +1684,12 @@
       "slug": "ebay-search",
       "name": "ebay-search",
       "category": "capabilities",
-      "description": "Search eBay listings - find items, auctions, deals, and compare prices",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/ebay-search",
       "files": [
-        "skills/capabilities/ebay-search/SKILL.md",
-        "skills/capabilities/ebay-search/skill.meta.json"
+        "skills\\capabilities\\ebay-search\\SKILL.md",
+        "skills\\capabilities\\ebay-search\\skill.meta.json"
       ],
       "metadata": {
         "slug": "ebay-search",
@@ -1564,12 +1710,12 @@
       "slug": "email-campaign",
       "name": "email-campaign",
       "category": "capabilities",
-      "description": "Build email campaigns - find emails, verify them, and prepare outreach",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/email-campaign",
       "files": [
-        "skills/capabilities/email-campaign/SKILL.md",
-        "skills/capabilities/email-campaign/skill.meta.json"
+        "skills\\capabilities\\email-campaign\\SKILL.md",
+        "skills\\capabilities\\email-campaign\\skill.meta.json"
       ],
       "metadata": {
         "slug": "email-campaign",
@@ -1590,12 +1736,12 @@
       "slug": "email-drafting",
       "name": "email-drafting",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "outreach",
       "path": "skills/capabilities/email-drafting",
       "files": [
-        "skills/capabilities/email-drafting/SKILL.md",
-        "skills/capabilities/email-drafting/skill.meta.json"
+        "skills\\capabilities\\email-drafting\\SKILL.md",
+        "skills\\capabilities\\email-drafting\\skill.meta.json"
       ],
       "metadata": {
         "slug": "email-drafting",
@@ -1617,12 +1763,12 @@
       "slug": "email-finder-hunter",
       "name": "email-finder-hunter",
       "category": "capabilities",
-      "description": "Email finder and verifier - find emails, verify deliverability, discover companies",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/email-finder-hunter",
       "files": [
-        "skills/capabilities/email-finder-hunter/SKILL.md",
-        "skills/capabilities/email-finder-hunter/skill.meta.json"
+        "skills\\capabilities\\email-finder-hunter\\SKILL.md",
+        "skills\\capabilities\\email-finder-hunter\\skill.meta.json"
       ],
       "metadata": {
         "slug": "email-finder-hunter",
@@ -1643,12 +1789,12 @@
       "slug": "email-finder-tomba",
       "name": "email-finder-tomba",
       "category": "capabilities",
-      "description": "Email finder and verifier - find emails from domains, LinkedIn, or company search",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/email-finder-tomba",
       "files": [
-        "skills/capabilities/email-finder-tomba/SKILL.md",
-        "skills/capabilities/email-finder-tomba/skill.meta.json"
+        "skills\\capabilities\\email-finder-tomba\\SKILL.md",
+        "skills\\capabilities\\email-finder-tomba\\skill.meta.json"
       ],
       "metadata": {
         "slug": "email-finder-tomba",
@@ -1669,12 +1815,12 @@
       "slug": "enrichment-nyne",
       "name": "enrichment-nyne",
       "category": "capabilities",
-      "description": "Intelligence and enrichment - person and company data, social profiles, events, and funding",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/enrichment-nyne",
       "files": [
-        "skills/capabilities/enrichment-nyne/SKILL.md",
-        "skills/capabilities/enrichment-nyne/skill.meta.json"
+        "skills\\capabilities\\enrichment-nyne\\SKILL.md",
+        "skills\\capabilities\\enrichment-nyne\\skill.meta.json"
       ],
       "metadata": {
         "slug": "enrichment-nyne",
@@ -1695,12 +1841,12 @@
       "slug": "event-prospecting-pipeline",
       "name": "event-prospecting-pipeline",
       "category": "playbooks",
-      "description": "Find attendees at conferences/events, research their companies, qualify against ICP, and launch outreach",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/playbooks/event-prospecting-pipeline",
       "files": [
-        "skills/playbooks/event-prospecting-pipeline/SKILL.md",
-        "skills/playbooks/event-prospecting-pipeline/skill.meta.json"
+        "skills\\playbooks\\event-prospecting-pipeline\\SKILL.md",
+        "skills\\playbooks\\event-prospecting-pipeline\\skill.meta.json"
       ],
       "metadata": {
         "slug": "event-prospecting-pipeline",
@@ -1722,12 +1868,12 @@
       "slug": "event-signals",
       "name": "event-signals",
       "category": "capabilities",
-      "description": "Extract leads from conferences, meetups, hackathons, and podcasts by analyzing speaker lists, sponsor lists, hackathon entries, and podcast guests. Discovers events via Sessionize, Confs.tech, Meetup, Luma, ListenNotes, and Devpost. Looks back 90 days and forward 180 days.",
+      "description": "",
       "tags": "lead-generation, research, competitive-intel",
       "path": "skills/packs/lead-gen-devtools/event-signals",
       "files": [
-        "skills/packs/lead-gen-devtools/event-signals/SKILL.md",
-        "skills/packs/lead-gen-devtools/event-signals/scripts/event_signals.py"
+        "skills\\packs\\lead-gen-devtools\\event-signals\\scripts\\event_signals.py",
+        "skills\\packs\\lead-gen-devtools\\event-signals\\SKILL.md"
       ],
       "metadata": {
         "slug": "event-signals",
@@ -1752,12 +1898,12 @@
       "slug": "expansion-signal-spotter",
       "name": "expansion-signal-spotter",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/composites/expansion-signal-spotter",
       "files": [
-        "skills/composites/expansion-signal-spotter/SKILL.md",
-        "skills/composites/expansion-signal-spotter/skill.meta.json"
+        "skills\\composites\\expansion-signal-spotter\\SKILL.md",
+        "skills\\composites\\expansion-signal-spotter\\skill.meta.json"
       ],
       "metadata": {
         "slug": "expansion-signal-spotter",
@@ -1783,12 +1929,12 @@
       "slug": "extract-webpage-data",
       "name": "extract-webpage-data",
       "category": "capabilities",
-      "description": "Extract structured data from web pages using AI",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/extract-webpage-data",
       "files": [
-        "skills/capabilities/extract-webpage-data/SKILL.md",
-        "skills/capabilities/extract-webpage-data/skill.meta.json"
+        "skills\\capabilities\\extract-webpage-data\\SKILL.md",
+        "skills\\capabilities\\extract-webpage-data\\skill.meta.json"
       ],
       "metadata": {
         "slug": "extract-webpage-data",
@@ -1809,12 +1955,12 @@
       "slug": "feature-launch-playbook",
       "name": "feature-launch-playbook",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "content",
       "path": "skills/composites/feature-launch-playbook",
       "files": [
-        "skills/composites/feature-launch-playbook/SKILL.md",
-        "skills/composites/feature-launch-playbook/skill.meta.json"
+        "skills\\composites\\feature-launch-playbook\\SKILL.md",
+        "skills\\composites\\feature-launch-playbook\\skill.meta.json"
       ],
       "metadata": {
         "slug": "feature-launch-playbook",
@@ -1836,12 +1982,12 @@
       "slug": "find-email-by-name",
       "name": "find-email-by-name",
       "category": "capabilities",
-      "description": "Find someone's email address given their name and company",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/find-email-by-name",
       "files": [
-        "skills/capabilities/find-email-by-name/SKILL.md",
-        "skills/capabilities/find-email-by-name/skill.meta.json"
+        "skills\\capabilities\\find-email-by-name\\SKILL.md",
+        "skills\\capabilities\\find-email-by-name\\skill.meta.json"
       ],
       "metadata": {
         "slug": "find-email-by-name",
@@ -1862,12 +2008,12 @@
       "slug": "find-skill",
       "name": "find-skill",
       "category": "capabilities",
-      "description": "Find and install skills from the Orthogonal skill library. Use when you need capabilities you don't have, want to discover available skills, or need to add new tools to your agent.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/find-skill",
       "files": [
-        "skills/capabilities/find-skill/SKILL.md",
-        "skills/capabilities/find-skill/skill.meta.json"
+        "skills\\capabilities\\find-skill\\SKILL.md",
+        "skills\\capabilities\\find-skill\\skill.meta.json"
       ],
       "metadata": {
         "slug": "find-skill",
@@ -1888,12 +2034,12 @@
       "slug": "find-twitter-influencers",
       "name": "find-twitter-influencers",
       "category": "capabilities",
-      "description": "Find Twitter/X influencers to promote a product or brand. Use when asked to find influencers, discover Twitter accounts for partnerships, identify creators in a niche, or build an influencer outreach list.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/find-twitter-influencers",
       "files": [
-        "skills/capabilities/find-twitter-influencers/SKILL.md",
-        "skills/capabilities/find-twitter-influencers/skill.meta.json"
+        "skills\\capabilities\\find-twitter-influencers\\SKILL.md",
+        "skills\\capabilities\\find-twitter-influencers\\skill.meta.json"
       ],
       "metadata": {
         "slug": "find-twitter-influencers",
@@ -1914,13 +2060,13 @@
       "slug": "funding-signal-monitor",
       "name": "funding-signal-monitor",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/composites/funding-signal-monitor",
       "files": [
-        "skills/composites/funding-signal-monitor/SKILL.md",
-        "skills/composites/funding-signal-monitor/scripts/search_funding.py",
-        "skills/composites/funding-signal-monitor/skill.meta.json"
+        "skills\\composites\\funding-signal-monitor\\scripts\\search_funding.py",
+        "skills\\composites\\funding-signal-monitor\\SKILL.md",
+        "skills\\composites\\funding-signal-monitor\\skill.meta.json"
       ],
       "metadata": {
         "slug": "funding-signal-monitor",
@@ -1949,12 +2095,12 @@
       "slug": "funding-signal-outreach",
       "name": "funding-signal-outreach",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "outreach",
       "path": "skills/composites/funding-signal-outreach",
       "files": [
-        "skills/composites/funding-signal-outreach/SKILL.md",
-        "skills/composites/funding-signal-outreach/skill.meta.json"
+        "skills\\composites\\funding-signal-outreach\\SKILL.md",
+        "skills\\composites\\funding-signal-outreach\\skill.meta.json"
       ],
       "metadata": {
         "slug": "funding-signal-outreach",
@@ -1981,12 +2127,12 @@
       "slug": "generate-voice-guide",
       "name": "generate-voice-guide",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "content, social",
       "path": "skills/capabilities/generate-voice-guide",
       "files": [
-        "skills/capabilities/generate-voice-guide/SKILL.md",
-        "skills/capabilities/generate-voice-guide/skill.meta.json"
+        "skills\\capabilities\\generate-voice-guide\\SKILL.md",
+        "skills\\capabilities\\generate-voice-guide\\skill.meta.json"
       ],
       "metadata": {
         "slug": "generate-voice-guide",
@@ -2009,12 +2155,12 @@
       "slug": "get-brand-assets",
       "name": "get-brand-assets",
       "category": "capabilities",
-      "description": "Get company logos, brand colors, fonts, and style guides",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/get-brand-assets",
       "files": [
-        "skills/capabilities/get-brand-assets/SKILL.md",
-        "skills/capabilities/get-brand-assets/skill.meta.json"
+        "skills\\capabilities\\get-brand-assets\\SKILL.md",
+        "skills\\capabilities\\get-brand-assets\\skill.meta.json"
       ],
       "metadata": {
         "slug": "get-brand-assets",
@@ -2035,12 +2181,12 @@
       "slug": "get-qualified-leads-from-luma",
       "name": "get-qualified-leads-from-luma",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/composites/get-qualified-leads-from-luma",
       "files": [
-        "skills/composites/get-qualified-leads-from-luma/SKILL.md",
-        "skills/composites/get-qualified-leads-from-luma/skill.meta.json"
+        "skills\\composites\\get-qualified-leads-from-luma\\SKILL.md",
+        "skills\\composites\\get-qualified-leads-from-luma\\skill.meta.json"
       ],
       "metadata": {
         "slug": "get-qualified-leads-from-luma",
@@ -2066,18 +2212,18 @@
       "slug": "github-repo-signals",
       "name": "github-repo-signals",
       "category": "capabilities",
-      "description": "Extract and score leads from GitHub repositories by analyzing stars, forks, issues, PRs, comments, and contributions. Produces unified multi-repo CSV with deduplicated user profiles. No paid API credits required.",
+      "description": "",
       "tags": "lead-generation, research, competitive-intel",
       "path": "skills/packs/lead-gen-devtools/github-repo-signals",
       "files": [
-        "skills/packs/lead-gen-devtools/github-repo-signals/SKILL.md",
-        "skills/packs/lead-gen-devtools/github-repo-signals/scripts/__init__.py",
-        "skills/packs/lead-gen-devtools/github-repo-signals/scripts/gh_common.py",
-        "skills/packs/lead-gen-devtools/github-repo-signals/scripts/gh_contributors.py",
-        "skills/packs/lead-gen-devtools/github-repo-signals/scripts/gh_issues_scanner.py",
-        "skills/packs/lead-gen-devtools/github-repo-signals/scripts/gh_repo_signals.py",
-        "skills/packs/lead-gen-devtools/github-repo-signals/scripts/gh_stars_forks.py",
-        "skills/packs/lead-gen-devtools/github-repo-signals/scripts/gh_techstack.py"
+        "skills\\packs\\lead-gen-devtools\\github-repo-signals\\scripts\\gh_common.py",
+        "skills\\packs\\lead-gen-devtools\\github-repo-signals\\scripts\\gh_contributors.py",
+        "skills\\packs\\lead-gen-devtools\\github-repo-signals\\scripts\\gh_issues_scanner.py",
+        "skills\\packs\\lead-gen-devtools\\github-repo-signals\\scripts\\gh_repo_signals.py",
+        "skills\\packs\\lead-gen-devtools\\github-repo-signals\\scripts\\gh_stars_forks.py",
+        "skills\\packs\\lead-gen-devtools\\github-repo-signals\\scripts\\gh_techstack.py",
+        "skills\\packs\\lead-gen-devtools\\github-repo-signals\\scripts\\__init__.py",
+        "skills\\packs\\lead-gen-devtools\\github-repo-signals\\SKILL.md"
       ],
       "metadata": {
         "slug": "github-repo-signals",
@@ -2102,13 +2248,13 @@
       "slug": "google-ad-scraper",
       "name": "google-ad-scraper",
       "category": "capabilities",
-      "description": "Scrape competitor ads from Google Ads by domain. Returns ad creatives, formats, and campaign details. Use for competitive ad research and messaging analysis.",
+      "description": "",
       "tags": "ads",
       "path": "skills/capabilities/google-ad-scraper",
       "files": [
-        "skills/capabilities/google-ad-scraper/SKILL.md",
-        "skills/capabilities/google-ad-scraper/scripts/search_google_ads.py",
-        "skills/capabilities/google-ad-scraper/skill.meta.json"
+        "skills\\capabilities\\google-ad-scraper\\scripts\\search_google_ads.py",
+        "skills\\capabilities\\google-ad-scraper\\SKILL.md",
+        "skills\\capabilities\\google-ad-scraper\\skill.meta.json"
       ],
       "metadata": {
         "slug": "google-ad-scraper",
@@ -2130,12 +2276,12 @@
       "slug": "google-search-ads-builder",
       "name": "google-search-ads-builder",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "ads",
       "path": "skills/composites/google-search-ads-builder",
       "files": [
-        "skills/composites/google-search-ads-builder/SKILL.md",
-        "skills/composites/google-search-ads-builder/skill.meta.json"
+        "skills\\composites\\google-search-ads-builder\\SKILL.md",
+        "skills\\composites\\google-search-ads-builder\\skill.meta.json"
       ],
       "metadata": {
         "slug": "google-search-ads-builder",
@@ -2160,22 +2306,22 @@
       "slug": "goose-graphics",
       "name": "goose-graphics",
       "category": "composites",
-      "description": "Portable visual skill pack for the Agent Skills ecosystem (Claude Code, Claude Desktop, Claude Cowork, Claude Design, Goose, Cursor, Codex). Discovers community-published styles + formats via the gooseworks CLI, runs an extract-style workflow on reference images, and exports rendered PNGs via Playwright.",
+      "description": "",
       "tags": "content, design, social",
       "path": "skills/composites/goose-graphics",
       "files": [
-        "skills/composites/goose-graphics/README.md",
-        "skills/composites/goose-graphics/SKILL.md",
-        "skills/composites/goose-graphics/extract-style.md",
-        "skills/composites/goose-graphics/screenshot/.gitignore",
-        "skills/composites/goose-graphics/screenshot/fetch-full-tweet.js",
-        "skills/composites/goose-graphics/screenshot/fetch-tweet.js",
-        "skills/composites/goose-graphics/screenshot/package-lock.json",
-        "skills/composites/goose-graphics/screenshot/package.json",
-        "skills/composites/goose-graphics/screenshot/screenshot.js",
-        "skills/composites/goose-graphics/skill.meta.json",
-        "skills/composites/goose-graphics/sources/ascii-art.md",
-        "skills/composites/goose-graphics/sources/unsplash.md"
+        "skills\\composites\\goose-graphics\\extract-style.md",
+        "skills\\composites\\goose-graphics\\README.md",
+        "skills\\composites\\goose-graphics\\screenshot\\.gitignore",
+        "skills\\composites\\goose-graphics\\screenshot\\fetch-full-tweet.js",
+        "skills\\composites\\goose-graphics\\screenshot\\fetch-tweet.js",
+        "skills\\composites\\goose-graphics\\screenshot\\package-lock.json",
+        "skills\\composites\\goose-graphics\\screenshot\\package.json",
+        "skills\\composites\\goose-graphics\\screenshot\\screenshot.js",
+        "skills\\composites\\goose-graphics\\SKILL.md",
+        "skills\\composites\\goose-graphics\\skill.meta.json",
+        "skills\\composites\\goose-graphics\\sources\\ascii-art.md",
+        "skills\\composites\\goose-graphics\\sources\\unsplash.md"
       ],
       "metadata": {
         "slug": "goose-graphics",
@@ -2207,12 +2353,12 @@
       "slug": "goose-graphics-create-format",
       "name": "goose-graphics-create-format",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "design, content",
       "path": "skills/composites/goose-graphics-create-format",
       "files": [
-        "skills/composites/goose-graphics-create-format/SKILL.md",
-        "skills/composites/goose-graphics-create-format/skill.meta.json"
+        "skills\\composites\\goose-graphics-create-format\\SKILL.md",
+        "skills\\composites\\goose-graphics-create-format\\skill.meta.json"
       ],
       "metadata": {
         "slug": "goose-graphics-create-format",
@@ -2244,12 +2390,12 @@
       "slug": "goose-graphics-create-style",
       "name": "goose-graphics-create-style",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "design, content",
       "path": "skills/composites/goose-graphics-create-style",
       "files": [
-        "skills/composites/goose-graphics-create-style/SKILL.md",
-        "skills/composites/goose-graphics-create-style/skill.meta.json"
+        "skills\\composites\\goose-graphics-create-style\\SKILL.md",
+        "skills\\composites\\goose-graphics-create-style\\skill.meta.json"
       ],
       "metadata": {
         "slug": "goose-graphics-create-style",
@@ -2281,12 +2427,12 @@
       "slug": "gtm-enrichment-deep",
       "name": "gtm-enrichment-deep",
       "category": "capabilities",
-      "description": "AI-agent-powered lead enrichment using Sixtyfour as primary source. Takes an email (+ optional name) and returns comprehensive person + company data with funding, AI/B2B classification, and full error visibility. Higher cost (~$0.20/lead) but simpler architecture.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/gtm-enrichment-deep",
       "files": [
-        "skills/capabilities/gtm-enrichment-deep/SKILL.md",
-        "skills/capabilities/gtm-enrichment-deep/skill.meta.json"
+        "skills\\capabilities\\gtm-enrichment-deep\\SKILL.md",
+        "skills\\capabilities\\gtm-enrichment-deep\\skill.meta.json"
       ],
       "metadata": {
         "slug": "gtm-enrichment-deep",
@@ -2307,12 +2453,12 @@
       "slug": "gtm-enrichment-smart",
       "name": "gtm-enrichment-smart",
       "category": "capabilities",
-      "description": "Multi-provider waterfall lead enrichment. Takes an email (+ optional name) and returns person + company data by cross-referencing cheap APIs first, using expensive AI agents only as fallback. Cost-efficient (~$0.04-$0.10/lead) with confidence scoring and full error visibility.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/gtm-enrichment-smart",
       "files": [
-        "skills/capabilities/gtm-enrichment-smart/SKILL.md",
-        "skills/capabilities/gtm-enrichment-smart/skill.meta.json"
+        "skills\\capabilities\\gtm-enrichment-smart\\SKILL.md",
+        "skills\\capabilities\\gtm-enrichment-smart\\skill.meta.json"
       ],
       "metadata": {
         "slug": "gtm-enrichment-smart",
@@ -2333,13 +2479,13 @@
       "slug": "hacker-news-scraper",
       "name": "hacker-news-scraper",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "monitoring",
       "path": "skills/capabilities/hacker-news-scraper",
       "files": [
-        "skills/capabilities/hacker-news-scraper/SKILL.md",
-        "skills/capabilities/hacker-news-scraper/scripts/search_hn.py",
-        "skills/capabilities/hacker-news-scraper/skill.meta.json"
+        "skills\\capabilities\\hacker-news-scraper\\scripts\\search_hn.py",
+        "skills\\capabilities\\hacker-news-scraper\\SKILL.md",
+        "skills\\capabilities\\hacker-news-scraper\\skill.meta.json"
       ],
       "metadata": {
         "slug": "hacker-news-scraper",
@@ -2361,12 +2507,12 @@
       "slug": "help-center-article-generator",
       "name": "help-center-article-generator",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "content",
       "path": "skills/composites/help-center-article-generator",
       "files": [
-        "skills/composites/help-center-article-generator/SKILL.md",
-        "skills/composites/help-center-article-generator/skill.meta.json"
+        "skills\\composites\\help-center-article-generator\\SKILL.md",
+        "skills\\composites\\help-center-article-generator\\skill.meta.json"
       ],
       "metadata": {
         "slug": "help-center-article-generator",
@@ -2388,12 +2534,12 @@
       "slug": "hiring-signal-outreach",
       "name": "hiring-signal-outreach",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "outreach",
       "path": "skills/composites/hiring-signal-outreach",
       "files": [
-        "skills/composites/hiring-signal-outreach/SKILL.md",
-        "skills/composites/hiring-signal-outreach/skill.meta.json"
+        "skills\\composites\\hiring-signal-outreach\\SKILL.md",
+        "skills\\composites\\hiring-signal-outreach\\skill.meta.json"
       ],
       "metadata": {
         "slug": "hiring-signal-outreach",
@@ -2420,12 +2566,12 @@
       "slug": "hyperlocal-weather-precip",
       "name": "hyperlocal-weather-precip",
       "category": "capabilities",
-      "description": "Hyperlocal weather data - precipitation, temperature, wind, soil moisture and more",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/hyperlocal-weather-precip",
       "files": [
-        "skills/capabilities/hyperlocal-weather-precip/SKILL.md",
-        "skills/capabilities/hyperlocal-weather-precip/skill.meta.json"
+        "skills\\capabilities\\hyperlocal-weather-precip\\SKILL.md",
+        "skills\\capabilities\\hyperlocal-weather-precip\\skill.meta.json"
       ],
       "metadata": {
         "slug": "hyperlocal-weather-precip",
@@ -2446,12 +2592,12 @@
       "slug": "icp-identification",
       "name": "icp-identification",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "research",
       "path": "skills/capabilities/icp-identification",
       "files": [
-        "skills/capabilities/icp-identification/SKILL.md",
-        "skills/capabilities/icp-identification/skill.meta.json"
+        "skills\\capabilities\\icp-identification\\SKILL.md",
+        "skills\\capabilities\\icp-identification\\skill.meta.json"
       ],
       "metadata": {
         "slug": "icp-identification",
@@ -2473,12 +2619,12 @@
       "slug": "icp-website-audit",
       "name": "icp-website-audit",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "research",
       "path": "skills/composites/icp-website-audit",
       "files": [
-        "skills/composites/icp-website-audit/SKILL.md",
-        "skills/composites/icp-website-audit/skill.meta.json"
+        "skills\\composites\\icp-website-audit\\SKILL.md",
+        "skills\\composites\\icp-website-audit\\skill.meta.json"
       ],
       "metadata": {
         "slug": "icp-website-audit",
@@ -2503,12 +2649,12 @@
       "slug": "icp-website-review",
       "name": "icp-website-review",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "research",
       "path": "skills/capabilities/icp-website-review",
       "files": [
-        "skills/capabilities/icp-website-review/SKILL.md",
-        "skills/capabilities/icp-website-review/skill.meta.json"
+        "skills\\capabilities\\icp-website-review\\SKILL.md",
+        "skills\\capabilities\\icp-website-review\\skill.meta.json"
       ],
       "metadata": {
         "slug": "icp-website-review",
@@ -2530,12 +2676,12 @@
       "slug": "identity-verification-didit",
       "name": "identity-verification-didit",
       "category": "capabilities",
-      "description": "Identity verification via phone/email OTP and AML screening using Didit API",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/identity-verification-didit",
       "files": [
-        "skills/capabilities/identity-verification-didit/SKILL.md",
-        "skills/capabilities/identity-verification-didit/skill.meta.json"
+        "skills\\capabilities\\identity-verification-didit\\SKILL.md",
+        "skills\\capabilities\\identity-verification-didit\\skill.meta.json"
       ],
       "metadata": {
         "slug": "identity-verification-didit",
@@ -2556,12 +2702,12 @@
       "slug": "image-analyzer",
       "name": "image-analyzer",
       "category": "capabilities",
-      "description": "Analyze images with AI - extract text, describe content, detect objects",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/image-analyzer",
       "files": [
-        "skills/capabilities/image-analyzer/SKILL.md",
-        "skills/capabilities/image-analyzer/skill.meta.json"
+        "skills\\capabilities\\image-analyzer\\SKILL.md",
+        "skills\\capabilities\\image-analyzer\\skill.meta.json"
       ],
       "metadata": {
         "slug": "image-analyzer",
@@ -2582,12 +2728,12 @@
       "slug": "inbound-lead-enrichment",
       "name": "inbound-lead-enrichment",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/composites/inbound-lead-enrichment",
       "files": [
-        "skills/composites/inbound-lead-enrichment/SKILL.md",
-        "skills/composites/inbound-lead-enrichment/skill.meta.json"
+        "skills\\composites\\inbound-lead-enrichment\\SKILL.md",
+        "skills\\composites\\inbound-lead-enrichment\\skill.meta.json"
       ],
       "metadata": {
         "slug": "inbound-lead-enrichment",
@@ -2612,12 +2758,12 @@
       "slug": "inbound-lead-qualification",
       "name": "inbound-lead-qualification",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/composites/inbound-lead-qualification",
       "files": [
-        "skills/composites/inbound-lead-qualification/SKILL.md",
-        "skills/composites/inbound-lead-qualification/skill.meta.json"
+        "skills\\composites\\inbound-lead-qualification\\SKILL.md",
+        "skills\\composites\\inbound-lead-qualification\\skill.meta.json"
       ],
       "metadata": {
         "slug": "inbound-lead-qualification",
@@ -2642,12 +2788,12 @@
       "slug": "inbound-lead-triage",
       "name": "inbound-lead-triage",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/composites/inbound-lead-triage",
       "files": [
-        "skills/composites/inbound-lead-triage/SKILL.md",
-        "skills/composites/inbound-lead-triage/skill.meta.json"
+        "skills\\composites\\inbound-lead-triage\\SKILL.md",
+        "skills\\composites\\inbound-lead-triage\\skill.meta.json"
       ],
       "metadata": {
         "slug": "inbound-lead-triage",
@@ -2674,14 +2820,14 @@
       "slug": "industry-scanner",
       "name": "industry-scanner",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "competitive-intel",
       "path": "skills/composites/industry-scanner",
       "files": [
-        "skills/composites/industry-scanner/SKILL.md",
-        "skills/composites/industry-scanner/config/example-config.json",
-        "skills/composites/industry-scanner/skill.meta.json",
-        "skills/composites/industry-scanner/templates/output-template.md"
+        "skills\\composites\\industry-scanner\\config\\example-config.json",
+        "skills\\composites\\industry-scanner\\SKILL.md",
+        "skills\\composites\\industry-scanner\\skill.meta.json",
+        "skills\\composites\\industry-scanner\\templates\\output-template.md"
       ],
       "metadata": {
         "slug": "industry-scanner",
@@ -2715,12 +2861,12 @@
       "slug": "instagram-scraper",
       "name": "instagram-scraper",
       "category": "capabilities",
-      "description": "Get Instagram profiles, posts, and reels",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/instagram-scraper",
       "files": [
-        "skills/capabilities/instagram-scraper/SKILL.md",
-        "skills/capabilities/instagram-scraper/skill.meta.json"
+        "skills\\capabilities\\instagram-scraper\\SKILL.md",
+        "skills\\capabilities\\instagram-scraper\\skill.meta.json"
       ],
       "metadata": {
         "slug": "instagram-scraper",
@@ -2741,12 +2887,12 @@
       "slug": "investor-call-prep",
       "name": "investor-call-prep",
       "category": "capabilities",
-      "description": "Prepare for investor calls by pulling upcoming meetings from Google Calendar, deeply researching each investor and their firm (website scraping, portfolio analysis, thesis extraction), checking for competitor conflicts, and outputting an honest prep sheet with compatibility assessments. Use when asked to prep for investor meetings, fundraising calls, VC meetings, or demo day.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/investor-call-prep",
       "files": [
-        "skills/capabilities/investor-call-prep/SKILL.md",
-        "skills/capabilities/investor-call-prep/skill.meta.json"
+        "skills\\capabilities\\investor-call-prep\\SKILL.md",
+        "skills\\capabilities\\investor-call-prep\\skill.meta.json"
       ],
       "metadata": {
         "slug": "investor-call-prep",
@@ -2767,12 +2913,12 @@
       "slug": "investor-research",
       "name": "investor-research",
       "category": "capabilities",
-      "description": "Research VCs, angels, and investors - portfolio, thesis, contact info",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/investor-research",
       "files": [
-        "skills/capabilities/investor-research/SKILL.md",
-        "skills/capabilities/investor-research/skill.meta.json"
+        "skills\\capabilities\\investor-research\\SKILL.md",
+        "skills\\capabilities\\investor-research\\skill.meta.json"
       ],
       "metadata": {
         "slug": "investor-research",
@@ -2793,15 +2939,15 @@
       "slug": "job-posting-intent",
       "name": "job-posting-intent",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation, outreach",
       "path": "skills/capabilities/job-posting-intent",
       "files": [
-        "skills/capabilities/job-posting-intent/SKILL.md",
-        "skills/capabilities/job-posting-intent/scripts/create_sheet.py",
-        "skills/capabilities/job-posting-intent/scripts/create_sheet_mcp.py",
-        "skills/capabilities/job-posting-intent/scripts/search_jobs.py",
-        "skills/capabilities/job-posting-intent/skill.meta.json"
+        "skills\\capabilities\\job-posting-intent\\scripts\\create_sheet.py",
+        "skills\\capabilities\\job-posting-intent\\scripts\\create_sheet_mcp.py",
+        "skills\\capabilities\\job-posting-intent\\scripts\\search_jobs.py",
+        "skills\\capabilities\\job-posting-intent\\SKILL.md",
+        "skills\\capabilities\\job-posting-intent\\skill.meta.json"
       ],
       "metadata": {
         "slug": "job-posting-intent",
@@ -2824,12 +2970,12 @@
       "slug": "job-scraper",
       "name": "job-scraper",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation, research",
       "path": "skills/capabilities/job-scraper",
       "files": [
-        "skills/capabilities/job-scraper/SKILL.md",
-        "skills/capabilities/job-scraper/skill.meta.json"
+        "skills\\capabilities\\job-scraper\\SKILL.md",
+        "skills\\capabilities\\job-scraper\\skill.meta.json"
       ],
       "metadata": {
         "slug": "job-scraper",
@@ -2852,12 +2998,12 @@
       "slug": "job-search",
       "name": "job-search",
       "category": "capabilities",
-      "description": "Search for jobs matching your skills, experience, and preferences",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/job-search",
       "files": [
-        "skills/capabilities/job-search/SKILL.md",
-        "skills/capabilities/job-search/skill.meta.json"
+        "skills\\capabilities\\job-search\\SKILL.md",
+        "skills\\capabilities\\job-search\\skill.meta.json"
       ],
       "metadata": {
         "slug": "job-search",
@@ -2878,12 +3024,12 @@
       "slug": "kol-content-monitor",
       "name": "kol-content-monitor",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "monitoring",
       "path": "skills/composites/kol-content-monitor",
       "files": [
-        "skills/composites/kol-content-monitor/SKILL.md",
-        "skills/composites/kol-content-monitor/skill.meta.json"
+        "skills\\composites\\kol-content-monitor\\SKILL.md",
+        "skills\\composites\\kol-content-monitor\\skill.meta.json"
       ],
       "metadata": {
         "slug": "kol-content-monitor",
@@ -2910,13 +3056,13 @@
       "slug": "kol-discovery",
       "name": "kol-discovery",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "outreach",
       "path": "skills/capabilities/kol-discovery",
       "files": [
-        "skills/capabilities/kol-discovery/SKILL.md",
-        "skills/capabilities/kol-discovery/scripts/kol_discovery.py",
-        "skills/capabilities/kol-discovery/skill.meta.json"
+        "skills\\capabilities\\kol-discovery\\scripts\\kol_discovery.py",
+        "skills\\capabilities\\kol-discovery\\SKILL.md",
+        "skills\\capabilities\\kol-discovery\\skill.meta.json"
       ],
       "metadata": {
         "slug": "kol-discovery",
@@ -2941,13 +3087,13 @@
       "slug": "kol-engager-icp",
       "name": "kol-engager-icp",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/capabilities/kol-engager-icp",
       "files": [
-        "skills/capabilities/kol-engager-icp/SKILL.md",
-        "skills/capabilities/kol-engager-icp/scripts/kol_engager_icp.py",
-        "skills/capabilities/kol-engager-icp/skill.meta.json"
+        "skills\\capabilities\\kol-engager-icp\\scripts\\kol_engager_icp.py",
+        "skills\\capabilities\\kol-engager-icp\\SKILL.md",
+        "skills\\capabilities\\kol-engager-icp\\skill.meta.json"
       ],
       "metadata": {
         "slug": "kol-engager-icp",
@@ -2972,13 +3118,13 @@
       "slug": "landing-page-intel",
       "name": "landing-page-intel",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "competitive-intel",
       "path": "skills/capabilities/landing-page-intel",
       "files": [
-        "skills/capabilities/landing-page-intel/SKILL.md",
-        "skills/capabilities/landing-page-intel/scripts/scrape_landing_page.py",
-        "skills/capabilities/landing-page-intel/skill.meta.json"
+        "skills\\capabilities\\landing-page-intel\\scripts\\scrape_landing_page.py",
+        "skills\\capabilities\\landing-page-intel\\SKILL.md",
+        "skills\\capabilities\\landing-page-intel\\skill.meta.json"
       ],
       "metadata": {
         "slug": "landing-page-intel",
@@ -3000,12 +3146,12 @@
       "slug": "launch-positioning-builder",
       "name": "launch-positioning-builder",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "brand",
       "path": "skills/composites/launch-positioning-builder",
       "files": [
-        "skills/composites/launch-positioning-builder/SKILL.md",
-        "skills/composites/launch-positioning-builder/skill.meta.json"
+        "skills\\composites\\launch-positioning-builder\\SKILL.md",
+        "skills\\composites\\launch-positioning-builder\\skill.meta.json"
       ],
       "metadata": {
         "slug": "launch-positioning-builder",
@@ -3030,11 +3176,11 @@
       "slug": "lead-discovery",
       "name": "lead-discovery",
       "category": "capabilities",
-      "description": "Orchestrator that runs first for lead generation requests. Gathers business context via website analysis or questions, identifies competitors, builds ICP, and routes to signal skills with pre-filled inputs.",
+      "description": "",
       "tags": "lead-generation, research, competitive-intel",
       "path": "skills/packs/lead-gen-devtools/lead-discovery",
       "files": [
-        "skills/packs/lead-gen-devtools/lead-discovery/SKILL.md"
+        "skills\\packs\\lead-gen-devtools\\lead-discovery\\SKILL.md"
       ],
       "metadata": {
         "slug": "lead-discovery",
@@ -3059,12 +3205,12 @@
       "slug": "lead-enrichment",
       "name": "lead-enrichment",
       "category": "capabilities",
-      "description": "Enrich leads with email, phone, company data using multiple data sources",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/lead-enrichment",
       "files": [
-        "skills/capabilities/lead-enrichment/SKILL.md",
-        "skills/capabilities/lead-enrichment/skill.meta.json"
+        "skills\\capabilities\\lead-enrichment\\SKILL.md",
+        "skills\\capabilities\\lead-enrichment\\skill.meta.json"
       ],
       "metadata": {
         "slug": "lead-enrichment",
@@ -3085,12 +3231,12 @@
       "slug": "lead-enrichment-sixtyfour",
       "name": "lead-enrichment-sixtyfour",
       "category": "capabilities",
-      "description": "AI-powered lead enrichment - find emails, phones, and enrich company/lead data",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/lead-enrichment-sixtyfour",
       "files": [
-        "skills/capabilities/lead-enrichment-sixtyfour/SKILL.md",
-        "skills/capabilities/lead-enrichment-sixtyfour/skill.meta.json"
+        "skills\\capabilities\\lead-enrichment-sixtyfour\\SKILL.md",
+        "skills\\capabilities\\lead-enrichment-sixtyfour\\skill.meta.json"
       ],
       "metadata": {
         "slug": "lead-enrichment-sixtyfour",
@@ -3111,15 +3257,15 @@
       "slug": "lead-qualification",
       "name": "lead-qualification",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/capabilities/lead-qualification",
       "files": [
-        "skills/capabilities/lead-qualification/SKILL.md",
-        "skills/capabilities/lead-qualification/qualification-prompts/ai-event-attendees-gtm.md",
-        "skills/capabilities/lead-qualification/qualification-prompts/juicebox-linkedin-commenters.md",
-        "skills/capabilities/lead-qualification/scripts/enrich_leads.py",
-        "skills/capabilities/lead-qualification/skill.meta.json"
+        "skills\\capabilities\\lead-qualification\\qualification-prompts\\ai-event-attendees-gtm.md",
+        "skills\\capabilities\\lead-qualification\\qualification-prompts\\juicebox-linkedin-commenters.md",
+        "skills\\capabilities\\lead-qualification\\scripts\\enrich_leads.py",
+        "skills\\capabilities\\lead-qualification\\SKILL.md",
+        "skills\\capabilities\\lead-qualification\\skill.meta.json"
       ],
       "metadata": {
         "slug": "lead-qualification",
@@ -3141,12 +3287,12 @@
       "slug": "leadership-change-outreach",
       "name": "leadership-change-outreach",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "outreach",
       "path": "skills/composites/leadership-change-outreach",
       "files": [
-        "skills/composites/leadership-change-outreach/SKILL.md",
-        "skills/composites/leadership-change-outreach/skill.meta.json"
+        "skills\\composites\\leadership-change-outreach\\SKILL.md",
+        "skills\\composites\\leadership-change-outreach\\skill.meta.json"
       ],
       "metadata": {
         "slug": "leadership-change-outreach",
@@ -3174,13 +3320,13 @@
       "slug": "linkedin-commenter-extractor",
       "name": "linkedin-commenter-extractor",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "outreach",
       "path": "skills/capabilities/linkedin-commenter-extractor",
       "files": [
-        "skills/capabilities/linkedin-commenter-extractor/SKILL.md",
-        "skills/capabilities/linkedin-commenter-extractor/scripts/extract_commenters.py",
-        "skills/capabilities/linkedin-commenter-extractor/skill.meta.json"
+        "skills\\capabilities\\linkedin-commenter-extractor\\scripts\\extract_commenters.py",
+        "skills\\capabilities\\linkedin-commenter-extractor\\SKILL.md",
+        "skills\\capabilities\\linkedin-commenter-extractor\\skill.meta.json"
       ],
       "metadata": {
         "slug": "linkedin-commenter-extractor",
@@ -3202,13 +3348,13 @@
       "slug": "linkedin-influencer-discovery",
       "name": "linkedin-influencer-discovery",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "outreach",
       "path": "skills/capabilities/linkedin-influencer-discovery",
       "files": [
-        "skills/capabilities/linkedin-influencer-discovery/SKILL.md",
-        "skills/capabilities/linkedin-influencer-discovery/scripts/discover_influencers.py",
-        "skills/capabilities/linkedin-influencer-discovery/skill.meta.json"
+        "skills\\capabilities\\linkedin-influencer-discovery\\scripts\\discover_influencers.py",
+        "skills\\capabilities\\linkedin-influencer-discovery\\SKILL.md",
+        "skills\\capabilities\\linkedin-influencer-discovery\\skill.meta.json"
       ],
       "metadata": {
         "slug": "linkedin-influencer-discovery",
@@ -3230,13 +3376,13 @@
       "slug": "linkedin-job-scraper",
       "name": "linkedin-job-scraper",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/capabilities/linkedin-job-scraper",
       "files": [
-        "skills/capabilities/linkedin-job-scraper/SKILL.md",
-        "skills/capabilities/linkedin-job-scraper/scripts/jobspy_scraper.py",
-        "skills/capabilities/linkedin-job-scraper/skill.meta.json"
+        "skills\\capabilities\\linkedin-job-scraper\\scripts\\jobspy_scraper.py",
+        "skills\\capabilities\\linkedin-job-scraper\\SKILL.md",
+        "skills\\capabilities\\linkedin-job-scraper\\skill.meta.json"
       ],
       "metadata": {
         "slug": "linkedin-job-scraper",
@@ -3258,12 +3404,12 @@
       "slug": "linkedin-message-writer",
       "name": "linkedin-message-writer",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "outreach, social",
       "path": "skills/capabilities/linkedin-message-writer",
       "files": [
-        "skills/capabilities/linkedin-message-writer/SKILL.md",
-        "skills/capabilities/linkedin-message-writer/skill.meta.json"
+        "skills\\capabilities\\linkedin-message-writer\\SKILL.md",
+        "skills\\capabilities\\linkedin-message-writer\\skill.meta.json"
       ],
       "metadata": {
         "slug": "linkedin-message-writer",
@@ -3286,19 +3432,19 @@
       "slug": "linkedin-outreach",
       "name": "linkedin-outreach",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "outreach",
       "path": "skills/capabilities/linkedin-outreach",
       "files": [
-        "skills/capabilities/linkedin-outreach/SKILL.md",
-        "skills/capabilities/linkedin-outreach/skill.meta.json",
-        "skills/capabilities/linkedin-outreach/templates/sequence-templates/competitor-engagement.md",
-        "skills/capabilities/linkedin-outreach/templates/sequence-templates/database-search.md",
-        "skills/capabilities/linkedin-outreach/templates/sequence-templates/event-attendee.md",
-        "skills/capabilities/linkedin-outreach/templates/sequence-templates/hiring-signal.md",
-        "skills/capabilities/linkedin-outreach/templates/sequence-templates/kol-engagement.md",
-        "skills/capabilities/linkedin-outreach/templates/sequence-templates/pain-language.md",
-        "skills/capabilities/linkedin-outreach/templates/tone-presets.json"
+        "skills\\capabilities\\linkedin-outreach\\SKILL.md",
+        "skills\\capabilities\\linkedin-outreach\\skill.meta.json",
+        "skills\\capabilities\\linkedin-outreach\\templates\\sequence-templates\\competitor-engagement.md",
+        "skills\\capabilities\\linkedin-outreach\\templates\\sequence-templates\\database-search.md",
+        "skills\\capabilities\\linkedin-outreach\\templates\\sequence-templates\\event-attendee.md",
+        "skills\\capabilities\\linkedin-outreach\\templates\\sequence-templates\\hiring-signal.md",
+        "skills\\capabilities\\linkedin-outreach\\templates\\sequence-templates\\kol-engagement.md",
+        "skills\\capabilities\\linkedin-outreach\\templates\\sequence-templates\\pain-language.md",
+        "skills\\capabilities\\linkedin-outreach\\templates\\tone-presets.json"
       ],
       "metadata": {
         "slug": "linkedin-outreach",
@@ -3320,13 +3466,13 @@
       "slug": "linkedin-post-research",
       "name": "linkedin-post-research",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "outreach",
       "path": "skills/capabilities/linkedin-post-research",
       "files": [
-        "skills/capabilities/linkedin-post-research/SKILL.md",
-        "skills/capabilities/linkedin-post-research/scripts/search_posts.py",
-        "skills/capabilities/linkedin-post-research/skill.meta.json"
+        "skills\\capabilities\\linkedin-post-research\\scripts\\search_posts.py",
+        "skills\\capabilities\\linkedin-post-research\\SKILL.md",
+        "skills\\capabilities\\linkedin-post-research\\skill.meta.json"
       ],
       "metadata": {
         "slug": "linkedin-post-research",
@@ -3348,13 +3494,13 @@
       "slug": "linkedin-profile-post-scraper",
       "name": "linkedin-profile-post-scraper",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "outreach",
       "path": "skills/capabilities/linkedin-profile-post-scraper",
       "files": [
-        "skills/capabilities/linkedin-profile-post-scraper/SKILL.md",
-        "skills/capabilities/linkedin-profile-post-scraper/scripts/scrape_linkedin_posts.py",
-        "skills/capabilities/linkedin-profile-post-scraper/skill.meta.json"
+        "skills\\capabilities\\linkedin-profile-post-scraper\\scripts\\scrape_linkedin_posts.py",
+        "skills\\capabilities\\linkedin-profile-post-scraper\\SKILL.md",
+        "skills\\capabilities\\linkedin-profile-post-scraper\\skill.meta.json"
       ],
       "metadata": {
         "slug": "linkedin-profile-post-scraper",
@@ -3376,12 +3522,12 @@
       "slug": "linkedin-scraper",
       "name": "linkedin-scraper",
       "category": "capabilities",
-      "description": "Get LinkedIn profiles, company pages, and posts",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/linkedin-scraper",
       "files": [
-        "skills/capabilities/linkedin-scraper/SKILL.md",
-        "skills/capabilities/linkedin-scraper/skill.meta.json"
+        "skills\\capabilities\\linkedin-scraper\\SKILL.md",
+        "skills\\capabilities\\linkedin-scraper\\skill.meta.json"
       ],
       "metadata": {
         "slug": "linkedin-scraper",
@@ -3402,15 +3548,15 @@
       "slug": "luma-event-attendees",
       "name": "luma-event-attendees",
       "category": "capabilities",
-      "description": "Find speakers, hosts, and guest profiles at conferences and events on Luma. Two modes - free direct scrape for hosts, or Apify-powered search for full guest profiles with LinkedIn/Twitter/bio.",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/capabilities/luma-event-attendees",
       "files": [
-        "skills/capabilities/luma-event-attendees/README.md",
-        "skills/capabilities/luma-event-attendees/SKILL.md",
-        "skills/capabilities/luma-event-attendees/scripts/apify_client.py",
-        "skills/capabilities/luma-event-attendees/scripts/scrape_event.py",
-        "skills/capabilities/luma-event-attendees/skill.meta.json"
+        "skills\\capabilities\\luma-event-attendees\\README.md",
+        "skills\\capabilities\\luma-event-attendees\\scripts\\apify_client.py",
+        "skills\\capabilities\\luma-event-attendees\\scripts\\scrape_event.py",
+        "skills\\capabilities\\luma-event-attendees\\SKILL.md",
+        "skills\\capabilities\\luma-event-attendees\\skill.meta.json"
       ],
       "metadata": {
         "slug": "luma-event-attendees",
@@ -3432,12 +3578,12 @@
       "slug": "market-research",
       "name": "market-research",
       "category": "capabilities",
-      "description": "Research market trends, size, competitors, and growth opportunities",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/market-research",
       "files": [
-        "skills/capabilities/market-research/SKILL.md",
-        "skills/capabilities/market-research/skill.meta.json"
+        "skills\\capabilities\\market-research\\SKILL.md",
+        "skills\\capabilities\\market-research\\skill.meta.json"
       ],
       "metadata": {
         "slug": "market-research",
@@ -3458,22 +3604,22 @@
       "slug": "meeting-brief",
       "name": "meeting-brief",
       "category": "composites",
-      "description": "Daily meeting preparation system that checks your calendar each morning, deeply researches external attendees (LinkedIn, company info, GitHub, past notes), and sends you personalized briefs via email (1 per person). Use when you want automated preparation for upcoming meetings with context about each person you're meeting.",
+      "description": "",
       "tags": "research",
       "path": "skills/composites/meeting-brief",
       "files": [
-        "skills/composites/meeting-brief/.gitignore",
-        "skills/composites/meeting-brief/EXAMPLE.md",
-        "skills/composites/meeting-brief/SETUP.md",
-        "skills/composites/meeting-brief/SKILL.md",
-        "skills/composites/meeting-brief/config.json.example",
-        "skills/composites/meeting-brief/scripts/check_calendar.sh",
-        "skills/composites/meeting-brief/scripts/format_for_slack.sh",
-        "skills/composites/meeting-brief/scripts/generate_brief.js",
-        "skills/composites/meeting-brief/scripts/research_person.js",
-        "skills/composites/meeting-brief/scripts/run_daily.sh",
-        "skills/composites/meeting-brief/scripts/send_slack.sh",
-        "skills/composites/meeting-brief/skill.meta.json"
+        "skills\\composites\\meeting-brief\\.gitignore",
+        "skills\\composites\\meeting-brief\\config.json.example",
+        "skills\\composites\\meeting-brief\\EXAMPLE.md",
+        "skills\\composites\\meeting-brief\\scripts\\check_calendar.sh",
+        "skills\\composites\\meeting-brief\\scripts\\format_for_slack.sh",
+        "skills\\composites\\meeting-brief\\scripts\\generate_brief.js",
+        "skills\\composites\\meeting-brief\\scripts\\research_person.js",
+        "skills\\composites\\meeting-brief\\scripts\\run_daily.sh",
+        "skills\\composites\\meeting-brief\\scripts\\send_slack.sh",
+        "skills\\composites\\meeting-brief\\SETUP.md",
+        "skills\\composites\\meeting-brief\\SKILL.md",
+        "skills\\composites\\meeting-brief\\skill.meta.json"
       ],
       "metadata": {
         "slug": "meeting-brief",
@@ -3495,12 +3641,12 @@
       "slug": "messaging-ab-tester",
       "name": "messaging-ab-tester",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "brand",
       "path": "skills/composites/messaging-ab-tester",
       "files": [
-        "skills/composites/messaging-ab-tester/SKILL.md",
-        "skills/composites/messaging-ab-tester/skill.meta.json"
+        "skills\\composites\\messaging-ab-tester\\SKILL.md",
+        "skills\\composites\\messaging-ab-tester\\skill.meta.json"
       ],
       "metadata": {
         "slug": "messaging-ab-tester",
@@ -3522,12 +3668,12 @@
       "slug": "meta-ad-policy-checker",
       "name": "meta-ad-policy-checker",
       "category": "composites",
-      "description": "Pre-flight policy check for Meta ads. Takes ad copy plus advertiser context, resolves and fetches the relevant Meta transparency-center policy pages at runtime, and returns a Pass / Fix Required / Block verdict with cited findings and rewrites.",
+      "description": "",
       "tags": "ads",
       "path": "skills/composites/meta-ad-policy-checker",
       "files": [
-        "skills/composites/meta-ad-policy-checker/SKILL.md",
-        "skills/composites/meta-ad-policy-checker/skill.meta.json"
+        "skills\\composites\\meta-ad-policy-checker\\SKILL.md",
+        "skills\\composites\\meta-ad-policy-checker\\skill.meta.json"
       ],
       "metadata": {
         "slug": "meta-ad-policy-checker",
@@ -3550,13 +3696,13 @@
       "slug": "meta-ad-scraper",
       "name": "meta-ad-scraper",
       "category": "capabilities",
-      "description": "Scrape competitor ads from Meta's Ad Library (Facebook, Instagram, Messenger, Threads, WhatsApp). Search by company name, Facebook Page URL, or keyword. Returns ad creatives, spend estimates, reach, impressions, and campaign details. Use for competitive ad research, messaging analysis, and creative inspiration.",
+      "description": "",
       "tags": "ads",
       "path": "skills/capabilities/meta-ad-scraper",
       "files": [
-        "skills/capabilities/meta-ad-scraper/SKILL.md",
-        "skills/capabilities/meta-ad-scraper/scripts/search_meta_ads.py",
-        "skills/capabilities/meta-ad-scraper/skill.meta.json"
+        "skills\\capabilities\\meta-ad-scraper\\scripts\\search_meta_ads.py",
+        "skills\\capabilities\\meta-ad-scraper\\SKILL.md",
+        "skills\\capabilities\\meta-ad-scraper\\skill.meta.json"
       ],
       "metadata": {
         "slug": "meta-ad-scraper",
@@ -3578,12 +3724,12 @@
       "slug": "meta-ads-analyzer",
       "name": "meta-ads-analyzer",
       "category": "composites",
-      "description": "Diagnose Meta Ads campaign performance using Meta's actual system mechanics — Breakdown Effect, Learning Phase, Auction Overlap, Pacing, and Creative Fatigue — and produce structured, testable recommendations that avoid judging segments by average CPA instead of marginal efficiency.",
+      "description": "",
       "tags": "ads",
       "path": "skills/composites/meta-ads-analyzer",
       "files": [
-        "skills/composites/meta-ads-analyzer/SKILL.md",
-        "skills/composites/meta-ads-analyzer/skill.meta.json"
+        "skills\\composites\\meta-ads-analyzer\\SKILL.md",
+        "skills\\composites\\meta-ads-analyzer\\skill.meta.json"
       ],
       "metadata": {
         "slug": "meta-ads-analyzer",
@@ -3606,12 +3752,12 @@
       "slug": "meta-ads-campaign-builder",
       "name": "meta-ads-campaign-builder",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "ads",
       "path": "skills/composites/meta-ads-campaign-builder",
       "files": [
-        "skills/composites/meta-ads-campaign-builder/SKILL.md",
-        "skills/composites/meta-ads-campaign-builder/skill.meta.json"
+        "skills\\composites\\meta-ads-campaign-builder\\SKILL.md",
+        "skills\\composites\\meta-ads-campaign-builder\\skill.meta.json"
       ],
       "metadata": {
         "slug": "meta-ads-campaign-builder",
@@ -3633,12 +3779,12 @@
       "slug": "multi-platform-search-searchapi",
       "name": "multi-platform-search-searchapi",
       "category": "capabilities",
-      "description": "Multi-platform search - YouTube, Amazon, eBay, Walmart, TikTok, Instagram, and more",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/multi-platform-search-searchapi",
       "files": [
-        "skills/capabilities/multi-platform-search-searchapi/SKILL.md",
-        "skills/capabilities/multi-platform-search-searchapi/skill.meta.json"
+        "skills\\capabilities\\multi-platform-search-searchapi\\SKILL.md",
+        "skills\\capabilities\\multi-platform-search-searchapi\\skill.meta.json"
       ],
       "metadata": {
         "slug": "multi-platform-search-searchapi",
@@ -3659,12 +3805,12 @@
       "slug": "news-signal-outreach",
       "name": "news-signal-outreach",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "outreach",
       "path": "skills/composites/news-signal-outreach",
       "files": [
-        "skills/composites/news-signal-outreach/SKILL.md",
-        "skills/composites/news-signal-outreach/skill.meta.json"
+        "skills\\composites\\news-signal-outreach\\SKILL.md",
+        "skills\\composites\\news-signal-outreach\\skill.meta.json"
       ],
       "metadata": {
         "slug": "news-signal-outreach",
@@ -3691,14 +3837,14 @@
       "slug": "newsletter-monitor",
       "name": "newsletter-monitor",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "monitoring",
       "path": "skills/composites/newsletter-monitor",
       "files": [
-        "skills/composites/newsletter-monitor/SKILL.md",
-        "skills/composites/newsletter-monitor/config/campaigns.json",
-        "skills/composites/newsletter-monitor/scripts/scan_newsletters.py",
-        "skills/composites/newsletter-monitor/skill.meta.json"
+        "skills\\composites\\newsletter-monitor\\config\\campaigns.json",
+        "skills\\composites\\newsletter-monitor\\scripts\\scan_newsletters.py",
+        "skills\\composites\\newsletter-monitor\\SKILL.md",
+        "skills\\composites\\newsletter-monitor\\skill.meta.json"
       ],
       "metadata": {
         "slug": "newsletter-monitor",
@@ -3723,12 +3869,12 @@
       "slug": "newsletter-signal-scanner",
       "name": "newsletter-signal-scanner",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "monitoring",
       "path": "skills/composites/newsletter-signal-scanner",
       "files": [
-        "skills/composites/newsletter-signal-scanner/SKILL.md",
-        "skills/composites/newsletter-signal-scanner/skill.meta.json"
+        "skills\\composites\\newsletter-signal-scanner\\SKILL.md",
+        "skills\\composites\\newsletter-signal-scanner\\skill.meta.json"
       ],
       "metadata": {
         "slug": "newsletter-signal-scanner",
@@ -3750,13 +3896,13 @@
       "slug": "newsletter-sponsorship-finder",
       "name": "newsletter-sponsorship-finder",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "monitoring",
       "path": "skills/capabilities/newsletter-sponsorship-finder",
       "files": [
-        "skills/capabilities/newsletter-sponsorship-finder/SKILL.md",
-        "skills/capabilities/newsletter-sponsorship-finder/scripts/search_newsletters.py",
-        "skills/capabilities/newsletter-sponsorship-finder/skill.meta.json"
+        "skills\\capabilities\\newsletter-sponsorship-finder\\scripts\\search_newsletters.py",
+        "skills\\capabilities\\newsletter-sponsorship-finder\\SKILL.md",
+        "skills\\capabilities\\newsletter-sponsorship-finder\\skill.meta.json"
       ],
       "metadata": {
         "slug": "newsletter-sponsorship-finder",
@@ -3775,15 +3921,50 @@
       }
     },
     {
+      "slug": "openapi-docs-narrative",
+      "name": "openapi-docs-narrative",
+      "category": "composites",
+      "description": "",
+      "tags": "content, research",
+      "path": "skills/composites/openapi-docs-narrative",
+      "files": [
+        "skills\\composites\\openapi-docs-narrative\\SKILL.md",
+        "skills\\composites\\openapi-docs-narrative\\skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "openapi-docs-narrative",
+        "category": "composites",
+        "tags": [
+          "content",
+          "research"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install openapi-docs-narrative",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Covers 8 doc sections: authentication, errors, pagination, versioning, idempotency, rate limits, environments, and overview",
+          "Provides section-specific templates tailored to API surface type (REST, cursor/offset pagination, OAuth vs API key)",
+          "Writes second-person developer prose with working HTTP and code examples",
+          "Surfaces placeholder values the team must fill before publishing",
+          "Calibrates depth and tone to external general, external enterprise, or internal developer audiences"
+        ]
+      }
+    },
+    {
       "slug": "outbound-prospecting-engine",
       "name": "outbound-prospecting-engine",
       "category": "playbooks",
-      "description": ">",
+      "description": "",
       "tags": "outreach",
       "path": "skills/playbooks/outbound-prospecting-engine",
       "files": [
-        "skills/playbooks/outbound-prospecting-engine/SKILL.md",
-        "skills/playbooks/outbound-prospecting-engine/skill.meta.json"
+        "skills\\playbooks\\outbound-prospecting-engine\\SKILL.md",
+        "skills\\playbooks\\outbound-prospecting-engine\\skill.meta.json"
       ],
       "metadata": {
         "slug": "outbound-prospecting-engine",
@@ -3805,12 +3986,12 @@
       "slug": "paid-channel-prioritizer",
       "name": "paid-channel-prioritizer",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "ads",
       "path": "skills/composites/paid-channel-prioritizer",
       "files": [
-        "skills/composites/paid-channel-prioritizer/SKILL.md",
-        "skills/composites/paid-channel-prioritizer/skill.meta.json"
+        "skills\\composites\\paid-channel-prioritizer\\SKILL.md",
+        "skills\\composites\\paid-channel-prioritizer\\skill.meta.json"
       ],
       "metadata": {
         "slug": "paid-channel-prioritizer",
@@ -3835,22 +4016,22 @@
       "slug": "pain-language-engagers",
       "name": "pain-language-engagers",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/capabilities/pain-language-engagers",
       "files": [
-        "skills/capabilities/pain-language-engagers/SKILL.md",
-        "skills/capabilities/pain-language-engagers/configs/artisan-ai.json",
-        "skills/capabilities/pain-language-engagers/configs/happy-robot.json",
-        "skills/capabilities/pain-language-engagers/configs/outset-ai.json",
-        "skills/capabilities/pain-language-engagers/output/artisan-ai-20260225_1237.csv",
-        "skills/capabilities/pain-language-engagers/output/artisan-ai-20260225_1344.csv",
-        "skills/capabilities/pain-language-engagers/output/outset-ai-20260225_1232.csv",
-        "skills/capabilities/pain-language-engagers/output/outset-ai-20260225_1237.csv",
-        "skills/capabilities/pain-language-engagers/output/outset-ai-20260225_1250-cleaned.csv",
-        "skills/capabilities/pain-language-engagers/output/outset-ai-20260225_1250.csv",
-        "skills/capabilities/pain-language-engagers/scripts/pain_language_engagers.py",
-        "skills/capabilities/pain-language-engagers/skill.meta.json"
+        "skills\\capabilities\\pain-language-engagers\\configs\\artisan-ai.json",
+        "skills\\capabilities\\pain-language-engagers\\configs\\happy-robot.json",
+        "skills\\capabilities\\pain-language-engagers\\configs\\outset-ai.json",
+        "skills\\capabilities\\pain-language-engagers\\output\\artisan-ai-20260225_1237.csv",
+        "skills\\capabilities\\pain-language-engagers\\output\\artisan-ai-20260225_1344.csv",
+        "skills\\capabilities\\pain-language-engagers\\output\\outset-ai-20260225_1232.csv",
+        "skills\\capabilities\\pain-language-engagers\\output\\outset-ai-20260225_1237.csv",
+        "skills\\capabilities\\pain-language-engagers\\output\\outset-ai-20260225_1250-cleaned.csv",
+        "skills\\capabilities\\pain-language-engagers\\output\\outset-ai-20260225_1250.csv",
+        "skills\\capabilities\\pain-language-engagers\\scripts\\pain_language_engagers.py",
+        "skills\\capabilities\\pain-language-engagers\\SKILL.md",
+        "skills\\capabilities\\pain-language-engagers\\skill.meta.json"
       ],
       "metadata": {
         "slug": "pain-language-engagers",
@@ -3875,12 +4056,12 @@
       "slug": "pdf-processor",
       "name": "pdf-processor",
       "category": "capabilities",
-      "description": "Process PDFs - extract text, tables, and structured data from documents",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/pdf-processor",
       "files": [
-        "skills/capabilities/pdf-processor/SKILL.md",
-        "skills/capabilities/pdf-processor/skill.meta.json"
+        "skills\\capabilities\\pdf-processor\\SKILL.md",
+        "skills\\capabilities\\pdf-processor\\skill.meta.json"
       ],
       "metadata": {
         "slug": "pdf-processor",
@@ -3901,12 +4082,12 @@
       "slug": "people-company-search-fiber",
       "name": "people-company-search-fiber",
       "category": "capabilities",
-      "description": "People, company, investor, and job search with LinkedIn data enrichment",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/people-company-search-fiber",
       "files": [
-        "skills/capabilities/people-company-search-fiber/SKILL.md",
-        "skills/capabilities/people-company-search-fiber/skill.meta.json"
+        "skills\\capabilities\\people-company-search-fiber\\SKILL.md",
+        "skills\\capabilities\\people-company-search-fiber\\skill.meta.json"
       ],
       "metadata": {
         "slug": "people-company-search-fiber",
@@ -3927,12 +4108,12 @@
       "slug": "person-lookup",
       "name": "person-lookup",
       "category": "capabilities",
-      "description": "Look up information about a person - work history, social profiles, contact info",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/person-lookup",
       "files": [
-        "skills/capabilities/person-lookup/SKILL.md",
-        "skills/capabilities/person-lookup/skill.meta.json"
+        "skills\\capabilities\\person-lookup\\SKILL.md",
+        "skills\\capabilities\\person-lookup\\skill.meta.json"
       ],
       "metadata": {
         "slug": "person-lookup",
@@ -3953,12 +4134,12 @@
       "slug": "phone-verification",
       "name": "phone-verification",
       "category": "capabilities",
-      "description": "Verify phone numbers using SMS one-time codes via the Didit API. Use when you need to confirm a user owns a phone number, implement SMS-based 2FA, or validate phone during signup/onboarding flows.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/phone-verification",
       "files": [
-        "skills/capabilities/phone-verification/SKILL.md",
-        "skills/capabilities/phone-verification/skill.meta.json"
+        "skills\\capabilities\\phone-verification\\SKILL.md",
+        "skills\\capabilities\\phone-verification\\skill.meta.json"
       ],
       "metadata": {
         "slug": "phone-verification",
@@ -3979,12 +4160,12 @@
       "slug": "pipeline-review",
       "name": "pipeline-review",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "research",
       "path": "skills/composites/pipeline-review",
       "files": [
-        "skills/composites/pipeline-review/SKILL.md",
-        "skills/composites/pipeline-review/skill.meta.json"
+        "skills\\composites\\pipeline-review\\SKILL.md",
+        "skills\\composites\\pipeline-review\\skill.meta.json"
       ],
       "metadata": {
         "slug": "pipeline-review",
@@ -4006,15 +4187,49 @@
       }
     },
     {
+      "slug": "postman-collection-storyteller",
+      "name": "postman-collection-storyteller",
+      "category": "composites",
+      "description": "",
+      "tags": "content",
+      "path": "skills/composites/postman-collection-storyteller",
+      "files": [
+        "skills\\composites\\postman-collection-storyteller\\SKILL.md",
+        "skills\\composites\\postman-collection-storyteller\\skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "postman-collection-storyteller",
+        "category": "composites",
+        "tags": [
+          "content"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install postman-collection-storyteller",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Audits a collection against 7 narrative quality criteria before writing",
+          "Writes collection, folder, and request-level descriptions with workflow sequencing rationale",
+          "Documents every collection variable with type, required/auto-set status, and example value",
+          "Annotates pre/post-request scripts with intent-focused comments",
+          "Produces a public Postman workspace overview page for developer portal publishing"
+        ]
+      }
+    },
+    {
       "slug": "prediction-market-odds",
       "name": "prediction-market-odds",
       "category": "capabilities",
-      "description": "Get prediction market odds and prices from Polymarket and Kalshi",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/prediction-market-odds",
       "files": [
-        "skills/capabilities/prediction-market-odds/SKILL.md",
-        "skills/capabilities/prediction-market-odds/skill.meta.json"
+        "skills\\capabilities\\prediction-market-odds\\SKILL.md",
+        "skills\\capabilities\\prediction-market-odds\\skill.meta.json"
       ],
       "metadata": {
         "slug": "prediction-market-odds",
@@ -4035,12 +4250,12 @@
       "slug": "prediction-markets-dome",
       "name": "prediction-markets-dome",
       "category": "capabilities",
-      "description": "Prediction markets data - Polymarket, Kalshi markets, prices, positions, and trades",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/prediction-markets-dome",
       "files": [
-        "skills/capabilities/prediction-markets-dome/SKILL.md",
-        "skills/capabilities/prediction-markets-dome/skill.meta.json"
+        "skills\\capabilities\\prediction-markets-dome\\SKILL.md",
+        "skills\\capabilities\\prediction-markets-dome\\skill.meta.json"
       ],
       "metadata": {
         "slug": "prediction-markets-dome",
@@ -4061,13 +4276,13 @@
       "slug": "product-hunt-scraper",
       "name": "product-hunt-scraper",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "monitoring",
       "path": "skills/capabilities/product-hunt-scraper",
       "files": [
-        "skills/capabilities/product-hunt-scraper/SKILL.md",
-        "skills/capabilities/product-hunt-scraper/scripts/scrape_producthunt.py",
-        "skills/capabilities/product-hunt-scraper/skill.meta.json"
+        "skills\\capabilities\\product-hunt-scraper\\scripts\\scrape_producthunt.py",
+        "skills\\capabilities\\product-hunt-scraper\\SKILL.md",
+        "skills\\capabilities\\product-hunt-scraper\\skill.meta.json"
       ],
       "metadata": {
         "slug": "product-hunt-scraper",
@@ -4089,13 +4304,13 @@
       "slug": "product-reel-generator",
       "name": "product-reel-generator",
       "category": "capabilities",
-      "description": "Generates Instagram-ready product reels from any e-commerce product page URL. Scrapes product images, classifies by type, generates AI-animated clips via Higgsfield API, creates text overlays with style presets, and composes a 15-20 second reel with music. Supports model-based and product-only reels.",
+      "description": "",
       "tags": "content",
       "path": "skills/packs/video-production/product-reel-generator",
       "files": [
-        "skills/packs/video-production/product-reel-generator/SKILL.md",
-        "skills/packs/video-production/product-reel-generator/scripts/higgsfield_video.py",
-        "skills/packs/video-production/product-reel-generator/skill.meta.json"
+        "skills\\packs\\video-production\\product-reel-generator\\scripts\\higgsfield_video.py",
+        "skills\\packs\\video-production\\product-reel-generator\\SKILL.md",
+        "skills\\packs\\video-production\\product-reel-generator\\skill.meta.json"
       ],
       "metadata": {
         "slug": "product-reel-generator",
@@ -4118,12 +4333,12 @@
       "slug": "programmatic-seo-planner",
       "name": "programmatic-seo-planner",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "seo",
       "path": "skills/composites/programmatic-seo-planner",
       "files": [
-        "skills/composites/programmatic-seo-planner/SKILL.md",
-        "skills/composites/programmatic-seo-planner/skill.meta.json"
+        "skills\\composites\\programmatic-seo-planner\\SKILL.md",
+        "skills\\composites\\programmatic-seo-planner\\skill.meta.json"
       ],
       "metadata": {
         "slug": "programmatic-seo-planner",
@@ -4150,12 +4365,12 @@
       "slug": "programmatic-seo-spy",
       "name": "programmatic-seo-spy",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "seo",
       "path": "skills/composites/programmatic-seo-spy",
       "files": [
-        "skills/composites/programmatic-seo-spy/SKILL.md",
-        "skills/composites/programmatic-seo-spy/skill.meta.json"
+        "skills\\composites\\programmatic-seo-spy\\SKILL.md",
+        "skills\\composites\\programmatic-seo-spy\\skill.meta.json"
       ],
       "metadata": {
         "slug": "programmatic-seo-spy",
@@ -4178,17 +4393,51 @@
       }
     },
     {
+      "slug": "rate-limit-ux-copywriter",
+      "name": "rate-limit-ux-copywriter",
+      "category": "composites",
+      "description": "",
+      "tags": "content",
+      "path": "skills/composites/rate-limit-ux-copywriter",
+      "files": [
+        "skills\\composites\\rate-limit-ux-copywriter\\SKILL.md",
+        "skills\\composites\\rate-limit-ux-copywriter\\skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "rate-limit-ux-copywriter",
+        "category": "composites",
+        "tags": [
+          "content"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install rate-limit-ux-copywriter",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Identifies the rate-limit model (fixed window, sliding window, token bucket) before writing any copy",
+          "Writes 429 error body JSON with machine-readable code, human-readable message, reset time, and upgrade URL",
+          "Documents rate-limit response headers with field tables and proactive usage code examples",
+          "Produces quota tier comparison tables, developer dashboard microcopy, and upgrade prompt variants",
+          "Covers 7 copy surfaces: error body, headers, quota table, dashboard UI, upgrade prompt, SDK warning, and docs prose"
+        ]
+      }
+    },
+    {
       "slug": "reddit-post-finder",
       "name": "reddit-post-finder",
       "category": "capabilities",
-      "description": "Scrape and search Reddit posts using Apify. Use when you need to find Reddit discussions, track competitor mentions, monitor product feedback, discover pain points, or analyze subreddit content. Supports keyword filtering, time-based searches, and subreddit-specific queries.",
+      "description": "",
       "tags": "monitoring",
       "path": "skills/capabilities/reddit-post-finder",
       "files": [
-        "skills/capabilities/reddit-post-finder/SKILL.md",
-        "skills/capabilities/reddit-post-finder/references/apify-config.md",
-        "skills/capabilities/reddit-post-finder/scripts/search_reddit.py",
-        "skills/capabilities/reddit-post-finder/skill.meta.json"
+        "skills\\capabilities\\reddit-post-finder\\references\\apify-config.md",
+        "skills\\capabilities\\reddit-post-finder\\scripts\\search_reddit.py",
+        "skills\\capabilities\\reddit-post-finder\\SKILL.md",
+        "skills\\capabilities\\reddit-post-finder\\skill.meta.json"
       ],
       "metadata": {
         "slug": "reddit-post-finder",
@@ -4210,12 +4459,12 @@
       "slug": "remotion-best-practices",
       "name": "remotion-best-practices",
       "category": "capabilities",
-      "description": "Best practices for Remotion - Video creation in React",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/remotion-best-practices",
       "files": [
-        "skills/capabilities/remotion-best-practices/SKILL.md",
-        "skills/capabilities/remotion-best-practices/skill.meta.json"
+        "skills\\capabilities\\remotion-best-practices\\SKILL.md",
+        "skills\\capabilities\\remotion-best-practices\\skill.meta.json"
       ],
       "metadata": {
         "slug": "remotion-best-practices",
@@ -4236,12 +4485,12 @@
       "slug": "restaurant-booking",
       "name": "restaurant-booking",
       "category": "capabilities",
-      "description": "Book restaurant reservations via browser automation. Use when asked to make dinner reservations, book a table, or find availability at restaurants. Supports OpenTable, Resy, and direct restaurant booking sites.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/restaurant-booking",
       "files": [
-        "skills/capabilities/restaurant-booking/SKILL.md",
-        "skills/capabilities/restaurant-booking/skill.meta.json"
+        "skills\\capabilities\\restaurant-booking\\SKILL.md",
+        "skills\\capabilities\\restaurant-booking\\skill.meta.json"
       ],
       "metadata": {
         "slug": "restaurant-booking",
@@ -4262,12 +4511,12 @@
       "slug": "review-intelligence-digest",
       "name": "review-intelligence-digest",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "research",
       "path": "skills/composites/review-intelligence-digest",
       "files": [
-        "skills/composites/review-intelligence-digest/SKILL.md",
-        "skills/composites/review-intelligence-digest/skill.meta.json"
+        "skills\\composites\\review-intelligence-digest\\SKILL.md",
+        "skills\\composites\\review-intelligence-digest\\skill.meta.json"
       ],
       "metadata": {
         "slug": "review-intelligence-digest",
@@ -4292,13 +4541,13 @@
       "slug": "review-scraper",
       "name": "review-scraper",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "monitoring",
       "path": "skills/capabilities/review-scraper",
       "files": [
-        "skills/capabilities/review-scraper/SKILL.md",
-        "skills/capabilities/review-scraper/scripts/scrape_reviews.py",
-        "skills/capabilities/review-scraper/skill.meta.json"
+        "skills\\capabilities\\review-scraper\\scripts\\scrape_reviews.py",
+        "skills\\capabilities\\review-scraper\\SKILL.md",
+        "skills\\capabilities\\review-scraper\\skill.meta.json"
       ],
       "metadata": {
         "slug": "review-scraper",
@@ -4320,13 +4569,13 @@
       "slug": "review-site-scraper",
       "name": "review-site-scraper",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "monitoring",
       "path": "skills/capabilities/review-site-scraper",
       "files": [
-        "skills/capabilities/review-site-scraper/SKILL.md",
-        "skills/capabilities/review-site-scraper/scripts/scrape_reviews.py",
-        "skills/capabilities/review-site-scraper/skill.meta.json"
+        "skills\\capabilities\\review-site-scraper\\scripts\\scrape_reviews.py",
+        "skills\\capabilities\\review-site-scraper\\SKILL.md",
+        "skills\\capabilities\\review-site-scraper\\skill.meta.json"
       ],
       "metadata": {
         "slug": "review-site-scraper",
@@ -4348,12 +4597,12 @@
       "slug": "sales-call-prep",
       "name": "sales-call-prep",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "research",
       "path": "skills/composites/sales-call-prep",
       "files": [
-        "skills/composites/sales-call-prep/SKILL.md",
-        "skills/composites/sales-call-prep/skill.meta.json"
+        "skills\\composites\\sales-call-prep\\SKILL.md",
+        "skills\\composites\\sales-call-prep\\skill.meta.json"
       ],
       "metadata": {
         "slug": "sales-call-prep",
@@ -4375,12 +4624,12 @@
       "slug": "sales-coaching",
       "name": "sales-coaching",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "research",
       "path": "skills/composites/sales-coaching",
       "files": [
-        "skills/composites/sales-coaching/SKILL.md",
-        "skills/composites/sales-coaching/skill.meta.json"
+        "skills\\composites\\sales-coaching\\SKILL.md",
+        "skills\\composites\\sales-coaching\\skill.meta.json"
       ],
       "metadata": {
         "slug": "sales-coaching",
@@ -4405,12 +4654,12 @@
       "slug": "sales-prospecting",
       "name": "sales-prospecting",
       "category": "capabilities",
-      "description": "Build targeted prospect lists with verified contact information",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/sales-prospecting",
       "files": [
-        "skills/capabilities/sales-prospecting/SKILL.md",
-        "skills/capabilities/sales-prospecting/skill.meta.json"
+        "skills\\capabilities\\sales-prospecting\\SKILL.md",
+        "skills\\capabilities\\sales-prospecting\\skill.meta.json"
       ],
       "metadata": {
         "slug": "sales-prospecting",
@@ -4428,15 +4677,49 @@
       }
     },
     {
+      "slug": "sdk-quickstart-hardening-guide",
+      "name": "sdk-quickstart-hardening-guide",
+      "category": "composites",
+      "description": "",
+      "tags": "content",
+      "path": "skills/composites/sdk-quickstart-hardening-guide",
+      "files": [
+        "skills\\composites\\sdk-quickstart-hardening-guide\\SKILL.md",
+        "skills\\composites\\sdk-quickstart-hardening-guide\\skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "sdk-quickstart-hardening-guide",
+        "category": "composites",
+        "tags": [
+          "content"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install sdk-quickstart-hardening-guide",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Audits a working snippet against 7 hardening criteria before writing any docs",
+          "Writes prerequisites, installation, and environment variable sections that survive cold-start by new developers",
+          "Generates the minimal runnable code path with inline intent comments and explicit expected output",
+          "Produces common-failure-mode diagnostics with Cause and Fix steps for every known error",
+          "Outputs a first-success checklist with next-step links for production readiness"
+        ]
+      }
+    },
+    {
       "slug": "send-sms-textbelt",
       "name": "send-sms-textbelt",
       "category": "capabilities",
-      "description": "Send SMS text messages to phone numbers. Use when the user asks to send a text, send an SMS, text someone, message a phone number, or send a notification via text message.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/send-sms-textbelt",
       "files": [
-        "skills/capabilities/send-sms-textbelt/SKILL.md",
-        "skills/capabilities/send-sms-textbelt/skill.meta.json"
+        "skills\\capabilities\\send-sms-textbelt\\SKILL.md",
+        "skills\\capabilities\\send-sms-textbelt\\skill.meta.json"
       ],
       "metadata": {
         "slug": "send-sms-textbelt",
@@ -4457,12 +4740,12 @@
       "slug": "seo-analyzer",
       "name": "seo-analyzer",
       "category": "capabilities",
-      "description": "Analyze website SEO - keywords, content, competitors, and improvement opportunities",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/seo-analyzer",
       "files": [
-        "skills/capabilities/seo-analyzer/SKILL.md",
-        "skills/capabilities/seo-analyzer/skill.meta.json"
+        "skills\\capabilities\\seo-analyzer\\SKILL.md",
+        "skills\\capabilities\\seo-analyzer\\skill.meta.json"
       ],
       "metadata": {
         "slug": "seo-analyzer",
@@ -4483,12 +4766,12 @@
       "slug": "seo-content-audit",
       "name": "seo-content-audit",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "seo",
       "path": "skills/composites/seo-content-audit",
       "files": [
-        "skills/composites/seo-content-audit/SKILL.md",
-        "skills/composites/seo-content-audit/skill.meta.json"
+        "skills\\composites\\seo-content-audit\\SKILL.md",
+        "skills\\composites\\seo-content-audit\\skill.meta.json"
       ],
       "metadata": {
         "slug": "seo-content-audit",
@@ -4515,12 +4798,12 @@
       "slug": "seo-content-engine",
       "name": "seo-content-engine",
       "category": "playbooks",
-      "description": ">",
+      "description": "",
       "tags": "seo",
       "path": "skills/playbooks/seo-content-engine",
       "files": [
-        "skills/playbooks/seo-content-engine/SKILL.md",
-        "skills/playbooks/seo-content-engine/skill.meta.json"
+        "skills\\playbooks\\seo-content-engine\\SKILL.md",
+        "skills\\playbooks\\seo-content-engine\\skill.meta.json"
       ],
       "metadata": {
         "slug": "seo-content-engine",
@@ -4542,13 +4825,13 @@
       "slug": "seo-domain-analyzer",
       "name": "seo-domain-analyzer",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "competitive-intel, seo",
       "path": "skills/capabilities/seo-domain-analyzer",
       "files": [
-        "skills/capabilities/seo-domain-analyzer/SKILL.md",
-        "skills/capabilities/seo-domain-analyzer/scripts/analyze_domain.py",
-        "skills/capabilities/seo-domain-analyzer/skill.meta.json"
+        "skills\\capabilities\\seo-domain-analyzer\\scripts\\analyze_domain.py",
+        "skills\\capabilities\\seo-domain-analyzer\\SKILL.md",
+        "skills\\capabilities\\seo-domain-analyzer\\skill.meta.json"
       ],
       "metadata": {
         "slug": "seo-domain-analyzer",
@@ -4571,12 +4854,12 @@
       "slug": "seo-opportunity-finder",
       "name": "seo-opportunity-finder",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "seo",
       "path": "skills/composites/seo-opportunity-finder",
       "files": [
-        "skills/composites/seo-opportunity-finder/SKILL.md",
-        "skills/composites/seo-opportunity-finder/skill.meta.json"
+        "skills\\composites\\seo-opportunity-finder\\SKILL.md",
+        "skills\\composites\\seo-opportunity-finder\\skill.meta.json"
       ],
       "metadata": {
         "slug": "seo-opportunity-finder",
@@ -4603,12 +4886,12 @@
       "slug": "seo-traffic-analyzer",
       "name": "seo-traffic-analyzer",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "competitive-intel, seo",
       "path": "skills/capabilities/seo-traffic-analyzer",
       "files": [
-        "skills/capabilities/seo-traffic-analyzer/SKILL.md",
-        "skills/capabilities/seo-traffic-analyzer/skill.meta.json"
+        "skills\\capabilities\\seo-traffic-analyzer\\SKILL.md",
+        "skills\\capabilities\\seo-traffic-analyzer\\skill.meta.json"
       ],
       "metadata": {
         "slug": "seo-traffic-analyzer",
@@ -4631,12 +4914,12 @@
       "slug": "sequence-performance",
       "name": "sequence-performance",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "research",
       "path": "skills/composites/sequence-performance",
       "files": [
-        "skills/composites/sequence-performance/SKILL.md",
-        "skills/composites/sequence-performance/skill.meta.json"
+        "skills\\composites\\sequence-performance\\SKILL.md",
+        "skills\\composites\\sequence-performance\\skill.meta.json"
       ],
       "metadata": {
         "slug": "sequence-performance",
@@ -4662,12 +4945,12 @@
       "slug": "setup-outreach-campaign-smartlead",
       "name": "setup-outreach-campaign-smartlead",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "outreach",
       "path": "skills/capabilities/setup-outreach-campaign-smartlead",
       "files": [
-        "skills/capabilities/setup-outreach-campaign-smartlead/SKILL.md",
-        "skills/capabilities/setup-outreach-campaign-smartlead/skill.meta.json"
+        "skills\\capabilities\\setup-outreach-campaign-smartlead\\SKILL.md",
+        "skills\\capabilities\\setup-outreach-campaign-smartlead\\skill.meta.json"
       ],
       "metadata": {
         "slug": "setup-outreach-campaign-smartlead",
@@ -4689,12 +4972,12 @@
       "slug": "signal-detection-pipeline",
       "name": "signal-detection-pipeline",
       "category": "playbooks",
-      "description": "Detect buying signals from multiple sources, qualify leads, and generate outreach context",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/playbooks/signal-detection-pipeline",
       "files": [
-        "skills/playbooks/signal-detection-pipeline/SKILL.md",
-        "skills/playbooks/signal-detection-pipeline/skill.meta.json"
+        "skills\\playbooks\\signal-detection-pipeline\\SKILL.md",
+        "skills\\playbooks\\signal-detection-pipeline\\skill.meta.json"
       ],
       "metadata": {
         "slug": "signal-detection-pipeline",
@@ -4716,15 +4999,15 @@
       "slug": "signal-scanner",
       "name": "signal-scanner",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/capabilities/signal-scanner",
       "files": [
-        "skills/capabilities/signal-scanner/SKILL.md",
-        "skills/capabilities/signal-scanner/configs/example.json",
-        "skills/capabilities/signal-scanner/configs/toma-bdc-signal.json",
-        "skills/capabilities/signal-scanner/scripts/signal_scanner.py",
-        "skills/capabilities/signal-scanner/skill.meta.json"
+        "skills\\capabilities\\signal-scanner\\configs\\example.json",
+        "skills\\capabilities\\signal-scanner\\configs\\toma-bdc-signal.json",
+        "skills\\capabilities\\signal-scanner\\scripts\\signal_scanner.py",
+        "skills\\capabilities\\signal-scanner\\SKILL.md",
+        "skills\\capabilities\\signal-scanner\\skill.meta.json"
       ],
       "metadata": {
         "slug": "signal-scanner",
@@ -4750,13 +5033,13 @@
       "slug": "site-content-catalog",
       "name": "site-content-catalog",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "content, seo",
       "path": "skills/capabilities/site-content-catalog",
       "files": [
-        "skills/capabilities/site-content-catalog/SKILL.md",
-        "skills/capabilities/site-content-catalog/scripts/catalog_content.py",
-        "skills/capabilities/site-content-catalog/skill.meta.json"
+        "skills\\capabilities\\site-content-catalog\\scripts\\catalog_content.py",
+        "skills\\capabilities\\site-content-catalog\\SKILL.md",
+        "skills\\capabilities\\site-content-catalog\\skill.meta.json"
       ],
       "metadata": {
         "slug": "site-content-catalog",
@@ -4779,12 +5062,12 @@
       "slug": "skill-creator",
       "name": "skill-creator",
       "category": "capabilities",
-      "description": "Create, structure, and package agent skills. Use when designing new skills, updating existing skills, or helping users build skills with scripts, references, and assets. Triggers on requests to create skills, write SKILL.md files, or structure skill directories.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/skill-creator",
       "files": [
-        "skills/capabilities/skill-creator/SKILL.md",
-        "skills/capabilities/skill-creator/skill.meta.json"
+        "skills\\capabilities\\skill-creator\\SKILL.md",
+        "skills\\capabilities\\skill-creator\\skill.meta.json"
       ],
       "metadata": {
         "slug": "skill-creator",
@@ -4805,12 +5088,12 @@
       "slug": "social-kit",
       "name": "social-kit",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "content, social",
       "path": "skills/composites/social-kit",
       "files": [
-        "skills/composites/social-kit/SKILL.md",
-        "skills/composites/social-kit/skill.meta.json"
+        "skills\\composites\\social-kit\\SKILL.md",
+        "skills\\composites\\social-kit\\skill.meta.json"
       ],
       "metadata": {
         "slug": "social-kit",
@@ -4847,12 +5130,12 @@
       "slug": "social-listening",
       "name": "social-listening",
       "category": "capabilities",
-      "description": "Monitor brand mentions, competitor activity, and industry conversations across social media and the web",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/social-listening",
       "files": [
-        "skills/capabilities/social-listening/SKILL.md",
-        "skills/capabilities/social-listening/skill.meta.json"
+        "skills\\capabilities\\social-listening\\SKILL.md",
+        "skills\\capabilities\\social-listening\\skill.meta.json"
       ],
       "metadata": {
         "slug": "social-listening",
@@ -4873,12 +5156,12 @@
       "slug": "social-media-scraping-scrapecreators",
       "name": "social-media-scraping-scrapecreators",
       "category": "capabilities",
-      "description": "Social media scraping - Instagram, TikTok, LinkedIn, and X/Twitter profiles, posts, and content",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/social-media-scraping-scrapecreators",
       "files": [
-        "skills/capabilities/social-media-scraping-scrapecreators/SKILL.md",
-        "skills/capabilities/social-media-scraping-scrapecreators/skill.meta.json"
+        "skills\\capabilities\\social-media-scraping-scrapecreators\\SKILL.md",
+        "skills\\capabilities\\social-media-scraping-scrapecreators\\skill.meta.json"
       ],
       "metadata": {
         "slug": "social-media-scraping-scrapecreators",
@@ -4899,12 +5182,12 @@
       "slug": "sponsored-newsletter-finder",
       "name": "sponsored-newsletter-finder",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "ads",
       "path": "skills/composites/sponsored-newsletter-finder",
       "files": [
-        "skills/composites/sponsored-newsletter-finder/SKILL.md",
-        "skills/composites/sponsored-newsletter-finder/skill.meta.json"
+        "skills\\composites\\sponsored-newsletter-finder\\SKILL.md",
+        "skills\\composites\\sponsored-newsletter-finder\\skill.meta.json"
       ],
       "metadata": {
         "slug": "sponsored-newsletter-finder",
@@ -4923,15 +5206,49 @@
       }
     },
     {
+      "slug": "status-incident-comms-writer",
+      "name": "status-incident-comms-writer",
+      "category": "composites",
+      "description": "",
+      "tags": "content",
+      "path": "skills/composites/status-incident-comms-writer",
+      "files": [
+        "skills\\composites\\status-incident-comms-writer\\SKILL.md",
+        "skills\\composites\\status-incident-comms-writer\\skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "status-incident-comms-writer",
+        "category": "composites",
+        "tags": [
+          "content"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install status-incident-comms-writer",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Assigns SEV-1 through SEV-4 severity and recommends update cadence before writing",
+          "Produces status page updates for all four incident phases: investigating, identified, monitoring, and resolved",
+          "Writes consumer email and Slack/Discord thread variants tuned for developer audiences",
+          "Generates a complete public postmortem template with timeline, root cause, and action items",
+          "Marks every field requiring engineering team input so comms can ship without guessing"
+        ]
+      }
+    },
+    {
       "slug": "structured-scraping-riveter",
       "name": "structured-scraping-riveter",
       "category": "capabilities",
-      "description": "Web scraping with structured data extraction - define your output schema",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/structured-scraping-riveter",
       "files": [
-        "skills/capabilities/structured-scraping-riveter/SKILL.md",
-        "skills/capabilities/structured-scraping-riveter/skill.meta.json"
+        "skills\\capabilities\\structured-scraping-riveter\\SKILL.md",
+        "skills\\capabilities\\structured-scraping-riveter\\skill.meta.json"
       ],
       "metadata": {
         "slug": "structured-scraping-riveter",
@@ -4952,13 +5269,13 @@
       "slug": "talking-head-video",
       "name": "talking-head-video",
       "category": "capabilities",
-      "description": "Creates talking head videos from any source material (docs, changelogs, blog posts, notes, transcripts). Produces multi-scene videos with avatar narration over screenshots/images using HeyGen v2 API. Supports Quick Shot and Full Producer modes.",
+      "description": "",
       "tags": "content",
       "path": "skills/packs/video-production/talking-head-video",
       "files": [
-        "skills/packs/video-production/talking-head-video/AVATAR-CONFIG.example.md",
-        "skills/packs/video-production/talking-head-video/SKILL.md",
-        "skills/packs/video-production/talking-head-video/skill.meta.json"
+        "skills\\packs\\video-production\\talking-head-video\\AVATAR-CONFIG.example.md",
+        "skills\\packs\\video-production\\talking-head-video\\SKILL.md",
+        "skills\\packs\\video-production\\talking-head-video\\skill.meta.json"
       ],
       "metadata": {
         "slug": "talking-head-video",
@@ -4981,12 +5298,12 @@
       "slug": "tam-builder",
       "name": "tam-builder",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "lead-generation",
       "path": "skills/capabilities/tam-builder",
       "files": [
-        "skills/capabilities/tam-builder/SKILL.md",
-        "skills/capabilities/tam-builder/skill.meta.json"
+        "skills\\capabilities\\tam-builder\\SKILL.md",
+        "skills\\capabilities\\tam-builder\\skill.meta.json"
       ],
       "metadata": {
         "slug": "tam-builder",
@@ -5008,12 +5325,12 @@
       "slug": "targeted-prospecting",
       "name": "targeted-prospecting",
       "category": "capabilities",
-      "description": "Build a prospect list of companies with decision makers, verified contact info, and hiring/intent signals. Use when asked to find leads by industry, build an account list with specific titles, prospect companies that are actively hiring, or create a targeted outreach list filtered by company size, location, and hiring activity.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/targeted-prospecting",
       "files": [
-        "skills/capabilities/targeted-prospecting/SKILL.md",
-        "skills/capabilities/targeted-prospecting/skill.meta.json"
+        "skills\\capabilities\\targeted-prospecting\\SKILL.md",
+        "skills\\capabilities\\targeted-prospecting\\skill.meta.json"
       ],
       "metadata": {
         "slug": "targeted-prospecting",
@@ -5034,12 +5351,12 @@
       "slug": "team-linkedin-profiles",
       "name": "team-linkedin-profiles",
       "category": "capabilities",
-      "description": "Find LinkedIn profiles of a specific team or department at a company. Use when asked to get LinkedIn profiles, find team members, or look up people in a particular team/department/group at a company.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/team-linkedin-profiles",
       "files": [
-        "skills/capabilities/team-linkedin-profiles/SKILL.md",
-        "skills/capabilities/team-linkedin-profiles/skill.meta.json"
+        "skills\\capabilities\\team-linkedin-profiles\\SKILL.md",
+        "skills\\capabilities\\team-linkedin-profiles\\skill.meta.json"
       ],
       "metadata": {
         "slug": "team-linkedin-profiles",
@@ -5060,13 +5377,13 @@
       "slug": "tech-stack-teardown",
       "name": "tech-stack-teardown",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "competitive-intel",
       "path": "skills/capabilities/tech-stack-teardown",
       "files": [
-        "skills/capabilities/tech-stack-teardown/SKILL.md",
-        "skills/capabilities/tech-stack-teardown/scripts/recon.py",
-        "skills/capabilities/tech-stack-teardown/skill.meta.json"
+        "skills\\capabilities\\tech-stack-teardown\\scripts\\recon.py",
+        "skills\\capabilities\\tech-stack-teardown\\SKILL.md",
+        "skills\\capabilities\\tech-stack-teardown\\skill.meta.json"
       ],
       "metadata": {
         "slug": "tech-stack-teardown",
@@ -5088,12 +5405,12 @@
       "slug": "terminal-gif-recordings",
       "name": "terminal-gif-recordings",
       "category": "capabilities",
-      "description": "Create polished terminal GIF recordings using VHS (Video Hardware Software) by Charmbracelet. Use when asked to create terminal demos, CLI gifs, command-line recordings, or animated terminal screenshots for documentation, READMEs, or marketing.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/terminal-gif-recordings",
       "files": [
-        "skills/capabilities/terminal-gif-recordings/SKILL.md",
-        "skills/capabilities/terminal-gif-recordings/skill.meta.json"
+        "skills\\capabilities\\terminal-gif-recordings\\SKILL.md",
+        "skills\\capabilities\\terminal-gif-recordings\\skill.meta.json"
       ],
       "metadata": {
         "slug": "terminal-gif-recordings",
@@ -5114,13 +5431,13 @@
       "slug": "tiktok-influencer-finder",
       "name": "tiktok-influencer-finder",
       "category": "capabilities",
-      "description": "Find TikTok influencers using Apify's Influencer Discovery Agent. Use when the user wants to discover TikTok creators or influencers in any niche.",
+      "description": "",
       "tags": "outreach",
       "path": "skills/capabilities/tiktok-influencer-finder",
       "files": [
-        "skills/capabilities/tiktok-influencer-finder/SKILL.md",
-        "skills/capabilities/tiktok-influencer-finder/scripts/find_influencers.py",
-        "skills/capabilities/tiktok-influencer-finder/skill.meta.json"
+        "skills\\capabilities\\tiktok-influencer-finder\\scripts\\find_influencers.py",
+        "skills\\capabilities\\tiktok-influencer-finder\\SKILL.md",
+        "skills\\capabilities\\tiktok-influencer-finder\\skill.meta.json"
       ],
       "metadata": {
         "slug": "tiktok-influencer-finder",
@@ -5142,12 +5459,12 @@
       "slug": "tiktok-search",
       "name": "tiktok-search",
       "category": "capabilities",
-      "description": "Search TikTok - find profiles, videos, hashtags, and trending content",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/tiktok-search",
       "files": [
-        "skills/capabilities/tiktok-search/SKILL.md",
-        "skills/capabilities/tiktok-search/skill.meta.json"
+        "skills\\capabilities\\tiktok-search\\SKILL.md",
+        "skills\\capabilities\\tiktok-search\\skill.meta.json"
       ],
       "metadata": {
         "slug": "tiktok-search",
@@ -5168,12 +5485,12 @@
       "slug": "topical-authority-mapper",
       "name": "topical-authority-mapper",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "seo",
       "path": "skills/composites/topical-authority-mapper",
       "files": [
-        "skills/composites/topical-authority-mapper/SKILL.md",
-        "skills/composites/topical-authority-mapper/skill.meta.json"
+        "skills\\composites\\topical-authority-mapper\\SKILL.md",
+        "skills\\composites\\topical-authority-mapper\\skill.meta.json"
       ],
       "metadata": {
         "slug": "topical-authority-mapper",
@@ -5200,12 +5517,12 @@
       "slug": "trending-ad-hook-spotter",
       "name": "trending-ad-hook-spotter",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "ads",
       "path": "skills/composites/trending-ad-hook-spotter",
       "files": [
-        "skills/composites/trending-ad-hook-spotter/SKILL.md",
-        "skills/composites/trending-ad-hook-spotter/skill.meta.json"
+        "skills\\composites\\trending-ad-hook-spotter\\SKILL.md",
+        "skills\\composites\\trending-ad-hook-spotter\\skill.meta.json"
       ],
       "metadata": {
         "slug": "trending-ad-hook-spotter",
@@ -5233,13 +5550,13 @@
       "slug": "twitter-mention-tracker",
       "name": "twitter-mention-tracker",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "monitoring",
       "path": "skills/capabilities/twitter-mention-tracker",
       "files": [
-        "skills/capabilities/twitter-mention-tracker/SKILL.md",
-        "skills/capabilities/twitter-mention-tracker/scripts/search_twitter.py",
-        "skills/capabilities/twitter-mention-tracker/skill.meta.json"
+        "skills\\capabilities\\twitter-mention-tracker\\scripts\\search_twitter.py",
+        "skills\\capabilities\\twitter-mention-tracker\\SKILL.md",
+        "skills\\capabilities\\twitter-mention-tracker\\skill.meta.json"
       ],
       "metadata": {
         "slug": "twitter-mention-tracker",
@@ -5261,12 +5578,12 @@
       "slug": "twitter-profile-lookup",
       "name": "twitter-profile-lookup",
       "category": "capabilities",
-      "description": "Look up Twitter/X profiles - get bio, followers, tweets, and engagement",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/twitter-profile-lookup",
       "files": [
-        "skills/capabilities/twitter-profile-lookup/SKILL.md",
-        "skills/capabilities/twitter-profile-lookup/skill.meta.json"
+        "skills\\capabilities\\twitter-profile-lookup\\SKILL.md",
+        "skills\\capabilities\\twitter-profile-lookup\\skill.meta.json"
       ],
       "metadata": {
         "slug": "twitter-profile-lookup",
@@ -5287,12 +5604,12 @@
       "slug": "uptime-monitor",
       "name": "uptime-monitor",
       "category": "capabilities",
-      "description": "Monitor website uptime - check availability, response times, and status",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/uptime-monitor",
       "files": [
-        "skills/capabilities/uptime-monitor/SKILL.md",
-        "skills/capabilities/uptime-monitor/skill.meta.json"
+        "skills\\capabilities\\uptime-monitor\\SKILL.md",
+        "skills\\capabilities\\uptime-monitor\\skill.meta.json"
       ],
       "metadata": {
         "slug": "uptime-monitor",
@@ -5313,12 +5630,12 @@
       "slug": "verify-email",
       "name": "verify-email",
       "category": "capabilities",
-      "description": "Verify if an email address is valid and deliverable",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/verify-email",
       "files": [
-        "skills/capabilities/verify-email/SKILL.md",
-        "skills/capabilities/verify-email/skill.meta.json"
+        "skills\\capabilities\\verify-email\\SKILL.md",
+        "skills\\capabilities\\verify-email\\skill.meta.json"
       ],
       "metadata": {
         "slug": "verify-email",
@@ -5339,12 +5656,12 @@
       "slug": "video-clipper",
       "name": "video-clipper",
       "category": "capabilities",
-      "description": "Repurposes long-form video (podcasts, interviews, talks) into short-form vertical clips for Instagram Reels, TikTok, and YouTube Shorts. Handles transcription, moment selection, clip extraction, speaker-tracked reframing (16:9 to 9:16), and animated captions.",
+      "description": "",
       "tags": "content",
       "path": "skills/packs/video-production/video-clipper",
       "files": [
-        "skills/packs/video-production/video-clipper/SKILL.md",
-        "skills/packs/video-production/video-clipper/skill.meta.json"
+        "skills\\packs\\video-production\\video-clipper\\SKILL.md",
+        "skills\\packs\\video-production\\video-clipper\\skill.meta.json"
       ],
       "metadata": {
         "slug": "video-clipper",
@@ -5367,12 +5684,12 @@
       "slug": "video-polish",
       "name": "video-polish",
       "category": "capabilities",
-      "description": "Takes an existing screen recording or demo video and adds professional zoom/pan effects synchronized to the narration. Uses transcript-driven zoom targeting and Remotion for rendering. Optionally replaces audio with a soundtrack.",
+      "description": "",
       "tags": "content",
       "path": "skills/packs/video-production/video-polish",
       "files": [
-        "skills/packs/video-production/video-polish/SKILL.md",
-        "skills/packs/video-production/video-polish/skill.meta.json"
+        "skills\\packs\\video-production\\video-polish\\SKILL.md",
+        "skills\\packs\\video-production\\video-polish\\skill.meta.json"
       ],
       "metadata": {
         "slug": "video-polish",
@@ -5395,12 +5712,12 @@
       "slug": "visual-brand-extractor",
       "name": "visual-brand-extractor",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "brand",
       "path": "skills/capabilities/visual-brand-extractor",
       "files": [
-        "skills/capabilities/visual-brand-extractor/SKILL.md",
-        "skills/capabilities/visual-brand-extractor/skill.meta.json"
+        "skills\\capabilities\\visual-brand-extractor\\SKILL.md",
+        "skills\\capabilities\\visual-brand-extractor\\skill.meta.json"
       ],
       "metadata": {
         "slug": "visual-brand-extractor",
@@ -5422,12 +5739,12 @@
       "slug": "voice-of-customer-synthesizer",
       "name": "voice-of-customer-synthesizer",
       "category": "composites",
-      "description": ">",
+      "description": "",
       "tags": "research",
       "path": "skills/composites/voice-of-customer-synthesizer",
       "files": [
-        "skills/composites/voice-of-customer-synthesizer/SKILL.md",
-        "skills/composites/voice-of-customer-synthesizer/skill.meta.json"
+        "skills\\composites\\voice-of-customer-synthesizer\\SKILL.md",
+        "skills\\composites\\voice-of-customer-synthesizer\\skill.meta.json"
       ],
       "metadata": {
         "slug": "voice-of-customer-synthesizer",
@@ -5454,12 +5771,12 @@
       "slug": "weather",
       "name": "weather",
       "category": "capabilities",
-      "description": "Get current weather and forecasts using free APIs (no API key required). Use when asked about weather, temperature, forecasts, or climate conditions for any location.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/weather",
       "files": [
-        "skills/capabilities/weather/SKILL.md",
-        "skills/capabilities/weather/skill.meta.json"
+        "skills\\capabilities\\weather\\SKILL.md",
+        "skills\\capabilities\\weather\\skill.meta.json"
       ],
       "metadata": {
         "slug": "weather",
@@ -5480,13 +5797,13 @@
       "slug": "web-archive-scraper",
       "name": "web-archive-scraper",
       "category": "capabilities",
-      "description": ">",
+      "description": "",
       "tags": "monitoring",
       "path": "skills/capabilities/web-archive-scraper",
       "files": [
-        "skills/capabilities/web-archive-scraper/SKILL.md",
-        "skills/capabilities/web-archive-scraper/scripts/search_archive.py",
-        "skills/capabilities/web-archive-scraper/skill.meta.json"
+        "skills\\capabilities\\web-archive-scraper\\scripts\\search_archive.py",
+        "skills\\capabilities\\web-archive-scraper\\SKILL.md",
+        "skills\\capabilities\\web-archive-scraper\\skill.meta.json"
       ],
       "metadata": {
         "slug": "web-archive-scraper",
@@ -5508,12 +5825,12 @@
       "slug": "web-research-parallel",
       "name": "web-research-parallel",
       "category": "capabilities",
-      "description": "Web research API with OpenAI-compatible chat completions and async tasks",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/web-research-parallel",
       "files": [
-        "skills/capabilities/web-research-parallel/SKILL.md",
-        "skills/capabilities/web-research-parallel/skill.meta.json"
+        "skills\\capabilities\\web-research-parallel\\SKILL.md",
+        "skills\\capabilities\\web-research-parallel\\skill.meta.json"
       ],
       "metadata": {
         "slug": "web-research-parallel",
@@ -5534,12 +5851,12 @@
       "slug": "web-scraping",
       "name": "web-scraping",
       "category": "capabilities",
-      "description": "Scrape websites, extract structured data, and automate browsers. Use when asked to scrape, extract, crawl, parse, or pull data from web pages or any URL.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/web-scraping",
       "files": [
-        "skills/capabilities/web-scraping/SKILL.md",
-        "skills/capabilities/web-scraping/skill.meta.json"
+        "skills\\capabilities\\web-scraping\\SKILL.md",
+        "skills\\capabilities\\web-scraping\\skill.meta.json"
       ],
       "metadata": {
         "slug": "web-scraping",
@@ -5560,12 +5877,12 @@
       "slug": "web-scraping-olostep",
       "name": "web-scraping-olostep",
       "category": "capabilities",
-      "description": "Web scraping, crawling, and AI-powered answer extraction at scale",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/web-scraping-olostep",
       "files": [
-        "skills/capabilities/web-scraping-olostep/SKILL.md",
-        "skills/capabilities/web-scraping-olostep/skill.meta.json"
+        "skills\\capabilities\\web-scraping-olostep\\SKILL.md",
+        "skills\\capabilities\\web-scraping-olostep\\skill.meta.json"
       ],
       "metadata": {
         "slug": "web-scraping-olostep",
@@ -5586,12 +5903,12 @@
       "slug": "web-search",
       "name": "web-search",
       "category": "capabilities",
-      "description": "Search the web, platforms, and datasets. Use when asked to search, find, look up, research, or discover information from the web, YouTube, Amazon, eBay, news, academic sources, or any online platform.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/web-search",
       "files": [
-        "skills/capabilities/web-search/SKILL.md",
-        "skills/capabilities/web-search/skill.meta.json"
+        "skills\\capabilities\\web-search\\SKILL.md",
+        "skills\\capabilities\\web-search\\skill.meta.json"
       ],
       "metadata": {
         "slug": "web-search",
@@ -5612,12 +5929,12 @@
       "slug": "web-search-andi",
       "name": "web-search-andi",
       "category": "capabilities",
-      "description": "Fast, high-quality web search with intelligent ranking and instant answers",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/web-search-andi",
       "files": [
-        "skills/capabilities/web-search-andi/SKILL.md",
-        "skills/capabilities/web-search-andi/skill.meta.json"
+        "skills\\capabilities\\web-search-andi\\SKILL.md",
+        "skills\\capabilities\\web-search-andi\\skill.meta.json"
       ],
       "metadata": {
         "slug": "web-search-andi",
@@ -5638,12 +5955,12 @@
       "slug": "web-search-exa",
       "name": "web-search-exa",
       "category": "capabilities",
-      "description": "Neural web search - find similar content, extract pages, and run deep research",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/web-search-exa",
       "files": [
-        "skills/capabilities/web-search-exa/SKILL.md",
-        "skills/capabilities/web-search-exa/skill.meta.json"
+        "skills\\capabilities\\web-search-exa\\SKILL.md",
+        "skills\\capabilities\\web-search-exa\\skill.meta.json"
       ],
       "metadata": {
         "slug": "web-search-exa",
@@ -5664,12 +5981,12 @@
       "slug": "web-search-jina",
       "name": "web-search-jina",
       "category": "capabilities",
-      "description": "Jina Search - fast web search returning SERP results",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/web-search-jina",
       "files": [
-        "skills/capabilities/web-search-jina/SKILL.md",
-        "skills/capabilities/web-search-jina/skill.meta.json"
+        "skills\\capabilities\\web-search-jina\\SKILL.md",
+        "skills\\capabilities\\web-search-jina\\skill.meta.json"
       ],
       "metadata": {
         "slug": "web-search-jina",
@@ -5690,12 +6007,12 @@
       "slug": "web-search-linkup",
       "name": "web-search-linkup",
       "category": "capabilities",
-      "description": "Web search and content fetching - search the web or extract content from URLs",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/web-search-linkup",
       "files": [
-        "skills/capabilities/web-search-linkup/SKILL.md",
-        "skills/capabilities/web-search-linkup/skill.meta.json"
+        "skills\\capabilities\\web-search-linkup\\SKILL.md",
+        "skills\\capabilities\\web-search-linkup\\skill.meta.json"
       ],
       "metadata": {
         "slug": "web-search-linkup",
@@ -5716,12 +6033,12 @@
       "slug": "web-search-perplexity",
       "name": "web-search-perplexity",
       "category": "capabilities",
-      "description": "Perplexity AI search and chat completions with real-time web data",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/web-search-perplexity",
       "files": [
-        "skills/capabilities/web-search-perplexity/SKILL.md",
-        "skills/capabilities/web-search-perplexity/skill.meta.json"
+        "skills\\capabilities\\web-search-perplexity\\SKILL.md",
+        "skills\\capabilities\\web-search-perplexity\\skill.meta.json"
       ],
       "metadata": {
         "slug": "web-search-perplexity",
@@ -5742,12 +6059,12 @@
       "slug": "web-search-tavily",
       "name": "web-search-tavily",
       "category": "capabilities",
-      "description": "AI-powered web search, crawling, extraction, and deep research",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/web-search-tavily",
       "files": [
-        "skills/capabilities/web-search-tavily/SKILL.md",
-        "skills/capabilities/web-search-tavily/skill.meta.json"
+        "skills\\capabilities\\web-search-tavily\\SKILL.md",
+        "skills\\capabilities\\web-search-tavily\\skill.meta.json"
       ],
       "metadata": {
         "slug": "web-search-tavily",
@@ -5768,12 +6085,12 @@
       "slug": "web-search-valyu",
       "name": "web-search-valyu",
       "category": "capabilities",
-      "description": "Web search, AI answers, content extraction, and async deep research",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/web-search-valyu",
       "files": [
-        "skills/capabilities/web-search-valyu/SKILL.md",
-        "skills/capabilities/web-search-valyu/skill.meta.json"
+        "skills\\capabilities\\web-search-valyu\\SKILL.md",
+        "skills\\capabilities\\web-search-valyu\\skill.meta.json"
       ],
       "metadata": {
         "slug": "web-search-valyu",
@@ -5791,15 +6108,50 @@
       }
     },
     {
+      "slug": "webhook-catalog-author",
+      "name": "webhook-catalog-author",
+      "category": "composites",
+      "description": "",
+      "tags": "content, research",
+      "path": "skills/composites/webhook-catalog-author",
+      "files": [
+        "skills\\composites\\webhook-catalog-author\\SKILL.md",
+        "skills\\composites\\webhook-catalog-author\\skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "webhook-catalog-author",
+        "category": "composites",
+        "tags": [
+          "content",
+          "research"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install webhook-catalog-author",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Audits event naming conventions and produces a grouped event taxonomy table",
+          "Writes per-event payload schema reference with typed field tables from sample JSON",
+          "Generates HMAC signature verification code in multiple languages with timing-safe comparison warnings",
+          "Documents delivery guarantees, retry policy with backoff table, and failed-delivery monitoring",
+          "Produces a deduplication guide with idempotent consumer code and a pre-production consumer checklist"
+        ]
+      }
+    },
+    {
       "slug": "website-screenshot-notte",
       "name": "website-screenshot-notte",
       "category": "capabilities",
-      "description": "Take screenshots of any website using Notte browser automation. Use when asked to screenshot, capture, or snap a webpage.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/website-screenshot-notte",
       "files": [
-        "skills/capabilities/website-screenshot-notte/SKILL.md",
-        "skills/capabilities/website-screenshot-notte/skill.meta.json"
+        "skills\\capabilities\\website-screenshot-notte\\SKILL.md",
+        "skills\\capabilities\\website-screenshot-notte\\skill.meta.json"
       ],
       "metadata": {
         "slug": "website-screenshot-notte",
@@ -5820,12 +6172,12 @@
       "slug": "yc-batch-evaluator",
       "name": "yc-batch-evaluator",
       "category": "capabilities",
-      "description": "Evaluate YC batch companies for investment — scrapes the YC directory, researches each company and its founders (work history, LinkedIn, website), assesses founder-company fit, and exports to Google Sheets with priority rankings. Use when asked to evaluate YC companies, research a YC batch, screen startups, or do due diligence on YC companies.",
+      "description": "",
       "tags": "",
       "path": "skills/capabilities/yc-batch-evaluator",
       "files": [
-        "skills/capabilities/yc-batch-evaluator/SKILL.md",
-        "skills/capabilities/yc-batch-evaluator/skill.meta.json"
+        "skills\\capabilities\\yc-batch-evaluator\\SKILL.md",
+        "skills\\capabilities\\yc-batch-evaluator\\skill.meta.json"
       ],
       "metadata": {
         "slug": "yc-batch-evaluator",
@@ -5846,16 +6198,16 @@
       "slug": "youtube-apify-transcript",
       "name": "youtube-apify-transcript",
       "category": "capabilities",
-      "description": "Fetch YouTube transcripts via APIFY API. Works from cloud IPs (Hetzner, AWS, etc.) by bypassing YouTube's bot detection. Free tier includes $5/month credits (~714 videos). No credit card required.",
+      "description": "",
       "tags": "research",
       "path": "skills/capabilities/youtube-apify-transcript",
       "files": [
-        "skills/capabilities/youtube-apify-transcript/CHANGELOG.md",
-        "skills/capabilities/youtube-apify-transcript/README.md",
-        "skills/capabilities/youtube-apify-transcript/SKILL.md",
-        "skills/capabilities/youtube-apify-transcript/package.json",
-        "skills/capabilities/youtube-apify-transcript/scripts/fetch_transcript.py",
-        "skills/capabilities/youtube-apify-transcript/skill.meta.json"
+        "skills\\capabilities\\youtube-apify-transcript\\CHANGELOG.md",
+        "skills\\capabilities\\youtube-apify-transcript\\package.json",
+        "skills\\capabilities\\youtube-apify-transcript\\README.md",
+        "skills\\capabilities\\youtube-apify-transcript\\scripts\\fetch_transcript.py",
+        "skills\\capabilities\\youtube-apify-transcript\\SKILL.md",
+        "skills\\capabilities\\youtube-apify-transcript\\skill.meta.json"
       ],
       "metadata": {
         "slug": "youtube-apify-transcript",
@@ -5877,13 +6229,13 @@
       "slug": "youtube-watcher",
       "name": "youtube-watcher",
       "category": "capabilities",
-      "description": "Fetch and read transcripts from YouTube videos. Use when you need to summarize a video, answer questions about its content, or extract information from it.",
+      "description": "",
       "tags": "content",
       "path": "skills/capabilities/youtube-watcher",
       "files": [
-        "skills/capabilities/youtube-watcher/SKILL.md",
-        "skills/capabilities/youtube-watcher/scripts/get_transcript.py",
-        "skills/capabilities/youtube-watcher/skill.meta.json"
+        "skills\\capabilities\\youtube-watcher\\scripts\\get_transcript.py",
+        "skills\\capabilities\\youtube-watcher\\SKILL.md",
+        "skills\\capabilities\\youtube-watcher\\skill.meta.json"
       ],
       "metadata": {
         "slug": "youtube-watcher",
@@ -5919,81 +6271,81 @@
         {
           "slug": "lead-discovery",
           "name": "lead-discovery",
-          "description": "Orchestrator that runs first for lead generation requests. Gathers business context via website analysis or questions, identifies competitors, builds ICP, and routes to signal skills with pre-filled inputs.",
+          "description": "",
           "path": "skills/packs/lead-gen-devtools/lead-discovery",
           "files": [
-            "skills/packs/lead-gen-devtools/lead-discovery/SKILL.md"
+            "skills\\packs\\lead-gen-devtools\\lead-discovery\\SKILL.md"
           ],
           "source": "pack"
         },
         {
           "slug": "github-repo-signals",
           "name": "github-repo-signals",
-          "description": "Extract and score leads from GitHub repositories by analyzing stars, forks, issues, PRs, comments, and contributions. Produces unified multi-repo CSV with deduplicated user profiles. No paid API credits required.",
+          "description": "",
           "path": "skills/packs/lead-gen-devtools/github-repo-signals",
           "files": [
-            "skills/packs/lead-gen-devtools/github-repo-signals/SKILL.md",
-            "skills/packs/lead-gen-devtools/github-repo-signals/scripts/__init__.py",
-            "skills/packs/lead-gen-devtools/github-repo-signals/scripts/gh_common.py",
-            "skills/packs/lead-gen-devtools/github-repo-signals/scripts/gh_contributors.py",
-            "skills/packs/lead-gen-devtools/github-repo-signals/scripts/gh_issues_scanner.py",
-            "skills/packs/lead-gen-devtools/github-repo-signals/scripts/gh_repo_signals.py",
-            "skills/packs/lead-gen-devtools/github-repo-signals/scripts/gh_stars_forks.py",
-            "skills/packs/lead-gen-devtools/github-repo-signals/scripts/gh_techstack.py"
+            "skills\\packs\\lead-gen-devtools\\github-repo-signals\\scripts\\gh_common.py",
+            "skills\\packs\\lead-gen-devtools\\github-repo-signals\\scripts\\gh_contributors.py",
+            "skills\\packs\\lead-gen-devtools\\github-repo-signals\\scripts\\gh_issues_scanner.py",
+            "skills\\packs\\lead-gen-devtools\\github-repo-signals\\scripts\\gh_repo_signals.py",
+            "skills\\packs\\lead-gen-devtools\\github-repo-signals\\scripts\\gh_stars_forks.py",
+            "skills\\packs\\lead-gen-devtools\\github-repo-signals\\scripts\\gh_techstack.py",
+            "skills\\packs\\lead-gen-devtools\\github-repo-signals\\scripts\\__init__.py",
+            "skills\\packs\\lead-gen-devtools\\github-repo-signals\\SKILL.md"
           ],
           "source": "pack"
         },
         {
           "slug": "community-signals",
           "name": "community-signals",
-          "description": "Extract leads from developer forums (Hacker News, Reddit) by detecting intent signals — alternative seeking, competitor pain, scaling challenges, DIY solutions, and migration intent. Scores users by intent strength and cross-platform presence.",
+          "description": "",
           "path": "skills/packs/lead-gen-devtools/community-signals",
           "files": [
-            "skills/packs/lead-gen-devtools/community-signals/SKILL.md",
-            "skills/packs/lead-gen-devtools/community-signals/scripts/community_signals.py"
+            "skills\\packs\\lead-gen-devtools\\community-signals\\scripts\\community_signals.py",
+            "skills\\packs\\lead-gen-devtools\\community-signals\\SKILL.md"
           ],
           "source": "pack"
         },
         {
           "slug": "competitor-signals",
           "name": "competitor-signals",
-          "description": "Extract leads from competitor product activity — Product Hunt commenters/upvoters, HN posts about competitors, case studies, testimonials, tech press, and switching signals. Detects people actively switching from competitors as highest-priority leads.",
+          "description": "",
           "path": "skills/packs/lead-gen-devtools/competitor-signals",
           "files": [
-            "skills/packs/lead-gen-devtools/competitor-signals/SKILL.md",
-            "skills/packs/lead-gen-devtools/competitor-signals/scripts/competitor_signals.py"
+            "skills\\packs\\lead-gen-devtools\\competitor-signals\\scripts\\competitor_signals.py",
+            "skills\\packs\\lead-gen-devtools\\competitor-signals\\SKILL.md"
           ],
           "source": "pack"
         },
         {
           "slug": "event-signals",
           "name": "event-signals",
-          "description": "Extract leads from conferences, meetups, hackathons, and podcasts by analyzing speaker lists, sponsor lists, hackathon entries, and podcast guests. Discovers events via Sessionize, Confs.tech, Meetup, Luma, ListenNotes, and Devpost. Looks back 90 days and forward 180 days.",
+          "description": "",
           "path": "skills/packs/lead-gen-devtools/event-signals",
           "files": [
-            "skills/packs/lead-gen-devtools/event-signals/SKILL.md",
-            "skills/packs/lead-gen-devtools/event-signals/scripts/event_signals.py"
+            "skills\\packs\\lead-gen-devtools\\event-signals\\scripts\\event_signals.py",
+            "skills\\packs\\lead-gen-devtools\\event-signals\\SKILL.md"
           ],
           "source": "pack"
         },
         {
           "slug": "demo-builder",
           "name": "demo-builder",
-          "description": "Builds personalized demo assets for top prospects using the founder's product API/MCP/SDK. Researches prospect, proposes demo concepts, builds working prototype, tests it, and generates comparison report with live demo link.",
+          "description": "",
           "path": "skills/packs/lead-gen-devtools/demo-builder",
           "files": [
-            "skills/packs/lead-gen-devtools/demo-builder/SKILL.md"
+            "skills\\packs\\lead-gen-devtools\\demo-builder\\SKILL.md"
           ],
           "source": "pack"
         },
         {
           "slug": "hiring-signal-outreach",
           "name": "hiring-signal-outreach",
-          "description": ">",
+          "description": "",
           "path": "skills/composites/hiring-signal-outreach",
           "files": [
-            "skills/composites/hiring-signal-outreach/SKILL.md",
-            "skills/composites/hiring-signal-outreach/skill.meta.json"
+            "skills\\composites\\hiring-signal-outreach\\SKILL.md",
+            "skills\\composites\\hiring-signal-outreach\\skill.meta.json"
           ],
           "source": "registry"
         }
@@ -6049,57 +6401,57 @@
         {
           "slug": "beat-sync-reel",
           "name": "beat-sync-reel",
-          "description": "Generates Instagram Reels where product image cuts are synced to audio beats. Accepts audio as a local file, URL, or search query. Uses librosa for beat detection, FFmpeg Ken Burns for scene animation, and Pillow for text overlays. No AI video generation — fully free, fast, and scalable.",
+          "description": "",
           "path": "skills/packs/video-production/beat-sync-reel",
           "files": [
-            "skills/packs/video-production/beat-sync-reel/SKILL.md",
-            "skills/packs/video-production/beat-sync-reel/skill.meta.json"
+            "skills\\packs\\video-production\\beat-sync-reel\\SKILL.md",
+            "skills\\packs\\video-production\\beat-sync-reel\\skill.meta.json"
           ],
           "source": "pack"
         },
         {
           "slug": "product-reel-generator",
           "name": "product-reel-generator",
-          "description": "Generates Instagram-ready product reels from any e-commerce product page URL. Scrapes product images, classifies by type, generates AI-animated clips via Higgsfield API, creates text overlays with style presets, and composes a 15-20 second reel with music. Supports model-based and product-only reels.",
+          "description": "",
           "path": "skills/packs/video-production/product-reel-generator",
           "files": [
-            "skills/packs/video-production/product-reel-generator/SKILL.md",
-            "skills/packs/video-production/product-reel-generator/scripts/higgsfield_video.py",
-            "skills/packs/video-production/product-reel-generator/skill.meta.json"
+            "skills\\packs\\video-production\\product-reel-generator\\scripts\\higgsfield_video.py",
+            "skills\\packs\\video-production\\product-reel-generator\\SKILL.md",
+            "skills\\packs\\video-production\\product-reel-generator\\skill.meta.json"
           ],
           "source": "pack"
         },
         {
           "slug": "talking-head-video",
           "name": "talking-head-video",
-          "description": "Creates talking head videos from any source material (docs, changelogs, blog posts, notes, transcripts). Produces multi-scene videos with avatar narration over screenshots/images using HeyGen v2 API. Supports Quick Shot and Full Producer modes.",
+          "description": "",
           "path": "skills/packs/video-production/talking-head-video",
           "files": [
-            "skills/packs/video-production/talking-head-video/AVATAR-CONFIG.example.md",
-            "skills/packs/video-production/talking-head-video/SKILL.md",
-            "skills/packs/video-production/talking-head-video/skill.meta.json"
+            "skills\\packs\\video-production\\talking-head-video\\AVATAR-CONFIG.example.md",
+            "skills\\packs\\video-production\\talking-head-video\\SKILL.md",
+            "skills\\packs\\video-production\\talking-head-video\\skill.meta.json"
           ],
           "source": "pack"
         },
         {
           "slug": "video-clipper",
           "name": "video-clipper",
-          "description": "Repurposes long-form video (podcasts, interviews, talks) into short-form vertical clips for Instagram Reels, TikTok, and YouTube Shorts. Handles transcription, moment selection, clip extraction, speaker-tracked reframing (16:9 to 9:16), and animated captions.",
+          "description": "",
           "path": "skills/packs/video-production/video-clipper",
           "files": [
-            "skills/packs/video-production/video-clipper/SKILL.md",
-            "skills/packs/video-production/video-clipper/skill.meta.json"
+            "skills\\packs\\video-production\\video-clipper\\SKILL.md",
+            "skills\\packs\\video-production\\video-clipper\\skill.meta.json"
           ],
           "source": "pack"
         },
         {
           "slug": "video-polish",
           "name": "video-polish",
-          "description": "Takes an existing screen recording or demo video and adds professional zoom/pan effects synchronized to the narration. Uses transcript-driven zoom targeting and Remotion for rendering. Optionally replaces audio with a soundtrack.",
+          "description": "",
           "path": "skills/packs/video-production/video-polish",
           "files": [
-            "skills/packs/video-production/video-polish/SKILL.md",
-            "skills/packs/video-production/video-polish/skill.meta.json"
+            "skills\\packs\\video-production\\video-polish\\SKILL.md",
+            "skills\\packs\\video-production\\video-polish\\skill.meta.json"
           ],
           "source": "pack"
         }

--- a/skills/composites/api-deprecation-sunset-planner/SKILL.md
+++ b/skills/composites/api-deprecation-sunset-planner/SKILL.md
@@ -1,0 +1,370 @@
+---
+name: api-deprecation-sunset-planner
+description: >
+  Plan and draft the complete deprecation-to-removal communication pipeline for an API endpoint, field, auth scheme, or SDK version: deprecation header strategy, phased announcement timeline, per-channel copy (docs, email, response headers, in-SDK warnings), upgrade prompts, and a final shutdown checklist. Scoped to planned deprecation comms — not emergency breaking changes (use breaking-change-comms-kit) and not changelog entries for already-shipped removals (use api-release-notes-composer). Use when an API team knows what they are deprecating and needs a full deprecation runway plan before the first announcement goes out.
+tags: [content, research]
+---
+
+# API Deprecation Sunset Planner
+
+Plan the full deprecation runway from first announcement to final removal. This skill produces the complete deprecation communication pipeline — header strategy, phased timeline, per-channel copy, migration prompts, and a shutdown checklist — so the team can run a clean deprecation without surprising consumers or burning support bandwidth.
+
+**Built for:** API product managers, DevRel engineers, and backend teams who know what they're deprecating and need a structured plan before anything goes out. The goal is a deprecation that consumers see coming, understand, and migrate from — without needing a support ticket.
+
+## Best Fit
+
+- Endpoint deprecations (retiring a URL path)
+- Response field deprecations (removing a field from an existing response)
+- Authentication scheme deprecations (retiring API key format, OAuth flow, etc.)
+- SDK major version deprecations (v2 → v3 migration window)
+- Webhook event type renaming or removal
+- API version end-of-life planning
+
+## Use Something Else
+
+- For emergency breaking changes that must go live before a full deprecation runway, use `breaking-change-comms-kit`.
+- For changelog entries documenting a removal that already shipped, use `api-release-notes-composer`.
+- For the full set of channel copy during an active breaking change window, use `breaking-change-comms-kit`.
+- For developer newsletter announcing the deprecation, use `developer-newsletter-composer`.
+
+## Inputs
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `deprecated_item` | Yes | What is being deprecated: endpoint path, field name, auth scheme, SDK version |
+| `replacement` | Yes | What consumers should use instead |
+| `reason` | No | Why this is being deprecated (briefly) |
+| `planned_removal_date` | Yes | When the item will be removed (hard cutoff) |
+| `announcement_date` | No | When the deprecation will first be announced |
+| `consumer_estimate` | No | Rough estimate of how many consumers use this item |
+| `detectable` | No | Can the API tell which consumers are still using the deprecated item? (yes/no) |
+| `deprecation_header` | No | Header name to use (default: `Deprecation`) |
+| `support_contacts` | No | Support alias, Slack channel, GitHub discussion URL |
+| `api_name` | Yes | Name of the API |
+
+## Phase 0 — Intake
+
+Ask only for what is missing.
+
+1. What specifically is being deprecated? (Endpoint path, field name, auth scheme, SDK version)
+2. What replaces it? What must consumers use instead?
+3. When will it be removed? (The hard cutoff date)
+4. When do you want the first announcement to go out?
+5. Can your system detect which consumers are currently using the deprecated item?
+
+## Phase 1 — Deprecation Assessment
+
+Before generating any comms, assess the deprecation's complexity:
+
+### Impact Assessment
+
+| Dimension | Questions to answer |
+|-----------|---------------------|
+| **Breadth** | How many consumers use this? Is usage concentrated or distributed? |
+| **Migration effort** | Is this a field rename (low) or a full auth flow change (high)? |
+| **Detectability** | Can you identify and contact specific consumers who need to migrate? |
+| **Replacement maturity** | Is the replacement generally available, or still in beta? |
+| **Runway adequacy** | Is the planned removal date realistic for the migration effort required? |
+
+Produce an assessment:
+
+```
+DEPRECATION ASSESSMENT
+
+Item: GET /v1/users (endpoint)
+Replacement: GET /v2/users
+Reason: v1 response shape does not support pagination
+Consumer estimate: ~40% of active API consumers
+Migration effort: Medium — response shape changed, consumers need minor updates
+Detectable: Yes — API can log requests to /v1/users
+Replacement maturity: GA since 2025-06-01
+Planned removal: 2026-09-01
+Announcement planned: 2026-05-15
+Runway: 109 days
+
+Assessment: Runway is adequate for a Medium-effort migration.
+Recommendation: Use 90-day standard deprecation timeline.
+```
+
+### Minimum Runway Guidelines
+
+| Migration effort | Minimum recommended runway |
+|------------------|-----------------------------|
+| Low (field rename, header change) | 60 days |
+| Medium (endpoint replacement, minor schema change) | 90 days |
+| High (auth overhaul, SDK major version, full resource migration) | 180 days |
+| Critical (auth, widely used, high migration effort) | 365 days |
+
+Flag if the planned removal date is shorter than the minimum for the effort level.
+
+## Phase 2 — Deprecation Header Strategy
+
+Define how the deprecated item will signal its status in API responses.
+
+### HTTP Deprecation Headers
+
+Use the IETF `Deprecation` header (RFC 9745) for endpoint and field deprecations:
+
+```http
+Deprecation: Sat, 01 Sep 2026 00:00:00 GMT
+Sunset: Sat, 01 Sep 2026 00:00:00 GMT
+Link: <https://docs.example.com/migration/v1-users>; rel="deprecation"
+```
+
+| Header | Value | Notes |
+|--------|-------|-------|
+| `Deprecation` | HTTP date of removal | When the item stops working |
+| `Sunset` | HTTP date of removal | Mirrors Deprecation for client library compatibility |
+| `Link` | URL with `rel="deprecation"` | Links to the migration guide |
+
+### When to Start Sending Deprecation Headers
+
+Send deprecation headers on every response from the deprecated endpoint or containing the deprecated field from the first announcement date. Do not wait until close to the sunset date.
+
+### SDK Deprecation Markers
+
+For SDK method deprecations, use the language-idiomatic deprecation marker:
+
+```javascript
+// JavaScript/TypeScript
+/** @deprecated Use client.users.listV2() instead. Removes 2026-09-01. */
+client.users.list = function() { ... }
+
+// Python
+import warnings
+def list_users(self, *args, **kwargs):
+    warnings.warn(
+        "list_users() is deprecated. Use list_users_v2() instead. Removes 2026-09-01.",
+        DeprecationWarning,
+        stacklevel=2
+    )
+```
+
+## Phase 3 — Phased Communication Timeline
+
+Build a deprecation comms timeline from the removal date backward.
+
+### Standard Deprecation Timeline (90-day example)
+
+| Phase | Timing | Actions |
+|-------|--------|---------|
+| **D-90: Announcement** | Day 0 | Enable deprecation headers. Post initial announcement. Email all consumers (if detectable, email affected only). Publish migration guide. |
+| **D-60: First reminder** | Day 30 | Email reminder. Update docs with warning banner. Post community reminder (Discord/Slack). |
+| **D-30: Escalation** | Day 60 | Email "final 30 days" notice. Increase docs banner prominence. Post in all relevant community channels. |
+| **D-14: Last chance** | Day 76 | Email consumers still on deprecated item (if detectable). Post "2 weeks left" community update. |
+| **D-7: Final warning** | Day 83 | Email final warning. Status page upcoming change notice. |
+| **D-0: Removal** | Day 90 | Remove deprecated item. Update docs. Publish removal notice. Update changelog. |
+| **D+3: Post-removal** | Day 93 | Monitor for unexpected support spike. Publish post-removal notice if support volume is high. |
+
+Compress or extend based on the impact assessment runway recommendation.
+
+```
+DEPRECATION TIMELINE — GET /v1/users sunset
+
+2026-05-15  (D-0/Announcement)  Enable Deprecation headers. Email all consumers.
+                                 Publish migration guide. Changelog entry.
+2026-06-14  (D-30 reminder)     Email reminder. Update docs banner to prominent warning.
+                                 Discord/Slack community reminder.
+2026-07-15  (D-60 escalation)   Email "final 60 days" notice. Increase docs prominence.
+2026-08-01  (D-30 final)        Email "final 30 days." Post all channels.
+2026-08-15  (D-14 last-chance)  Email unconverted consumers (if detectable).
+2026-08-25  (D-7 final warning) Email final warning. Status page notice.
+2026-09-01  (D-0 removal)       Remove /v1/users. Update docs. Publish removal changelog.
+2026-09-04  (D+3 follow-up)     Support review. Post-removal notice if needed.
+```
+
+## Phase 4 — Per-Channel Copy
+
+### Initial Announcement Email
+
+```
+Subject: Deprecation notice: [Deprecated item] removes on [Date]
+
+Starting today, [deprecated item] is deprecated and will be removed on [Date].
+
+What to use instead: [replacement item] — [one-sentence description]
+Migration guide: [URL]
+
+[If detectable: We can see your account is actively using [deprecated item].
+You'll need to migrate before [Date] to avoid service interruption.]
+
+[If workaround period applies:] During the deprecation window, [deprecated item] will
+continue to work normally. Deprecation headers are now included in responses.
+
+Questions? [support alias or channel]
+— [Team name]
+```
+
+---
+
+### Reminder Email (D-30)
+
+```
+Subject: Reminder: [Deprecated item] removes in 30 days ([Date])
+
+A reminder: [deprecated item] will stop working on [Date] — 30 days from now.
+
+If you haven't started your migration, now is the time. [Migration guide →](URL)
+
+[If detectable: We can see your account is still using [deprecated item] on
+average [N] times per [day/week].]
+
+Questions? [support alias]
+— [Team name]
+```
+
+---
+
+### Last-Chance Email (D-14, for detectable consumers only)
+
+```
+Subject: Action required: [Deprecated item] removes in 14 days
+
+[Deprecated item] will stop working on [Date] — 14 days from now.
+Your account is still using it.
+
+→ Migration guide: [URL]
+→ Need help? [support alias]
+
+If you need more time, contact [support alias] before [Date] to discuss options.
+— [Team name]
+```
+
+---
+
+### Docs Banner Copy
+
+**Warning stage (D-90 to D-30):**
+```
+⚠ Deprecated: [Item name] will be removed on [Date]. Migrate to [replacement] using the [migration guide →](URL).
+```
+
+**Final stage (D-30 to D-0):**
+```
+⛔ Removal in [N] days: [Item name] will stop working on [Date]. [Migrate now →](URL)
+```
+
+---
+
+### Discord/Slack Community Post
+
+**Initial:**
+```
+📣 Deprecation notice: [Item name] is deprecated and will be removed on [Date].
+
+Replacement: [What to use instead]
+Migration guide: [URL]
+
+Deprecation response headers are now live. Check your integration logs for Deprecation/Sunset headers.
+
+Questions? Reply here or reach out in #api-support.
+```
+
+**D-30 reminder:**
+```
+⏰ 30 days left: [Item name] retires on [Date].
+
+If you haven't migrated yet: [migration guide URL]
+
+We'll post another reminder at D-7.
+```
+
+---
+
+### Status Page Upcoming Change
+
+```
+[Upcoming] [Item name] removal — [Date]
+[API name]: [Item name] will be removed on [Date].
+Consumers using this item must migrate to [replacement] before that date.
+Migration guide: [URL]
+```
+
+---
+
+### Changelog Entry
+
+Use in conjunction with `api-release-notes-composer`. Supply this brief:
+
+```
+Deprecated: [Item name]
+Replacement: [What to use instead]
+Sunset date: [Date]
+Migration guide URL: [URL]
+```
+
+## Phase 5 — Migration Guide Outline
+
+Produce a migration guide outline (full content via `api-release-notes-composer` or `breaking-change-comms-kit`):
+
+```markdown
+# Migration: [Deprecated item] → [Replacement]
+
+## What is changing and why
+
+## Who is affected
+
+## Migration steps
+
+### Step 1:
+### Step 2:
+
+## Before and after
+
+**Before:**
+
+**After:**
+
+## Testing your migration
+
+## Deadline and support
+```
+
+## Phase 6 — Shutdown Checklist
+
+Provide this checklist for the day of removal:
+
+```markdown
+## Removal day checklist — [Date]
+
+Pre-removal (the day before):
+- [ ] Confirm migration guide is current and links are not broken
+- [ ] Confirm docs banner has been updated to "Removal tomorrow" language
+- [ ] Notify on-call team that a change is scheduled
+
+Removal (D-0):
+- [ ] Remove / disable the deprecated endpoint, field, or scheme
+- [ ] Update API docs — remove deprecated item from reference, update all examples
+- [ ] Remove deprecation header from all responses (no longer needed after removal)
+- [ ] Publish removal entry in changelog (use api-release-notes-composer)
+- [ ] Post removal notice in Discord/Slack and on status page
+- [ ] Update SDK to throw a clear error if old method is called
+
+Post-removal (D+3):
+- [ ] Review support ticket volume — is there an unexpected spike?
+- [ ] If spike: triage whether affected consumers were notified and when
+- [ ] If a large enterprise consumer is blocked: escalate to account management
+- [ ] Archive the deprecated item's docs page (do not delete — keep for historical search)
+```
+
+## Phase 7 — Output
+
+Deliver as a single document:
+
+1. Deprecation assessment
+2. Minimum runway check
+3. Deprecation header configuration
+4. Phased communication timeline
+5. All channel copy (email × 3, docs banner × 2, Discord/Slack × 2, status page, changelog brief)
+6. Migration guide outline
+7. Removal day checklist
+8. `[URL: ...]` and `[FILL: ...]` placeholders list
+
+## Guardrails
+
+- Do not generate comms before confirming the replacement exists and is generally available
+- Do not set a removal date that is shorter than the minimum runway for the effort level without flagging it
+- Do not omit the migration guide link from any channel copy
+- Do not write removal comms (D-0 or later) before the planned removal date is confirmed
+- If the deprecated item has no detectable consumer signal, flag that targeted last-chance emails are not possible and widen to all-consumer communications
+- Flag if the replacement is still in beta — deprecating an item before the replacement is GA is a support risk

--- a/skills/composites/api-deprecation-sunset-planner/skill.meta.json
+++ b/skills/composites/api-deprecation-sunset-planner/skill.meta.json
@@ -1,0 +1,26 @@
+{
+  "slug": "api-deprecation-sunset-planner",
+  "category": "composites",
+  "tags": [
+    "content",
+    "research"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install api-deprecation-sunset-planner",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "requires_skills": [
+    "api-release-notes-composer"
+  ],
+  "features": [
+    "Assesses migration effort, consumer breadth, and detectable usage before building the plan",
+    "Validates the planned removal date against minimum runway guidelines by migration effort level",
+    "Produces HTTP Deprecation/Sunset header configuration with IETF RFC 9745 format and SDK deprecation markers",
+    "Builds a phased backward-planning timeline with action items from D-90 announcement through D+3 post-removal",
+    "Delivers all channel copy variants (email x3, docs banner x2, Discord, status page) and a day-of removal checklist"
+  ]
+}

--- a/skills/composites/api-release-notes-composer/SKILL.md
+++ b/skills/composites/api-release-notes-composer/SKILL.md
@@ -1,0 +1,251 @@
+---
+name: api-release-notes-composer
+description: >
+  Turn a raw list of merged PRs, tickets, commits, or a plain diff summary into structured, semver-aware API changelog entries for developer audiences. Produces additive, breaking, deprecated, and removed sections, writes concise developer-facing prose for each change, and flags upgrade implications. Pure reasoning skill scoped to API versioning comms. Use when an API team needs to convert ship artifacts into a polished changelog before a release — not for general product launch kits (use feature-launch-playbook) and not for support articles (use help-center-article-generator).
+tags: [content, research]
+---
+
+# API Release Notes Composer
+
+Turn raw ship data into clean, developer-facing API release notes. This skill handles the mechanical and editorial work of converting PRs, tickets, and commit messages into a structured, semver-versioned changelog that API consumers can actually act on.
+
+**Built for:** API teams, developer-experience writers, and backend engineers who need a polished changelog entry before a release goes out — without spending an hour wrangling copy.
+
+## Best Fit
+
+- Weekly or monthly API version releases
+- Individual endpoint additions, changes, and removals
+- Breaking-change windows with migration requirements
+- Deprecation notices with sunset timelines
+- SDK patch and minor release notes
+
+## Use Something Else
+
+- If you need a full launch kit — email, social, in-app banner, LinkedIn post — use `feature-launch-playbook`.
+- If you need support KB articles or step-by-step how-to docs, use `help-center-article-generator`.
+- If you need the full breaking-change comms kit (migration guide + channel copy), use `breaking-change-comms-kit`.
+- If you need a recurring developer digest newsletter, use `developer-newsletter-composer`.
+
+## Inputs
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `version` | Yes | Semver string: `2.4.0`, `1.0.0-rc.1`, etc. |
+| `previous_version` | No | Anchors the diff window for readers |
+| `release_date` | No | ISO date string or human-readable |
+| `raw_changes` | Yes | PR list, ticket list, commit log, diff summary, or plain prose bullet list |
+| `api_surface` | No | REST, GraphQL, gRPC, or WebSocket — affects section framing |
+| `audience` | No | External consumers, internal teams, or both |
+| `include_migration_hints` | No | Default: `true` for breaking changes |
+| `format` | No | `markdown` (default), `json`, or `html` |
+
+## Phase 0 — Intake
+
+Ask only for what is missing. Do not prompt for every field up front.
+
+1. What version is being released?
+2. What is the raw list of changes? (PRs, tickets, commits, or prose)
+3. Is this an external developer-facing changelog or an internal one?
+4. Are there any known breaking changes?
+5. Is there a release date to include?
+
+If the user pastes a raw commit log or PR list directly, start processing immediately without asking for confirmation.
+
+## Phase 1 — Change Classification
+
+Before writing anything, classify each change into one of five buckets:
+
+| Bucket | Semver Impact | What belongs here |
+|--------|---------------|-------------------|
+| **Added** | Minor | New endpoints, new fields, new query params, new event types |
+| **Changed** | Patch or Minor | Behavior tweaks, response shape adjustments that don't break consumers |
+| **Breaking** | Major | Removed endpoints, renamed fields, changed required params, new auth requirements |
+| **Deprecated** | Minor | Endpoints or fields still functional but sunset-scheduled |
+| **Fixed** | Patch | Bug fixes, correctness improvements, performance without contract change |
+| **Removed** | Major | Previously deprecated items now gone |
+| **Security** | Patch or Major | Vulnerability patches, auth behavior hardening |
+
+### Classification Rules
+
+- If the change removes or renames a field, endpoint, or enum value → **Breaking**
+- If the change adds a new optional field or endpoint → **Added**
+- If the change modifies an existing response without removing anything → **Changed**
+- If the change was already deprecated in a prior version and is now gone → **Removed**
+- If no consumers need to change code → **Fixed** or **Changed**
+- When unsure, err toward **Breaking** and flag it for review
+
+Produce a classification table before writing prose:
+
+```
+CHANGE CLASSIFICATION
+
+Breaking (2):
+- PR #482: Removed `user.legacy_id` field from /v2/users response
+- PR #501: Changed auth header from `X-Token` to `Authorization: Bearer`
+
+Added (3):
+- PR #477: New GET /v2/users/:id/sessions endpoint
+- PR #489: Added `created_by` field to /v2/projects response
+- PR #495: New webhook event: `project.archived`
+
+Fixed (1):
+- PR #498: Pagination cursor now stable under concurrent writes
+
+Deprecated (1):
+- PR #503: GET /v1/users is now deprecated; sunset: 2026-10-01
+```
+
+Show this classification to the user if there are breaking changes, and ask for confirmation before drafting changelog prose.
+
+## Phase 2 — Semver Version Check
+
+Validate the provided version number against the classified changes:
+
+| Scenario | Correct Version | Flag if Wrong |
+|----------|----------------|---------------|
+| Only **Fixed** changes | Patch bump (x.y.Z) | Warn if minor or major bumped unnecessarily |
+| **Added** but no breaking | Minor bump (x.Y.0) | Warn if patch used |
+| Any **Breaking** or **Removed** | Major bump (X.0.0) | Hard flag if minor or patch used |
+
+If the declared version and the change classification disagree, surface the mismatch clearly:
+
+```
+⚠ Version mismatch: You declared 2.3.1 (patch), but the changes include
+breaking: removed `user.legacy_id`. This is a major version bump (3.0.0).
+Proceed with 2.3.1 anyway, or update the version?
+```
+
+## Phase 3 — Write the Changelog Entry
+
+Use the following structure. Omit sections that have no entries.
+
+### Changelog Entry Template
+
+```markdown
+## [VERSION] — RELEASE_DATE
+
+### Breaking Changes
+
+> ⚠ Action required before upgrading.
+
+- **Removed `user.legacy_id`** — The `legacy_id` field has been removed from all `/v2/users` responses. Use `id` instead. [Migration guide →](#migration-legacy-id)
+- **Auth header format changed** — `X-Token` is no longer accepted. Use `Authorization: Bearer <token>`. Update your request headers before upgrading.
+
+### Added
+
+- **`GET /v2/users/:id/sessions`** — Returns the active sessions for a user. Supports `limit` and `cursor` pagination parameters.
+- **`created_by` on projects** — All `/v2/projects` responses now include a `created_by` object with `id`, `name`, and `email`.
+- **`project.archived` webhook event** — Fired when a project moves to archived state. See [Webhook Events →](#webhooks).
+
+### Fixed
+
+- Pagination cursors for `/v2/users` are now stable under concurrent write loads. Previously, a cursor could skip items when new records were inserted mid-page.
+
+### Deprecated
+
+- **`GET /v1/users`** — This endpoint is deprecated and will be removed on **2026-10-01**. Migrate to `GET /v2/users`. [Migration guide →](#migration-v1-users)
+```
+
+### Prose Rules
+
+- Lead with the change name in **bold**
+- Use plain, active-voice developer English
+- Do not invent behavior or claims not present in the source data
+- For breaking changes: always include what to use instead
+- For deprecated items: always include the sunset date if known
+- For new endpoints: name the endpoint path, not just the feature name
+- Avoid marketing language: no "powerful", "seamless", "industry-leading"
+- Aim for one to three sentences per entry; no essay paragraphs
+
+### Length Targets
+
+| Change count | Expected length |
+|-------------|-----------------|
+| 1-5 changes | 150-300 words |
+| 6-15 changes | 300-600 words |
+| 16+ changes | Group into subsections by resource or domain |
+
+If there are more than 15 changes, group them:
+
+```markdown
+### Added
+
+#### Users API
+- ...
+
+#### Projects API
+- ...
+
+#### Webhooks
+- ...
+```
+
+## Phase 4 — Migration Hints (Breaking Changes)
+
+When there are breaking changes, append a migration section unless `include_migration_hints` is false.
+
+```markdown
+## Migration Guide — v2.3.x → v3.0.0
+
+### `user.legacy_id` removal
+
+**Before:**
+```json
+{ "id": "usr_01", "legacy_id": "12345" }
+```
+
+**After:**
+```json
+{ "id": "usr_01" }
+```
+
+**What to change:** Replace any reads of `user.legacy_id` with `user.id`. The `id` field has been stable since v2.0.
+
+---
+
+### Auth header change
+
+**Before:**
+```http
+X-Token: your-token-here
+```
+
+**After:**
+```http
+Authorization: Bearer your-token-here
+```
+
+**What to change:** Update your HTTP client configuration to use the `Authorization` header with the `Bearer` scheme.
+```
+
+Migration hint rules:
+- Show a before/after code pair for every breaking change where possible
+- Keep code examples minimal — enough to show the change, not a full tutorial
+- If a migration is complex, note that a full guide is available and link a placeholder
+
+## Phase 5 — Output
+
+Default format: Markdown.
+
+Deliver:
+1. The full changelog entry
+2. Migration section (if applicable)
+3. A two-sentence TL;DR suitable for a Slack/Discord announcement
+4. Recommended semver version (if it differs from what was declared)
+
+### TL;DR Template
+
+```
+v3.0.0 is out. Breaking: removed `user.legacy_id` and changed auth header format.
+Upgrade path: swap `X-Token` for `Authorization: Bearer`, drop `legacy_id` reads, and
+use `GET /v2/users/:id/sessions` for session data (new).
+```
+
+## Guardrails
+
+- Do not invent API behavior not present in the source changes
+- Do not write marketing copy — this is a technical changelog
+- Do not skip the version mismatch check
+- Do not omit migration hints for breaking changes without the user explicitly disabling them
+- Do not merge a patch and a major change into a single vague "improved reliability" bullet
+- If source data is too sparse to write accurate prose, ask for clarification before guessing

--- a/skills/composites/api-release-notes-composer/skill.meta.json
+++ b/skills/composites/api-release-notes-composer/skill.meta.json
@@ -1,0 +1,23 @@
+{
+  "slug": "api-release-notes-composer",
+  "category": "composites",
+  "tags": [
+    "content",
+    "research"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install api-release-notes-composer",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Classifies PRs, tickets, and commits into Added, Breaking, Deprecated, Fixed, and Removed buckets before writing",
+    "Validates the declared semver version against the change set and flags mismatches",
+    "Writes structured developer-facing changelog prose with endpoint paths, field names, and active-voice copy",
+    "Appends before/after migration hints for every breaking change",
+    "Outputs a Slack/Discord-ready two-sentence TL;DR alongside the full changelog entry"
+  ]
+}

--- a/skills/composites/breaking-change-comms-kit/SKILL.md
+++ b/skills/composites/breaking-change-comms-kit/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: breaking-change-comms-kit
+description: >
+  Build a coordinated, multi-channel communication plan for a breaking API or platform change. Produces a phased timeline, migration steps, per-channel copy (docs banner, email, in-product warning, status page notice), and a support-ready FAQ. Scoped to breaking-change rollout comms — not general feature launch assets (use feature-launch-playbook) and not API changelog entries (use api-release-notes-composer). Use when an engineering or DevRel team needs to roll out a breaking change without surprising consumers and without burning support bandwidth.
+tags: [content, outreach]
+---
+
+# Breaking Change Comms Kit
+
+Coordinate a breaking change rollout across every channel your API consumers rely on. This skill produces the full comms package: migration guide, timeline, channel-specific copy, and a support FAQ — so developers get the information they need before they hit the wall.
+
+**Built for:** API teams, DevRel, and developer-support leads who need to ship a breaking change cleanly. The goal is zero surprise upgrades and minimal support tickets.
+
+## Best Fit
+
+- Endpoint removal or renaming
+- Field removal or type change in API responses
+- Authentication scheme changes
+- SDK major version bumps with non-backward-compatible contracts
+- Webhook payload schema breaking changes
+- Required parameter additions
+- Pagination contract changes
+
+## Use Something Else
+
+- For changelog entries only, use `api-release-notes-composer`.
+- For general product feature launch copy, use `feature-launch-playbook`.
+- For deprecation-only planning (no breaking change yet), use `api-deprecation-sunset-planner`.
+- For incident comms, use `status-incident-comms-writer`.
+
+## Inputs
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `change_summary` | Yes | What is breaking and what replaces it |
+| `affected_surface` | Yes | Endpoint(s), field(s), auth scheme, SDK version, etc. |
+| `break_date` | Yes | When the breaking change goes live |
+| `deprecation_date` | No | When the old behavior was first deprecated (if applicable) |
+| `migration_path` | Yes | What consumers must do to stay compatible |
+| `affected_audience` | No | All consumers, specific tiers, specific SDK users |
+| `support_contacts` | No | Slack channel, email alias, GitHub discussion URL |
+| `tone` | No | Technical/direct (default), empathetic, enterprise-formal |
+
+## Phase 0 — Intake
+
+Ask only for what is missing. Keep it conversational.
+
+1. What is breaking? Be specific: endpoint path, field name, auth header, SDK method.
+2. What replaces it? What does the consumer need to use instead?
+3. When does the old behavior stop working? (the hard cutoff date)
+4. Was this previously announced as deprecated? If yes, when?
+5. Who is affected — all API consumers, or a specific tier / SDK version?
+6. Where should affected developers go for help? (Slack, email, GitHub)
+
+## Phase 1 — Impact Assessment
+
+Before writing any copy, map the impact to guide urgency and channel selection.
+
+### Impact Tiers
+
+| Tier | Criteria | Comms Approach |
+|------|----------|----------------|
+| **Critical** | Auth, core resource CRUD, required for all consumers | Maximum lead time (90+ days), all channels, dedicated migration page |
+| **High** | Widely-used endpoint or field, affects most integrations | 60-day lead, email + docs + in-product warning |
+| **Medium** | Specific feature area, affects a subset of consumers | 30-day lead, docs + email |
+| **Low** | Rarely-used edge, minimal consumer impact | 14-day lead, docs + changelog |
+
+Produce an impact tier assessment before writing comms:
+
+```
+IMPACT ASSESSMENT
+
+Change: Removing `X-Token` auth header support
+Tier: Critical — affects 100% of API consumers
+Deprecation window: Previously announced 2026-01-15
+Hard cutoff: 2026-07-01 (167 days from today)
+Recommended lead time: 90 days minimum ✓
+```
+
+## Phase 2 — Rollout Timeline
+
+Build a comms timeline from the hard cutoff date backward.
+
+### Standard Timeline Template
+
+| Day | Action |
+|-----|--------|
+| T-90 | Initial announcement: email + docs banner + changelog entry |
+| T-60 | Reminder: email + in-product warning for affected consumers |
+| T-30 | Final warning: email + prominent docs banner + Slack/Discord post |
+| T-14 | Last-chance: email to consumers who have not migrated (if detectable) |
+| T-7 | Final heads-up: email + status page notice |
+| T-0 | Change goes live: update docs, publish removal notice, close deprecation banner |
+| T+3 | Post-removal check: confirm no unexpected support spike, publish closure notice |
+
+Compress or expand based on impact tier and available lead time:
+
+```
+ROLLOUT TIMELINE — Auth Header Change (T-0: 2026-07-01)
+
+2026-04-02  (T-90)  Initial announcement — email, docs banner, changelog
+2026-05-01  (T-60)  Reminder email + in-product warning
+2026-06-01  (T-30)  Final warning email + docs banner escalation
+2026-06-17  (T-14)  Last-chance email to unmigrated consumers
+2026-06-24  (T-7)   Status page preview notice
+2026-07-01  (T-0)   Change live — remove old endpoint, update docs
+2026-07-04  (T+3)   Post-removal support review
+```
+
+## Phase 3 — Migration Guide
+
+The migration guide is the most important artifact. Write it first.
+
+### Migration Guide Structure
+
+```markdown
+# Migration Guide: [Change Name]
+
+## What is changing
+
+[One paragraph. State exactly what stops working and when.]
+
+## Who is affected
+
+[Specific criteria: SDK versions, API versions, auth methods, endpoint users.]
+
+## What to do
+
+### Step 1: [Action]
+[Minimal, copy-paste-safe instructions. Code examples where applicable.]
+
+### Step 2: [Action]
+...
+
+## Before and after
+
+**Before:**
+[Code or request example showing old behavior]
+
+**After:**
+[Code or request example showing new behavior]
+
+## Testing your migration
+
+[How to verify the migration worked before the cutoff date. Staging environment, test mode, etc.]
+
+## If you need help
+
+[Link to support channel, GitHub discussion, migration office hours, or contact alias.]
+```
+
+### Migration Guide Rules
+
+- One step per action; do not bundle multiple changes into one step
+- Show real code, not pseudo-code
+- Include language variants if the change affects SDK methods across languages
+- State the testing/verification step explicitly — do not assume consumers will figure it out
+- Do not use "simply", "just", or "easy" — migration work is real work
+
+## Phase 4 — Per-Channel Copy
+
+Generate copy for each relevant channel. Use the impact tier to select channels.
+
+### Docs Banner
+
+```markdown
+> ⚠ **Breaking change on 2026-07-01:** `X-Token` auth header support is being removed.
+> Migrate to `Authorization: Bearer <token>` before July 1st.
+> [Migration guide →](/docs/migration/auth-header)
+```
+
+Banner rules:
+- One sentence on what is changing and when
+- One sentence on what to do
+- One link to the migration guide
+- Use `⚠` for breaking changes, `ℹ` for deprecations
+
+### Email Announcement
+
+```
+Subject: Action required — [Change Name] breaking change on [Date]
+
+Hi [developer name / team],
+
+On [Date], we're removing support for [old behavior]. This affects anyone who [specific criterion].
+
+What you need to do:
+1. [Step 1]
+2. [Step 2]
+
+[Link to migration guide]
+
+We've provided a [staging environment / test endpoint] so you can verify your migration before the deadline.
+
+Questions? [Support channel / contact]
+
+— [Team name]
+```
+
+Email rules:
+- Subject must include "action required" and the date
+- First sentence states the change and date — no preamble
+- Steps are numbered, not bulleted
+- Single CTA: migration guide
+- Offer a support escalation path
+- Keep to under 200 words
+
+### In-Product Warning
+
+```
+This integration uses a deprecated API method (X-Token auth).
+It will stop working on July 1, 2026. [Migrate now →]
+```
+
+In-product rules:
+- One sentence max
+- Include the hard date
+- Deep link to migration guide, not docs home
+
+### Status Page Notice
+
+```
+[Upcoming] Auth header change — July 1, 2026
+X-Token header support is being removed on July 1, 2026.
+All integrations must migrate to Authorization: Bearer.
+Migration guide: [URL]
+```
+
+### Slack / Discord Announcement
+
+```
+📢 Breaking change heads-up: we're removing X-Token auth header support on July 1, 2026.
+
+If you use the API, you'll need to switch to `Authorization: Bearer <token>` before that date.
+
+→ Migration guide: [URL]
+→ Questions: #api-support
+```
+
+## Phase 5 — Support FAQ
+
+Produce 5–8 FAQ entries that support staff can use verbatim when tickets arrive.
+
+```markdown
+## Breaking Change FAQ — [Change Name]
+
+**Q: My app broke after [Date]. What happened?**
+A: On [Date], we removed support for [old behavior]. Your app needs to [one-sentence action]. See the migration guide: [URL]
+
+**Q: How do I know if I'm affected?**
+A: You're affected if your integration [specific criterion, e.g., "sends the X-Token header" or "calls GET /v1/users"].
+
+**Q: Can I get an extension?**
+A: The deadline is firm at [Date]. If your migration is in progress and you need a short-term exception, contact [support alias] before [Date-7].
+
+**Q: I migrated but things still aren't working. What should I check?**
+A: [Most common post-migration issue and how to diagnose it.]
+
+**Q: Where can I find help?**
+A: [Support channel, migration office hours, or contact information.]
+```
+
+FAQ rules:
+- Write answers in first person plural from the team's perspective
+- The "broke" FAQ must always come first — it is the highest-volume ticket
+- Include a clear escalation path for consumers who need a deadline extension
+- Do not write "unfortunately" or "we apologize" in support copy
+
+## Phase 6 — Output Package
+
+Deliver everything as one document with clear section headers:
+
+1. Impact assessment
+2. Rollout timeline
+3. Migration guide
+4. Docs banner copy
+5. Email copy (initial announcement)
+6. In-product warning copy
+7. Slack/Discord copy
+8. Status page notice
+9. Support FAQ
+
+Mark any section that needs a real URL placeholder with `[URL: <description>]` so the team can fill them in.
+
+## Guardrails
+
+- Do not invent migration steps not derivable from the change description
+- Do not omit the hard-cutoff date from any channel copy
+- Do not use "breaking change" in support FAQ copy — consumers already know it broke; use action-oriented language
+- Do not write comms that leave consumers without a migration path
+- If the user has not provided a migration path, ask before generating Phase 3 and beyond
+- Flag if the declared lead time is shorter than the recommended minimum for the impact tier

--- a/skills/composites/breaking-change-comms-kit/skill.meta.json
+++ b/skills/composites/breaking-change-comms-kit/skill.meta.json
@@ -1,0 +1,26 @@
+{
+  "slug": "breaking-change-comms-kit",
+  "category": "composites",
+  "tags": [
+    "content",
+    "outreach"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install breaking-change-comms-kit",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "requires_skills": [
+    "api-release-notes-composer"
+  ],
+  "features": [
+    "Tiers the impact of a breaking change (Critical/High/Medium/Low) and selects channels accordingly",
+    "Generates a backward-planning rollout timeline from the hard cutoff date",
+    "Writes a step-by-step migration guide with before/after code examples",
+    "Produces per-channel copy for docs banner, email, in-product warning, status page, and Slack",
+    "Delivers a support-ready FAQ so the team can handle tickets verbatim"
+  ]
+}

--- a/skills/composites/developer-newsletter-composer/SKILL.md
+++ b/skills/composites/developer-newsletter-composer/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: developer-newsletter-composer
+description: >
+  Assemble a recurring developer-facing changelog newsletter from a list of shipped work: release highlights, deprecations approaching sunset, ecosystem and integration news, and a clear call to action. Scoped to DX/DevRel changelog newsletters sent to API consumers and developer communities — not newsletter discovery or sponsorship tools (use newsletter-monitor or sponsored-newsletter-finder) and not general product email copy (use feature-launch-playbook). Use when a DevRel team needs to ship a developer digest that reads like it was written by an engineer, not a marketer.
+tags: [content, social]
+---
+
+# Developer Newsletter Composer
+
+Write a developer changelog newsletter from raw shipped work. This skill assembles recurring developer digests — the kind of email or community post that API consumers and developer community members actually read: signal-dense, technically precise, no fluff, and built around what changed this week or month.
+
+**Built for:** DevRel leads, API PMs, and developer community managers who ship a recurring developer newsletter but spend too long turning ship data into readable prose.
+
+## Best Fit
+
+- Weekly or monthly API developer digests
+- SDK release and changelog newsletters
+- Developer community Substack or Beehiiv publications
+- GitHub Discussions or Discord announcements summarizing recent changes
+- Internal engineering all-hands update emails with an API consumer angle
+
+## Use Something Else
+
+- To discover newsletters to sponsor or partner with, use `sponsored-newsletter-finder` or `newsletter-monitor`.
+- To write general product launch emails, use `feature-launch-playbook`.
+- To write a single API release's changelog entry, use `api-release-notes-composer`.
+- To write a breaking-change announcement email only, use `breaking-change-comms-kit`.
+
+## Inputs
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `period` | Yes | Time range: "week of May 12", "April 2026", etc. |
+| `shipped_items` | Yes | List of releases, PRs, features, fixes shipped this period |
+| `deprecations` | No | Upcoming deprecations and their sunset dates |
+| `ecosystem_notes` | No | Partner integrations, community contributions, third-party news |
+| `cta` | No | Primary call to action for this issue |
+| `publication_name` | No | Name of the newsletter or publication |
+| `audience` | No | External API consumers, internal engineers, or community |
+| `tone` | No | Technical/direct (default), friendly-developer, formal |
+| `format` | No | Email (default), Markdown for GitHub/Discord, or both |
+| `issue_number` | No | Issue number for publications that track issues |
+
+## Phase 0 — Intake
+
+Ask only for what is missing.
+
+1. What period does this issue cover?
+2. What shipped this period? (Paste a list of PRs, tickets, release notes, or bullet points)
+3. Are there any deprecations approaching their sunset date that developers need to act on?
+4. Any ecosystem or integration news to include?
+5. What should the reader do after reading this? (Primary CTA)
+
+If the user pastes a raw list of changes, start organizing immediately.
+
+## Phase 1 — Content Triage
+
+Before writing, sort the raw ship data into buckets and identify what deserves the most space:
+
+### Triage Buckets
+
+| Bucket | What belongs here | Space weight |
+|--------|-------------------|--------------|
+| **Highlights** | New capabilities, notable endpoints, SDK features, performance wins | Heavy |
+| **Action required** | Breaking changes going live, deprecations reaching deadline | Always lead if present |
+| **Deprecations** | Upcoming sunsets, migration windows opening | Medium if actionable |
+| **Fixes** | Bug fixes and correctness improvements | Light — bullet list only |
+| **Ecosystem** | New integrations, community contributions, third-party tools | Medium |
+| **Coming up** | Announced upcoming changes, previews | Light |
+
+Produce a triage summary before writing:
+
+```
+CONTENT TRIAGE — Week of May 12, 2026
+
+Action required (1):
+- v1 users endpoint retires June 1 — migration window closing
+
+Highlights (2):
+- New batch create endpoint for /v2/projects
+- Python SDK 3.0 released with async-first design
+
+Deprecations (1):
+- X-Token header deprecated since Jan 2026 — 30 days to sunset
+
+Fixes (3):
+- Cursor stability fix for /v2/users under concurrent load
+- Webhook signature verification now handles non-UTF-8 bodies
+- Rate limit headers now include Retry-After on 429
+
+Ecosystem (1):
+- New community Zapier integration by @contributor_handle
+```
+
+Show this triage if there is an "action required" item. The team may want to promote it to a standalone breaking-change email instead of burying it in the digest.
+
+## Phase 2 — Newsletter Structure
+
+### Standard Structure
+
+```
+[Subject line / headline]
+
+[Short intro — 1-2 sentences. What period, what tone, hook the reader.]
+
+⚠ [Action required section — only if present. Always first.]
+
+🚀 [Highlights — 1-3 items with enough context to be useful]
+
+🔧 [Fixes — brief bullet list]
+
+📦 [Ecosystem / integrations — optional]
+
+📅 [Coming up — optional]
+
+[CTA]
+
+[Footer: unsubscribe, docs link, community link]
+```
+
+## Phase 3 — Write the Issue
+
+### Subject Line
+
+```
+[API Name] Developer Digest — [Period]: [Headline change or feature]
+```
+
+Examples:
+- "Gooseworks API Digest — May 2026: Python SDK 3.0 + batch endpoints"
+- "Gooseworks Developer Update — Week of May 12: Action required before June 1"
+
+Rules:
+- Include the period
+- If there is an action-required item, the subject must signal it
+- Do not use emoji in the subject line
+- Keep under 60 characters if possible
+
+### Intro (2 sentences max)
+
+```markdown
+Here's what shipped in the [API Name] ecosystem this week. One item requires action before [date].
+```
+
+Rules:
+- State the period
+- If action is required, say so in the intro
+- No "excited to share" or "we're thrilled to announce"
+
+### Action Required Section
+
+```markdown
+## ⚠ Action required before [Date]
+
+**[Change name]** — The [old behavior] stops working on **[Date]**. If you haven't migrated yet,
+[one-sentence action]. Full migration guide: [URL]
+```
+
+Rules:
+- Bold the change name
+- Bold the deadline date
+- One-sentence action
+- Single link to migration guide
+- Do not bury this section — it goes first
+
+### Highlights Section
+
+Write 1–3 highlight items. Each item gets 2–4 sentences.
+
+```markdown
+## 🚀 This week
+
+**[Feature or endpoint name]**
+[What it is in one sentence. What problem it solves or what it enables. How to use it or where to find it in the docs.]
+
+---
+
+**Python SDK 3.0**
+The Python SDK is now async-first. All methods return coroutines by default; if you need
+synchronous behavior, use the `SyncClient` class. [See the migration guide →](URL)
+```
+
+Highlight rules:
+- Lead with the name in bold
+- One sentence on what it is
+- One sentence on why it matters
+- One sentence with a link to docs, examples, or the full changelog entry
+- Do not summarize every PR — pick 1–3 items that represent the most value to readers
+
+### Fixes Section
+
+```markdown
+## 🔧 Fixes
+
+- **Pagination cursors** — Cursors for `/v2/users` are now stable under concurrent write loads.
+- **Webhook signatures** — Signature verification now handles request bodies with non-UTF-8 content.
+- **Rate limit headers** — `Retry-After` header is now included on all `429` responses.
+```
+
+Fixes rules:
+- Bold the affected area
+- One sentence per fix
+- No bug IDs or PR numbers unless the audience is internal
+- 3–8 bullets maximum; group if there are more
+
+### Ecosystem Section
+
+```markdown
+## 📦 Ecosystem
+
+**Zapier integration by @contributor_handle** — The community has shipped a Zapier integration
+that connects [API Name] events to 5,000+ apps. [Install it →](URL)
+```
+
+### Coming Up Section
+
+```markdown
+## 📅 Coming up
+
+- `GET /v1/users` retires **June 1, 2026** — 30 days to migrate. [Migration guide →](URL)
+- Python SDK 3.1 planned for June — adds streaming response support.
+```
+
+### CTA
+
+```markdown
+Questions? Join us in [#api-community](URL) or reply to this email.
+
+→ [Full changelog](URL)  |  [Docs](URL)  |  [Status page](URL)
+```
+
+## Phase 4 — Tone and Voice Rules
+
+Apply to every section:
+
+- Write to developers, not end users
+- Use endpoint paths, field names, and method names — not marketing names
+- Active voice throughout
+- No "powerful", "seamless", "world-class", "exciting", "delighted"
+- No "we're thrilled to announce" or "we're excited to share"
+- Numbers and specifics over vague claims: "50ms faster" not "noticeably faster"
+- If you can't say what improved specifically, say "bug fix" and move on
+- Emoji in section headers only — not in prose
+
+## Phase 5 — Format Variants
+
+### Email (default)
+
+Plain text with Markdown-compatible headers. Include an unsubscribe footer placeholder.
+
+### Markdown for GitHub / Discord
+
+Use Discord-compatible Markdown (no HTML). Bold with `**`, no `<details>` blocks. Keep under 2000 characters for Discord; use a link to the full version if longer.
+
+### Both
+
+Deliver email version first, then a clearly marked Discord/GitHub variant.
+
+## Phase 6 — Output
+
+Deliver:
+1. Subject line (3 variants if useful)
+2. Full newsletter body in requested format(s)
+3. Triage summary used to build the issue
+4. Any `[URL: ...]` placeholders that need real links
+5. A note if any shipped item should be promoted to a standalone breaking-change email instead
+
+## Guardrails
+
+- Do not invent features or fixes not present in the source data
+- Do not write marketing copy — this is developer-to-developer communication
+- Do not bury action-required items — they must appear first
+- Do not skip the "coming up" section when there are known upcoming deprecation deadlines
+- Do not write more than 3 highlights — more than that loses developer attention
+- If the user provides more than 3 highlight candidates, ask which ones matter most

--- a/skills/composites/developer-newsletter-composer/skill.meta.json
+++ b/skills/composites/developer-newsletter-composer/skill.meta.json
@@ -1,0 +1,23 @@
+{
+  "slug": "developer-newsletter-composer",
+  "category": "composites",
+  "tags": [
+    "content",
+    "social"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install developer-newsletter-composer",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Triages raw ship data into highlights, action-required, deprecations, fixes, and ecosystem buckets",
+    "Writes developer-voice prose with endpoint paths and field names, zero marketing language",
+    "Always surfaces action-required items first with deadline, one-sentence action, and migration link",
+    "Outputs email and Discord/GitHub Markdown variants with appropriate length constraints",
+    "Delivers subject line variants and flags any item that warrants its own standalone breaking-change email"
+  ]
+}

--- a/skills/composites/openapi-docs-narrative/SKILL.md
+++ b/skills/composites/openapi-docs-narrative/SKILL.md
@@ -1,0 +1,400 @@
+---
+name: openapi-docs-narrative
+description: >
+  Write the conceptual and narrative spine of API documentation: authentication flows, error model, pagination strategy, versioning policy, idempotency guide, and rate-limit context. These are the sections that OpenAPI/Swagger spec generation cannot produce. Scoped to reference-doc narrative copy for developer portals and API docs sites — not help center support articles (use help-center-article-generator) and not SDK quickstarts (use sdk-quickstart-hardening-guide). Use when an API team has a working spec but their docs portal still reads like raw JSON.
+tags: [content, research]
+---
+
+# OpenAPI Docs Narrative
+
+Write the human-readable layer of API documentation that spec generators can't produce. This skill covers authentication, errors, pagination, versioning, idempotency, and other cross-cutting concepts that every API consumer needs to understand before they write a single line of code.
+
+**Built for:** API product managers, developer-experience writers, and backend teams who have a working OpenAPI spec or endpoint set but whose documentation portal still reads like raw YAML.
+
+## Best Fit
+
+- Authentication and authorization guides (API keys, OAuth, JWT, scoped tokens)
+- Error reference pages (error codes, error object shapes, retry guidance)
+- Pagination documentation (cursor, offset, keyset strategies)
+- Versioning policy pages (how versions are numbered, how long they are supported)
+- Idempotency guides (how to use idempotency keys, which endpoints support them)
+- Rate limit and quota context pages (not copy — use `rate-limit-ux-copywriter` for copy)
+- Getting-started conceptual overview (not quickstart code — use `sdk-quickstart-hardening-guide`)
+
+## Use Something Else
+
+- For step-by-step SDK quickstart with runnable code, use `sdk-quickstart-hardening-guide`.
+- For support KB articles from tickets, use `help-center-article-generator`.
+- For changelog entries, use `api-release-notes-composer`.
+- For webhook payload and event catalog, use `webhook-catalog-author`.
+- For Postman collection narrative, use `postman-collection-storyteller`.
+
+## Inputs
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `section` | Yes | Which doc section to write. See Section Menu below. |
+| `api_name` | Yes | The name of the API or product |
+| `api_description` | No | One paragraph on what the API does |
+| `auth_scheme` | No | API key, OAuth 2.0, JWT, HMAC, mTLS, etc. |
+| `base_url` | No | Used in code examples |
+| `error_format` | No | Sample error object JSON, or description of error shape |
+| `pagination_type` | No | cursor, offset, page-number, keyset, link-header |
+| `versioning_strategy` | No | URL path, header, date-based, semver |
+| `audience` | No | External developers, internal consumers, or both |
+| `tone` | No | Technical/direct (default), friendly, enterprise |
+| `existing_draft` | No | Any existing prose to improve rather than write from scratch |
+
+## Section Menu
+
+Specify one or more of these sections per request:
+
+| Section ID | What it covers |
+|------------|---------------|
+| `authentication` | Auth methods, credential formats, token scoping, rotation |
+| `errors` | Error object structure, status codes used, retry logic |
+| `pagination` | Strategy type, how to use cursors/offsets, result limits |
+| `versioning` | Version numbering, support lifecycle, migration expectations |
+| `idempotency` | Idempotency key usage, which endpoints support it, failure behavior |
+| `rate-limits` | Conceptual rate limit explainer (pairs with `rate-limit-ux-copywriter`) |
+| `environments` | Production, sandbox, staging endpoints and key differences |
+| `overview` | Conceptual intro: what the API is, who it's for, what you can build |
+
+## Phase 0 — Intake
+
+Ask only for what is missing. Skip questions where the section makes the answer obvious.
+
+1. Which section(s) should I write?
+2. What is the API called and what does it do in one paragraph?
+3. What auth scheme does the API use?
+4. What does a typical error response look like? (Paste an example or describe the shape.)
+5. What pagination strategy does the API use?
+6. Is there an existing draft or docs page I should improve rather than start fresh?
+
+If the user pastes an existing docs page, focus on rewriting and improving it. Ask fewer questions.
+
+## Phase 1 — Audience and Depth Calibration
+
+Before writing, calibrate depth and tone:
+
+| Audience | Depth | Style |
+|----------|-------|-------|
+| External developers (general) | Full context, code examples for multiple languages | Friendly-technical |
+| External developers (enterprise) | Full context, compliance notes, security considerations | Formal-technical |
+| Internal developers | Concise, assume API familiarity, reference-style | Technical, minimal prose |
+| Mixed | Full context, optional "Advanced" callout sections | Friendly-technical |
+
+## Phase 2 — Section Writing
+
+### `authentication` — Auth Guide
+
+```markdown
+# Authentication
+
+The [API Name] API uses [auth scheme] for all requests.
+
+## [Auth Method 1: e.g., API Keys]
+
+[What API keys are in this context. One paragraph.]
+
+### Getting your key
+
+[How to obtain a key. Portal URL placeholder, or CLI command if applicable.]
+
+### Using your key
+
+All requests must include your API key in the `Authorization` header:
+
+```http
+GET /v2/resources HTTP/1.1
+Host: api.example.com
+Authorization: Bearer YOUR_API_KEY
+```
+
+### Key rotation
+
+[How to rotate keys without downtime. Dual-key overlap period if applicable.]
+
+### Scoped tokens
+
+[If the API supports scopes, list them and explain what each scope grants.]
+
+| Scope | Access |
+|-------|--------|
+| `read:users` | Read user profiles |
+| `write:users` | Create and update user records |
+| `admin` | Full account access |
+
+## Security considerations
+
+- Never expose API keys in client-side code or public repositories
+- Use environment variables for key storage
+- Rotate keys immediately if compromised
+- [Link to key management docs →]
+```
+
+### `errors` — Error Reference
+
+```markdown
+# Errors
+
+The [API Name] API uses standard HTTP status codes. All error responses include a JSON body.
+
+## Error object
+
+```json
+{
+  "error": {
+    "code": "resource_not_found",
+    "message": "The requested user does not exist.",
+    "request_id": "req_01abc",
+    "docs_url": "https://docs.example.com/errors/resource_not_found"
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `code` | string | Machine-readable error code. Use this for programmatic handling. |
+| `message` | string | Human-readable description. Do not use this for programmatic handling. |
+| `request_id` | string | Include this in support requests for fast debugging. |
+| `docs_url` | string | Link to the specific error reference page. |
+
+## Status codes used
+
+| Code | Meaning | Common cause |
+|------|---------|--------------|
+| `200` | OK | Request succeeded |
+| `201` | Created | Resource created |
+| `400` | Bad Request | Malformed request, missing required field |
+| `401` | Unauthorized | Missing or invalid API key |
+| `403` | Forbidden | Valid key, insufficient scope |
+| `404` | Not Found | Resource does not exist |
+| `409` | Conflict | Duplicate resource or state conflict |
+| `422` | Unprocessable Entity | Valid format, invalid business logic |
+| `429` | Too Many Requests | Rate limit exceeded |
+| `500` | Internal Server Error | Unexpected server error |
+
+## Retrying requests
+
+Retry requests that receive `429` or `5xx` responses using exponential backoff:
+
+```python
+import time
+
+def with_retry(request_fn, max_retries=3):
+    for attempt in range(max_retries):
+        response = request_fn()
+        if response.status_code not in (429, 500, 502, 503, 504):
+            return response
+        wait = 2 ** attempt
+        time.sleep(wait)
+    raise Exception("Max retries exceeded")
+```
+
+Do not retry `4xx` responses (except `429`). They indicate a client error that won't resolve by retrying.
+```
+
+### `pagination` — Pagination Guide
+
+Choose the appropriate template based on the API's strategy.
+
+**Cursor pagination:**
+
+```markdown
+# Pagination
+
+The [API Name] API uses cursor-based pagination for collection endpoints.
+
+## How it works
+
+Each list response includes a `next_cursor` value. Pass this value as the `cursor`
+query parameter on your next request to fetch the following page.
+
+```http
+GET /v2/users?limit=50
+```
+
+```json
+{
+  "data": [...],
+  "pagination": {
+    "next_cursor": "cur_01abc",
+    "has_more": true
+  }
+}
+```
+
+```http
+GET /v2/users?limit=50&cursor=cur_01abc
+```
+
+When `has_more` is `false`, you have reached the last page.
+
+## Parameters
+
+| Parameter | Type | Default | Max | Description |
+|-----------|------|---------|-----|-------------|
+| `limit` | integer | 20 | 100 | Records per page |
+| `cursor` | string | — | — | Opaque cursor from previous response |
+
+## Cursor stability
+
+Cursors are stable for [X hours/days]. Do not store cursors beyond that window.
+Cursors are invalidated by [deletion of the record they point to / dataset changes].
+```
+
+### `versioning` — API Versioning Policy
+
+```markdown
+# API Versioning
+
+## Version strategy
+
+[API Name] uses [URL path versioning / date-based versioning / header versioning].
+
+```http
+GET /v2/users
+Authorization: Bearer YOUR_KEY
+```
+
+## Supported versions
+
+| Version | Status | End of life |
+|---------|--------|-------------|
+| v3 | Current | — |
+| v2 | Maintained | 2027-01-01 |
+| v1 | Deprecated | 2026-07-01 |
+
+## What constitutes a breaking change
+
+We treat these as breaking changes that require a version bump:
+- Removing a field from a response
+- Changing a field type
+- Removing an endpoint
+- Changing required parameters
+- Changing authentication requirements
+
+We do not treat these as breaking:
+- Adding new optional fields to responses
+- Adding new optional query parameters
+- Adding new endpoints
+- Fixing bugs where the old behavior was clearly wrong
+
+## Upgrade process
+
+When a new major version is released, we provide:
+1. A migration guide
+2. A [90-day / 6-month] overlap period where both versions are live
+3. Deprecation headers on old-version responses
+
+We send breaking-change announcements to [list / changelog / email].
+```
+
+### `idempotency` — Idempotency Guide
+
+```markdown
+# Idempotency
+
+## What is idempotency
+
+An idempotent request produces the same result when repeated. For write operations,
+this means you can safely retry a request without creating duplicate records.
+
+## Which endpoints support idempotency
+
+Idempotency keys are supported on `POST` requests that create or mutate resources:
+
+| Endpoint | Idempotent |
+|----------|-----------|
+| `POST /v2/payments` | ✓ |
+| `POST /v2/users` | ✓ |
+| `DELETE /v2/users/:id` | ✓ (naturally idempotent) |
+| `GET /v2/users` | ✓ (all GETs are naturally idempotent) |
+
+## How to use idempotency keys
+
+Include an `Idempotency-Key` header with a unique string per logical operation.
+Use a UUID or ULID. Do not reuse keys across different operations.
+
+```http
+POST /v2/payments HTTP/1.1
+Authorization: Bearer YOUR_KEY
+Idempotency-Key: 01HZXR7B4F6NCQZK38T5P1E29M
+Content-Type: application/json
+
+{ "amount": 5000, "currency": "usd", "customer": "cust_01abc" }
+```
+
+## Key behavior
+
+- Keys are scoped to your account and expire after [24 hours / 7 days].
+- If you submit the same key with different request bodies, the API returns a `409 Conflict`.
+- A successful response is cached against the key; subsequent requests with the same key return the cached response without re-executing.
+```
+
+### `overview` — Conceptual Introduction
+
+```markdown
+# [API Name] API Overview
+
+[Two to three paragraphs. What the API is, what it lets developers build, and what
+the high-level request/response model looks like. No marketing language.]
+
+## Base URL
+
+```
+https://api.example.com
+```
+
+All requests use HTTPS. HTTP requests are not supported.
+
+## Request format
+
+The API accepts JSON bodies for all `POST`, `PUT`, and `PATCH` requests.
+Set the `Content-Type: application/json` header on requests with a body.
+
+## Response format
+
+All responses are JSON. Successful responses return an HTTP `2xx` status code
+and a response body shaped to the endpoint.
+
+## Authentication
+
+All requests require a valid API key. See [Authentication →](#authentication).
+
+## Next steps
+
+- [Quickstart →](#quickstart)
+- [Authentication →](#authentication)
+- [Errors →](#errors)
+- [API Reference →](#reference)
+```
+
+## Phase 3 — Copy Quality Rules
+
+Apply these rules to every section written:
+
+- Write in second person: "You can use…", "Your request should include…"
+- Use active voice throughout
+- Never use "simply" or "just" or "easily"
+- Include at least one code example per major concept
+- HTTP examples should use real header names and realistic placeholder values
+- Tables for enumerations (status codes, scopes, parameters) rather than prose lists
+- Cross-link related sections instead of repeating content
+- Aim for scannable structure: every section should be navigable with a table of contents
+
+## Phase 4 — Output
+
+Deliver:
+1. The requested section(s) as formatted Markdown
+2. A list of placeholder values the team needs to fill in (e.g., `[URL: support contact]`, `[X hours: cursor TTL]`)
+3. Notes on any assumptions made due to missing inputs
+
+## Guardrails
+
+- Do not invent auth flows, error codes, or behavior not described by the user
+- Do not write marketing copy — API docs are for developers who have already decided to integrate
+- Do not use "industry-leading", "powerful", or "seamless"
+- If the user provides contradictory information (e.g., says "cursor pagination" but provides an offset-based example), surface the conflict before writing
+- Mark all real-URL placeholders clearly so the team does not ship placeholder text

--- a/skills/composites/openapi-docs-narrative/skill.meta.json
+++ b/skills/composites/openapi-docs-narrative/skill.meta.json
@@ -1,0 +1,23 @@
+{
+  "slug": "openapi-docs-narrative",
+  "category": "composites",
+  "tags": [
+    "content",
+    "research"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install openapi-docs-narrative",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Covers 8 doc sections: authentication, errors, pagination, versioning, idempotency, rate limits, environments, and overview",
+    "Provides section-specific templates tailored to API surface type (REST, cursor/offset pagination, OAuth vs API key)",
+    "Writes second-person developer prose with working HTTP and code examples",
+    "Surfaces placeholder values the team must fill before publishing",
+    "Calibrates depth and tone to external general, external enterprise, or internal developer audiences"
+  ]
+}

--- a/skills/composites/postman-collection-storyteller/SKILL.md
+++ b/skills/composites/postman-collection-storyteller/SKILL.md
@@ -1,0 +1,285 @@
+---
+name: postman-collection-storyteller
+description: >
+  Add collection-level and folder-level narrative to a Postman or Bruno API workspace: workflow intent descriptions, variable setup stories, happy-path request ordering, edge-case request annotations, and pre/post-script explanations. Scoped to API workspace documentation narrative — not API reference docs (use openapi-docs-narrative) and not SDK quickstarts (use sdk-quickstart-hardening-guide). Use when a team has a working Postman collection but every folder is blank and every request is named by its HTTP method.
+tags: [content]
+---
+
+# Postman Collection Storyteller
+
+Write the narrative layer that makes an API collection actually useful for a developer seeing it for the first time. This skill covers collection-level context, folder-level intent, request ordering rationale, variable documentation, pre/post-request script explanations, and edge-case annotations.
+
+**Built for:** API teams, DevRel engineers, and integration specialists who have a working Postman or Bruno collection but whose workspace reads like raw endpoint lists with no guidance on what to run, in what order, or why.
+
+## Best Fit
+
+- Postman collection descriptions (collection level, folder level, request level)
+- Workspace README / overview documents
+- Environment variable documentation inside collections
+- Pre-request and post-request script comments
+- Happy-path workflow sequencing explanations
+- Edge-case and error-response request annotations
+- Public Postman workspace pages for developer portals
+
+## Use Something Else
+
+- For full API reference documentation, use `openapi-docs-narrative`.
+- For a runnable code quickstart, use `sdk-quickstart-hardening-guide`.
+- For webhook event catalog, use `webhook-catalog-author`.
+
+## Inputs
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `collection_name` | Yes | Name of the Postman/Bruno collection |
+| `api_name` | Yes | Name of the API |
+| `api_description` | No | What the API does in 1-2 sentences |
+| `folder_list` | Yes | List of folders and the requests inside each |
+| `variable_list` | No | Collection or environment variables used |
+| `auth_scheme` | No | How auth is configured in the collection |
+| `known_workflows` | No | Key use-case flows the collection is meant to demonstrate |
+| `pre_post_scripts` | No | Any pre/post-request scripts that need explanation |
+| `existing_descriptions` | No | Any existing descriptions to improve |
+| `audience` | No | Internal team, public developer portal, or enterprise partner |
+
+## Phase 0 — Intake
+
+Ask only for what is missing.
+
+1. What is the collection called and what API does it cover?
+2. What folders and requests are in the collection? (Paste the structure or describe it)
+3. What are the 2-3 key workflows a developer would use this collection to complete?
+4. What variables does the collection use? (base URL, API key, IDs, etc.)
+5. Are there pre/post-request scripts that need explanation?
+
+If the user pastes a collection structure, extract what you can before asking questions.
+
+## Phase 1 — Collection Audit
+
+Before writing anything, audit the collection structure against these quality criteria:
+
+| Criterion | Good | Needs Work |
+|-----------|------|-----------|
+| Collection description | Explains purpose, audience, prerequisites | Blank or auto-generated |
+| Folder descriptions | Explain workflow intent | Blank |
+| Request names | Verb + resource (e.g., "Create User") | Method + path only (e.g., "POST /v2/users") |
+| Request descriptions | Explain when and why, not just what | Blank |
+| Variable documentation | Every variable explained with an example | Variables listed without description |
+| Happy path ordering | Requests sequenced to mirror real-world flow | Alphabetical or random order |
+| Edge cases annotated | Error responses have their own documented requests | Only success cases shown |
+
+Produce an audit summary:
+
+```
+COLLECTION AUDIT — Gooseworks API
+
+✗ Collection description: blank
+✗ Folder "Users": blank description, 6 of 8 requests have no description
+✗ Request names: 4 named by method/path only
+✓ Variables: base_url and api_key defined with examples
+✗ Happy path: requests not sequenced for onboarding flow
+✗ Edge cases: no 401 or 429 example requests
+```
+
+Share the audit and confirm the scope of work before writing.
+
+## Phase 2 — Collection-Level Description
+
+```markdown
+# [Collection Name]
+
+This collection lets you explore and test the [API Name] API without writing any code.
+It covers [the main resource areas / key workflows], is organized into folders by workflow,
+and uses environment variables for all credentials and IDs.
+
+## Who this is for
+
+[Internal engineers testing integrations / external developers evaluating the API /
+enterprise partners building their integration]
+
+## Prerequisites
+
+Before running requests in this collection:
+
+1. **API key** — Set `api_key` in your active environment. [Get your key →](URL)
+2. **Base URL** — Set `base_url` to `https://api.example.com` for production or
+   `https://sandbox.api.example.com` for testing
+3. **[Other prereq]** — [Describe it]
+
+## Environments
+
+| Environment | `base_url` |
+|-------------|-----------|
+| Production | `https://api.example.com` |
+| Sandbox | `https://sandbox.api.example.com` |
+
+## Workflow guide
+
+Run the folders in this order for the recommended onboarding path:
+
+1. **Authentication** — Get a token and confirm it works
+2. **Users** — Create a test user you can reference in later requests
+3. **Projects** — Create a project and attach it to your user
+4. **Webhooks** — Register a webhook endpoint to receive events
+
+Within each folder, requests are sequenced to mirror a realistic flow.
+```
+
+## Phase 3 — Folder-Level Descriptions
+
+For each folder, write a description that explains the workflow intent and sequencing rationale.
+
+### Folder Description Template
+
+```markdown
+## [Folder Name]
+
+[One sentence on what this folder covers and what workflow it enables.]
+
+Run the requests in this order for the complete flow:
+
+1. **[Request name]** — [Why this comes first. What it sets up for subsequent requests.]
+2. **[Request name]** — [What this does and what the response contains that you'll need later.]
+3. **[Request name]** — [Continue the flow.]
+
+The `[variable_name]` variable is automatically set by the post-response script in
+"[Request name]" — you don't need to set it manually.
+
+### Edge cases
+
+Run these requests to test error handling:
+
+- **[Request name]** — Tests the 401 response when the API key is invalid or missing.
+- **[Request name]** — Tests the 429 response when the rate limit is exceeded.
+```
+
+### Folder Sequencing Rules
+
+- Sequence requests in the order a developer would actually run them, not alphabetically
+- If a request sets a variable used by a later request, call that out explicitly
+- Include at least one edge-case request per folder for APIs that have clear error states
+- Keep descriptions under 150 words per folder
+
+## Phase 4 — Request-Level Descriptions
+
+For key requests (especially any without a description), write a concise request description.
+
+### Request Description Template
+
+```markdown
+Creates a new user account. Returns the user object including the `id` field, which
+is used by the "Create Project" request in the Projects folder.
+
+Set `role` to `admin` to test permissions-restricted endpoints.
+```
+
+### Request Naming Guide
+
+If the collection has poorly named requests, suggest better names:
+
+| Current name | Suggested name |
+|-------------|----------------|
+| `POST /v2/users` | `Create User` |
+| `GET /v2/users/:id` | `Get User by ID` |
+| `PATCH /v2/users/:id` | `Update User` |
+| `DELETE /v2/users/:id` | `Delete User` |
+| `GET /v2/users` | `List Users` |
+| `POST /v2/auth/token` | `Get Access Token` |
+
+Rules:
+- Use `Verb + Resource` for CRUD requests
+- Use `Resource + Qualifier` for specialized endpoints: "List Users by Team", "Get User Sessions"
+- Avoid HTTP method names in the display name
+
+## Phase 5 — Variable Documentation
+
+Write a variables reference table for the collection README or the collection-level description.
+
+```markdown
+## Variables
+
+Set these in your Postman environment before running requests:
+
+| Variable | Required | Description | Example |
+|----------|----------|-------------|---------|
+| `base_url` | Yes | API base URL | `https://api.example.com` |
+| `api_key` | Yes | Your API key from the dashboard | `sk_live_abc123` |
+| `user_id` | Auto-set | Set by "Create User" post-response script | `usr_01abc` |
+| `project_id` | Auto-set | Set by "Create Project" post-response script | `proj_01abc` |
+
+Variables marked **Auto-set** are populated by post-response scripts —
+you do not need to set them manually if you run the requests in order.
+```
+
+## Phase 6 — Pre/Post-Script Explanations
+
+If the collection has pre-request or post-response scripts, annotate them with inline comments.
+
+### Pre-request script example
+
+```javascript
+// Generate a unique idempotency key for this request.
+// This prevents duplicate records if the request is retried.
+const key = pm.variables.replaceIn('{{$guid}}');
+pm.request.headers.add({ key: 'Idempotency-Key', value: key });
+```
+
+### Post-response script example
+
+```javascript
+// Store the new user's ID as a collection variable.
+// Subsequent requests in the "Projects" folder use {{user_id}} automatically.
+const response = pm.response.json();
+pm.collectionVariables.set('user_id', response.data.user.id);
+```
+
+Script annotation rules:
+- One comment per logical action, not per line of code
+- Explain the *why*, not the *what*
+- If a script sets a variable used by other requests, say which requests use it
+
+## Phase 7 — Public Workspace Page
+
+If the collection will be published to a public Postman workspace, write a workspace overview:
+
+```markdown
+# [API Name] — Official Postman Collection
+
+Explore the [API Name] API without writing code. This workspace includes:
+
+- **[N] requests** covering [resource list]
+- Sequenced workflows for the most common integration patterns
+- Edge-case requests for error handling testing
+- Environment templates for production and sandbox
+
+## Get started
+
+1. Fork this collection into your Postman workspace
+2. Create an environment using the "Gooseworks Sandbox" template
+3. Set `api_key` to your API key from [the dashboard →](URL)
+4. Run the **Authentication** folder first to confirm your credentials work
+
+## Feedback
+
+Found a bug or missing example? [Open an issue →](URL)
+```
+
+## Phase 8 — Output
+
+Deliver:
+1. Audit summary
+2. Collection-level description (full)
+3. Folder descriptions for every folder
+4. Request descriptions for requests with none or poor descriptions
+5. Variable reference table
+6. Pre/post-script annotations (if applicable)
+7. Request renaming suggestions (if applicable)
+8. Placeholder URLs list
+
+## Guardrails
+
+- Do not invent API behavior not described by the user or inferable from request/response shapes
+- Do not rename requests without explicitly labeling the suggestions as recommendations
+- Do not write public-workspace copy that promises more than what is in the collection
+- Mark all placeholder URLs with `[URL: description]`
+- If the collection has no edge-case requests, recommend adding them rather than pretending they exist

--- a/skills/composites/postman-collection-storyteller/skill.meta.json
+++ b/skills/composites/postman-collection-storyteller/skill.meta.json
@@ -1,0 +1,22 @@
+{
+  "slug": "postman-collection-storyteller",
+  "category": "composites",
+  "tags": [
+    "content"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install postman-collection-storyteller",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Audits a collection against 7 narrative quality criteria before writing",
+    "Writes collection, folder, and request-level descriptions with workflow sequencing rationale",
+    "Documents every collection variable with type, required/auto-set status, and example value",
+    "Annotates pre/post-request scripts with intent-focused comments",
+    "Produces a public Postman workspace overview page for developer portal publishing"
+  ]
+}

--- a/skills/composites/rate-limit-ux-copywriter/SKILL.md
+++ b/skills/composites/rate-limit-ux-copywriter/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: rate-limit-ux-copywriter
+description: >
+  Write rate-limit and quota UX copy for developer-facing API surfaces: 429 error response messages, rate-limit documentation prose, retry-after guidance, quota tier descriptions, and upgrade path prompts. Scoped to the developer-facing copy layer of rate limiting — not the conceptual rate-limit explainer section of API docs (use openapi-docs-narrative) and not help center support articles about rate limits (use help-center-article-generator). Use when an API team needs to replace "Too Many Requests" with copy that tells developers what to do next without generating a support ticket.
+tags: [content]
+---
+
+# Rate Limit UX Copywriter
+
+Write the copy that wraps your rate-limiting system. This skill covers the developer-facing text layer: 429 error bodies, rate limit response headers, quota documentation, retry guidance, developer dashboard quota UI, and upgrade prompts — the copy that turns a confusing HTTP 429 into a developer-trustworthy product experience.
+
+**Built for:** API product managers, DevRel engineers, and backend engineers who have a working rate-limiting system but whose error responses say "Too Many Requests" and nothing else, and whose quota docs don't exist yet.
+
+## Best Fit
+
+- 429 error response body copy
+- `Retry-After` and rate limit header documentation strings
+- Quota tier description tables
+- Developer dashboard rate-limit status UI microcopy
+- Rate-limit upgrade prompt copy
+- In-SDK rate limit warning messages
+- API docs rate-limit context section copy (distinct from the narrative explainer)
+
+## Use Something Else
+
+- For the full conceptual rate-limit explainer in API docs, use `openapi-docs-narrative` (section: `rate-limits`).
+- For help center articles answering "Why am I being rate limited?", use `help-center-article-generator`.
+- For quota tier pricing copy aimed at buyers, this skill does not cover commercial/pricing copy.
+
+## Inputs
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `rate_limit_type` | Yes | Per-second, per-minute, per-hour, per-day, per-account, per-endpoint, etc. |
+| `limit_values` | No | Actual numeric limits by tier |
+| `tier_names` | No | Free, Pro, Enterprise, etc. |
+| `retry_after_behavior` | No | Fixed window, sliding window, or token bucket |
+| `headers_used` | No | `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `Retry-After`, etc. |
+| `upgrade_path` | No | URL or action for upgrading quota |
+| `contact_path` | No | Support alias or contact URL for enterprise quota requests |
+| `api_name` | Yes | Name of the API |
+| `copy_surface` | Yes | Which surfaces to write copy for. See Surface Menu below. |
+
+## Surface Menu
+
+Specify one or more surfaces per request:
+
+| Surface ID | What needs copy |
+|------------|----------------|
+| `error-body` | 429 JSON error response body |
+| `headers` | Rate limit response header documentation strings |
+| `quota-table` | Tier quota comparison table |
+| `dashboard-ui` | Rate limit status panel microcopy |
+| `upgrade-prompt` | Inline upgrade nudge copy |
+| `sdk-warning` | SDK client-side rate limit warning message |
+| `docs-section` | Short rate-limit context prose for docs page |
+
+## Phase 0 — Intake
+
+Ask only for what is missing.
+
+1. What is the API called?
+2. What kind of rate limiting does it use? (per-second, per-minute, per-day, per-account)
+3. What are the actual limits by tier? (e.g., Free: 100 req/min, Pro: 1000 req/min)
+4. Which surfaces need copy? (error body, docs, dashboard, upgrade prompt, SDK warning)
+5. What should a developer do when they hit the limit? (Wait and retry, upgrade, contact sales)
+
+## Phase 1 — Rate Limit Context Model
+
+Before writing any copy, understand the rate limiting model:
+
+| Model | Behavior | Copy implication |
+|-------|----------|-----------------|
+| **Fixed window** | Resets on the clock (e.g., every minute at :00) | State the reset time explicitly |
+| **Sliding window** | Resets N seconds after your last request | Explain "your window moves with your requests" |
+| **Token bucket** | Refills at a steady rate; burst allowed | Explain burst capacity and refill rate |
+| **Concurrent** | Limits simultaneous open connections, not request count | Different — not time-based |
+
+Confirm the model before writing retry guidance, since the retry strategy differs by model.
+
+## Phase 2 — 429 Error Body Copy
+
+### 429 Response Template
+
+The 429 error body should answer four questions: what happened, which limit was hit, when it resets, and what to do.
+
+```json
+{
+  "error": {
+    "code": "rate_limit_exceeded",
+    "message": "You have exceeded the request limit for your plan. Slow down and retry after the window resets.",
+    "limit": 100,
+    "remaining": 0,
+    "reset_at": "2026-05-15T14:01:00Z",
+    "retry_after": 42,
+    "docs_url": "https://docs.example.com/rate-limits",
+    "upgrade_url": "https://app.example.com/upgrade"
+  }
+}
+```
+
+| Field | Value | Copy notes |
+|-------|-------|-----------|
+| `code` | `rate_limit_exceeded` | Machine-readable. Use `rate_limit_exceeded`, not `too_many_requests`. |
+| `message` | Human-readable prose | Tell the developer exactly what to do. See message templates below. |
+| `limit` | Integer | The limit that was hit |
+| `remaining` | `0` on a 429 | Confirms the bucket is empty |
+| `reset_at` | ISO 8601 UTC | When the window resets. Required. |
+| `retry_after` | Seconds as integer | Echo of the `Retry-After` header. Required. |
+| `docs_url` | URL | Deep link to rate limit docs. Do not link to the homepage. |
+| `upgrade_url` | URL | Only include if an upgrade would raise this specific limit. |
+
+### Error Message Copy Templates
+
+**General rate limit (fixed window):**
+```
+"You have exceeded [N] requests per [period] on the [Free/Pro] plan.
+Your limit resets at [time] UTC ([N] seconds). Retry after that time,
+or upgrade to [Plan] for [N] requests per [period]."
+```
+
+**Per-endpoint rate limit:**
+```
+"The [GET /v2/users] endpoint is rate-limited to [N] requests per [period].
+Your limit resets in [N] seconds. Consider caching responses or using the
+[bulk endpoint] for high-volume reads."
+```
+
+**Concurrent connection limit:**
+```
+"You have reached the maximum of [N] concurrent connections.
+Close an existing connection before opening a new one."
+```
+
+**Account-level quota:**
+```
+"Your account has reached its monthly API quota of [N] requests.
+Your quota resets on [date]. To continue, upgrade your plan or contact
+[sales / support] for a quota increase."
+```
+
+### Message Writing Rules
+
+- State the limit that was hit, not just "rate limit exceeded"
+- State the reset time in both absolute UTC and as a relative seconds value
+- Suggest the specific action (retry after N seconds, use bulk endpoint, upgrade)
+- Do not write "please" in error messages — it does not help and wastes space
+- Do not write "sorry" — own the limit as a feature, not an apology
+- Do not use the message field for upsell unless an upgrade is a genuine solution
+
+## Phase 3 — Rate Limit Header Documentation
+
+Document the headers included in every API response (not just 429s) that let developers track their usage.
+
+```markdown
+## Rate limit headers
+
+Every API response includes headers showing your current rate limit status:
+
+| Header | Type | Description |
+|--------|------|-------------|
+| `X-RateLimit-Limit` | integer | Your plan's request limit for this endpoint per [period] |
+| `X-RateLimit-Remaining` | integer | Requests remaining in the current window |
+| `X-RateLimit-Reset` | Unix timestamp | When the current window resets |
+| `Retry-After` | integer (seconds) | Seconds to wait before retrying. Present on 429 responses only. |
+
+### Using the headers
+
+Check `X-RateLimit-Remaining` proactively to avoid hitting the limit:
+
+```javascript
+const remaining = parseInt(response.headers['x-ratelimit-remaining'], 10);
+const resetAt = parseInt(response.headers['x-ratelimit-reset'], 10);
+
+if (remaining < 10) {
+  const waitMs = (resetAt - Math.floor(Date.now() / 1000)) * 1000;
+  console.warn(`Approaching rate limit. Consider pausing for ${waitMs}ms.`);
+}
+```
+```
+
+## Phase 4 — Quota Tier Documentation Table
+
+```markdown
+## Plans and limits
+
+| Plan | Requests per minute | Requests per day | Concurrent connections | Webhook endpoints |
+|------|--------------------|-----------------|-----------------------|-------------------|
+| Free | 60 | 1,000 | 2 | 1 |
+| Pro | 1,000 | 100,000 | 10 | 10 |
+| Enterprise | Custom | Custom | Custom | Unlimited |
+
+Limits apply per account. Burst traffic above the per-minute limit is absorbed up to
+[N] requests before throttling begins.
+
+Need higher limits? [Contact us →](URL)
+```
+
+### Quota Table Rules
+
+- Include every meaningful dimension (per-minute, per-day, concurrent, feature-specific)
+- Show "Custom" for enterprise rather than a number that can be negotiated
+- Add a note about burst capacity if the API supports it
+- Link directly to the upgrade or contact page, not the pricing homepage
+
+## Phase 5 — Developer Dashboard Microcopy
+
+For the rate-limit status panel in a developer dashboard or settings page:
+
+```markdown
+**API usage**
+
+[Progress bar: 850 / 1,000 requests used this minute]
+
+85% of your per-minute limit used.
+Resets in 14 seconds.
+
+[View full usage →]
+
+---
+
+**Monthly quota**
+
+[Progress bar: 82,400 / 100,000 requests used this month]
+
+You've used 82% of your monthly quota. At this rate, you'll reach your limit
+in approximately 6 days.
+
+[Upgrade plan →] to avoid interruptions.
+```
+
+### Dashboard Copy Rules
+
+- Use the exact same time units consistently (don't mix "seconds" and "minutes" for the same counter)
+- Show both the absolute usage number and the percentage
+- Predictive language ("you'll reach your limit in ~N days") is helpful but must be clearly marked as an estimate
+- The upgrade CTA should appear at 80%+ usage
+
+## Phase 6 — Upgrade Prompt Copy
+
+```markdown
+**You've reached your rate limit**
+
+Your [Free] plan allows [60] requests per minute. You've hit that limit.
+
+- [Pro plan →] — [1,000] requests per minute, no interruptions
+- [Contact us →] — Custom limits for high-volume or enterprise use
+
+Your current window resets in [N] seconds if you'd like to continue on your current plan.
+```
+
+### Upgrade Prompt Rules
+
+- State the current limit and the upgrade limit side by side
+- Do not write "upgrade now to unlock unlimited API access" unless it is actually unlimited
+- Give the developer the option to wait if they do not want to upgrade
+- Keep to under 75 words
+
+## Phase 7 — SDK Warning Copy
+
+For SDK client-side warnings before a 429 is hit (proactive, using `X-RateLimit-Remaining`):
+
+```javascript
+// SDK warning message — not an error, just a heads-up
+console.warn(
+  `[ExampleSDK] Rate limit warning: ${remaining} requests remaining in the current window. ` +
+  `Window resets in ${secondsToReset}s. Consider adding a delay or using batch endpoints.`
+);
+```
+
+SDK warning rules:
+- Prefix with the SDK name so it is clear where the warning comes from
+- Show remaining count and reset time
+- Suggest a concrete action (delay, batch endpoint)
+- Fire at a threshold (e.g., fewer than 10 remaining), not at every request
+
+## Phase 8 — Output
+
+Deliver the requested surfaces as a single document with clear labeled sections. Include:
+
+1. Rate limit context model assessment
+2. 429 error body with field documentation
+3. Error message copy variants (general, per-endpoint, account-level as applicable)
+4. Header documentation table and code example
+5. Quota tier table
+6. Dashboard microcopy
+7. Upgrade prompt copy
+8. SDK warning template
+
+Flag any placeholder values that need real numbers or URLs.
+
+## Guardrails
+
+- Do not write apologetic error messages ("sorry for the inconvenience")
+- Do not invent limit values — if not provided, use `[N]` placeholders
+- Do not link to the pricing or upgrade page from a 429 error unless upgrading actually solves the specific limit hit
+- Do not promise "unlimited" requests in upgrade copy unless the plan is genuinely unlimited
+- If the retry window model is not confirmed, default to showing both absolute time and relative seconds and flag the assumption

--- a/skills/composites/rate-limit-ux-copywriter/skill.meta.json
+++ b/skills/composites/rate-limit-ux-copywriter/skill.meta.json
@@ -1,0 +1,22 @@
+{
+  "slug": "rate-limit-ux-copywriter",
+  "category": "composites",
+  "tags": [
+    "content"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install rate-limit-ux-copywriter",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Identifies the rate-limit model (fixed window, sliding window, token bucket) before writing any copy",
+    "Writes 429 error body JSON with machine-readable code, human-readable message, reset time, and upgrade URL",
+    "Documents rate-limit response headers with field tables and proactive usage code examples",
+    "Produces quota tier comparison tables, developer dashboard microcopy, and upgrade prompt variants",
+    "Covers 7 copy surfaces: error body, headers, quota table, dashboard UI, upgrade prompt, SDK warning, and docs prose"
+  ]
+}

--- a/skills/composites/sdk-quickstart-hardening-guide/SKILL.md
+++ b/skills/composites/sdk-quickstart-hardening-guide/SKILL.md
@@ -1,0 +1,340 @@
+---
+name: sdk-quickstart-hardening-guide
+description: >
+  Turn a working SDK snippet or API integration into a copy-paste-safe quickstart: prerequisites checklist, environment variable setup, the minimal runnable code path, common failure modes with diagnostic steps, and a first-success verification checklist. Scoped to SDK and API developer quickstarts for docs portals and README files — not help center support articles (use help-center-article-generator) and not conceptual API doc narrative (use openapi-docs-narrative). Use when an engineering or DevRel team has a working integration example but needs it to survive being copy-pasted cold by a developer who has never used the product before.
+tags: [content]
+---
+
+# SDK Quickstart Hardening Guide
+
+Take a working code snippet and make it actually work for a developer who is seeing your product for the first time. This skill covers the gap between "works on my machine" and "copy-paste-safe": prerequisites, environment setup, the minimal runnable path, failure modes, and a first-success checkpoint.
+
+**Built for:** DevRel engineers, API PMs, and backend developers who have a working code sample but whose quickstart still generates support tickets for missing dependencies, wrong env var names, or unclear success states.
+
+## Best Fit
+
+- SDK README "Getting started" sections
+- Docs portal quickstart pages
+- Developer onboarding code samples
+- Integration guides for third-party platforms
+- Code examples embedded in API reference pages
+- CI/CD integration starter recipes
+
+## Use Something Else
+
+- For support KB articles from ticket clusters, use `help-center-article-generator`.
+- For conceptual API doc sections (auth guide, error reference), use `openapi-docs-narrative`.
+- For Postman collection narrative, use `postman-collection-storyteller`.
+
+## Inputs
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `working_snippet` | Yes | The code that works — raw or as a paste |
+| `sdk_name` | Yes | Name of the SDK or API |
+| `language` | Yes | Target language(s) |
+| `package_name` | No | npm/pip/gem/etc. package identifier |
+| `env_vars` | No | List of environment variables the snippet uses |
+| `auth_scheme` | No | API key, OAuth, JWT, etc. |
+| `success_state` | No | What the developer should see when it works |
+| `known_failure_modes` | No | Errors the team already knows consumers hit |
+| `target_platform` | No | Node.js, Python, browser, serverless, etc. |
+| `docs_url` | No | Base URL for links to deeper reference |
+
+## Phase 0 — Intake
+
+Ask only for what is missing. If the user pastes a snippet, extract what you can from it.
+
+1. What SDK or API does this quickstart cover?
+2. Which language and runtime are you targeting?
+3. What does the developer need to have before running this? (Account, package, env vars)
+4. What should a developer see when the snippet runs successfully?
+5. What are the most common errors or failures you already see from new users?
+
+If the snippet is pasted, infer as much as possible from it before asking questions.
+
+## Phase 1 — Snippet Audit
+
+Before writing anything, audit the raw snippet against these hardening criteria:
+
+| Criterion | Pass | Fail |
+|-----------|------|------|
+| All required packages listed | Named and versioned | Implicit assumption |
+| All env vars listed | Named, described, and example-valued | Hardcoded secrets or unnamed vars |
+| Auth setup explicit | Shows exactly where key/token goes | Auth left as "fill in here" |
+| Error states surfaced | At least one failure mode handled | Silent fail or bare try/catch |
+| Success state defined | Developer knows what "worked" looks like | Ambiguous final output |
+| Minimal runnable path | Single logical action end-to-end | Multiple orthogonal examples |
+| Import/install statement | First line or prereqs section | Jumps straight to usage |
+
+Produce an audit summary before generating the quickstart:
+
+```
+SNIPPET AUDIT
+
+✓ Package identified: @example/sdk
+✗ Env vars: EXAMPLE_API_KEY used but never listed or described
+✓ Auth: Bearer token placement is explicit
+✗ Error handling: bare catch block with no user-actionable guidance
+✗ Success state: response logged but no description of what success looks like
+✓ Minimal path: single resource creation — appropriate scope
+```
+
+If critical items fail (env vars, success state, auth), ask the user to fill them in before generating the quickstart.
+
+## Phase 2 — Prerequisites Section
+
+Write the prerequisites block. This is the section most quickstarts skip and the #1 source of cold-start failures.
+
+### Prerequisites Template
+
+```markdown
+## Prerequisites
+
+Before you begin:
+
+- **[SDK/API] account** — [Sign up at [URL] / Contact sales at [URL]]
+- **API key** — Find your key in [Settings → API keys [URL]]
+- **[Runtime] [version]+** — [Node.js 18+, Python 3.9+, etc.]
+- **Package manager** — npm, yarn, pip, gem, etc.
+
+If you are using a sandbox/test environment, use your **test key** (prefix: `sk_test_`).
+Do not use production keys for development.
+```
+
+### Prerequisites Rules
+
+- List everything, including obvious things like "a [runtime] installation"
+- Always include where to get an API key with a real or placeholder URL
+- Call out the difference between test/sandbox and production credentials if the API has them
+- If there are version requirements, state the minimum version
+
+## Phase 3 — Installation Section
+
+```markdown
+## Installation
+
+```bash
+npm install @example/sdk
+# or
+yarn add @example/sdk
+```
+
+Check the [changelog →](URL) if you need a specific version.
+```
+
+Rules:
+- Show the exact install command for the target package manager
+- Do not show only one package manager if there are common alternatives
+- Do not include a specific version number in the install command unless the user specifies a pinned version requirement
+- Link to the changelog or release notes from the install section
+
+## Phase 4 — Environment Setup Section
+
+This is the most common place quickstarts break in the wild.
+
+```markdown
+## Environment setup
+
+The SDK reads credentials from environment variables. Set these before running:
+
+```bash
+# .env (do not commit this file)
+EXAMPLE_API_KEY=your_key_here
+EXAMPLE_BASE_URL=https://api.example.com  # optional, defaults to production
+```
+
+Load the `.env` file in your application:
+
+```javascript
+// Node.js
+import 'dotenv/config';
+
+// or require
+require('dotenv').config();
+```
+
+| Variable | Required | Description | Example value |
+|----------|----------|-------------|---------------|
+| `EXAMPLE_API_KEY` | Yes | Your API key from the dashboard | `sk_live_abc123` |
+| `EXAMPLE_BASE_URL` | No | Override the API base URL | `https://api.example.com` |
+
+> ⚠ Never hardcode API keys in source code. Add `.env` to `.gitignore`.
+```
+
+### Environment Setup Rules
+
+- Table every env var with required/optional, description, and example value
+- Always include the `.gitignore`/do-not-commit warning
+- Show how to load `.env` in the target runtime if applicable
+- If there are different env vars for test vs production, show both
+
+## Phase 5 — The Quickstart Code
+
+Write the minimal runnable path. One clean action. No branching, no optional complexity.
+
+### Code Block Rules
+
+- One complete, runnable file — not a snippet that requires context to understand
+- Include all imports at the top
+- Use descriptive variable names (no `x`, `temp`, `data`)
+- Annotate non-obvious lines with inline comments explaining intent, not mechanics
+- Keep to under 40 lines if possible
+- Show the output or result explicitly at the end
+
+### Minimal Runnable Path Template
+
+```markdown
+## Quickstart
+
+Create a file called `quickstart.[ext]` and paste the following:
+
+```[language]
+import ExampleSDK from '@example/sdk';
+
+// Initialize the client with your API key
+const client = new ExampleSDK({
+  apiKey: process.env.EXAMPLE_API_KEY,
+});
+
+async function main() {
+  // Create your first resource
+  const result = await client.users.create({
+    name: 'Test User',
+    email: 'test@example.com',
+  });
+
+  // result.id is the new user's identifier
+  console.log('Created user:', result.id);
+}
+
+main().catch(console.error);
+```
+
+Run it:
+
+```bash
+node quickstart.js
+```
+
+Expected output:
+
+```
+Created user: usr_01abc123
+```
+
+If you see a user ID logged, the integration is working correctly.
+```
+
+## Phase 6 — Failure Modes and Diagnostic Steps
+
+The #2 source of support tickets. Write this section explicitly for the errors the team already knows about.
+
+### Failure Modes Template
+
+```markdown
+## Common issues
+
+### `401 Unauthorized`
+
+**Cause:** Missing or invalid API key.
+
+**Fix:**
+1. Check that `EXAMPLE_API_KEY` is set in your environment: `echo $EXAMPLE_API_KEY`
+2. Verify the key is active in your [dashboard → API keys [URL]]
+3. If using a test key, check that it starts with `sk_test_`
+
+---
+
+### `ENOTFOUND api.example.com` / `Failed to fetch`
+
+**Cause:** Network error or wrong base URL.
+
+**Fix:**
+1. Check your internet connection
+2. If you set `EXAMPLE_BASE_URL`, verify it does not have a trailing slash
+3. If behind a proxy or firewall, ensure `api.example.com:443` is reachable
+
+---
+
+### `TypeError: Cannot read properties of undefined`
+
+**Cause:** The SDK client was initialized before environment variables were loaded.
+
+**Fix:** Move the `require('dotenv').config()` call before the `new ExampleSDK(...)` initialization.
+```
+
+### Failure Modes Rules
+
+- Cover every failure mode the user identified as known
+- Infer likely failures from the snippet (missing env vars, network calls, auth)
+- Format as: **Cause** → **Fix** with numbered steps
+- Never write "Contact support" as the only fix step — always give a diagnostic action first
+- Always include a "Contact support" fallback with an actual contact path after the diagnostic steps
+
+## Phase 7 — First-Success Checklist
+
+End with a checklist the developer can tick off to confirm the integration is ready for production use.
+
+```markdown
+## Next steps
+
+If your quickstart ran successfully:
+
+- [ ] Replace the test data with real input values
+- [ ] Handle errors explicitly (see [Error handling →](URL))
+- [ ] Store your API key in a secrets manager for production (not `.env`)
+- [ ] Review the [rate limit docs →](URL) before going to production
+- [ ] Set up [webhooks →](URL) if you need real-time event delivery
+
+**Need help?** [Community forum →](URL) | [Support →](URL)
+```
+
+## Phase 8 — Multi-Language Variants
+
+If the user requests multiple languages, generate each as a separate code block under the same prerequisite/env structure. Do not repeat prerequisites and env var tables per language — instead use tabs or clearly labeled sections.
+
+```markdown
+## Quickstart
+
+Select your language:
+
+### Node.js
+...
+
+### Python
+...
+
+### Ruby
+...
+```
+
+Rules:
+- Keep the same logical action across all language variants
+- Do not use language-idiomatic shortcuts that obscure what is happening
+- If a language-specific library has a different env var loading pattern, note it
+
+## Phase 9 — Output
+
+Deliver the full quickstart as a single Markdown document:
+
+1. Prerequisites
+2. Installation
+3. Environment setup
+4. Quickstart code
+5. Common issues
+6. Next steps
+
+Also flag:
+- Any placeholder values that need real URLs or data
+- Any failure mode the user mentioned that could not be addressed without more information
+- Any snippet behaviors that may surprise developers (e.g., async-only, connection pooling, singleton pattern)
+
+## Guardrails
+
+- Do not invent package names, env var names, or API behavior not present in the source snippet
+- Do not skip the prerequisites section — it is mandatory even if it seems obvious
+- Do not write "contact support" as the first or only troubleshooting step
+- Do not include sample data that looks realistic but could be mistaken for real credentials
+- If the snippet uses hardcoded credentials, flag this as a security issue before writing the quickstart
+- Mark all placeholder URLs with `[URL: description]` so the team can fill them before publishing

--- a/skills/composites/sdk-quickstart-hardening-guide/skill.meta.json
+++ b/skills/composites/sdk-quickstart-hardening-guide/skill.meta.json
@@ -1,0 +1,22 @@
+{
+  "slug": "sdk-quickstart-hardening-guide",
+  "category": "composites",
+  "tags": [
+    "content"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install sdk-quickstart-hardening-guide",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Audits a working snippet against 7 hardening criteria before writing any docs",
+    "Writes prerequisites, installation, and environment variable sections that survive cold-start by new developers",
+    "Generates the minimal runnable code path with inline intent comments and explicit expected output",
+    "Produces common-failure-mode diagnostics with Cause and Fix steps for every known error",
+    "Outputs a first-success checklist with next-step links for production readiness"
+  ]
+}

--- a/skills/composites/status-incident-comms-writer/SKILL.md
+++ b/skills/composites/status-incident-comms-writer/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: status-incident-comms-writer
+description: >
+  Draft API and infrastructure incident communications for developer-facing status pages and consumer email notifications: initial acknowledgement, timed rolling updates, resolution summary, and a customer-facing postmortem. Scoped to developer and API consumer incident comms — not uptime monitoring (use uptime-monitor) and not general breaking-change rollout comms (use breaking-change-comms-kit). Use when an engineering or DevRel team needs to communicate a live API or service incident to developers without writing from scratch under pressure.
+tags: [content]
+---
+
+# Status Incident Comms Writer
+
+Draft developer-facing incident communications under pressure. This skill produces the full incident communication arc — from the first "we're investigating" post to the final public postmortem — so your team can spend its time fixing the problem, not writing copy.
+
+**Built for:** Engineering leads, DevRel teams, and developer-support managers who need to communicate a live API or infrastructure incident to developers while simultaneously trying to resolve it.
+
+## Best Fit
+
+- API downtime or degraded availability incidents
+- Webhook delivery failures or event processing delays
+- Authentication service disruptions
+- Database or storage outages affecting API consumers
+- Third-party dependency failures affecting the API surface
+- Elevated error rates, latency spikes, or data processing delays
+
+## Use Something Else
+
+- For setting up uptime monitoring and alerts, use `uptime-monitor`.
+- For coordinating a planned breaking-change rollout, use `breaking-change-comms-kit`.
+- For deprecation sunset announcements, use `api-deprecation-sunset-planner`.
+
+## Inputs
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `incident_description` | Yes | What is failing, what impact it has on consumers |
+| `incident_status` | Yes | `investigating`, `identified`, `monitoring`, `resolved` |
+| `affected_services` | Yes | Specific endpoints, webhooks, auth, SDK, etc. |
+| `start_time` | Yes | ISO 8601 or human-readable timestamp |
+| `end_time` | No | Required for resolved/postmortem comms |
+| `root_cause` | No | Required for postmortem; not needed for initial comms |
+| `consumer_impact` | No | What developers are experiencing (errors, latency, data gaps) |
+| `workaround` | No | Any temporary workaround available |
+| `next_update_time` | No | When the next update will be posted |
+| `channel` | No | `status-page` (default), `email`, `slack`, or `all` |
+
+## Phase 0 — Intake
+
+Minimal intake — incidents move fast. Ask only for what is required.
+
+1. What is failing right now? (Specific services or endpoints)
+2. What status phase are you in? (Investigating / identified / monitoring / resolved)
+3. When did the incident start?
+4. Is there a workaround developers can use right now?
+
+Do not ask for root cause during the `investigating` phase — it is not yet known.
+
+## Phase 1 — Incident Severity Assessment
+
+Before writing, assign a severity level to calibrate communication frequency and channel selection:
+
+| Severity | Criteria | Communication cadence |
+|----------|----------|-----------------------|
+| **SEV-1 (Critical)** | Full API down, auth broken, all consumers affected | Every 15-30 minutes |
+| **SEV-2 (High)** | Subset of endpoints failing, degraded success rate, major feature broken | Every 30-60 minutes |
+| **SEV-3 (Medium)** | Non-critical feature degraded, elevated latency, partial webhook failure | Every 1-2 hours |
+| **SEV-4 (Low)** | Minor issue, workaround available, minimal consumer impact | Once at detection, once at resolution |
+
+State the severity level before writing any comms:
+
+```
+SEVERITY ASSESSMENT
+
+Status: Investigating
+Affected: All webhook deliveries failing — 100% failure rate since 14:22 UTC
+Impact: Consumers using webhooks cannot receive real-time events
+Workaround: None available
+Severity: SEV-2 (High)
+Recommended update cadence: Every 30-60 minutes
+```
+
+## Phase 2 — Status Page Update Templates
+
+### Initial Acknowledgement (Investigating)
+
+```markdown
+**Investigating — [Affected Service] disruption**
+
+We are investigating an issue affecting [specific service/endpoint].
+
+**Impact:** [One sentence on what consumers are experiencing. Be specific: "Webhook deliveries are failing" not "some features may be degraded."]
+
+**Affected:** [List specific endpoints, features, or services]
+
+**Started:** [Time in UTC] ([Time in user's timezone if known])
+
+We are actively investigating. Our next update will be posted by [time].
+
+— [Team name]
+```
+
+**Rules for initial acknowledgement:**
+- Post within 5 minutes of declaring an incident
+- Be specific about impact — "degraded performance" is not acceptable
+- Do not speculate on root cause
+- Commit to a next-update time and honor it
+- Do not include "we apologize for the inconvenience" in the first post — it wastes space; action matters more
+
+---
+
+### Identified Update (Root Cause Known)
+
+```markdown
+**Identified — [Affected Service] disruption**
+
+We have identified the cause of the [service] issue.
+
+**Root cause:** [One sentence. Specific. Technical enough to be credible.]
+
+**Impact:** [Current state — is it the same, improving, or worsening?]
+
+**Current status:** Our engineering team is [actively deploying a fix / rolling back / rerouting traffic].
+
+**Expected resolution:** [Time estimate if available] / [We will update at [time] with status]
+
+— [Team name]
+```
+
+**Rules:**
+- State the root cause in one sentence — do not write a full explanation here
+- State what the team is actively doing, not just what the problem is
+- Give an expected resolution time only if you are confident; "we will update by [time]" is safer than a wrong ETA
+
+---
+
+### Rolling Update (During Resolution)
+
+```markdown
+**Update [N] — [Time UTC]**
+
+[One to two sentences on current status: improving, stable, still investigating.]
+
+[If applicable: "The fix has been deployed and we are monitoring recovery. Webhook delivery failure rate has dropped from 100% to 12%."]
+
+Next update: [time UTC]
+```
+
+**Rules:**
+- Mark each update with a number and timestamp
+- Include a measurable signal if available (error rate percentage, latency reading)
+- Keep rolling updates under 75 words
+- Always include the next-update time
+
+---
+
+### Monitoring Update (Fix Deployed, Watching)
+
+```markdown
+**Monitoring — Fix deployed**
+
+We have deployed a fix for the [service] issue. [Service] is recovering and we are
+monitoring for full stabilization.
+
+**Current state:** [Error rate, latency, or delivery rate — specific metric if available]
+
+We will confirm resolution when metrics return to baseline. Next update: [time UTC]
+```
+
+---
+
+### Resolution Notice
+
+```markdown
+**Resolved — [Affected Service] incident**
+
+The [service] incident has been resolved as of [time UTC].
+
+**Duration:** [Start time] – [End time] ([N hours N minutes])
+
+**Impact summary:** [How many consumers were affected, what they experienced, for how long.]
+
+**Fix:** [One sentence on what was done to resolve the incident.]
+
+We will publish a full postmortem on [date]. [Link once available]
+
+Thank you for your patience.
+— [Team name]
+```
+
+**Rules:**
+- Include the exact resolved time in UTC
+- Include total duration
+- State the impact concisely — do not minimize it
+- Link the postmortem when it is available; if not yet written, commit to a date
+
+---
+
+### Consumer Email Notification
+
+Use for SEV-1/SEV-2 incidents or when consumers rely on email rather than a status page.
+
+```
+Subject: [ACTION REQUIRED / Service notice]: [API Name] [service] incident — [status]
+
+We are [investigating / have identified / have resolved] an issue affecting [service].
+
+Impact: [One sentence. Be specific.]
+Started: [Time UTC]
+[Resolved: [Time UTC]]
+
+[If workaround is available]: Temporary workaround: [one sentence on what to do now]
+
+We will post updates to our status page: [URL]
+
+Questions? Contact: [support alias or channel]
+
+— [Team name]
+```
+
+**Email rules:**
+- Subject must include the incident status in brackets
+- Include "ACTION REQUIRED" only if consumers need to change their behavior (e.g., retry with backoff, switch to a fallback endpoint)
+- Do not send more than one email per severity level per hour; direct developers to the status page for rolling updates
+
+## Phase 3 — Slack / Discord Incident Thread
+
+For internal or community-facing Slack/Discord:
+
+```
+⚠️ Incident update — [Time UTC]
+
+Status: [Investigating / Identified / Monitoring / Resolved]
+Affected: [Services]
+Impact: [One sentence]
+[Workaround if available]
+
+Status page: [URL]
+Next update: [time]
+```
+
+Rules:
+- Use the thread, not the channel, for rolling updates
+- Pin the first message in the thread
+- Post the resolution update in both the thread and the original channel
+
+## Phase 4 — Postmortem
+
+Write only after the incident is resolved and the team has completed an internal review.
+
+```markdown
+# Postmortem: [Incident Title]
+
+**Date:** [Date]
+**Duration:** [Start] – [End] ([N hours N minutes])
+**Severity:** [SEV level]
+**Status:** Resolved
+
+## Impact
+
+[Two to four sentences: who was affected, what they experienced, measurable impact
+(requests failed, webhooks delayed, data window affected).]
+
+## Timeline
+
+| Time (UTC) | Event |
+|------------|-------|
+| [HH:MM] | First alert triggered |
+| [HH:MM] | On-call engineer paged |
+| [HH:MM] | Root cause identified |
+| [HH:MM] | Fix deployed |
+| [HH:MM] | Monitoring confirms recovery |
+| [HH:MM] | Incident declared resolved |
+
+## Root cause
+
+[Two to four sentences on the technical root cause. Be specific and honest.
+Do not blame a single person. Do not use "human error" without explaining the systemic cause.]
+
+## Resolution
+
+[One to two sentences on what was done to fix the incident.]
+
+## What went well
+
+- [Thing the team did right during the incident]
+- [Communication that worked]
+
+## What could be improved
+
+- [Gap in detection, alerting, or response]
+- [Tooling or process that slowed resolution]
+
+## Action items
+
+| Action | Owner | Target date |
+|--------|-------|-------------|
+| [Add alert for [signal]] | [Team/person] | [Date] |
+| [Improve [component]] | [Team/person] | [Date] |
+
+---
+
+*If you experienced impact during this incident and have questions, contact [support alias].*
+```
+
+**Postmortem rules:**
+- Publish within 5 business days of resolution
+- Be honest about what broke and why — vague postmortems erode developer trust more than the incident itself
+- Action items must have owners and dates — unassigned action items are not action items
+- Do not assign blame to individuals
+
+## Phase 5 — Output
+
+Deliver all applicable templates for the current incident phase in a single document:
+
+- Severity assessment
+- Status page updates (all applicable phases)
+- Consumer email (if SEV-1 or SEV-2)
+- Slack/Discord thread copy
+- Postmortem template (pre-filled where information is available)
+
+Mark fields that require engineering team input with `[FILL: description]`.
+
+## Guardrails
+
+- Do not speculate on root cause during the `investigating` phase
+- Do not minimize impact — "some consumers may experience" when 100% are failing is not acceptable
+- Do not commit to a resolution ETA unless the team has confirmed it
+- Do not write a postmortem until the incident is resolved
+- Do not omit the incident duration from the resolution notice
+- Never write "we apologize for the inconvenience" as the first or only response — action and information come first

--- a/skills/composites/status-incident-comms-writer/skill.meta.json
+++ b/skills/composites/status-incident-comms-writer/skill.meta.json
@@ -1,0 +1,22 @@
+{
+  "slug": "status-incident-comms-writer",
+  "category": "composites",
+  "tags": [
+    "content"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install status-incident-comms-writer",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Assigns SEV-1 through SEV-4 severity and recommends update cadence before writing",
+    "Produces status page updates for all four incident phases: investigating, identified, monitoring, and resolved",
+    "Writes consumer email and Slack/Discord thread variants tuned for developer audiences",
+    "Generates a complete public postmortem template with timeline, root cause, and action items",
+    "Marks every field requiring engineering team input so comms can ship without guessing"
+  ]
+}

--- a/skills/composites/webhook-catalog-author/SKILL.md
+++ b/skills/composites/webhook-catalog-author/SKILL.md
@@ -1,0 +1,351 @@
+---
+name: webhook-catalog-author
+description: >
+  Build a complete, developer-facing webhooks event catalog: event taxonomy and naming conventions, payload schema documentation with field tables, signing and verification instructions, retry and delivery guarantee policies, deduplication patterns, and a consumer implementation checklist. Scoped to webhooks reference documentation — not general API narrative (use openapi-docs-narrative) and not changelog entries (use api-release-notes-composer). Use when an API team ships webhook events but the docs stop at "we send a POST request to your endpoint."
+tags: [content, research]
+---
+
+# Webhook Catalog Author
+
+Write the full developer reference for your webhook system. This skill covers every layer of webhooks documentation that teams skip: event taxonomy, payload schemas, signing/verification, delivery guarantees, retries, deduplication, and a consumer checklist. The output is ready to publish to a developer portal.
+
+**Built for:** API teams, DevRel engineers, and platform engineers who have a working webhook system but whose docs say "we'll send you a POST" and nothing else.
+
+## Best Fit
+
+- Event catalog reference pages (all events, their payloads, when they fire)
+- Webhook security documentation (signature verification)
+- Delivery and retry policy documentation
+- Consumer implementation guides (endpoint setup, verification, deduplication)
+- Payload schema reference tables
+
+## Use Something Else
+
+- For conceptual API auth/error/pagination docs, use `openapi-docs-narrative`.
+- For help center articles from support tickets, use `help-center-article-generator`.
+- For Postman collection narrative, use `postman-collection-storyteller`.
+- For new webhook event announcement copy, use `api-release-notes-composer`.
+
+## Inputs
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `api_name` | Yes | Name of the API or product |
+| `event_list` | Yes | List of webhook event names, or prose description of what events exist |
+| `payload_examples` | No | Sample JSON payloads for each event |
+| `signing_scheme` | No | HMAC-SHA256, RSA, Ed25519, or "none" |
+| `signing_header` | No | The header name used to deliver the signature |
+| `retry_policy` | No | Retry count, backoff strategy, timeout |
+| `delivery_guarantee` | No | At-least-once, at-most-once, or exactly-once |
+| `idempotency_field` | No | Field in the payload used for deduplication (e.g., `event.id`) |
+| `endpoint_requirements` | No | Required response codes, timeout requirements |
+| `existing_docs` | No | Existing webhook docs to improve |
+
+## Phase 0 — Intake
+
+Ask only for what is missing.
+
+1. What is the API called?
+2. What webhook events does it send? (List them or paste the event names)
+3. Do you have sample payloads I can use to document the schemas?
+4. How does the API sign webhook requests? (HMAC, RSA, or unsigned)
+5. What is the retry policy if the consumer endpoint fails?
+6. Is there a unique ID field in payloads that consumers can use for deduplication?
+
+If the user pastes event names or sample payloads, start processing immediately.
+
+## Phase 1 — Event Taxonomy
+
+Before writing any reference, organize the event list into a taxonomy. Events should be grouped by resource and named consistently.
+
+### Naming Convention Audit
+
+Check the provided event names against these standard patterns:
+
+| Pattern | Example | Notes |
+|---------|---------|-------|
+| `resource.action` | `user.created` | Most common; prefer this |
+| `resource.action.qualifier` | `payment.failed.insufficient_funds` | Use only when action alone is ambiguous |
+| `resource_action` | `user_created` | Acceptable; flag if inconsistent with other events |
+| `ACTION_RESOURCE` | `USER_CREATED` | Discourage; uppercase is non-standard for webhooks |
+
+Flag naming inconsistencies:
+
+```
+NAMING AUDIT
+
+✓ user.created — follows resource.action pattern
+✓ user.updated — consistent
+✗ project_archived — inconsistent with dot-notation events above
+✗ PAYMENT.FAILED — uppercase; recommend: payment.failed
+```
+
+### Event Taxonomy Table
+
+Produce a grouped event catalog table as the opening of the webhooks reference:
+
+```markdown
+## Events
+
+| Event | Trigger | Resource |
+|-------|---------|----------|
+| `user.created` | A new user account is created | User |
+| `user.updated` | A user's profile is updated | User |
+| `user.deleted` | A user account is deleted | User |
+| `project.created` | A new project is created | Project |
+| `project.archived` | A project is moved to archived state | Project |
+| `payment.succeeded` | A payment is processed successfully | Payment |
+| `payment.failed` | A payment attempt fails | Payment |
+```
+
+## Phase 2 — Payload Schema Documentation
+
+Write a reference section for each event.
+
+### Per-Event Reference Template
+
+```markdown
+### `user.created`
+
+Fired when a new user account is created.
+
+#### Payload
+
+```json
+{
+  "event": {
+    "id": "evt_01abc",
+    "type": "user.created",
+    "created_at": "2026-05-15T12:00:00Z",
+    "api_version": "2026-01-01"
+  },
+  "data": {
+    "user": {
+      "id": "usr_01abc",
+      "name": "Taylor Kim",
+      "email": "taylor@example.com",
+      "created_at": "2026-05-15T12:00:00Z",
+      "plan": "pro"
+    }
+  }
+}
+```
+
+#### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `event.id` | string | Unique event ID. Use for deduplication. |
+| `event.type` | string | Event type. Always `user.created` for this event. |
+| `event.created_at` | string (ISO 8601) | When the event was generated. |
+| `event.api_version` | string | The API version that generated this event. |
+| `data.user.id` | string | The new user's unique identifier. |
+| `data.user.name` | string | The user's display name. |
+| `data.user.email` | string | The user's email address. |
+| `data.user.created_at` | string (ISO 8601) | When the user was created. |
+| `data.user.plan` | string | Subscription plan: `free`, `pro`, or `enterprise`. |
+```
+
+### Payload Documentation Rules
+
+- Document every field in the payload with type and description
+- Use ISO 8601 for all datetime fields; note the format explicitly
+- Mark nullable fields as `string | null`
+- Mark enum fields with their possible values
+- Use realistic but non-real placeholder values in examples
+- If field names are inconsistent between events, note it and recommend standardization
+
+## Phase 3 — Security: Signing and Verification
+
+This is the most safety-critical section. Write it with full code examples.
+
+### Signing Documentation Template
+
+```markdown
+## Verifying webhook signatures
+
+All webhook requests from [API Name] include a signature header so you can verify
+that the request came from us and was not tampered with.
+
+### Signature header
+
+```
+[HEADER_NAME]: sha256=[SIGNATURE_HEX]
+```
+
+The value is an HMAC-SHA256 hex digest of the raw request body, computed using
+your webhook signing secret.
+
+### Getting your signing secret
+
+Your signing secret is in [Settings → Webhooks → [URL]].
+Use the **signing secret**, not your API key.
+
+### Verification code
+
+```javascript
+const crypto = require('crypto');
+
+function verifyWebhook(rawBody, signatureHeader, signingSecret) {
+  const expected = crypto
+    .createHmac('sha256', signingSecret)
+    .update(rawBody, 'utf8')
+    .digest('hex');
+
+  const received = signatureHeader.replace('sha256=', '');
+
+  return crypto.timingSafeEqual(
+    Buffer.from(expected, 'hex'),
+    Buffer.from(received, 'hex')
+  );
+}
+```
+
+```python
+import hmac
+import hashlib
+
+def verify_webhook(raw_body: bytes, signature_header: str, signing_secret: str) -> bool:
+    expected = hmac.new(
+        signing_secret.encode('utf-8'),
+        raw_body,
+        hashlib.sha256
+    ).hexdigest()
+    received = signature_header.replace('sha256=', '')
+    return hmac.compare_digest(expected, received)
+```
+
+> ⚠ Always use a constant-time comparison (`timingSafeEqual` / `compare_digest`).
+> Do not use `===` or `==` for signature comparison — these are vulnerable to timing attacks.
+
+### Rotation
+
+If your signing secret is compromised:
+1. Generate a new secret in [Settings → Webhooks → [URL]]
+2. Update your consumer endpoint to accept the new secret
+3. There is a [N-minute] overlap period where both secrets are valid
+4. Remove the old secret after confirming your endpoint uses the new one
+```
+
+### Security Rules
+
+- Always include the timing-safe comparison warning
+- Always include the signing secret rotation procedure
+- Show code examples in at least two languages
+- Explicitly use `rawBody` — warn against parsing before verifying
+- If the API is unsigned, note this explicitly and recommend the user validate the source IP if available
+
+## Phase 4 — Delivery and Retry Policy
+
+```markdown
+## Delivery
+
+### Guarantee
+
+[API Name] webhooks use **at-least-once delivery**. You may receive the same event
+more than once. Use the `event.id` field to deduplicate.
+
+### Endpoint requirements
+
+Your endpoint must:
+- Accept `POST` requests
+- Respond with a `2xx` status code within **[N] seconds**
+- Return the response before processing — do not wait for long-running work
+
+### Retry policy
+
+If your endpoint does not return a `2xx` within the timeout, or returns a `4xx` or `5xx`,
+we retry delivery using exponential backoff:
+
+| Attempt | Delay |
+|---------|-------|
+| 1 | Immediate |
+| 2 | 5 minutes |
+| 3 | 30 minutes |
+| 4 | 2 hours |
+| 5 | 6 hours |
+
+After [N] failed attempts, the event is marked undeliverable and you will receive
+an alert at [notification method].
+
+### Viewing failed deliveries
+
+You can inspect and manually retry failed webhook deliveries in [Settings → Webhooks → [URL]].
+```
+
+## Phase 5 — Deduplication Guide
+
+```markdown
+## Deduplication
+
+Because [API Name] uses at-least-once delivery, your consumer must be idempotent.
+
+Use the `event.id` field as your deduplication key:
+
+```javascript
+const processedEvents = new Set(); // Use a persistent store in production (Redis, DB)
+
+app.post('/webhooks', (req, res) => {
+  const event = req.body;
+
+  if (processedEvents.has(event.event.id)) {
+    // Already processed — acknowledge and skip
+    return res.status(200).send('ok');
+  }
+
+  processedEvents.add(event.event.id);
+
+  // Process the event
+  handleEvent(event);
+
+  res.status(200).send('ok');
+});
+```
+
+Key properties of `event.id`:
+- Globally unique across all events for your account
+- Stable across retries — the same event delivery always has the same `event.id`
+- Safe to use as a database primary key or cache key
+```
+
+## Phase 6 — Consumer Implementation Checklist
+
+```markdown
+## Consumer checklist
+
+Before going to production with your webhook consumer:
+
+- [ ] **Verify signatures** on every incoming request ([Verification guide →](#verifying-webhook-signatures))
+- [ ] **Respond within [N] seconds** — offload long-running work to a background job
+- [ ] **Return 2xx immediately** — do not block the response on processing
+- [ ] **Implement deduplication** using `event.id` ([Deduplication guide →](#deduplication))
+- [ ] **Handle retries gracefully** — your handler must be idempotent
+- [ ] **Log `event.id` and `event.type`** on every received event for debugging
+- [ ] **Test in sandbox/staging** before enabling production webhooks
+- [ ] **Monitor for failed deliveries** in [Settings → Webhooks → [URL]]
+```
+
+## Phase 7 — Output
+
+Deliver as a single Markdown document with these sections:
+
+1. Events table (full taxonomy)
+2. Per-event payload reference (all events)
+3. Signing and verification (with code examples)
+4. Delivery and retry policy
+5. Deduplication guide
+6. Consumer checklist
+
+Also deliver:
+- Naming convention issues found during the taxonomy audit
+- A list of `[URL: ...]` placeholders needing real links
+- Any payload fields that were ambiguous and need clarification from the team
+
+## Guardrails
+
+- Do not invent event names or payload fields not described by the user
+- Do not skip the timing-safe comparison warning in the signing section
+- Do not present unsigned webhooks as secure without noting the limitation
+- Do not use realistic-looking fake user data (no real names, real emails)
+- If a delivery guarantee is not specified, default to documenting at-least-once and flag that the user should confirm
+- Flag any event naming inconsistencies rather than silently normalizing them

--- a/skills/composites/webhook-catalog-author/skill.meta.json
+++ b/skills/composites/webhook-catalog-author/skill.meta.json
@@ -1,0 +1,23 @@
+{
+  "slug": "webhook-catalog-author",
+  "category": "composites",
+  "tags": [
+    "content",
+    "research"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install webhook-catalog-author",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Audits event naming conventions and produces a grouped event taxonomy table",
+    "Writes per-event payload schema reference with typed field tables from sample JSON",
+    "Generates HMAC signature verification code in multiple languages with timing-safe comparison warnings",
+    "Documents delivery guarantees, retry policy with backoff table, and failed-delivery monitoring",
+    "Produces a deduplication guide with idempotent consumer code and a pre-production consumer checklist"
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds a **developer-relations pack** of **10 new composite skills** focused on API and DevRel communications (release notes, breaking changes, reference-doc narrative, SDK quickstarts, webhooks, newsletters, Postman collections, incident comms, rate-limit UX, and deprecation planning).
- Regenerates `skills-index.json` via `npm run build:index` so all new skills appear in the top-level catalog.

## Pack: 10 skills

| Skill | Description |
|-------|-------------|
| `api-release-notes-composer` | Classifies ship artifacts into semver buckets, validates the version bump, and writes developer-facing changelog prose with migration hints and a short TL;DR. |
| `breaking-change-comms-kit` | Tiers impact, builds a backward-planning rollout timeline, migration guide, and per-channel copy (docs banner, email, in-product, Slack, status, FAQ). |
| `openapi-docs-narrative` | Writes the conceptual spine of API docs: auth, errors, pagination, versioning, idempotency, environments, and overview — not raw OpenAPI field dumps. |
| `sdk-quickstart-hardening-guide` | Audits a working snippet, then produces prerequisites, env setup, minimal runnable code, failure-mode diagnostics, and a first-success checklist. |
| `webhook-catalog-author` | Builds event taxonomy, per-event payload tables, signing/verification code, delivery/retry policy, deduplication guidance, and a consumer checklist. |
| `developer-newsletter-composer` | Triages shipped work into a recurring developer digest with action-required items first; supports email and Discord-style Markdown. |
| `postman-collection-storyteller` | Audits a Postman/Bruno workspace and writes collection, folder, and request narrative, variable docs, and script intent comments. |
| `status-incident-comms-writer` | Drafts SEV-scoped incident comms from investigating through resolution and a public postmortem template. |
| `rate-limit-ux-copywriter` | Produces 429 bodies, rate-limit header docs, quota tier tables, dashboard microcopy, upgrade prompts, and SDK warning templates. |
| `api-deprecation-sunset-planner` | Plans deprecation headers, phased timelines, all channel copy variants, migration outline, and a removal-day checklist. |

### Scope boundaries (vs existing skills)

Each `SKILL.md` includes **Use something else** sections that point to `feature-launch-playbook`, `help-center-article-generator`, `uptime-monitor`, and related composites so this pack stays distinct from GTM and support workflows.

## Test plan

- [ ] `node scripts/build-index.js` (already run; index committed)
- [ ] `node --test test/goose-skills-targets.test.js test/goose-skills-packs.test.js scripts/__tests__/build-index.test.js`
- [ ] Spot-check a few `SKILL.md` files for frontmatter `name` / `description` / `tags` alignment with `skill.meta.json`
