### PR TITLE
Add UTM tracking plan builder skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Works with [Claude Code](https://claude.ai/claude-code) &middot; [Cursor](https:
 
 [![npm version](https://img.shields.io/npm/v/goose-skills?color=blue)](https://www.npmjs.com/package/goose-skills)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
-[![Skills](https://img.shields.io/badge/skills-108-orange)]()
+[![Skills](https://img.shields.io/badge/skills-109-orange)]()
 
 <br />
 
@@ -27,7 +27,7 @@ Works with [Claude Code](https://claude.ai/claude-code) &middot; [Cursor](https:
 
 - [Quick Start](#-quick-start)
 - [Commands](#-commands)
-- [Skills Catalog (108)](#-skills-catalog-108)
+- [Skills Catalog (109)](#-skills-catalog-109)
 - [Usage Examples](#-usage-examples)
 - [Building from Source](#-building-from-source)
 - [Skill Metadata Contract](#-skill-metadata-contract)
@@ -62,11 +62,11 @@ npx gooseworks update                      # Update to latest skill version
 
 ---
 
-## Skills Catalog (108)
+## Skills Catalog (109)
 
-**51 Capabilities** (atomic, single-purpose tools) &middot; **52 Composites** (multi-skill chains) &middot; **5 Playbooks** (end-to-end workflows)
+**51 Capabilities** (atomic, single-purpose tools) &middot; **53 Composites** (multi-skill chains) &middot; **5 Playbooks** (end-to-end workflows)
 
-### Ads (9)
+### Ads (10)
 
 | Skill | Type | Description |
 |-------|------|-------------|
@@ -79,6 +79,7 @@ npx gooseworks update                      # Update to latest skill version
 | `meta-ads-campaign-builder` | Comp | End-to-end Meta Ads campaign builder |
 | `paid-channel-prioritizer` | Comp | Recommend which paid channels to start with |
 | `trending-ad-hook-spotter` | Comp | Monitor social for trending narratives to map to ad hooks |
+| `utm-tracking-plan-builder` | Comp | Create campaign tracking taxonomies, UTM naming rules, QA checklists, and analytics handoff docs |
 
 ### Brand (4)
 

--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-05-07",
+  "generated": "2026-05-27",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -5301,6 +5301,34 @@
         "source": "orthogonal",
         "installation": {
           "base_command": "npx goose-skills install uptime-monitor",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
+      }
+    },
+    {
+      "slug": "utm-tracking-plan-builder",
+      "name": "utm-tracking-plan-builder",
+      "category": "composites",
+      "description": "Create campaign tracking taxonomies, UTM naming rules, QA checklists, and analytics handoff docs for paid, lifecycle, partner, and content campaigns.",
+      "tags": "ads, monitoring",
+      "path": "skills/composites/utm-tracking-plan-builder",
+      "files": [
+        "skills/composites/utm-tracking-plan-builder/SKILL.md",
+        "skills/composites/utm-tracking-plan-builder/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "utm-tracking-plan-builder",
+        "category": "composites",
+        "tags": [
+          "ads",
+          "monitoring"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install utm-tracking-plan-builder",
           "supports": [
             "claude",
             "cursor",

--- a/skills/composites/utm-tracking-plan-builder/SKILL.md
+++ b/skills/composites/utm-tracking-plan-builder/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: utm-tracking-plan-builder
+description: Create campaign tracking taxonomies, UTM naming rules, QA checklists, and analytics handoff docs for paid, lifecycle, partner, and content campaigns.
+tags: [ads, monitoring]
+---
+
+Use this skill when the user needs campaign links and analytics naming to be consistent before launch, or when messy campaign data needs to be cleaned into a usable taxonomy.
+
+The goal is to produce a practical tracking plan that marketers, sales, RevOps, and analytics teams can use without debating naming every time a campaign ships.
+
+## Non-Negotiables
+
+- Do not invent analytics platform capabilities or claim a setup is working without evidence.
+- Keep naming rules simple enough for humans to follow under deadline pressure.
+- Use one canonical taxonomy and map exceptions back to it.
+- Preserve existing conventions when they are already used in reports, dashboards, or CRM fields.
+- Flag any change that would break historical reporting.
+- Separate launch-ready rules from cleanup recommendations for old data.
+- Do not ask the user to rebuild every campaign just to make the plan look tidy.
+
+## Intake
+
+Identify what the user already has:
+
+- campaign channels
+- ad platforms or email tools
+- analytics destination
+- CRM or warehouse destination
+- current naming examples
+- reporting questions that matter
+- team owners
+- launch date or migration deadline
+
+If the user only has a messy export, infer patterns from the data and label uncertain fields clearly.
+
+## Workflow
+
+### 1. Identify Reporting Jobs
+
+Start by listing the decisions the taxonomy must support.
+
+Common jobs:
+
+- compare channels
+- compare campaigns
+- compare audiences
+- compare offers
+- compare creative angles
+- attribute qualified pipeline
+- track partner or influencer performance
+- separate tests from evergreen campaigns
+- diagnose missing or broken tracking
+
+Reject fields that do not answer a reporting job. Extra fields become clutter and reduce compliance.
+
+### 2. Audit Current Names
+
+Review existing campaign names, link examples, exports, dashboards, or CRM fields.
+
+Extract:
+
+- repeated patterns
+- inconsistent spellings
+- duplicated channel names
+- missing fields
+- over-specific values
+- ambiguous abbreviations
+- values that mix multiple concepts
+- fields used by current dashboards
+
+Classify each issue as launch blocker, reporting risk, or cleanup later.
+
+### 3. Define The Canonical Taxonomy
+
+Create a concise standard with required and optional fields.
+
+Use stable field meanings:
+
+- source: where traffic originates
+- medium: channel class
+- campaign: initiative or launch
+- content: creative, message, or placement variant
+- term: keyword, audience, or targeting detail when relevant
+
+Add internal fields only when the team has a destination for them, such as CRM campaign, lifecycle stage, offer, region, owner, or experiment id.
+
+For each field, define:
+
+- purpose
+- allowed format
+- allowed values or value pattern
+- examples
+- owner
+- when to leave blank
+
+### 4. Build Naming Rules
+
+Write rules that prevent future drift:
+
+- lowercase unless the existing analytics tool requires otherwise
+- use one word separator consistently
+- avoid spaces
+- avoid punctuation that breaks exports
+- keep values short but readable
+- do not encode the same fact in two fields
+- do not put dates in every field unless the team reports by launch cohort
+- make tests explicitly identifiable
+- reserve temporary values for experiments only
+
+If the user has legacy naming, include a translation map from old values to new values.
+
+### 5. Create Campaign Templates
+
+Produce templates for the user's actual channels.
+
+Common templates:
+
+- paid search
+- paid social
+- organic social
+- email lifecycle
+- newsletter sponsorship
+- webinar or event
+- partner referral
+- creator or influencer
+- sales outbound
+- retargeting
+
+For each template, provide:
+
+- required fields
+- sample values
+- final link pattern in plain text
+- analytics expectation
+- CRM or reporting expectation
+
+### 6. Add QA Checks
+
+Create a pre-launch checklist:
+
+- every destination page loads
+- every link includes required fields
+- field values match the allowed list
+- campaign values match launch brief
+- paid platform names map to canonical source values
+- test variants are distinguishable
+- CRM campaign or owner is present when required
+- no internal notes are exposed in public links
+- reporting owner has a sample link before launch
+
+Create a post-launch checklist:
+
+- traffic appears in analytics
+- conversions retain the campaign fields
+- CRM records show expected source values
+- dashboard filters do not split one campaign into multiple rows
+- missing values are logged for cleanup
+
+### 7. Produce The Handoff
+
+Return one compact operating document.
+
+The handoff should include:
+
+1. Status: ready, needs review, or insufficient evidence
+2. Reporting jobs supported
+3. Canonical taxonomy
+4. Allowed values
+5. Channel templates
+6. QA checklist
+7. Legacy cleanup map
+8. Owner rules
+9. Risks and unresolved questions
+
+## Quality Check
+
+Before finishing, verify:
+
+- The taxonomy can answer the user's stated reporting questions.
+- Required fields are few enough that the team will actually use them.
+- Values are readable without a decoder.
+- Legacy reporting risks are called out.
+- The plan distinguishes launch rules from historical cleanup.
+- No claim depends on unverified analytics behavior.

--- a/skills/composites/utm-tracking-plan-builder/skill.meta.json
+++ b/skills/composites/utm-tracking-plan-builder/skill.meta.json
@@ -1,0 +1,16 @@
+{
+  "slug": "utm-tracking-plan-builder",
+  "category": "composites",
+  "tags": [
+    "ads",
+    "monitoring"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install utm-tracking-plan-builder",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a `utm-tracking-plan-builder` composite skill for campaign tracking taxonomy, UTM naming rules, QA checks, and analytics handoff docs.
- Updates the generated skill index and README catalog counts.

## Validation
- `npm run validate:skills`
- `npm test`
- Clean-clone `npm run ci`
- Clean-clone `git diff --exit-code skills-index.json` after index generation