### PR TITLE
Add implementation kickoff planner skill

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-05-07",
+  "generated": "2026-05-25",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -2570,6 +2570,33 @@
         "source": "orthogonal",
         "installation": {
           "base_command": "npx goose-skills install image-analyzer",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
+      }
+    },
+    {
+      "slug": "implementation-kickoff-planner",
+      "name": "implementation-kickoff-planner",
+      "category": "composites",
+      "description": "Plan post-sale implementation kickoff for B2B customers by converting closed-won context into agendas, owner maps, milestone plans, risks, data requests, and customer-ready kickoff materials.",
+      "tags": "outreach",
+      "path": "skills/composites/implementation-kickoff-planner",
+      "files": [
+        "skills/composites/implementation-kickoff-planner/SKILL.md",
+        "skills/composites/implementation-kickoff-planner/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "implementation-kickoff-planner",
+        "category": "composites",
+        "tags": [
+          "outreach"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install implementation-kickoff-planner",
           "supports": [
             "claude",
             "cursor",

--- a/skills/composites/implementation-kickoff-planner/SKILL.md
+++ b/skills/composites/implementation-kickoff-planner/SKILL.md
@@ -1,0 +1,328 @@
+---
+name: implementation-kickoff-planner
+description: Plan post-sale implementation kickoff for B2B customers by converting closed-won context into agendas, owner maps, milestone plans, risks, data requests, and customer-ready kickoff materials.
+tags: [outreach]
+---
+
+# Implementation Kickoff Planner
+
+Turn a newly closed deal, paid pilot, renewal expansion, or professional-services project into a clean implementation kickoff plan. This skill converts sales context into customer-ready kickoff materials so the delivery team starts with the right scope, owners, milestones, risks, and success criteria.
+
+Core principle: the first implementation meeting should not rediscover the deal. It should confirm the outcome, assign owners, expose risks early, and create momentum toward the first measurable win.
+
+## When To Use
+
+- A deal just closed and the team needs to prepare the customer kickoff.
+- A paid pilot, proof of concept, onboarding engagement, or services project needs a delivery plan.
+- A seller needs to hand off discovery notes to customer success, implementation, or solutions engineering.
+- A founder is delivering the work personally and needs a structured kickoff agenda.
+- A renewal or expansion includes new implementation work.
+- A project is at risk because sales promised one thing and delivery needs to clarify scope.
+
+## Inputs
+
+Ask for the smallest complete packet available:
+
+1. Customer company, industry, size, region, and business unit.
+2. Sold package, scope, price, contract term, start date, and target go-live date.
+3. Original pain, desired outcome, urgency, and buying trigger.
+4. Success criteria agreed during sales.
+5. Stakeholders: buyer, champion, executive sponsor, day-to-day owner, technical owner, procurement/legal, implementation team.
+6. Sales notes, proposal, statement of work, mutual action plan, or signed order form.
+7. Promises made: deliverables, timeline, integrations, support level, training, reports, custom work, exclusions.
+8. Required customer inputs: data, access, users, brand assets, technical details, approvals, payment confirmation.
+9. Known risks: unclear scope, missing owner, unrealistic timeline, integration complexity, data quality, legal/security, change management.
+10. Internal constraints: delivery capacity, dependencies, tools, support process, escalation path.
+
+If inputs are incomplete, produce a kickoff plan with assumptions and a `Needs Confirmation` section.
+
+## Operating Rules
+
+- Do not invent contract terms, product capabilities, implementation dates, or service commitments.
+- If sales notes and contract terms conflict, mark the conflict instead of choosing silently.
+- Keep customer-facing material simple and outcome-oriented.
+- Keep internal risk notes separate from customer-facing copy.
+- Every milestone needs an owner, expected output, and acceptance signal.
+- Every requested customer input needs a deadline and reason.
+- Prefer the smallest first win that proves value quickly.
+- Do not ask for unnecessary access, credentials, private data, or administrative permissions.
+- If payment, tax, banking, legal, or KYC steps are incomplete, route them to the user or appropriate owner rather than treating them as implementation work.
+
+## Workflow
+
+### Phase 1: Normalize The Sale
+
+Create a handoff summary:
+
+| Field | Value |
+|---|---|
+| Customer | [Company] |
+| Package / Scope | [What was sold] |
+| Business Outcome | [Customer goal] |
+| Primary Use Case | [Workflow or problem] |
+| Target Date | [Date or unknown] |
+| Success Criteria | [Measurable success signal] |
+| Key Stakeholders | [Names/roles] |
+| First Value Moment | [Earliest useful deliverable] |
+| Main Risk | [Risk] |
+| Missing Information | [Gaps] |
+
+Then summarize:
+
+- Why they bought.
+- What they expect first.
+- What must be true for them to call the implementation successful.
+- What should not be in scope.
+
+### Phase 2: Build The Stakeholder Map
+
+Map each stakeholder by role and needed action:
+
+| Person / Role | Type | Cares About | Required Action | Risk If Missing |
+|---|---|---|---|---|
+| [Name / Role] | Buyer / Champion / Technical / Executive / Delivery | [Priority] | [Action] | [Risk] |
+
+Stakeholder types:
+
+- **Economic Buyer**: owns budget and final value judgment.
+- **Champion**: wants the project to succeed and helps coordinate internally.
+- **Day-to-Day Owner**: attends working sessions and approves execution details.
+- **Technical Owner**: grants access, validates integrations, reviews security/data flow.
+- **Executive Sponsor**: cares about outcome and timeline.
+- **Delivery Owner**: internal person responsible for implementation.
+- **Blocker / Risk Owner**: person whose delay can stall the project.
+
+If a required stakeholder is missing, add it to `Needs Confirmation`.
+
+### Phase 3: Define The Kickoff Objective
+
+Write one sentence:
+
+The kickoff should align [customer team] and [delivery team] on [business outcome], confirm [scope], assign [owners], and start [first value milestone] by [date].
+
+Then define:
+
+- Primary outcome.
+- Scope boundary.
+- First value milestone.
+- Decisions needed in kickoff.
+- Inputs required before kickoff.
+- Inputs required after kickoff.
+
+### Phase 4: Create The Kickoff Agenda
+
+Default agenda for a 45-minute kickoff:
+
+| Time | Topic | Owner | Goal |
+|---:|---|---|---|
+| 0-5 min | Introductions and roles | [Owner] | Confirm who owns what |
+| 5-10 min | Why this project exists | [Owner] | Reconfirm business outcome |
+| 10-15 min | Scope and success criteria | [Owner] | Confirm what success means |
+| 15-25 min | Implementation path | [Owner] | Walk through milestones |
+| 25-32 min | Customer inputs and access | [Owner] | Confirm required materials |
+| 32-38 min | Risks and dependencies | [Owner] | Surface blockers early |
+| 38-43 min | Next steps and dates | [Owner] | Assign actions |
+| 43-45 min | Open questions | [Owner] | Close gaps |
+
+Adjust timing for:
+
+- 30-minute kickoff: compress introductions, scope, and next steps.
+- 60-minute kickoff: add workflow walkthrough, technical/data review, and Q&A.
+- Technical kickoff: spend more time on access, data, integration, security, and environments.
+- Executive kickoff: spend more time on outcomes, timeline, risk, and governance.
+
+### Phase 5: Build The Milestone Plan
+
+Create a milestone table:
+
+| Milestone | Owner | Customer Input | Output | Acceptance Signal | Target Date |
+|---|---|---|---|---|---|
+| Kickoff completed | [Owner] | Stakeholders attend | Confirmed plan | Action items accepted | [Date] |
+| Inputs received | [Owner] | [Data/access/assets] | Ready to build | Inputs complete | [Date] |
+| First value delivered | [Owner] | [Dependency] | [Deliverable] | Customer can use/review it | [Date] |
+| Review and revisions | [Owner] | Feedback | Updated deliverable | Sign-off or next iteration | [Date] |
+| Go-live / handoff | [Owner] | Approval | Launch/handoff | Success criteria met | [Date] |
+
+Rules:
+
+- Keep the first milestone achievable within 1-7 days when possible.
+- Do not create more than 6 milestones unless the project is explicitly complex.
+- Include a decision or acceptance signal for each milestone.
+- If dates are unknown, use relative timing such as `T+2 business days`.
+
+### Phase 6: Identify Risks And Dependencies
+
+Create a risk register:
+
+| Risk | Likelihood | Impact | Owner | Mitigation | Escalation Trigger |
+|---|---|---|---|---|---|
+| [Risk] | Low / Medium / High | Low / Medium / High | [Owner] | [Action] | [Trigger] |
+
+Common risks:
+
+- No clear customer owner.
+- Required access or data unavailable.
+- Scope from sales is broader than the signed package.
+- Timeline depends on third-party integration.
+- Customer has not defined success criteria.
+- Legal/security/procurement not complete.
+- Payment or invoice confirmation is missing.
+- Stakeholders disagree on priority.
+- Implementation requires product capability that is not confirmed.
+
+### Phase 7: Prepare Customer-Facing Materials
+
+Generate these sections:
+
+#### Kickoff Email
+
+```
+Subject: Kickoff for [project/outcome]
+
+Hi [First Name],
+
+Excited to get started on [project/outcome].
+
+For the kickoff, I suggest we use the time to confirm:
+- the outcome we are aiming for
+- the exact scope and first milestone
+- who owns each input and decision
+- the timeline to first value
+
+To prepare, please send or confirm:
+- [Input 1]
+- [Input 2]
+- [Input 3]
+
+Proposed agenda:
+1. Roles and success criteria
+2. Scope and timeline
+3. Required inputs/access
+4. Risks and open questions
+5. Next steps
+
+[Meeting time or scheduling CTA]
+
+[Sender]
+```
+
+#### Kickoff One-Pager
+
+Include:
+
+- Project objective.
+- Success criteria.
+- Scope.
+- Out of scope.
+- Stakeholders.
+- Milestones.
+- Required inputs.
+- Open questions.
+- Immediate next steps.
+
+#### Customer Input Request
+
+Create a concise list:
+
+| Input Needed | Why It Is Needed | Owner | Deadline |
+|---|---|---|---|
+| [Input] | [Reason] | [Owner] | [Date] |
+
+### Phase 8: Prepare Internal Handoff Notes
+
+Create an internal-only section:
+
+- **Sales promise summary:** [What was promised]
+- **Contract/scope caveats:** [Known limitations]
+- **Relationship notes:** [Champion, buyer style, sensitivities]
+- **Risks to watch:** [Risks]
+- **Upsell/expansion hints:** [Only if grounded in discovery]
+- **Do not say:** [Claims or promises to avoid]
+- **Escalation path:** [Who handles payment/legal/scope/product issues]
+
+## Output Format
+
+### 1. Executive Handoff Summary
+
+Briefly describe:
+
+- Customer and package.
+- Business outcome.
+- First value milestone.
+- Biggest risk.
+- Next action.
+
+### 2. Stakeholder Map
+
+Use the stakeholder table from Phase 2.
+
+### 3. Kickoff Objective And Agenda
+
+Include the kickoff objective sentence and agenda table.
+
+### 4. Milestone Plan
+
+Use the milestone table from Phase 5.
+
+### 5. Risk Register
+
+Use the risk table from Phase 6.
+
+### 6. Customer-Facing Drafts
+
+Provide:
+
+- Kickoff email.
+- Kickoff one-pager.
+- Customer input request.
+
+### 7. Internal Handoff Notes
+
+Provide the internal-only section from Phase 8.
+
+### 8. Needs Confirmation
+
+List missing or conflicting details:
+
+- [Missing customer owner]
+- [Unconfirmed go-live date]
+- [Potential scope conflict]
+- [Payment/legal/security item that needs owner action]
+
+## Quality Checklist
+
+Before finalizing, verify:
+
+- The plan starts from the customer's desired outcome.
+- Scope and out-of-scope are explicit.
+- Every milestone has an owner and acceptance signal.
+- Customer input requests explain why each input is needed.
+- Risks are concrete and assigned.
+- Customer-facing copy does not expose internal uncertainty unnecessarily.
+- Internal notes do not invent facts or commitments.
+- Legal, payment, KYC, tax, banking, or identity items are routed to the correct human owner.
+
+## Example Mini Output
+
+```
+Customer: Northstar Logistics
+Package: 24-hour website conversion audit
+Outcome: Increase quote requests from landscaping fleet managers
+First value milestone: Audit draft delivered within 24 hours of receiving URL and target offer
+Main risk: Customer has not confirmed the primary CTA or target persona
+
+Kickoff Objective:
+The kickoff should align Northstar and the delivery team on the quote-request outcome,
+confirm the page and offer in scope, assign input owners, and start the audit once the
+website URL and target persona are confirmed.
+
+Required Inputs:
+| Input Needed | Why | Owner | Deadline |
+| Website URL | Defines audit scope | Customer | Before kickoff |
+| Target customer | Determines messaging criteria | Customer | Before kickoff |
+| Primary offer | Needed for CTA and hero rewrite | Customer | Before kickoff |
+
+Next Action:
+Send kickoff email requesting URL, target customer, primary offer, and preferred CTA.
+```
+

--- a/skills/composites/implementation-kickoff-planner/skill.meta.json
+++ b/skills/composites/implementation-kickoff-planner/skill.meta.json
@@ -1,0 +1,15 @@
+{
+  "slug": "implementation-kickoff-planner",
+  "category": "composites",
+  "tags": [
+    "outreach"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install implementation-kickoff-planner",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds `implementation-kickoff-planner`, a composite outreach skill for turning newly closed deals, paid pilots, renewals, and services projects into customer-ready implementation kickoff plans.

The skill helps an agent produce:

- sales-to-delivery handoff summaries
- stakeholder maps
- kickoff objectives and agendas
- milestone plans with owners and acceptance signals
- risk registers
- customer input requests
- kickoff emails and one-pagers
- internal handoff notes

## Why

Goose Skills has strong pre-sale and deal-progression skills. This adds a post-sale workflow that protects revenue after the deal is won: making sure implementation starts cleanly, scope is understood, and the first value milestone is clear.

## Validation

- `/Users/domyin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/build-index.js`
- `/Users/domyin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node scripts/validate-skills.js`
- `/Users/domyin/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --test test/goose-skills-targets.test.js test/goose-skills-packs.test.js scripts/__tests__/build-index.test.js scripts/__tests__/validate-skills.test.js`
