### PR TITLE
Add email-newsletter skill

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-05-07",
+  "generated": "2026-05-31",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -1663,6 +1663,36 @@
             "codex"
           ]
         }
+      }
+    },
+    {
+      "slug": "email-newsletter",
+      "name": "email-newsletter",
+      "category": "capabilities",
+      "description": "Draft and design paste-ready HTML email newsletters for tools such as Loops, Mailchimp, Beehiiv, and Resend, including subject lines, preheader, body copy, plain-text fallback, and email-client-safe layout guidance.",
+      "tags": "content, outreach, design",
+      "path": "skills/capabilities/email-newsletter",
+      "files": [
+        "skills/capabilities/email-newsletter/SKILL.md",
+        "skills/capabilities/email-newsletter/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "email-newsletter",
+        "category": "capabilities",
+        "tags": [
+          "content",
+          "outreach",
+          "design"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install email-newsletter",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "author": "Satyajeet Sawant"
       }
     },
     {

--- a/skills/capabilities/email-newsletter/SKILL.md
+++ b/skills/capabilities/email-newsletter/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: email-newsletter
+description: Draft and design paste-ready HTML email newsletters for tools such as Loops, Mailchimp, Beehiiv, and Resend, including subject lines, preheader, body copy, plain-text fallback, and email-client-safe layout guidance.
+tags: [content, outreach, design]
+---
+
+# Email Newsletter
+
+Create a polished newsletter that is ready for human review and import into an email platform. The skill turns a rough brief into a finished package: strategic angle, subject line options, preheader, complete email body, plain-text version, and implementation notes for the target platform.
+
+Use this when the user asks for a newsletter, launch email, update email, founder note, content roundup, product digest, event recap, or nurture email that needs to look and read like a real campaign rather than a generic blog post.
+
+## Intake
+
+Collect only what is missing. If the user already gave enough context, proceed with sensible defaults and state the assumptions.
+
+- Audience: who will receive it and what they already know
+- Goal: clicks, replies, activation, event registration, product education, retention, or founder trust
+- Source material: notes, links, product update, blog draft, customer story, or bullet list
+- Brand voice: concise, founder-led, editorial, technical, playful, formal, or pasted examples
+- Platform: Loops, Mailchimp, Beehiiv, Resend, or generic HTML
+- Design mode: plain editorial, product update, image-led, roundup, announcement, or digest
+- Required call to action: one primary action and optional secondary action
+- Compliance details: sender name, mailing address, unsubscribe handling, and any legal footer constraints
+
+## Newsletter Strategy
+
+Before drafting, decide the newsletter shape.
+
+- Announcement: one clear change, one reason it matters, one action
+- Editorial note: human opening, useful insight, supporting links, soft action
+- Product digest: short intro, grouped updates, benefit-first descriptions, action buttons
+- Content roundup: tight theme, curated links, one-sentence value for each link
+- Event recap: what happened, proof that it mattered, replay or next event action
+- Nurture email: one pain point, one teaching point, one next step
+
+Pick the shape that best matches the goal. Do not force a long newsletter when a short one will convert better.
+
+## Drafting Workflow
+
+Start with the reader's reason to care. The first screen should explain the value without requiring background knowledge.
+
+Create three to five subject lines with different angles: direct benefit, curiosity, specificity, founder voice, and urgency only when legitimate. Keep them easy to understand in an inbox. Create two preheader options that complete the subject line instead of repeating it.
+
+Write the body in a scannable structure:
+
+- A short opening that feels written by a human
+- One central idea or announcement
+- Supporting sections with compact headings
+- Specific details, numbers, names, dates, or examples where available
+- One primary call to action
+- A graceful close that does not add another competing ask
+
+Avoid hype, vague superlatives, fake urgency, and filler transitions. Do not over-personalize with fields the user did not provide.
+
+## Design And HTML Guidance
+
+Produce email-client-safe HTML when the user asks for a designed version. Favor a simple single-column layout, inline styling, accessible contrast, descriptive image alt text, mobile-friendly spacing, and buttons with clear visible labels.
+
+Do not rely on scripts, forms, embedded video, external style sheets, web fonts, complex positioning, hover-only interactions, or layout techniques that common inboxes strip. If the user wants images, provide stable image slots and alt text rather than inventing hosted asset locations.
+
+For Loops and Resend, keep the HTML portable and lightweight. For Mailchimp and Beehiiv, include any platform-specific merge-tag placeholders only if the user provides them or asks for that platform's defaults.
+
+Always include a plain-text fallback. It should preserve the same message hierarchy, links, and call to action without sounding like raw design notes.
+
+## Quality Checks
+
+Before delivering, run this review:
+
+- Subject and preheader work together and do not promise something the email does not deliver
+- The first paragraph makes the value clear
+- There is only one primary call to action
+- The body can be scanned in under thirty seconds
+- Claims are supported by source material or framed as assumptions
+- The design works without images
+- Links are clearly labeled and easy to replace
+- Footer and unsubscribe needs are acknowledged for the selected platform
+- Plain-text version is complete
+
+If the source brief is thin, label assumptions and provide a concise list of optional details that would improve the next revision.
+
+## Output Format
+
+Return the package in this order:
+
+1. Campaign summary: audience, goal, angle, and selected newsletter shape
+2. Subject line options with the recommended choice called out
+3. Preheader options
+4. Final newsletter copy
+5. HTML version when requested or when the platform expects paste-ready HTML
+6. Plain-text version
+7. Import notes for the selected platform
+8. Final quality-check notes
+
+Never send or schedule the campaign automatically. The output is a reviewed draft package for the human to approve and import.

--- a/skills/capabilities/email-newsletter/skill.meta.json
+++ b/skills/capabilities/email-newsletter/skill.meta.json
@@ -1,0 +1,18 @@
+{
+  "slug": "email-newsletter",
+  "category": "capabilities",
+  "tags": [
+    "content",
+    "outreach",
+    "design"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install email-newsletter",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "author": "Satyajeet Sawant"
+}


### PR DESCRIPTION
## Summary
- Adds an email-newsletter capability skill for creating review-ready newsletter packages.
- Covers intake, newsletter strategy, subject lines, preheaders, body copy, HTML guidance, plain-text fallback, platform import notes, and quality checks.
- Keeps sending/scheduling out of scope so the skill remains human-review-first.

## Testing
- npm run ci
