### PR TITLE
Add mutual action plan builder skill

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-05-07",
+  "generated": "2026-05-24",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -3647,6 +3647,34 @@
         "source": "orthogonal",
         "installation": {
           "base_command": "npx goose-skills install multi-platform-search-searchapi",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
+      }
+    },
+    {
+      "slug": "mutual-action-plan-builder",
+      "name": "mutual-action-plan-builder",
+      "category": "composites",
+      "description": "Build mutual action plans for late-stage B2B deals, pilots, renewals, and expansions with milestones, owners, exit criteria, risks, and buyer-ready next steps.",
+      "tags": "content, outreach",
+      "path": "skills/composites/mutual-action-plan-builder",
+      "files": [
+        "skills/composites/mutual-action-plan-builder/SKILL.md",
+        "skills/composites/mutual-action-plan-builder/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "mutual-action-plan-builder",
+        "category": "composites",
+        "tags": [
+          "content",
+          "outreach"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install mutual-action-plan-builder",
           "supports": [
             "claude",
             "cursor",

--- a/skills/composites/mutual-action-plan-builder/SKILL.md
+++ b/skills/composites/mutual-action-plan-builder/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: mutual-action-plan-builder
+description: Build mutual action plans for late-stage B2B deals, pilots, renewals, and expansions with milestones, owners, exit criteria, risks, and buyer-ready next steps.
+tags: [content, outreach]
+---
+
+# Mutual Action Plan Builder
+
+Create a mutual action plan that a seller and buyer can both use to move a deal from active evaluation to signed agreement, pilot launch, renewal, or expansion. The plan turns scattered notes into a shared timeline with owners, milestones, proof requirements, decision gates, and risk controls.
+
+Core principle: a mutual action plan is not a seller task list. It is a shared operating document. It should make the buyer's internal process visible, reduce surprises, and give every stakeholder a clear reason to act by a specific date.
+
+## When To Use
+
+- A deal is past discovery and needs a clear path to decision.
+- A pilot or proof of concept needs success criteria before it starts.
+- A champion needs help coordinating finance, legal, security, IT, procurement, and leadership.
+- A renewal or expansion has multiple dependencies and a fixed deadline.
+- A seller needs to recover a stalled opportunity by making next steps concrete.
+- A customer success team needs a shared plan for onboarding, adoption, or expansion.
+
+## Inputs
+
+Ask for the smallest complete packet available:
+
+1. Deal type: new purchase, pilot, proof of concept, renewal, expansion, migration, or replacement.
+2. Buyer company, business unit, team size, and target users.
+3. Current stage and latest buyer-confirmed next step.
+4. Target decision date, launch date, renewal date, or deadline.
+5. Product or package under evaluation, pricing range, contract term, and implementation scope.
+6. Buying committee: champion, economic buyer, technical reviewer, legal, security, procurement, finance, implementation owner, end users.
+7. Known buyer process: security review, legal review, budget approval, procurement intake, vendor onboarding, pilot signoff, data access, IT approval.
+8. Success criteria: business outcome, technical requirements, adoption threshold, pilot metrics, reporting needs, and acceptance evidence.
+9. Risks and blockers: missing stakeholders, competing priorities, budget uncertainty, legal concerns, integration risk, timeline pressure, unclear owner.
+10. Notes from calls, emails, CRM fields, proposal docs, security questionnaires, procurement requests, or implementation plans.
+
+If details are missing, proceed with explicit assumptions and a missing-information checklist. Do not invent buyer commitments.
+
+## Operating Rules
+
+- Separate confirmed buyer commitments from seller assumptions.
+- Make every milestone owner-specific. Avoid vague owners such as "team" unless no individual is known.
+- Every phase must have an exit criterion that proves it is complete.
+- Include buyer-side work, not only seller-side work.
+- Show dependencies clearly. Legal cannot finish before redlines are exchanged; pilot signoff cannot happen before success metrics are agreed.
+- Keep dates realistic. If no date is confirmed, use relative timing and flag it as tentative.
+- Name risks without blaming the buyer. The plan should help the champion coordinate, not pressure them.
+- Do not create legal, procurement, security, tax, or payment obligations on behalf of the user or buyer.
+
+## Workflow
+
+### Phase 1: Identify The Decision Path
+
+Determine the target outcome:
+
+- Signed contract
+- Pilot approval
+- Pilot completion
+- Security approval
+- Procurement approval
+- Renewal decision
+- Expansion approval
+- Implementation launch
+
+Then identify the most likely path:
+
+1. Technical fit confirmed.
+2. Business value confirmed.
+3. Security and legal reviewed.
+4. Commercial terms agreed.
+5. Procurement and vendor setup completed.
+6. Final buyer approval received.
+7. Launch or handoff completed.
+
+Rewrite the path in buyer language. For example:
+
+Approve a 90-day pilot for the revenue operations team, validate integration with the CRM, confirm reporting accuracy, complete security review, and decide on annual rollout by the end of the quarter.
+
+### Phase 2: Build The Milestone Table
+
+Create a milestone table with these columns:
+
+- Phase
+- Milestone
+- Buyer owner
+- Seller owner
+- Target date
+- Dependencies
+- Exit criterion
+- Evidence or artifact
+- Status
+- Risk level
+
+Common milestones:
+
+- Confirm business problem and desired outcome.
+- Align on success metrics.
+- Confirm stakeholder map and approval process.
+- Review technical requirements.
+- Complete integration or data-access check.
+- Complete security review.
+- Complete legal review.
+- Confirm commercial proposal.
+- Submit procurement intake.
+- Finalize implementation plan.
+- Secure executive approval.
+- Sign agreement.
+- Launch pilot or production rollout.
+- Review pilot results.
+- Decide renewal or expansion.
+
+Use status values:
+
+- Not started
+- In progress
+- Waiting on buyer
+- Waiting on seller
+- Blocked
+- Complete
+
+Use risk levels:
+
+- Low
+- Medium
+- High
+- Unknown
+
+### Phase 3: Define Success Criteria
+
+For pilots and proof-of-concept deals, create a success criteria section:
+
+- Business objective
+- Metric
+- Baseline
+- Target
+- Measurement method
+- Data owner
+- Review date
+- Pass or fail threshold
+
+Examples:
+
+- Reduce manual review time by 30 percent.
+- Process 500 records with less than 2 percent error rate.
+- Support single sign-on with the buyer's identity provider.
+- Generate a weekly report accepted by the business owner.
+- Achieve usage by at least 10 active users in the pilot group.
+
+For renewals and expansions, adapt success criteria:
+
+- Adoption trend
+- Usage by team
+- Business outcome achieved
+- Open support issues
+- Executive sponsor sentiment
+- Expansion use cases
+- Renewal risk signals
+
+### Phase 4: Map Stakeholders And Responsibilities
+
+Build a stakeholder table:
+
+- Name
+- Role
+- Decision influence
+- What they need to approve
+- Concern or objection
+- Evidence needed
+- Next action
+- Owner
+- Due date
+
+Decision influence options:
+
+- Champion
+- Economic buyer
+- Technical reviewer
+- Security reviewer
+- Legal reviewer
+- Procurement owner
+- Finance approver
+- Executive sponsor
+- Implementation owner
+- End-user representative
+- Unknown
+
+If a required stakeholder is unknown, mark it as a gap and add a task to identify them.
+
+### Phase 5: Surface Risks And Recovery Actions
+
+Create a risk register:
+
+- Risk
+- Signal
+- Impact
+- Probability
+- Mitigation
+- Owner
+- Trigger date
+
+Common risks:
+
+- No confirmed economic buyer.
+- Security review not started.
+- Legal redlines delayed.
+- Procurement timeline unknown.
+- Success criteria not agreed before pilot.
+- Champion lacks authority.
+- Competing project may take budget.
+- Technical dependency lacks an owner.
+- Renewal date is close but value proof is incomplete.
+
+For each high-risk item, write a recovery action that can happen this week.
+
+### Phase 6: Produce Buyer-Ready Outputs
+
+Return these deliverables:
+
+1. Executive mutual action plan summary.
+2. Milestone table.
+3. Success criteria table.
+4. Stakeholder responsibility map.
+5. Risk register.
+6. This-week action list.
+7. Champion email that introduces the plan.
+8. Missing-information checklist.
+
+The champion email should be short, practical, and easy to forward. It should position the plan as a way to keep both sides aligned.
+
+## Quality Bar
+
+Before finalizing, verify:
+
+- The target outcome is explicit.
+- Every milestone has at least one owner.
+- Every major phase has an exit criterion.
+- Buyer-side dependencies are included.
+- Risks are specific and actionable.
+- Missing information is clearly separated from confirmed facts.
+- Dates are labeled as confirmed, tentative, or proposed.
+- The plan can be forwarded to a buyer without sounding like vendor pressure.
+- Legal, security, procurement, and payment steps are framed as buyer-owned processes, not obligations created by the assistant.
+
+## Output Format
+
+Start with a short summary:
+
+- Target outcome
+- Target date
+- Current stage
+- Biggest risk
+- This week's most important action
+
+Then provide:
+
+1. Mutual action plan table.
+2. Success criteria table.
+3. Stakeholder map.
+4. Risk register.
+5. This-week action list.
+6. Champion email.
+7. Missing-information checklist.
+
+Use markdown tables unless the user asks for spreadsheet-ready CSV.
+
+## Example Prompts
+
+- Build a mutual action plan from these sales notes.
+- Turn this pilot discussion into a buyer-ready MAP.
+- Create a plan to get this renewal approved before the deadline.
+- Help my champion coordinate security, legal, procurement, and finance.
+- Convert this stalled late-stage deal into a concrete next-step plan.

--- a/skills/composites/mutual-action-plan-builder/skill.meta.json
+++ b/skills/composites/mutual-action-plan-builder/skill.meta.json
@@ -1,0 +1,16 @@
+{
+  "slug": "mutual-action-plan-builder",
+  "category": "composites",
+  "tags": [
+    "content",
+    "outreach"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install mutual-action-plan-builder",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Add a mutual-action-plan-builder composite skill for late-stage B2B deals, pilots, renewals, and expansions.
- Covers milestone planning, buyer/seller owners, exit criteria, success criteria, stakeholder mapping, risk registers, and champion-ready follow-up.
- Regenerate skills-index.json.

## Validation
- /Users/domyin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/build-index.js
- /Users/domyin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/validate-skills.js
- /Users/domyin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test test/goose-skills-targets.test.js test/goose-skills-packs.test.js scripts/__tests__/build-index.test.js scripts/__tests__/validate-skills.test.js