### PR TITLE
Add business case builder skill

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-05-07",
+  "generated": "2026-05-24",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -437,6 +437,34 @@
         "source": "orthogonal",
         "installation": {
           "base_command": "npx goose-skills install browser-automation-notte",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
+      }
+    },
+    {
+      "slug": "business-case-builder",
+      "name": "business-case-builder",
+      "category": "composites",
+      "description": "Build buyer-ready internal business cases for B2B software purchases from discovery notes, pain points, pricing, ROI assumptions, stakeholder concerns, and procurement requirements.",
+      "tags": "content, outreach",
+      "path": "skills/composites/business-case-builder",
+      "files": [
+        "skills/composites/business-case-builder/SKILL.md",
+        "skills/composites/business-case-builder/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "business-case-builder",
+        "category": "composites",
+        "tags": [
+          "content",
+          "outreach"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install business-case-builder",
           "supports": [
             "claude",
             "cursor",

--- a/skills/composites/business-case-builder/SKILL.md
+++ b/skills/composites/business-case-builder/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: business-case-builder
+description: Build buyer-ready internal business cases for B2B software purchases from discovery notes, pain points, pricing, ROI assumptions, stakeholder concerns, and procurement requirements.
+tags: [content, outreach]
+---
+
+# Business Case Builder
+
+Turn messy sales notes into a business case a champion can forward internally. The skill converts pain, cost, risk, expected value, and implementation effort into an executive-ready memo, ROI model, approval one-pager, and stakeholder-specific objection answers.
+
+Core principle: a business case is not a sales pitch. It is an internal decision document. Make the recommendation easy to defend, conservative with numbers, explicit about assumptions, and honest about implementation risk.
+
+## When To Use
+
+- A champion likes the product but needs help convincing finance, procurement, IT, legal, or leadership.
+- A deal is stuck after demo because the buyer needs budget approval.
+- A seller needs an ROI narrative grounded in the buyer's actual pain, not generic claims.
+- A founder needs a procurement-ready memo for a mid-market or enterprise opportunity.
+- A customer success team needs an expansion or renewal business case.
+
+## Inputs
+
+Ask for the smallest complete packet available:
+
+1. Buyer company, industry, size, and relevant business unit.
+2. Champion name, role, authority level, and what they care about.
+3. Current problem, broken workflow, or missed opportunity.
+4. Current cost estimates: time spent, headcount, tools, error rates, missed revenue, churn, risk exposure, or operational delays.
+5. Proposed product, pricing, package, contract length, services, and implementation effort.
+6. Expected outcomes and any proof: customer stories, benchmark data, pilot results, usage data, or analyst notes.
+7. Buying committee: economic buyer, technical reviewer, procurement, legal, security, end users, and likely blockers.
+8. Approval context: budget cycle, deadline, competing priorities, required format, and whether the case must be conservative or aggressive.
+
+If data is missing, proceed with clearly labeled assumptions. Never invent precision. Use ranges when confidence is low.
+
+## Operating Rules
+
+- Separate facts from assumptions. Every number must be labeled as provided, estimated, benchmarked, or unknown.
+- Use conservative math first. If optimistic upside exists, place it in a separate upside scenario.
+- Do not promise revenue, savings, compliance, or risk reduction that the evidence does not support.
+- Make the champion look credible. Write in an internal, defensible tone rather than vendor marketing language.
+- Show the cost of inaction. Compare buying the product against staying with the current process.
+- Include implementation risk and mitigation. Buyers trust a plan that names the hard parts.
+- Preserve stakeholder nuance. Finance, IT, legal, security, and end users need different reasons to support the same purchase.
+
+## Workflow
+
+### Phase 1: Clarify The Decision
+
+Identify:
+
+- Decision requested: buy, pilot, expand, renew, replace, consolidate, or delay.
+- Approval owner: who can say yes.
+- Recommended package and term.
+- Main success metric.
+- Deadline or event driving urgency.
+- Consequence of doing nothing.
+
+Write a one-sentence decision statement:
+
+Approve [purchase or action] for [team or use case] to achieve [business outcome] by [timeframe], with [budget or range] and [implementation owner].
+
+### Phase 2: Build The Value Model
+
+Convert the buyer's pain into value categories:
+
+- Time savings
+- Labor capacity recovered
+- Revenue lift or pipeline acceleration
+- Cost avoidance
+- Vendor consolidation
+- Risk reduction
+- Compliance or audit readiness
+- Customer experience improvement
+- Employee experience improvement
+- Strategic optionality
+
+For each category, capture:
+
+- Baseline: current state and cost driver.
+- Assumption: formula and source.
+- Expected impact: conservative, expected, and upside if possible.
+- Confidence: high, medium, low, or blocked.
+
+Use simple formulas:
+
+- Annual time cost = hours per week x loaded hourly cost x 52.
+- Capacity recovered = current effort minus expected effort.
+- Payback period = total investment divided by monthly value.
+- Net value = annual value minus annual investment.
+- ROI = net value divided by annual investment.
+
+If the inputs are weak, produce a directional model and list the exact data needed to validate it.
+
+### Phase 3: Map Stakeholder Concerns
+
+Create a stakeholder table:
+
+- Stakeholder
+- What they care about
+- Likely objection
+- Evidence they need
+- Recommended message
+- Owner for follow-up
+
+Common stakeholder priorities:
+
+- Economic buyer: payback, risk, strategic priority.
+- Finance: budget fit, assumptions, contract terms.
+- Procurement: vendor comparison, negotiation points, process.
+- IT or security: integration, data access, admin controls, support model.
+- Legal: contract risk, data processing, liability.
+- Champion: internal credibility, timeline, adoption.
+- End users: workflow fit, training, time saved.
+
+### Phase 4: Write The Business Case
+
+Produce these sections in order:
+
+1. Executive summary.
+2. Decision requested.
+3. Current state and cost of inaction.
+4. Recommended solution.
+5. Financial case.
+6. Strategic case.
+7. Implementation plan.
+8. Risks and mitigations.
+9. Stakeholder-specific responses.
+10. Data needed to finalize approval.
+
+Keep the memo concise. If the user asks for a longer version, include detail in an appendix.
+
+### Phase 5: Produce Approval Assets
+
+Create the following deliverables:
+
+1. Executive memo: one to two pages.
+2. ROI table: conservative, expected, and upside scenarios.
+3. Champion forwardable email: short note they can send to the buyer committee.
+4. Procurement one-pager: package, pricing, use case, business owner, timeline, open items.
+5. Objection response sheet: finance, IT, legal, procurement, end users.
+6. Missing-data checklist: exact facts needed to strengthen or validate the case.
+
+## Quality Bar
+
+Before finalizing, verify:
+
+- Every numeric claim has a source label.
+- The recommended decision is explicit.
+- The cost of inaction is stated.
+- The math is simple enough for a finance reviewer to audit.
+- Risks are named without undermining the recommendation.
+- The output helps the buyer make an internal decision without sounding like vendor copy.
+- Any legal, security, compliance, or financial claim that needs owner approval is flagged.
+
+## Output Format
+
+Return the executive memo first, then the ROI table, stakeholder map, champion email, procurement one-pager, and missing-data checklist.
+
+Use markdown tables for ROI and stakeholder mapping unless the user asks for spreadsheet-ready CSV.
+
+Confidence levels:
+
+- High: directly supported by buyer-provided data or signed pilot results.
+- Medium: supported by reasonable estimates, benchmarks, or comparable customer evidence.
+- Low: plausible but needs validation.
+- Blocked: missing data prevents a defensible claim.
+
+## Example Prompts
+
+- Build a business case for this prospect using our discovery notes and pricing.
+- Turn this champion's pain points into a CFO-ready approval memo.
+- Create a conservative ROI model for this expansion deal.
+- Help write the internal business case our buyer can forward to procurement.
+- Build stakeholder-specific objection answers for finance, IT, legal, and end users.

--- a/skills/composites/business-case-builder/skill.meta.json
+++ b/skills/composites/business-case-builder/skill.meta.json
@@ -1,0 +1,16 @@
+{
+  "slug": "business-case-builder",
+  "category": "composites",
+  "tags": [
+    "content",
+    "outreach"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install business-case-builder",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add a business-case-builder composite skill for turning sales discovery notes into buyer-ready approval assets.
- Include metadata for Claude, Cursor, and Codex installation.
- Regenerate skills-index.json.

## Validation
- /Users/domyin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/build-index.js
- /Users/domyin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/validate-skills.js
- /Users/domyin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test test/goose-skills-targets.test.js test/goose-skills-packs.test.js scripts/__tests__/build-index.test.js scripts/__tests__/validate-skills.test.js