### PR TITLE
Add ROI calculator builder skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Works with [Claude Code](https://claude.ai/claude-code) &middot; [Cursor](https:
 
 - [Quick Start](#-quick-start)
 - [Commands](#-commands)
-- [Skills Catalog (108)](#-skills-catalog-108)
+- [Skills Catalog (109)](#-skills-catalog-109)
 - [Usage Examples](#-usage-examples)
 - [Building from Source](#-building-from-source)
 - [Skill Metadata Contract](#-skill-metadata-contract)
@@ -62,9 +62,9 @@ npx gooseworks update                      # Update to latest skill version
 
 ---
 
-## Skills Catalog (108)
+## Skills Catalog (109)
 
-**51 Capabilities** (atomic, single-purpose tools) &middot; **52 Composites** (multi-skill chains) &middot; **5 Playbooks** (end-to-end workflows)
+**51 Capabilities** (atomic, single-purpose tools) &middot; **53 Composites** (multi-skill chains) &middot; **5 Playbooks** (end-to-end workflows)
 
 ### Ads (9)
 
@@ -189,7 +189,7 @@ npx gooseworks update                      # Update to latest skill version
 | `outbound-prospecting-engine` | Play | End-to-end outbound prospecting engine |
 | `tiktok-influencer-finder` | Cap | Find TikTok influencers using Apify |
 
-### Research (12)
+### Research (13)
 
 | Skill | Type | Description |
 |-------|------|-------------|
@@ -200,6 +200,7 @@ npx gooseworks update                      # Update to latest skill version
 | `meeting-brief` | Comp | Daily meeting prep with deep attendee research |
 | `pipeline-review` | Comp | Pipeline analysis from CRM/tracking data |
 | `review-intelligence-digest` | Comp | Scrape reviews, extract themes and proof points |
+| `roi-calculator-builder` | Comp | Build defensible ROI calculators and buyer-ready business cases |
 | `sales-call-prep` | Comp | Pre-sales-call intelligence composite |
 | `sales-coaching` | Comp | AI sales coach analyzing all sales data |
 | `sequence-performance` | Comp | Email campaign/sequence performance review |

--- a/scripts/__tests__/validate-skills.test.js
+++ b/scripts/__tests__/validate-skills.test.js
@@ -13,7 +13,14 @@ function makeFixtureRoot() {
   fs.mkdirSync(path.join(root, 'skills', 'capabilities'), { recursive: true });
   // Schemas are looked up under ROOT — symlink the real schemas dir so we
   // don't have to copy/maintain a fixture schema.
-  fs.symlinkSync(path.join(REPO_ROOT, 'schemas'), path.join(root, 'schemas'));
+  const schemaSource = path.join(REPO_ROOT, 'schemas');
+  const schemaTarget = path.join(root, 'schemas');
+  try {
+    fs.symlinkSync(schemaSource, schemaTarget, process.platform === 'win32' ? 'junction' : 'dir');
+  } catch (err) {
+    if (err.code !== 'EPERM') throw err;
+    fs.cpSync(schemaSource, schemaTarget, { recursive: true });
+  }
   return root;
 }
 

--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -14,6 +14,7 @@ const ROOT = process.env.GOOSE_SKILLS_ROOT
 const OUTPUT = path.join(ROOT, 'skills-index.json');
 
 function parseFrontmatter(content) {
+  content = content.replace(/\r\n/g, '\n');
   const match = content.match(/^---\n([\s\S]*?)\n---/);
   if (!match) return {};
 
@@ -31,6 +32,10 @@ function parseFrontmatter(content) {
   return result;
 }
 
+function toIndexPath(filePath) {
+  return path.relative(ROOT, filePath).replace(/\\/g, '/');
+}
+
 const SKIP_DIRS = new Set(['.tmp', '__pycache__', 'node_modules', '.git']);
 const SKIP_EXTS = new Set(['.pyc', '.pyo']);
 const SKIP_FILES = new Set(['.DS_Store', 'Thumbs.db']);
@@ -39,7 +44,11 @@ function collectFiles(dir) {
   const files = [];
   if (!fs.existsSync(dir)) return files;
 
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+  const entries = fs
+    .readdirSync(dir, { withFileTypes: true })
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+
+  for (const entry of entries) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) {
       if (SKIP_DIRS.has(entry.name)) continue;
@@ -76,7 +85,7 @@ function scanCategory(category) {
     const metaFromFrontmatter = parseFrontmatter(content);
     const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
 
-    const allFiles = collectFiles(skillDir).map((f) => path.relative(ROOT, f));
+    const allFiles = collectFiles(skillDir).map(toIndexPath);
 
     skills.push({
       slug,
@@ -127,7 +136,7 @@ function scanPacks(registrySkills) {
 
       const content = fs.readFileSync(skillMd, 'utf8');
       const frontmatter = parseFrontmatter(content);
-      const allFiles = collectFiles(skillDir).map((f) => path.relative(ROOT, f));
+      const allFiles = collectFiles(skillDir).map(toIndexPath);
 
       subSkills.push({
         slug: skillSlug,

--- a/scripts/validate-skills.js
+++ b/scripts/validate-skills.js
@@ -27,6 +27,14 @@ const allowedTags = new Set(schema.properties.tags.items.enum);
 const errors = [];
 const slugs = new Set();
 
+function toIndexPath(filePath) {
+  return path.relative(ROOT, filePath).replace(/\\/g, '/');
+}
+
+function normalizeIndexPath(indexPath) {
+  return indexPath.replace(/\\/g, '/');
+}
+
 // Walk the entire skills/ tree to find every SKILL.md location.
 // Used at the end to assert every skill is represented in the index that
 // build-index.js produces (catches RC1-style drift where skills exist on
@@ -38,7 +46,7 @@ function collectSkillMdDirs(dir, results = []) {
     if (entry.isDirectory()) {
       collectSkillMdDirs(full, results);
     } else if (entry.name === 'SKILL.md') {
-      results.push(path.relative(ROOT, path.dirname(full)));
+      results.push(toIndexPath(path.dirname(full)));
     }
   }
   return results;
@@ -127,7 +135,7 @@ if (fs.existsSync(indexPath)) {
     // backend sync and the Payload CMS push) iterate idx.skills[] only.
     const topLevelPaths = new Set();
     for (const s of index.skills || []) {
-      if (s.path) topLevelPaths.add(s.path);
+      if (s.path) topLevelPaths.add(normalizeIndexPath(s.path));
     }
 
     const missing = allSkillMdDirs.filter((d) => !topLevelPaths.has(d));

--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-05-07",
+  "generated": "2026-05-30",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -4336,6 +4336,33 @@
         ],
         "installation": {
           "base_command": "npx goose-skills install review-site-scraper",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
+      }
+    },
+    {
+      "slug": "roi-calculator-builder",
+      "name": "roi-calculator-builder",
+      "category": "composites",
+      "description": ">",
+      "tags": "research",
+      "path": "skills/composites/roi-calculator-builder",
+      "files": [
+        "skills/composites/roi-calculator-builder/SKILL.md",
+        "skills/composites/roi-calculator-builder/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "roi-calculator-builder",
+        "category": "composites",
+        "tags": [
+          "research"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install roi-calculator-builder",
           "supports": [
             "claude",
             "cursor",

--- a/skills/composites/roi-calculator-builder/SKILL.md
+++ b/skills/composites/roi-calculator-builder/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: roi-calculator-builder
+description: >
+  Build a defensible ROI calculator for sales, success, or product marketing teams.
+  Turns customer pain, pricing, usage, labor cost, conversion lift, and risk assumptions
+  into a buyer-ready business case with conservative/base/aggressive scenarios,
+  payback period, sensitivity checks, discovery questions, and spreadsheet-ready fields.
+  Use when a team needs to quantify value before a demo, proposal, renewal, or expansion ask.
+tags: [research]
+---
+
+# ROI Calculator Builder
+
+Build a buyer-ready return-on-investment model that a sales or success team can use in discovery, proposals, renewal reviews, and expansion conversations.
+
+Core principle: a good ROI calculator is not a hype sheet. It is a transparent business case that shows the buyer where the value comes from, which assumptions are uncertain, and what would have to be true for the investment to make sense.
+
+## When to Use
+
+- "Build an ROI calculator for this product"
+- "Turn these customer outcomes into a sales business case"
+- "Help me quantify payback for a renewal"
+- "Create a value model for this prospect"
+- "Show which assumptions matter most before we pitch finance"
+
+## Phase 0: Intake
+
+Collect only what is available. If a field is missing, use a clearly labeled assumption and ask a follow-up question.
+
+### Product and Deal Context
+
+1. Product or service being evaluated.
+2. Buyer segment, industry, company size, and buyer role.
+3. Pricing model, contract term, implementation cost, services cost, and expected usage.
+4. Sales motion: new logo, expansion, renewal, win-back, or partner-led.
+5. Primary value hypothesis: save time, reduce spend, increase revenue, reduce risk, improve quality, or improve speed.
+
+### Baseline Inputs
+
+6. Current process or tool being replaced.
+7. Current volume: users, transactions, leads, tickets, meetings, campaigns, or other relevant units.
+8. Current labor cost or fully loaded hourly cost by role.
+9. Current error rate, cycle time, conversion rate, cost per unit, or missed opportunity rate.
+10. Any known customer proof: benchmark, case study metric, support quote, review, or historical result.
+
+### Buyer Constraints
+
+11. Budget owner and approval threshold.
+12. Payback expectation.
+13. Procurement, security, migration, or adoption concerns.
+14. Internal alternatives the buyer may compare against.
+
+## Phase 1: Select Value Drivers
+
+Choose the smallest set of drivers that explain most of the value. Avoid stacking weak claims.
+
+### Common Driver Types
+
+| Driver | Use when | Example metric |
+|---|---|---|
+| Time saved | Manual work is being automated or compressed | Hours saved per week |
+| Cost avoided | A tool, agency, contractor, or process can be reduced | Spend avoided per year |
+| Revenue lift | Conversion, win rate, retention, or expansion improves | Incremental gross profit |
+| Capacity unlocked | Same team can handle more volume without hiring | Added output per employee |
+| Risk reduced | Compliance, outages, errors, or churn risk decline | Expected loss avoided |
+| Speed improved | Work moves faster and creates earlier cash flow | Days saved per cycle |
+| Quality improved | Rework, defects, escalations, or refunds fall | Cost of poor quality avoided |
+
+For each selected driver, define:
+
+- Baseline: what happens today.
+- Intervention: what changes after adoption.
+- Unit economics: how one unit translates into value.
+- Confidence: high, medium, or low.
+- Evidence: source for the assumption.
+
+## Phase 2: Build Scenario Model
+
+Create three scenarios so the buyer can see the range without feeling pushed.
+
+### Conservative Scenario
+
+Use only the most defensible assumptions. Include adoption friction, ramp time, and partial utilization. This scenario should still be credible if the buyer is skeptical.
+
+### Base Scenario
+
+Use the most likely assumptions based on the prospect context and available proof. Do not copy the best customer result unless the prospect closely matches that customer.
+
+### Aggressive Scenario
+
+Show upside, but label it clearly. Use this to illustrate potential, not to anchor the decision.
+
+### Output Fields
+
+Produce a table with these fields:
+
+- Value driver.
+- Input metric.
+- Baseline value.
+- Improved value.
+- Annualized value created.
+- Evidence source.
+- Confidence.
+- Notes and caveats.
+
+Then produce a summary:
+
+- Total annual value in each scenario.
+- Total first-year cost.
+- Net first-year value.
+- Payback period.
+- Return multiple.
+- Break-even threshold.
+
+## Phase 3: Sensitivity Check
+
+Identify the two or three assumptions that change the conclusion the most.
+
+For each critical assumption, answer:
+
+- What happens if the assumption is cut in half?
+- What happens if adoption is delayed by one quarter?
+- What happens if only one team uses the product?
+- What happens if implementation takes longer than expected?
+- What is the minimum improvement needed to break even?
+
+If the model only works under aggressive assumptions, say so directly and recommend a narrower pilot or a different value story.
+
+## Phase 4: Buyer-Ready Narrative
+
+Turn the model into a concise business case.
+
+### Executive Summary
+
+Write five sentences:
+
+1. Current business problem.
+2. Why the problem has economic weight.
+3. Proposed change.
+4. Expected value range.
+5. Payback and main risk.
+
+### Finance-Friendly Assumptions
+
+List every assumption in plain language. Mark each as observed, customer-backed, benchmarked, or estimated.
+
+### Discovery Questions
+
+Generate questions that validate the weakest assumptions:
+
+- Volume question.
+- Labor cost question.
+- Current process question.
+- Error or rework question.
+- Adoption question.
+- Budget and approval question.
+
+### Objection Handling
+
+For each likely objection, provide a response grounded in the model:
+
+- "The savings seem too high."
+- "We do not know our baseline."
+- "Implementation will take too long."
+- "This is not a priority this quarter."
+- "We can build this internally."
+- "Finance will not accept soft savings."
+
+## Phase 5: Deliverables
+
+Return these artifacts:
+
+1. ROI calculator table with conservative, base, and aggressive scenarios.
+2. Assumptions register with evidence and confidence.
+3. Executive summary for a business case memo.
+4. Discovery question list for the seller.
+5. Sensitivity analysis.
+6. Buyer-safe caveats and pilot recommendation.
+
+## Quality Bar
+
+- Do not invent precise numbers without labeling them as estimates.
+- Do not mix revenue, profit, and savings without explaining the basis.
+- Do not count the same benefit twice.
+- Prefer fewer strong drivers over many weak ones.
+- Separate hard value from soft value.
+- Make the model usable by a skeptical finance buyer.
+- If the value story is weak, recommend repositioning instead of forcing the ROI.
+
+## Output Template
+
+### Inputs Received
+
+Summarize known inputs and missing inputs.
+
+### Scenario Summary
+
+| Scenario | Annual value | First-year cost | Net value | Payback | Confidence |
+|---|---:|---:|---:|---:|---|
+| Conservative | | | | | |
+| Base | | | | | |
+| Aggressive | | | | | |
+
+### Driver Detail
+
+| Driver | Baseline | Improvement | Annual value | Evidence | Confidence |
+|---|---|---|---:|---|---|
+| | | | | | |
+
+### Critical Assumptions
+
+List the assumptions that most affect the outcome.
+
+### Buyer Narrative
+
+Provide the five-sentence executive summary.
+
+### Discovery Questions
+
+List the questions that would tighten the model.
+
+### Caveats
+
+State what is uncertain, what should be validated in a pilot, and what should not be claimed yet.

--- a/skills/composites/roi-calculator-builder/skill.meta.json
+++ b/skills/composites/roi-calculator-builder/skill.meta.json
@@ -1,0 +1,15 @@
+{
+  "slug": "roi-calculator-builder",
+  "category": "composites",
+  "tags": [
+    "research"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install roi-calculator-builder",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add the `roi-calculator-builder` composite skill for buyer-ready ROI models and business cases
- update the catalog README and generated skills index
- make skill index generation/validation stable on Windows by normalizing CRLF/path separators and avoiding symlink-only test setup

## Testing
- npm run build:index
- npm run validate:skills
- npm test
- git diff --check