### PR TITLE
Add customer-reference-request skill

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-05-07",
+  "generated": "2026-05-31",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -1388,6 +1388,35 @@
             "codex"
           ]
         }
+      }
+    },
+    {
+      "slug": "customer-reference-request",
+      "name": "customer-reference-request",
+      "category": "composites",
+      "description": "Build customer reference request packages for B2B teams, including candidate scoring, permission-safe asks, email drafts, call prep, quote approval, logo approval, and follow-up tracking.",
+      "tags": "outreach, content",
+      "path": "skills/composites/customer-reference-request",
+      "files": [
+        "skills/composites/customer-reference-request/SKILL.md",
+        "skills/composites/customer-reference-request/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "customer-reference-request",
+        "category": "composites",
+        "tags": [
+          "outreach",
+          "content"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install customer-reference-request",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "author": "Satyajeet Sawant"
       }
     },
     {

--- a/skills/composites/customer-reference-request/SKILL.md
+++ b/skills/composites/customer-reference-request/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: customer-reference-request
+description: Build customer reference request packages for B2B teams, including candidate scoring, permission-safe asks, email drafts, call prep, quote approval, logo approval, and follow-up tracking.
+tags: [outreach, content]
+---
+
+# Customer Reference Request
+
+Turn happy customers into permission-safe sales proof without making the customer feel used. This skill helps customer marketing, founders, sales, and customer success teams ask for reference calls, testimonial quotes, logo approval, short case-study participation, review requests, or public social proof.
+
+Use this when the user wants to ask a customer for a reference, create a customer proof program, request logo or quote approval, prepare a reference call, follow up after a customer agrees, or turn customer success notes into a polished ask.
+
+## Intake
+
+Collect only the details needed for the requested proof motion.
+
+- Customer company and contact
+- Relationship owner and account context
+- Product or use case
+- Proof type: reference call, quote, review, logo, case study, webinar, social post, or analyst reference
+- Sensitivity level: public, private sales-only, anonymous, under NDA, or internal only
+- Customer outcome: metric, story, workflow improvement, before and after, or qualitative win
+- Ask size: tiny, light, medium, or high commitment
+- Deadline or sales deal where the reference is needed
+- Approval constraints: legal, brand, procurement, executive sponsor, customer marketing, or no known constraints
+
+If the user has CRM notes, call transcripts, support tickets, QBR notes, renewal notes, or customer emails, use them as source material. Do not invent customer claims, metrics, permission status, or legal approval.
+
+## Reference Motion Selection
+
+Choose the lowest-friction ask that still satisfies the business need.
+
+- Tiny ask: private quote approval, one-sentence testimonial, logo permission, review prompt
+- Light ask: fifteen-minute reference call, short written answer set, anonymous case note
+- Medium ask: named mini case study, customer story interview, webinar quote
+- High commitment: public case study, event speaker, analyst reference, sales reference program
+
+When the customer is busy, under legal constraints, or recently escalated a support issue, downgrade the ask size. When the customer is enthusiastic, renewed recently, expanded usage, or already praised the product publicly, a larger ask can be appropriate.
+
+## Candidate Scoring
+
+Score candidates before drafting outreach.
+
+- Relationship warmth: recent positive interaction, executive sponsor, customer success owner
+- Proof strength: specific outcome, named use case, measurable impact, relevant buyer persona
+- Approval risk: regulated industry, legal review, brand restrictions, procurement constraints
+- Reciprocity: what value the customer gets from participating
+- Timing: renewal window, implementation phase, recent launch, recent support issue
+- Fit for requested proof type: the right customer for the right audience
+
+Return a simple verdict for each customer: ask now, ask softly, warm up first, or do not ask yet.
+
+## Ask Strategy
+
+Every request should be specific, respectful, and easy to decline.
+
+Include:
+
+- Why this customer was selected
+- The exact proof asset or activity requested
+- Expected time commitment
+- Where the proof will be used
+- Whether it is public or private
+- Approval path and review rights
+- A graceful opt-out
+- A reciprocal benefit where appropriate
+
+Avoid vague asks such as "Can we feature you?" without explaining the format, time burden, and approval control. Never imply public use before permission is granted.
+
+## Drafting Package
+
+Create the materials that match the selected proof motion.
+
+For a reference call:
+
+- Short request email from the relationship owner
+- Internal brief for the salesperson
+- Customer-facing call agenda
+- Guardrails on topics not to ask
+- Thank-you follow-up
+
+For quote or logo approval:
+
+- Permission request email
+- Draft quote or logo usage language
+- Approval options
+- Legal or brand-review note
+- Reminder follow-up
+
+For a case study or testimonial:
+
+- Soft ask email
+- Interview question set
+- Story angle
+- Approval workflow
+- Follow-up after interview
+
+For a review request:
+
+- Short request email
+- Review-site positioning note
+- Optional prompt list
+- Thank-you follow-up
+
+## Output Format
+
+Return the package in this order:
+
+1. Recommendation: proof motion, ask size, and customer readiness verdict
+2. Risk notes: approval, relationship, timing, and claim-support concerns
+3. Primary outreach draft
+4. Follow-up draft
+5. Internal enablement note for sales or customer success
+6. Customer-facing agenda or approval language when relevant
+7. Tracking fields for CRM or spreadsheet
+8. Quality-check notes
+
+## Quality Checks
+
+Before delivering, verify:
+
+- The ask is specific and bounded
+- The customer can say no without awkwardness
+- Public, private, anonymous, and NDA usage are clearly separated
+- Any metric or claim is supported by source material
+- Time commitment is explicit
+- Approval rights are clear
+- The message sounds like it came from the relationship owner, not a marketing blast
+- There is one primary ask, not several competing asks
+
+If the source material is thin, draft a softer warm-up message instead of a hard ask.

--- a/skills/composites/customer-reference-request/skill.meta.json
+++ b/skills/composites/customer-reference-request/skill.meta.json
@@ -1,0 +1,17 @@
+{
+  "slug": "customer-reference-request",
+  "category": "composites",
+  "tags": [
+    "outreach",
+    "content"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install customer-reference-request",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "author": "Satyajeet Sawant"
+}


### PR DESCRIPTION
## Summary
- Adds a customer-reference-request composite skill for B2B customer proof workflows.
- Covers candidate scoring, proof-motion selection, permission-safe asks, reference-call prep, quote/logo approval, follow-ups, and tracking fields.
- Emphasizes approval rights, source-supported claims, private vs public use, and a graceful opt-out.

## Testing
- npm run build:index
- npm run ci
