### PR TITLE
Add offer intake gate skill

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-05-07",
+  "generated": "2026-05-21",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -3772,6 +3772,40 @@
             "codex"
           ]
         }
+      }
+    },
+    {
+      "slug": "offer-intake-gate",
+      "name": "offer-intake-gate",
+      "category": "composites",
+      "description": "Qualify and shape a new paid offer before building GTM assets. Use when a founder, consultant, creator, or team wants to launch a new product, service, package, paid experiment, monetization idea, or revenue line and needs crisp customer, pain, scope, price, channel, proof, and risk decisions before execution.",
+      "tags": "research, brand",
+      "path": "skills/composites/offer-intake-gate",
+      "files": [
+        "skills/composites/offer-intake-gate/SKILL.md",
+        "skills/composites/offer-intake-gate/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "offer-intake-gate",
+        "category": "composites",
+        "tags": [
+          "research",
+          "brand"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install offer-intake-gate",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Front-loads buyer, pain, price, proof, delivery, and distribution questions before GTM execution",
+          "Scores offer readiness with a simple gate",
+          "Routes ready offers to launch, positioning, outreach, or paid-channel skills",
+          "Blocks premature landing pages and campaigns when the offer is still unclear"
+        ]
       }
     },
     {

--- a/skills/composites/offer-intake-gate/SKILL.md
+++ b/skills/composites/offer-intake-gate/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: offer-intake-gate
+description: Qualify and shape a new paid offer before building GTM assets. Use when a founder, consultant, creator, or team wants to launch a new product, service, package, paid experiment, monetization idea, or revenue line and needs crisp customer, pain, scope, price, channel, proof, and risk decisions before execution.
+tags: [research, brand]
+---
+
+# Offer Intake Gate
+
+Turn a vague monetization idea into a clear, testable paid offer. This skill is a gate before launch plans, landing pages, ads, outreach, or content. It prevents the agent from producing polished GTM assets for an offer that is not yet defined enough to sell.
+
+## When to use
+
+Use this skill when the user says they want to:
+
+- make a new paid product, service, package, audit, course, template, community, tool, or retainer
+- monetize an existing capability, audience, workflow, or internal process
+- choose what to charge for, who to sell it to, or how to package it
+- decide whether a product idea is worth building or selling first
+- convert a custom service into a repeatable offer
+
+Do not use it for mature offers that already have a clear buyer, price, promise, proof, and channel. In those cases, route to positioning, launch, outbound, ads, or content skills.
+
+## Non-negotiables
+
+- Keep the user out of vague brainstorming. Convert every idea into a concrete buyer, trigger, promise, deliverable, price, and next validation action.
+- Separate what the user can prove today from what is only a claim.
+- Prefer the smallest paid validation path before a large build.
+- Flag legal, platform, privacy, health, financial, and security risk early.
+- Do not recommend ads, funnels, or automation until the offer passes the readiness gate.
+
+## Intake questions
+
+Ask only for missing information. If the user gives a rough idea, infer what you can, then ask the highest-leverage gaps in one batch.
+
+Collect:
+
+1. Buyer: who has the budget and urgency?
+2. Trigger: what happened recently that makes them care now?
+3. Pain: what expensive, embarrassing, slow, risky, or recurring problem exists?
+4. Current alternative: how do they solve it today?
+5. Promise: what outcome can be delivered in a specific time window?
+6. Deliverable: what exactly does the buyer receive?
+7. Scope boundary: what is explicitly not included?
+8. Proof: what evidence, examples, audience, customer quotes, credentials, or demos exist?
+9. Price hypothesis: one entry price, one standard price, one premium price.
+10. Distribution: where can the first ten buyers be reached without paid ads?
+11. Delivery capacity: how many can be fulfilled this week and this month?
+12. Risk: any regulated domain, private data, platform terms, claims, or dependency risk?
+
+## Gate scoring
+
+Score each dimension from 0 to 2.
+
+- Buyer clarity
+- Pain urgency
+- Outcome specificity
+- Proof strength
+- Delivery feasibility
+- Price plausibility
+- Distribution access
+- Risk control
+
+Interpretation:
+
+- 13 to 16: ready to package and sell
+- 9 to 12: run a paid validation sprint
+- 5 to 8: narrow the buyer or outcome
+- 0 to 4: do discovery before building
+
+Always explain the score in plain language. Scores are decision aids, not theater.
+
+## Output format
+
+Produce a concise offer brief with:
+
+- Offer name
+- Buyer
+- Trigger
+- Pain
+- Promise
+- Deliverable
+- Scope boundaries
+- Price ladder
+- Proof assets
+- Distribution wedge
+- Risk notes
+- Gate score
+- Recommendation: sell now, validate first, narrow, or pause
+- Next three actions
+
+The next actions must be practical and time-boxed. At least one should test willingness to pay, not just interest.
+
+## Routing after the gate
+
+If the offer scores 13 or higher:
+
+- Use launch-positioning-builder for positioning.
+- Use feature-launch-playbook for a launch kit.
+- Use cold-email-outreach or linkedin-outreach for direct sales.
+- Use paid-channel-prioritizer only if the user has budget and a working conversion path.
+
+If the offer scores 9 to 12:
+
+- Recommend a paid validation sprint.
+- Draft a short buyer DM, a one-page offer memo, and a manual delivery plan.
+- Ask the user to contact a small named list before building more assets.
+
+If the offer scores below 9:
+
+- Run customer discovery.
+- Narrow the ICP.
+- Replace broad promises with one painful use case.
+- Do not create a landing page or ad campaign yet.
+
+## Quality bar
+
+A good result should make the user more decisive. It should remove options, not add a dozen more. If two offers are possible, rank them and pick one default path with a clear reason.

--- a/skills/composites/offer-intake-gate/skill.meta.json
+++ b/skills/composites/offer-intake-gate/skill.meta.json
@@ -1,0 +1,22 @@
+{
+  "slug": "offer-intake-gate",
+  "category": "composites",
+  "tags": [
+    "research",
+    "brand"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install offer-intake-gate",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Front-loads buyer, pain, price, proof, delivery, and distribution questions before GTM execution",
+    "Scores offer readiness with a simple gate",
+    "Routes ready offers to launch, positioning, outreach, or paid-channel skills",
+    "Blocks premature landing pages and campaigns when the offer is still unclear"
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `offer-intake-gate`, a composite GTM skill that qualifies and shapes a new paid offer before an agent starts creating launch, outreach, ads, or content assets.

The skill helps founders and operators clarify buyer, trigger, pain, deliverable, scope, proof, pricing, distribution, delivery capacity, and risk before moving into downstream GTM work.

## Why this belongs in Goose Skills

Goose has strong launch, positioning, outreach, paid-channel, and content workflows. This adds the upstream gate that decides whether an offer is defined enough to use those workflows, or whether the user should first narrow the buyer/outcome or run a paid validation sprint.

## Validation

- `npm run build:index`
- `npm run validate:skills`
- `npm test`

Note: the test suite prints expected error output for negative regression cases, but completes with 19/19 tests passing.