### PR TITLE
Add deal-desk-packet skill

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-05-07",
+  "generated": "2026-05-31",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -1472,6 +1472,40 @@
             "codex"
           ]
         }
+      }
+    },
+    {
+      "slug": "deal-desk-packet",
+      "name": "deal-desk-packet",
+      "category": "composites",
+      "description": ">",
+      "tags": "outreach, research",
+      "path": "skills/composites/deal-desk-packet",
+      "files": [
+        "skills/composites/deal-desk-packet/SKILL.md",
+        "skills/composites/deal-desk-packet/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "deal-desk-packet",
+        "category": "composites",
+        "tags": [
+          "outreach",
+          "research"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install deal-desk-packet",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "features": [
+          "Builds internal approval memos for late-stage sales deals",
+          "Maps stakeholders, procurement steps, legal review, security review, and close risks",
+          "Creates buyer-facing recap emails and next-meeting agendas without exposing internal risk language",
+          "Separates confirmed facts, assumptions, and unknowns before recommending concessions"
+        ]
       }
     },
     {

--- a/skills/composites/deal-desk-packet/SKILL.md
+++ b/skills/composites/deal-desk-packet/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: deal-desk-packet
+description: >
+  Build a late-stage sales deal desk packet from deal notes, calls, pricing
+  context, security concerns, legal blockers, stakeholder maps, and close plans.
+  Produces an internal approval memo, negotiation map, procurement checklist,
+  buyer-facing follow-up, risk register, and next-meeting agenda. Use when an
+  AE, founder, sales leader, or RevOps team needs to move a complex deal through
+  discount, legal, security, procurement, or executive approval without losing
+  control of the narrative.
+tags: [outreach, research]
+---
+
+# Deal Desk Packet
+
+Turn messy late-stage deal context into a crisp deal desk packet that a sales
+team can use to align internally and guide the buyer through the remaining path
+to signature.
+
+The skill is deliberately practical. It does not invent commercial authority,
+legal positions, security answers, or buyer commitments. It separates confirmed
+facts from seller assumptions, flags missing evidence, and creates the exact
+artifacts needed for the next internal or buyer-facing step.
+
+## When to Use
+
+Use this skill when the user says things like:
+
+- Build a deal desk packet.
+- Help me prep for procurement.
+- Turn these deal notes into an approval memo.
+- We need a close plan for this enterprise deal.
+- Summarize legal, security, pricing, and stakeholder risks.
+- Draft the buyer follow-up after a negotiation call.
+- I need internal approval for discounting or custom terms.
+
+Do not use this for first-touch outreach, general pipeline review, or a normal
+discovery-call brief unless the deal is already in a late-stage approval,
+procurement, legal, security, or negotiation motion.
+
+## Required Inputs
+
+Ask for only the missing inputs that matter for the current packet. If the user
+provides messy notes, start with those and mark unknowns rather than blocking.
+
+Minimum viable inputs:
+
+- Company and deal owner.
+- Product or package being sold.
+- Current stage and desired next step.
+- Target close date or event.
+- Main buyer problem and desired outcome.
+- Known stakeholders and their influence.
+- Commercial ask, pricing range, or approval needed.
+- Open objections, blockers, and required approvals.
+
+Useful optional inputs:
+
+- Call notes or transcript snippets.
+- Security questionnaire themes.
+- Legal or procurement asks.
+- Competitive context.
+- Prior customer proof, case studies, or reference options.
+- Implementation plan or success criteria.
+- Existing proposal, order form summary, or renewal context.
+
+## Output Modes
+
+Choose the lightest packet that solves the user's immediate need.
+
+- Fast packet: one-page internal summary, risk list, next actions, buyer follow-up.
+- Full packet: complete internal memo, negotiation map, approval ask, close plan,
+  procurement checklist, and buyer-facing recap.
+- Rescue packet: for stalled deals. Focus on stale risks, missing champions,
+  unowned approvals, re-entry message, and an honest go/no-go recommendation.
+- Executive packet: for CEO, CRO, finance, or legal review. Compress context,
+  quantify upside, name risk, and state the exact decision requested.
+
+If the user does not specify a mode, produce the full packet for enterprise or
+multi-stakeholder deals and the fast packet for smaller deals.
+
+## Workflow
+
+### 1. Reconstruct the Deal
+
+Create a short deal snapshot:
+
+- Account and opportunity.
+- Current stage.
+- Contract value or commercial scope if known.
+- Buyer problem.
+- Desired business outcome.
+- Close date pressure.
+- Approval path.
+- Decision owner.
+- Internal owner.
+
+Label each item as confirmed, inferred, or unknown. If something is inferred,
+explain the inference in one short phrase.
+
+### 2. Map Stakeholders
+
+Build a stakeholder map with:
+
+- Economic buyer.
+- Champion.
+- Technical evaluator.
+- Legal owner.
+- Security owner.
+- Procurement owner.
+- Executive sponsor.
+- Likely blocker.
+
+For each stakeholder, capture role, current sentiment, what they need, risk if
+ignored, and the next best touch. If a role is unknown, leave it in the map as a
+gap instead of pretending the stakeholder exists.
+
+### 3. Identify the Decision Path
+
+Turn the remaining process into a dated or sequenced path:
+
+- Business approval.
+- Security review.
+- Legal review.
+- Procurement and vendor setup.
+- Finance or budget approval.
+- Implementation readiness.
+- Signature.
+
+Show the owner, buyer-side dependency, seller-side dependency, and risk for each
+step. Name any step with no clear owner as a red flag.
+
+### 4. Build the Commercial Position
+
+Summarize:
+
+- Current package and terms.
+- Requested discount, concession, or exception.
+- Business reason for the ask.
+- What the buyer gives in return.
+- Renewal, expansion, reference, payment, or timing implications.
+- Walk-away line if known.
+
+Never invent a walk-away line or legal authority. If the user has not provided
+approval limits, mark them unknown and ask for approval before presenting a firm
+commercial position.
+
+### 5. Compile Proof and Gaps
+
+Create a proof table:
+
+- Claim.
+- Evidence available.
+- Evidence strength.
+- Where it will be used.
+- Missing proof.
+
+Prioritize proof that supports the buyer's desired outcome, not generic product
+claims. If proof is weak, propose a safer phrasing and a request for stronger
+evidence.
+
+### 6. Create the Packet
+
+Produce these sections in order:
+
+1. Internal executive summary.
+2. Deal facts and assumptions.
+3. Stakeholder map.
+4. Decision path and close plan.
+5. Commercial ask and approval request.
+6. Risk register.
+7. Proof and evidence map.
+8. Procurement, legal, and security checklist.
+9. Buyer-facing recap email.
+10. Next-meeting agenda.
+
+For a fast packet, include sections 1, 4, 6, 9, and 10.
+
+## Internal Executive Summary
+
+The summary should fit on one screen and answer:
+
+- What decision is needed?
+- Why now?
+- What is the upside?
+- What could break?
+- What is the recommended move?
+- What should the internal approver say yes, no, or modify?
+
+Use direct language. Avoid sales puffery. Executives need a judgment, not a
+tour of the deal.
+
+## Risk Register
+
+Every packet must include a risk register with:
+
+- Risk.
+- Severity.
+- Owner.
+- Evidence.
+- Mitigation.
+- Deadline.
+- Current status.
+
+Default severities:
+
+- Critical: could kill the deal or create unacceptable terms.
+- High: can delay signature or require executive approval.
+- Medium: needs management but should not block alone.
+- Low: monitor only.
+
+Do not bury legal, security, or procurement risk in narrative paragraphs. Put
+them in the risk register.
+
+## Buyer-Facing Recap
+
+Draft a buyer-facing recap that:
+
+- Confirms agreed goals.
+- Names the remaining process without sounding pushy.
+- Lists owner-to-owner next steps.
+- Repeats open questions.
+- Avoids internal discount logic or private risk language.
+- Keeps the tone collaborative and specific.
+
+If the user has not provided the buyer's tone preference, use concise,
+professional language.
+
+## Negotiation Guardrails
+
+Before suggesting any concession, check:
+
+- Is the concession authorized?
+- What is the buyer giving in return?
+- Does it affect implementation, support, liability, security, or renewal?
+- Is there a cleaner non-price option?
+- Does the concession create a precedent the company would regret?
+
+When authority is unclear, recommend an approval question rather than a
+concession.
+
+## Quality Gates
+
+Before finalizing, verify:
+
+- Confirmed facts, assumptions, and unknowns are clearly separated.
+- No legal, security, or commercial authority is invented.
+- Every high or critical risk has an owner and mitigation.
+- The buyer-facing recap omits internal-only information.
+- The approval ask is specific enough for a yes, no, or modified yes.
+- The next meeting agenda maps to the actual blockers.
+- The packet is short enough to be used in the next internal meeting.
+
+## Follow-Up Actions
+
+End with a short action list:
+
+- Owner.
+- Action.
+- Deadline.
+- Evidence needed.
+- Message or meeting where it will be handled.
+
+If the user wants, also produce a separate short Slack-style internal update and
+a cleaner email version for the buyer.

--- a/skills/composites/deal-desk-packet/skill.meta.json
+++ b/skills/composites/deal-desk-packet/skill.meta.json
@@ -1,0 +1,22 @@
+{
+  "slug": "deal-desk-packet",
+  "category": "composites",
+  "tags": [
+    "outreach",
+    "research"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install deal-desk-packet",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "features": [
+    "Builds internal approval memos for late-stage sales deals",
+    "Maps stakeholders, procurement steps, legal review, security review, and close risks",
+    "Creates buyer-facing recap emails and next-meeting agendas without exposing internal risk language",
+    "Separates confirmed facts, assumptions, and unknowns before recommending concessions"
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds deal-desk-packet, a composite skill for late-stage sales deal desk packets.
- Covers stakeholder mapping, approval memos, procurement/legal/security checklists, risk registers, buyer recaps, and next-meeting agendas.
- Regenerates skills-index.json so the new skill is discoverable.

## Testing
- npm run ci