### PR TITLE
Add objection response bank skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Works with [Claude Code](https://claude.ai/claude-code) &middot; [Cursor](https:
 
 [![npm version](https://img.shields.io/npm/v/goose-skills?color=blue)](https://www.npmjs.com/package/goose-skills)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Skills](https://img.shields.io/badge/skills-108-orange)]()
+[![Skills](https://img.shields.io/badge/skills-109-orange)]()
 
 <br />
 
@@ -27,7 +27,7 @@ Works with [Claude Code](https://claude.ai/claude-code) &middot; [Cursor](https:
 
 - [Quick Start](#-quick-start)
 - [Commands](#-commands)
-- [Skills Catalog (108)](#-skills-catalog-108)
+- [Skills Catalog (109)](#-skills-catalog-109)
 - [Usage Examples](#-usage-examples)
 - [Building from Source](#-building-from-source)
 - [Skill Metadata Contract](#-skill-metadata-contract)
@@ -62,9 +62,9 @@ npx gooseworks update                      # Update to latest skill version
 
 ---
 
-## Skills Catalog (108)
+## Skills Catalog (109)
 
-**51 Capabilities** (atomic, single-purpose tools) &middot; **52 Composites** (multi-skill chains) &middot; **5 Playbooks** (end-to-end workflows)
+**51 Capabilities** (atomic, single-purpose tools) &middot; **53 Composites** (multi-skill chains) &middot; **5 Playbooks** (end-to-end workflows)
 
 ### Ads (9)
 
@@ -166,7 +166,7 @@ npx gooseworks update                      # Update to latest skill version
 | `twitter-mention-tracker` | Cap | Search Twitter/X posts with date filtering |
 | `web-archive-scraper` | Cap | Wayback Machine scraper for archived sites |
 
-### Outreach (18)
+### Outreach (19)
 
 | Skill | Type | Description |
 |-------|------|-------------|
@@ -186,6 +186,7 @@ npx gooseworks update                      # Update to latest skill version
 | `linkedin-post-research` | Cap | Search LinkedIn posts by keyword |
 | `linkedin-profile-post-scraper` | Cap | Scrape recent posts from LinkedIn profiles |
 | `news-signal-outreach` | Comp | News-triggered signal outreach |
+| `objection-response-bank` | Comp | Build evidence-backed responses for recurring sales objections |
 | `outbound-prospecting-engine` | Play | End-to-end outbound prospecting engine |
 | `tiktok-influencer-finder` | Cap | Find TikTok influencers using Apify |
 

--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-05-07",
+  "generated": "2026-05-25",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -3772,6 +3772,40 @@
             "codex"
           ]
         }
+      }
+    },
+    {
+      "slug": "objection-response-bank",
+      "name": "objection-response-bank",
+      "category": "composites",
+      "description": "Turn scattered sales objections from calls, emails, reviews, competitors, and customer proof into an evidence-backed response bank with discovery questions, talk tracks, follow-up snippets, and enablement guidance.",
+      "tags": "outreach, research",
+      "path": "skills/composites/objection-response-bank",
+      "files": [
+        "skills/composites/objection-response-bank/SKILL.md",
+        "skills/composites/objection-response-bank/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "objection-response-bank",
+        "category": "composites",
+        "tags": [
+          "outreach",
+          "research"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install objection-response-bank",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "requires_skills": [
+          "voice-of-customer-synthesizer",
+          "review-intelligence-digest",
+          "competitor-intel",
+          "email-drafting"
+        ]
       }
     },
     {

--- a/skills/composites/objection-response-bank/SKILL.md
+++ b/skills/composites/objection-response-bank/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: objection-response-bank
+description: Turn scattered sales objections from calls, emails, reviews, competitors, and customer proof into an evidence-backed response bank with discovery questions, talk tracks, follow-up snippets, and enablement guidance.
+tags: [outreach, research]
+---
+
+# Objection Response Bank
+
+Build a reusable objection response bank from real buyer language and real proof. The goal is not to create clever rebuttals. The goal is to help a sales team answer recurring objections with confidence, accuracy, and useful next questions.
+
+**Built for:** Founders, PMMs, RevOps, and small sales teams that hear the same objections across calls but do not yet have a mature enablement system.
+
+## When to Use
+
+- "We keep hearing the same objections on sales calls"
+- "Build objection handling for our sales team"
+- "Turn these call notes into objection responses"
+- "We lose deals on pricing, security, timing, or switching cost"
+- "Create follow-up snippets for common buyer pushback"
+
+## Inputs
+
+Ask for the smallest useful set of inputs. Do not wait for perfect data if the team already has enough signal.
+
+1. Product, ICP, and deal motion
+2. Recent call notes, transcripts, emails, or CRM loss reasons
+3. Known competitors and comparison notes
+4. Customer proof: quotes, case studies, usage metrics, logos, or support outcomes
+5. Existing positioning, pricing, security, implementation, and ROI materials
+6. Desired output format: rep guide, call prep sheet, email snippets, or enablement doc
+
+If proof is thin, mark the response as low-confidence and ask for better evidence instead of inventing claims.
+
+## Phase 1: Normalize the Objections
+
+Collect buyer pushback from the supplied material and group it by the actual blocker, not by surface wording.
+
+Common categories:
+
+- Price and budget
+- Timing and priority
+- Status quo or internal build
+- Security, compliance, and procurement
+- Switching cost and implementation effort
+- Missing feature or integration
+- Competitive comparison
+- Trust, maturity, and proof
+- Role-specific concern from a buyer, champion, technical evaluator, or finance stakeholder
+
+For each objection, capture:
+
+- The buyer's raw language
+- Who says it
+- Where in the deal it appears
+- What fear or constraint sits underneath it
+- Whether it is a real blocker, a negotiation signal, or a disguised lack of urgency
+
+## Phase 2: Separate Truth From Tactics
+
+Do not treat every objection as something to defeat. Classify each one:
+
+| Type | Meaning | Best Move |
+|---|---|---|
+| Valid blocker | The product may not fit the buyer today | Acknowledge clearly and qualify out or set a future path |
+| Risk concern | The buyer needs proof or implementation confidence | Bring evidence, plan, and references |
+| Value gap | The buyer does not believe the outcome is worth the cost | Reconnect price to pain, urgency, and measurable impact |
+| Competitive frame | The buyer is comparing against another option | Reframe around selection criteria and tradeoffs |
+| Process friction | Legal, security, finance, or procurement is slowing motion | Provide assets and next-step clarity |
+| Stall | The buyer is avoiding a decision | Ask direct priority and consequence questions |
+
+If an objection reveals a product weakness, say so. The bank should help the team sell responsibly, not hide reality.
+
+## Phase 3: Build the Evidence Map
+
+For each objection, find the strongest available support:
+
+- Customer quote
+- Quantified result
+- Product capability
+- Implementation timeline
+- Security or compliance fact
+- Support or success process
+- Competitive tradeoff
+- Pricing or ROI math
+- Roadmap caveat, only if already approved to share
+
+Use evidence tiers:
+
+- **Tier 1:** Direct customer proof or quantified outcome
+- **Tier 2:** Internal data, product fact, or approved case example
+- **Tier 3:** Reasoned explanation with no hard proof yet
+
+Never present Tier 3 as if it were proven. Add a "proof gap" note so the team knows what asset to create next.
+
+## Phase 4: Write the Response Bank
+
+Create a concise bank that reps can use during calls and after calls.
+
+For each objection, include:
+
+1. **Objection:** The buyer language, not a cleaned-up internal label
+2. **Underlying concern:** What the buyer is really worried about
+3. **Call response:** A short answer a rep can say naturally
+4. **Discovery question:** A question that reveals whether the objection is real
+5. **Proof to use:** The strongest available evidence and confidence tier
+6. **Follow-up snippet:** Email or chat wording for after the call
+7. **Avoid saying:** Risky claims, overpromises, or defensive phrasing
+8. **Owner:** Sales, product, security, finance, or leadership
+
+Keep responses specific. A useful response names tradeoffs, timing, buyer role, and proof. A weak response sounds like a generic sales script.
+
+## Phase 5: Add Role-Specific Handling
+
+Adapt major objections for different stakeholders.
+
+| Stakeholder | What They Need | Response Style |
+|---|---|---|
+| Economic buyer | Business impact, risk, payback | Outcome-first and concise |
+| Champion | Internal selling help | Memorable proof and clear next steps |
+| Technical evaluator | Architecture, security, limits | Precise facts and caveats |
+| Finance | Cost control and ROI | Numbers, assumptions, and alternatives |
+| Legal or security | Process confidence | Documents, owners, and timelines |
+
+If the same objection should be handled differently by role, create separate response variants.
+
+## Phase 6: Create Follow-Up Assets
+
+Package the bank into assets the team can actually reuse:
+
+- Call-side quick reference
+- Post-call email snippets
+- Champion enablement bullets
+- Internal escalation notes for product or leadership
+- Proof gaps and asset requests
+- Training prompts for role-play
+
+Prioritize the top five objections first. A short bank used every week is better than a long bank no one opens.
+
+## Output Format
+
+Produce the response bank in this structure:
+
+## Objection Response Bank: [Product or Segment]
+
+### Summary
+
+- Top objections:
+- Strongest proof available:
+- Weakest proof gaps:
+- Recommended sales behavior:
+
+### Priority Bank
+
+| Priority | Objection | Buyer Role | Root Concern | Confidence | Owner |
+|---|---|---|---|---|---|
+| 1 | [Raw objection] | [Role] | [Concern] | [High/Medium/Low] | [Owner] |
+
+### Objection Detail
+
+#### [Objection Name]
+
+**Buyer language:** "[Raw phrase]"
+
+**What it really means:** [Underlying concern]
+
+**Call response:** [Natural spoken answer]
+
+**Discovery question:** [Question that qualifies the concern]
+
+**Proof to use:** [Evidence and tier]
+
+**Follow-up snippet:** [Email or chat response]
+
+**Avoid saying:** [Risky or weak phrasing]
+
+**Proof gap:** [What should be created or found next]
+
+### Enablement Notes
+
+- What to train first:
+- What product or proof gaps to escalate:
+- What objections should qualify a prospect out:
+- What should be reviewed again after the next five to ten sales calls:
+
+## Quality Bar
+
+- Responses must sound like something a competent human would say on a call.
+- Every strong claim must have a proof source or a confidence label.
+- The bank must separate valid buyer concerns from weak negotiation stalls.
+- The output should be short enough for sales use but specific enough to prevent generic replies.
+- Do not invent customer quotes, compliance status, integrations, or roadmap commitments.
+- Do not recommend pressuring buyers when the product is not a fit.
+
+## Good Response Pattern
+
+Use this shape for most call responses:
+
+1. Acknowledge the concern.
+2. Clarify the buyer's exact situation.
+3. Offer the most relevant proof or tradeoff.
+4. Ask for a next step that tests whether the concern is resolved.
+
+Example structure:
+
+"That is a fair concern. The key question is whether [specific risk] matters more than [specific outcome]. For teams like [segment], the pattern we see is [evidence]. If we can show [proof] and map the rollout to [constraint], would that address the risk enough to continue evaluation?"
+
+Only use examples as structure. Rewrite them in the user's actual product language.

--- a/skills/composites/objection-response-bank/skill.meta.json
+++ b/skills/composites/objection-response-bank/skill.meta.json
@@ -1,0 +1,22 @@
+{
+  "slug": "objection-response-bank",
+  "category": "composites",
+  "tags": [
+    "outreach",
+    "research"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install objection-response-bank",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "requires_skills": [
+    "voice-of-customer-synthesizer",
+    "review-intelligence-digest",
+    "competitor-intel",
+    "email-drafting"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a new composite objection-response-bank skill for turning repeated buyer objections into evidence-backed response guidance.
- Include workflow phases for intake, objection clustering, evidence mapping, role-specific handling, follow-up snippets, and QA.
- Update the README catalog counts and regenerate skills-index.json.

## Validation
- npm run validate:skills
- npm run build:index
- npm test
- npm run ci
- git diff --check

## Notes
- AI-assisted contribution using Codex tooling.