### PR TITLE
Add proof-led case study skill

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-05-07",
+  "generated": "2026-05-20",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -4174,6 +4174,42 @@
         "requires_skills": [
           "seo-domain-analyzer",
           "site-content-catalog"
+        ]
+      }
+    },
+    {
+      "slug": "proof-led-case-study",
+      "name": "proof-led-case-study",
+      "category": "composites",
+      "description": "Turn real customer proof, payment receipts, demos, maintainer feedback, or usage metrics into a credible case study, founder post, launch thread, and reusable proof packet without inventing claims or exposing private details.",
+      "tags": "content, social, brand",
+      "path": "skills/composites/proof-led-case-study",
+      "files": [
+        "skills/composites/proof-led-case-study/SKILL.md",
+        "skills/composites/proof-led-case-study/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "proof-led-case-study",
+        "category": "composites",
+        "tags": [
+          "content",
+          "social",
+          "brand"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install proof-led-case-study",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Evidence ledger for public claims",
+          "Privacy and redaction guardrails",
+          "Case study, X thread, LinkedIn post, and reuse packet outputs",
+          "Metric extrapolation labeling",
+          "Pre-publication credibility red team"
         ]
       }
     },

--- a/skills/composites/proof-led-case-study/SKILL.md
+++ b/skills/composites/proof-led-case-study/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: proof-led-case-study
+description: Turn real customer proof, payment receipts, demos, maintainer feedback, or usage metrics into a credible case study, founder post, launch thread, and reusable proof packet without inventing claims or exposing private details.
+---
+
+# Proof-Led Case Study
+
+Use this skill when the user has a real result and wants public-facing assets that feel specific, credible, and safe to publish. Good inputs include customer wins, screenshots, payment receipts, usage metrics, shipped pull requests, testimonials, support tickets, demo recordings, pilot notes, or before-and-after workflow evidence.
+
+Do not use this skill to manufacture social proof. If the evidence is thin, produce a cautious draft and a gap list instead of filling the gaps with hype.
+
+## Output
+
+Produce four assets:
+
+1. A proof ledger that separates verified facts, inferred context, private details, missing evidence, and claims that must be removed.
+2. A short public case study that explains the problem, the action taken, the result, and why it matters.
+3. A founder-led social post or thread for X or LinkedIn, written in a direct first-person voice.
+4. A reuse packet with approved metrics, anonymized names, screenshot redaction notes, captions, alt text, and follow-up variants.
+
+When the user asks for only one asset, still build the proof ledger first internally and then return the requested asset.
+
+## Non-Negotiables
+
+Never invent revenue, customer names, dates, quantities, screenshots, endorsements, approval status, or causality.
+
+Never include private payment details, wallet addresses, private account identifiers, tax information, private emails, private tokens, unblurred personal information, or anything that could expose a customer or maintainer without permission.
+
+Never imply that a result is repeatable unless the evidence supports that claim.
+
+Never quote a private message as if it were approved marketing copy. Paraphrase private feedback unless the user explicitly says it is approved for public use.
+
+If a screenshot contains sensitive information, describe exactly what should be blurred or cropped before publication.
+
+## Workflow
+
+### 1. Intake
+
+Collect the minimum needed facts:
+
+- What happened.
+- Who benefited.
+- What changed before and after.
+- What proof exists.
+- Which details must stay private.
+- Where the asset will be published.
+- Desired tone and whether the user wants names or anonymization.
+
+If the user already provided enough evidence, proceed without asking follow-up questions.
+
+### 2. Build the proof ledger
+
+Create a private working ledger with five columns:
+
+- Verified facts.
+- Evidence source.
+- Safe public wording.
+- Risk or caveat.
+- Needed approval or redaction.
+
+Classify each claim as verified, plausible but unsupported, private, or remove.
+
+For metrics, keep the exact arithmetic visible. If a run rate or extrapolation is useful, label it as an extrapolation and state the time window.
+
+### 3. Decide the narrative frame
+
+Choose the strongest honest frame:
+
+- Before and after: the clearest operational improvement.
+- Unexpected result: a surprising outcome that still has evidence.
+- Workflow reveal: how the work actually happened.
+- Trust proof: why the audience should believe the result.
+- Lesson learned: what others can use without overclaiming.
+
+Avoid turning every story into a generic launch announcement. The proof should drive the structure.
+
+### 4. Draft the case study
+
+Use this structure:
+
+- One-sentence result.
+- Starting constraint.
+- What was tried.
+- What changed.
+- Evidence and caveats.
+- Practical takeaway.
+
+Keep the case study concrete. Use dates, time windows, dollar amounts, counts, or named artifacts only when they are safe to publish.
+
+### 5. Draft the social asset
+
+For X, write a short thread with a sharp opening line, proof in the first two posts, and a practical lesson near the end. Keep each post standalone enough to survive screenshots.
+
+For LinkedIn, write a single post with shorter paragraphs, fewer punchlines, and a more explicit takeaway.
+
+For founder voice, prefer plain sentences over marketing language. Specificity is the style.
+
+### 6. Red-team before delivery
+
+Check:
+
+- Does every numeric claim have evidence?
+- Could any person, customer, maintainer, wallet, payment account, or private thread be identified?
+- Is the causal claim too strong?
+- Is the result framed as guaranteed when it was one observed case?
+- Is any private screenshot being treated as public?
+- Would the named platform or maintainer consider the post spammy or manipulative?
+
+Revise until the answer passes those checks.
+
+## Final Response Format
+
+Return:
+
+- Proof ledger summary.
+- Public case study.
+- Social post or thread.
+- Redaction and approval checklist.
+- Optional follow-up variants if they add real value.
+
+Keep drafts publishable, not padded. If the safest answer is to publish less, say so and explain which claims were removed.

--- a/skills/composites/proof-led-case-study/skill.meta.json
+++ b/skills/composites/proof-led-case-study/skill.meta.json
@@ -1,0 +1,24 @@
+{
+  "slug": "proof-led-case-study",
+  "category": "composites",
+  "tags": [
+    "content",
+    "social",
+    "brand"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install proof-led-case-study",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Evidence ledger for public claims",
+    "Privacy and redaction guardrails",
+    "Case study, X thread, LinkedIn post, and reuse packet outputs",
+    "Metric extrapolation labeling",
+    "Pre-publication credibility red team"
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds `proof-led-case-study`, a composite GTM skill for turning real customer proof, receipts, demos, maintainer feedback, or usage metrics into credible public case studies and founder-led social assets.
- Includes guardrails for evidence classification, privacy redaction, metric caveats, and pre-publication red-team checks.
- Rebuilds `skills-index.json` so the skill is discoverable by downstream consumers.

## Validation
- `npm run validate:skills`
- `npm run build:index`
- `npm run ci`

Submitted in response to the public Gooseworks builder call for useful agent skills. If this qualifies for the builder bounty, I can coordinate payout details privately.