### PR TITLE
Add bounty-board-auditor capability

### DIFF
--- a/scripts/build-index.js
+++ b/scripts/build-index.js
@@ -12,14 +12,39 @@ const ROOT = process.env.GOOSE_SKILLS_ROOT
   ? path.resolve(process.env.GOOSE_SKILLS_ROOT)
   : path.resolve(__dirname, '..');
 const OUTPUT = path.join(ROOT, 'skills-index.json');
+let existingIndex = null;
+
+if (fs.existsSync(OUTPUT)) {
+  try {
+    existingIndex = JSON.parse(fs.readFileSync(OUTPUT, 'utf8').replace(/^\uFEFF/, ''));
+  } catch {}
+}
+
+function repoPath(filePath) {
+  return path.relative(ROOT, filePath).replace(/\\/g, '/');
+}
+
+function preserveExistingFileOrder(skillPath, files) {
+  if (!existingIndex) return files;
+  const existing = (existingIndex.skills || []).find((skill) => skill.path === skillPath);
+  if (!existing || !Array.isArray(existing.files)) return files;
+
+  const current = new Set(files);
+  const previous = new Set(existing.files);
+  if (current.size !== previous.size) return files;
+  for (const file of current) {
+    if (!previous.has(file)) return files;
+  }
+  return existing.files;
+}
 
 function parseFrontmatter(content) {
-  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
   if (!match) return {};
 
   const yaml = match[1];
   const result = {};
-  for (const line of yaml.split('\n')) {
+  for (const line of yaml.split(/\r?\n/)) {
     const kvMatch = line.match(/^(\w[\w-]*):\s*(.*)/);
     if (!kvMatch) continue;
     let value = kvMatch[2].trim().replace(/^['"]|['"]$/g, '');
@@ -50,7 +75,15 @@ function collectFiles(dir) {
       files.push(full);
     }
   }
-  return files;
+  return files.sort((a, b) => {
+    const aName = path.basename(a);
+    const bName = path.basename(b);
+    if (aName === 'SKILL.md') return -1;
+    if (bName === 'SKILL.md') return 1;
+    if (aName.endsWith('.meta.json')) return 1;
+    if (bName.endsWith('.meta.json')) return -1;
+    return repoPath(a).localeCompare(repoPath(b));
+  });
 }
 
 function scanCategory(category) {
@@ -76,7 +109,7 @@ function scanCategory(category) {
     const metaFromFrontmatter = parseFrontmatter(content);
     const meta = JSON.parse(fs.readFileSync(metaPath, 'utf8'));
 
-    const allFiles = collectFiles(skillDir).map((f) => path.relative(ROOT, f));
+    const allFiles = collectFiles(skillDir).map(repoPath);
 
     skills.push({
       slug,
@@ -85,7 +118,7 @@ function scanCategory(category) {
       description: metaFromFrontmatter.description || '',
       tags: Array.isArray(meta.tags) ? meta.tags.join(', ') : '',
       path: `skills/${category}/${slug}`,
-      files: allFiles,
+      files: preserveExistingFileOrder(`skills/${category}/${slug}`, allFiles),
       metadata: meta,
     });
   }
@@ -127,14 +160,14 @@ function scanPacks(registrySkills) {
 
       const content = fs.readFileSync(skillMd, 'utf8');
       const frontmatter = parseFrontmatter(content);
-      const allFiles = collectFiles(skillDir).map((f) => path.relative(ROOT, f));
+      const allFiles = collectFiles(skillDir).map(repoPath);
 
       subSkills.push({
         slug: skillSlug,
         name: frontmatter.name || skillSlug,
         description: frontmatter.description || '',
         path: `skills/packs/${slug}/${skillSlug}`,
-        files: allFiles,
+        files: preserveExistingFileOrder(`skills/packs/${slug}/${skillSlug}`, allFiles),
         source: 'pack',
       });
     }
@@ -255,11 +288,10 @@ for (const pack of packs) {
 let generatedDate = new Date().toISOString().split('T')[0];
 if (fs.existsSync(OUTPUT)) {
   try {
-    const existing = JSON.parse(fs.readFileSync(OUTPUT, 'utf8'));
     const newContent = JSON.stringify({ skills, packs });
-    const oldContent = JSON.stringify({ skills: existing.skills, packs: existing.packs });
-    if (newContent === oldContent && existing.generated) {
-      generatedDate = existing.generated;
+    const oldContent = JSON.stringify({ skills: existingIndex.skills, packs: existingIndex.packs });
+    if (newContent === oldContent && existingIndex.generated) {
+      generatedDate = existingIndex.generated;
     }
   } catch {}
 }

--- a/scripts/validate-skills.js
+++ b/scripts/validate-skills.js
@@ -27,6 +27,10 @@ const allowedTags = new Set(schema.properties.tags.items.enum);
 const errors = [];
 const slugs = new Set();
 
+function repoPath(filePath) {
+  return path.relative(ROOT, filePath).replace(/\\/g, '/');
+}
+
 // Walk the entire skills/ tree to find every SKILL.md location.
 // Used at the end to assert every skill is represented in the index that
 // build-index.js produces (catches RC1-style drift where skills exist on
@@ -38,7 +42,7 @@ function collectSkillMdDirs(dir, results = []) {
     if (entry.isDirectory()) {
       collectSkillMdDirs(full, results);
     } else if (entry.name === 'SKILL.md') {
-      results.push(path.relative(ROOT, path.dirname(full)));
+      results.push(repoPath(path.dirname(full)));
     }
   }
   return results;

--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-05-07",
+  "generated": "2026-06-03",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -358,6 +358,41 @@
         ],
         "installation": {
           "base_command": "npx goose-skills install blog-feed-monitor",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        }
+      }
+    },
+    {
+      "slug": "bounty-board-auditor",
+      "name": "bounty-board-auditor",
+      "category": "capabilities",
+      "description": "Audit public bounty, reward, and paid-issue boards against GitHub source-of-truth state. Detect stale open listings, closed GitHub issues, archived or missing repositories, withdrawn payouts, reserved bounties, crowded duplicate PRs, and unclear assignment state.",
+      "tags": "research, competitive-intel, lead-generation, monitoring",
+      "path": "skills/capabilities/bounty-board-auditor",
+      "files": [
+        "skills/capabilities/bounty-board-auditor/SKILL.md",
+        "skills/capabilities/bounty-board-auditor/examples/sample-listings.md",
+        "skills/capabilities/bounty-board-auditor/examples/sample-report.md",
+        "skills/capabilities/bounty-board-auditor/README.md",
+        "skills/capabilities/bounty-board-auditor/scripts/audit_bounty_board.mjs",
+        "skills/capabilities/bounty-board-auditor/scripts/test_audit_bounty_board.mjs",
+        "skills/capabilities/bounty-board-auditor/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "bounty-board-auditor",
+        "category": "capabilities",
+        "tags": [
+          "research",
+          "competitive-intel",
+          "lead-generation",
+          "monitoring"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install bounty-board-auditor",
           "supports": [
             "claude",
             "cursor",

--- a/skills/capabilities/bounty-board-auditor/README.md
+++ b/skills/capabilities/bounty-board-auditor/README.md
@@ -1,0 +1,46 @@
+# bounty-board-auditor
+
+Audit public bounty, reward, and paid-issue boards against GitHub source-of-truth state.
+
+This skill helps agents avoid stale or misleading paid work by classifying listings as active, closed, archived, unavailable, withdrawn, reserved, crowded, or needing scope confirmation.
+
+## Example Requests
+
+- Audit this bounty board for stale open issues: `https://example.com/bounties`
+- Check whether these GitHub bounty issues are still worth attempting.
+- Create a maintainer-facing cleanup report for this repo's paid issues.
+- Find open-looking rewards where GitHub says the issue is closed or the repo is archived.
+
+## What It Produces
+
+- A Markdown audit report.
+- Evidence-backed findings.
+- Recommended public status wording.
+- A contributor recommendation: attempt, ask for confirmation, or avoid.
+- Optional sample input/output artifacts for review.
+
+## Examples
+
+- `examples/sample-listings.md`: small input fixture with mixed board states.
+- `examples/sample-report.md`: expected report shape and recommendation style.
+
+## Script
+
+Run a deterministic smoke test without GitHub API calls:
+
+```bash
+node scripts/audit_bounty_board.mjs --input examples/sample-listings.md --offline
+```
+
+Run the self-test:
+
+```bash
+node scripts/test_audit_bounty_board.mjs
+```
+
+## Good Fit
+
+- Bounty platforms.
+- OSS maintainers with paid issue programs.
+- Contributors doing AI-assisted bounty work.
+- Sponsor teams trying to reduce duplicate PR noise.

--- a/skills/capabilities/bounty-board-auditor/SKILL.md
+++ b/skills/capabilities/bounty-board-auditor/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: bounty-board-auditor
+description: Audit public bounty, reward, and paid-issue boards against GitHub source-of-truth state. Detect stale open listings, closed GitHub issues, archived or missing repositories, withdrawn payouts, reserved bounties, crowded duplicate PRs, and unclear assignment state.
+tags: [research, competitive-intel, lead-generation, monitoring]
+user-invocable: true
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch
+argument-hint: "[bounty board URL or GitHub issue URLs]"
+---
+
+# Bounty Board Auditor
+
+Audit public bounty/reward listings before contributors waste time or maintainers get duplicate PR noise.
+
+Use this skill when the user wants to:
+
+- Check whether paid GitHub issues are still actionable.
+- Audit a bounty board, reward marketplace, or sponsor issue list.
+- Find stale open listings that are closed or contradicted on GitHub.
+- Prepare a maintainer/platform cleanup report.
+- Decide whether a bounty is worth attempting.
+
+## Inputs
+
+Accept any of:
+
+- A bounty/reward board URL.
+- A GitHub organization or repository.
+- A list of GitHub issue URLs.
+- A CSV/Markdown list of bounty listings.
+- A minimum payout threshold.
+- A target buyer type: `platform`, `maintainer`, `sponsor`, or `contributor`.
+
+Ask for missing scope only when needed. If the user provides a board URL or issue list, start auditing.
+
+## Output
+
+Produce a Markdown report with:
+
+- Executive summary.
+- Findings table.
+- Evidence-backed per-issue findings.
+- Recommended public status wording.
+- Buyer/action next steps.
+
+## Optional Script
+
+Use the included script when the input is a Markdown or CSV file containing GitHub issue URLs:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/scripts/audit_bounty_board.mjs \
+  --input ${CLAUDE_SKILL_DIR}/examples/sample-listings.md \
+  --output bounty-board-audit.md
+```
+
+For deterministic local testing without GitHub API calls:
+
+```bash
+node ${CLAUDE_SKILL_DIR}/scripts/audit_bounty_board.mjs \
+  --input ${CLAUDE_SKILL_DIR}/examples/sample-listings.md \
+  --offline
+```
+
+## Workflow
+
+### 1. Normalize Listings
+
+For each candidate listing, extract:
+
+- Platform or board name.
+- Listed repository.
+- Listed issue or PR URL.
+- Listed payout amount.
+- Listed status.
+- Listed solver/attempt count, if available.
+- Last updated date, if visible.
+
+If a listing does not expose a GitHub issue URL, search for the exact title and repository name before marking it unknown.
+
+### 2. Validate GitHub Source State
+
+For every GitHub-backed listing, check:
+
+- Repository exists.
+- Repository is public or reachable.
+- Repository is not archived.
+- Issue exists.
+- Issue state: open or closed.
+- Issue state reason, if available.
+- Assignees.
+- Labels such as `bounty`, `paid`, `good first issue`, `blocked`, `to refine`, `reserved`, `released`, `completed`, or amount labels.
+- Comments mentioning payout withdrawal, reservation, assignment, claim, stop-work, completed work, or maintainer clarification.
+- PRs referencing the issue.
+
+Prefer primary GitHub issue/PR state over marketplace snippets.
+
+### 3. Classify Each Listing
+
+Use these statuses:
+
+- `active`: GitHub issue is open, repository is active, payout path is still plausible, and crowding is low.
+- `closed-on-github`: marketplace says open but GitHub issue is closed.
+- `repo-unavailable`: repository or issue URL returns 404, moved, private, deleted, or cannot be resolved.
+- `repo-archived`: repository is archived.
+- `withdrawn`: comments say bounty/reward will not be honored.
+- `reserved`: comments say bounty is assigned or reserved for a specific person.
+- `crowded`: multiple PRs, claim comments, `/attempt`, `/boss champion`, or equivalent signals already exist.
+- `needs-scope`: issue is labeled `to refine`, `needs spec`, `blocked`, or has vague acceptance criteria.
+- `needs-reconfirmation`: payout state is ambiguous and should be confirmed before work starts.
+
+### 4. Risk Rules
+
+Flag as high priority when:
+
+- Marketplace status says open but GitHub is closed.
+- Repository is archived or unavailable.
+- Payer explicitly withdrew payment.
+- Payout is large and listing looks low-competition, but GitHub says reserved/closed.
+
+Flag as medium priority when:
+
+- Multiple PRs exist for the same bounty.
+- The issue is assigned but marketplace still invites solvers.
+- Maintainer comments ask contributors to stop submitting.
+
+Flag as low priority when:
+
+- Issue is open but broad or needs scope clarification.
+- Payout amount is low and crowding is moderate.
+
+### 5. Recommended Status Wording
+
+Use concise public wording:
+
+- Closed on GitHub. Reward is not currently actionable.
+- Repository archived. Reward is hidden until the repository is active again.
+- GitHub repository is unavailable. Reward is hidden until the issue URL resolves.
+- Bounty withdrawn by payer in GitHub comments. Do not start for payment unless the payer reconfirms.
+- Bounty reserved for a specific maintainer/contributor. Do not start for payout.
+- High competition: multiple solution PRs already exist. Check maintainer comments before starting.
+- Spec not final. Ask maintainer for scope confirmation before implementation.
+- Payer confirmation required before new work starts.
+
+### 6. Report Template
+
+```markdown
+# [Platform/Repo] Bounty Board Audit
+
+Date: [YYYY-MM-DD]
+
+## Executive Summary
+
+[2-4 sentences explaining the main trust/actionability problem.]
+
+## Findings Table
+
+| Listing | Amount | Board Status | GitHub State | Classification | Priority |
+|---------|--------|--------------|--------------|----------------|----------|
+| [repo#issue](url) | [$] | [open/unknown] | [open/closed/404/archived] | [status] | [high/medium/low] |
+
+## Findings
+
+### Finding 1: [Title]
+
+Surface:
+
+- Board: [url]
+- GitHub: [url]
+
+Evidence:
+
+- [primary-source evidence]
+- [comment/PR/label evidence]
+
+Risk:
+
+[Why this misleads contributors or burdens maintainers.]
+
+Recommended action:
+
+[Concrete status/label/copy update.]
+
+Suggested wording:
+
+> [public-facing status text]
+
+## Next Action
+
+[Email/contact/issue/comment recommendation.]
+```
+
+## Contributor Guidance
+
+If the user wants to attempt a bounty, do not recommend implementation unless:
+
+- GitHub issue is open.
+- Repository is active and reachable.
+- Payout rules are visible.
+- No maintainer comment says stop, reserved, withdrawn, or completed.
+- Assignment rules are satisfied.
+- Existing PR count is low or the user has explicit maintainer confirmation.
+
+If these checks fail, recommend a cleanup audit or confirmation message instead of a PR.
+
+## Evidence Standard
+
+Do not claim a payout is available from a marketplace listing alone. Treat payment as unverified until primary source evidence supports it.
+
+Do not claim money was earned unless there is proof of acceptance and payment.

--- a/skills/capabilities/bounty-board-auditor/examples/sample-listings.md
+++ b/skills/capabilities/bounty-board-auditor/examples/sample-listings.md
@@ -1,0 +1,19 @@
+# Sample Listings
+
+Use this fixture to test the `bounty-board-auditor` workflow.
+
+## Listings
+
+| Board | Listing | Amount | Board Status | GitHub |
+|-------|---------|--------|--------------|--------|
+| ExampleRewards | Storybook select control bug | $110 | Open | https://github.com/storybookjs/storybook/issues/12641 |
+| ExampleRewards | Archived repo bounty | $100 | Open | https://github.com/rodrigompy/bugb/issues/1 |
+| ExampleBounties | macOS threading bounty | $250 | Open | https://github.com/jaseg/python-mpv/issues/61 |
+| ExampleBounties | Broad ComfyUI integration | $1050 | Open | https://github.com/jbilcke-hf/clapper/issues/5 |
+
+## Expected Classifications
+
+- Storybook issue: `closed-on-github`
+- Archived repo bounty: `repo-archived`
+- macOS threading bounty: `withdrawn` if comments confirm payer withdrawal
+- Broad ComfyUI integration: `needs-scope` if labels or comments show unresolved scope

--- a/skills/capabilities/bounty-board-auditor/examples/sample-report.md
+++ b/skills/capabilities/bounty-board-auditor/examples/sample-report.md
@@ -1,0 +1,120 @@
+# ExampleRewards Bounty Board Audit
+
+Date: 2026-06-02
+
+## Executive Summary
+
+The sample board has several open-looking rewards that are not cleanly actionable when checked against GitHub. The highest-risk issues are listings where the board says open but GitHub shows closed, archived, unavailable, withdrawn, reserved, or heavily crowded state.
+
+## Findings Table
+
+| Listing | Amount | Board Status | GitHub State | Classification | Priority |
+|---------|--------|--------------|--------------|----------------|----------|
+| storybookjs/storybook#12641 | $110 | Open | Closed/completed | closed-on-github | High |
+| rodrigompy/bugb#1 | $100 | Open | Repo archived, issue closed | repo-archived | High |
+| jaseg/python-mpv#61 | $250 | Open | Open issue, payout withdrawn in comments | withdrawn | High |
+| jbilcke-hf/clapper#5 | $1050 | Open | Open issue, scope not final | needs-scope | Medium |
+
+## Findings
+
+### Finding 1: Storybook #12641 Shows Open On The Board But Closed On GitHub
+
+Surface:
+
+- Board: ExampleRewards
+- GitHub: `https://github.com/storybookjs/storybook/issues/12641`
+
+Evidence:
+
+- Board status says open.
+- GitHub issue state is closed.
+- GitHub state reason is completed.
+
+Risk:
+
+Contributors may start work for a reward that is no longer actionable on the source issue.
+
+Recommended action:
+
+Synchronize board state from GitHub and hide the listing from active rewards.
+
+Suggested wording:
+
+> Closed on GitHub. Reward is not currently actionable.
+
+### Finding 2: Archived Repo Bounty Is Still Listed As Open
+
+Surface:
+
+- Board: ExampleRewards
+- GitHub: `https://github.com/rodrigompy/bugb/issues/1`
+
+Evidence:
+
+- Board status says open.
+- GitHub repository is archived.
+- GitHub issue state is closed.
+
+Risk:
+
+An archived repository is not a normal implementation target. Contributors may waste time on a reward that cannot be merged.
+
+Recommended action:
+
+Hide archived-repository rewards from active listings.
+
+Suggested wording:
+
+> Repository archived and issue closed on GitHub. Reward is not currently actionable.
+
+### Finding 3: Bounty Withdrawn In GitHub Comments
+
+Surface:
+
+- Board: ExampleBounties
+- GitHub: `https://github.com/jaseg/python-mpv/issues/61`
+
+Evidence:
+
+- Board status says open.
+- GitHub comments say the bounty is no longer active and will not be honored.
+
+Risk:
+
+This is a direct payout trust issue. The board invites work that the payer says they will not pay for.
+
+Recommended action:
+
+Mark as withdrawn or require payer reconfirmation.
+
+Suggested wording:
+
+> Bounty withdrawn by payer in GitHub comments. Do not start for payment unless the payer reconfirms.
+
+### Finding 4: High-Value Listing Needs Scope Confirmation
+
+Surface:
+
+- Board: ExampleBounties
+- GitHub: `https://github.com/jbilcke-hf/clapper/issues/5`
+
+Evidence:
+
+- Board status says open.
+- The issue is broad and requires scope refinement before implementation.
+
+Risk:
+
+The amount is attractive, but the implementation target is not crisp enough for safe contributor work.
+
+Recommended action:
+
+Add a preflight state before contributors start implementation.
+
+Suggested wording:
+
+> Spec not final. Ask maintainer for scope confirmation before implementation.
+
+## Next Action
+
+Send the board operator a concise cleanup report with exact stale listings, GitHub evidence, and recommended public wording.

--- a/skills/capabilities/bounty-board-auditor/scripts/audit_bounty_board.mjs
+++ b/skills/capabilities/bounty-board-auditor/scripts/audit_bounty_board.mjs
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import https from 'node:https';
+import process from 'node:process';
+import assert from 'node:assert/strict';
+
+function parseArgs(argv) {
+  const args = {
+    input: null,
+    output: null,
+    offline: false,
+    token: process.env.GITHUB_TOKEN || process.env.GH_TOKEN || '',
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--input') args.input = argv[++i];
+    else if (arg === '--output') args.output = argv[++i];
+    else if (arg === '--token') args.token = argv[++i];
+    else if (arg === '--offline') args.offline = true;
+    else if (arg === '--self-test') {
+      runSelfTest();
+      process.exit(0);
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!args.input) throw new Error('Missing required --input path');
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/audit_bounty_board.mjs --input examples/sample-listings.md --output audit.md
+  node scripts/audit_bounty_board.mjs --input examples/sample-listings.md --offline
+
+Options:
+  --input <path>   Markdown or CSV file containing GitHub issue URLs.
+  --output <path>  Optional report path. Defaults to stdout.
+  --token <token>  Optional GitHub token. Defaults to GITHUB_TOKEN or GH_TOKEN.
+  --offline        Do not call GitHub; emit needs-reconfirmation findings.
+  --self-test      Run deterministic classification checks.`);
+}
+
+function extractIssueRefs(text) {
+  const pattern = /https:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\/issues\/(\d+)/g;
+  const refs = [];
+  const seen = new Set();
+  let match;
+
+  while ((match = pattern.exec(text)) !== null) {
+    const [url, owner, repo, issueNumber] = match;
+    const key = `${owner}/${repo}#${issueNumber}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    refs.push({
+      owner,
+      repo,
+      issueNumber: Number(issueNumber),
+      key,
+      url,
+    });
+  }
+
+  return refs;
+}
+
+function classifyCommentSignals(commentTexts) {
+  if (commentTexts.some((body) => /\b(withdrawn|not honor|no longer active|will not pay|bounty.*closed)\b/.test(body))) {
+    return {
+      classification: 'withdrawn',
+      priority: 'High',
+      evidence: 'GitHub comments contain withdrawal or no-payment language.',
+      wording: 'Bounty withdrawn by payer in GitHub comments. Do not start for payment unless the payer reconfirms.',
+    };
+  }
+
+  if (commentTexts.some((body) => /\b(reserved|assigned to|assigned for|assigned exclusively)\b/.test(body))) {
+    return {
+      classification: 'reserved',
+      priority: 'High',
+      evidence: 'GitHub comments contain explicit reservation or assignment language.',
+      wording: 'Bounty reserved for a specific maintainer/contributor. Do not start for payout.',
+    };
+  }
+
+  const crowdSignals = commentTexts.filter((body) => (
+    /(^|\s)(\/attempt|\/boss\s+champion)\b|\b(claiming it|claimed|already working|opened pr|submitted.*pr|pull\/\d+|pr\s*#\d+)\b/.test(body)
+  ));
+
+  if (crowdSignals.length) {
+    return {
+      classification: 'crowded',
+      priority: crowdSignals.length > 1 ? 'High' : 'Medium',
+      evidence: 'GitHub comments contain claim, attempt, or PR-submission language.',
+      wording: 'High competition: multiple solution or claim signals already exist. Check maintainer comments before starting.',
+    };
+  }
+
+  return null;
+}
+
+function runSelfTest() {
+  assert.equal(classifyCommentSignals(['bounty withdrawn by payer']).classification, 'withdrawn');
+  assert.equal(classifyCommentSignals(['this bounty is reserved for alice']).classification, 'reserved');
+  assert.equal(classifyCommentSignals(['/attempt #12']).classification, 'crowded');
+  assert.equal(classifyCommentSignals(['opened pr #14 for this']).classification, 'crowded');
+  assert.equal(classifyCommentSignals(['thanks for the report']), null);
+  console.log('bounty-board-auditor classification self-test passed');
+}
+
+function githubRequest(path, token) {
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'User-Agent': 'bounty-board-auditor',
+    'X-GitHub-Api-Version': '2022-11-28',
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  return new Promise((resolve) => {
+    const req = https.request(
+      {
+        hostname: 'api.github.com',
+        path,
+        method: 'GET',
+        headers,
+      },
+      (res) => {
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
+          body += chunk;
+        });
+        res.on('end', () => {
+          let parsed = {};
+          try {
+            parsed = body ? JSON.parse(body) : {};
+          } catch {
+            parsed = { message: body };
+          }
+          resolve({ status: res.statusCode || 0, body: parsed });
+        });
+      },
+    );
+    req.on('error', (error) => resolve({ status: 0, body: { message: error.message } }));
+    req.end();
+  });
+}
+
+async function auditRef(ref, args) {
+  if (args.offline) {
+    return {
+      ...ref,
+      githubState: 'not checked',
+      classification: 'needs-reconfirmation',
+      priority: 'Medium',
+      evidence: ['Offline mode did not call GitHub.'],
+      wording: 'Payer confirmation required before new work starts.',
+    };
+  }
+
+  const repoResult = await githubRequest(`/repos/${ref.owner}/${ref.repo}`, args.token);
+  if (repoResult.status === 404) {
+    return unavailable(ref, 'Repository returned 404 from GitHub.');
+  }
+  if (repoResult.status < 200 || repoResult.status >= 300) {
+    return unavailable(ref, `GitHub repository request failed: ${repoResult.status} ${repoResult.body.message || ''}`.trim());
+  }
+  if (repoResult.body.archived) {
+    return {
+      ...ref,
+      githubState: 'repo archived',
+      classification: 'repo-archived',
+      priority: 'High',
+      evidence: ['GitHub repository is archived.'],
+      wording: 'Repository archived. Reward is hidden until the repository is active again.',
+    };
+  }
+
+  const issueResult = await githubRequest(`/repos/${ref.owner}/${ref.repo}/issues/${ref.issueNumber}`, args.token);
+  if (issueResult.status === 404) {
+    return unavailable(ref, 'Issue returned 404 from GitHub.');
+  }
+  if (issueResult.status < 200 || issueResult.status >= 300) {
+    return unavailable(ref, `GitHub issue request failed: ${issueResult.status} ${issueResult.body.message || ''}`.trim());
+  }
+
+  const issue = issueResult.body;
+  const evidence = [
+    `GitHub issue state: ${issue.state}${issue.state_reason ? ` (${issue.state_reason})` : ''}.`,
+  ];
+
+  if (issue.assignees?.length) {
+    evidence.push(`Assigned to: ${issue.assignees.map((a) => a.login).join(', ')}.`);
+  }
+
+  const labelNames = (issue.labels || []).map((label) => String(label.name || '').toLowerCase());
+  if (labelNames.length) evidence.push(`Labels: ${labelNames.join(', ')}.`);
+
+  if (issue.state === 'closed') {
+    return {
+      ...ref,
+      githubState: `closed${issue.state_reason ? `/${issue.state_reason}` : ''}`,
+      classification: 'closed-on-github',
+      priority: 'High',
+      evidence,
+      wording: 'Closed on GitHub. Reward is not currently actionable.',
+    };
+  }
+
+  const scopeLabels = ['to refine', 'needs spec', 'blocked', 'needs design', 'needs triage'];
+  if (labelNames.some((name) => scopeLabels.some((needle) => name.includes(needle)))) {
+    return {
+      ...ref,
+      githubState: 'open',
+      classification: 'needs-scope',
+      priority: 'Medium',
+      evidence,
+      wording: 'Spec not final. Ask maintainer for scope confirmation before implementation.',
+    };
+  }
+
+  const commentsResult = await githubRequest(
+    `/repos/${ref.owner}/${ref.repo}/issues/${ref.issueNumber}/comments?per_page=100`,
+    args.token,
+  );
+  if (commentsResult.status >= 200 && commentsResult.status < 300 && Array.isArray(commentsResult.body)) {
+    const commentTexts = commentsResult.body.map((comment) => String(comment.body || '').toLowerCase());
+    const commentSignal = classifyCommentSignals(commentTexts);
+    if (commentSignal) {
+      return {
+        ...ref,
+        githubState: 'open',
+        classification: commentSignal.classification,
+        priority: commentSignal.priority,
+        evidence: [...evidence, commentSignal.evidence],
+        wording: commentSignal.wording,
+      };
+    }
+  }
+
+  return {
+    ...ref,
+    githubState: 'open',
+    classification: 'active',
+    priority: 'Low',
+    evidence,
+    wording: 'Issue appears open. Confirm payout rules before starting implementation.',
+  };
+}
+
+function unavailable(ref, reason) {
+  return {
+    ...ref,
+    githubState: 'unavailable',
+    classification: 'repo-unavailable',
+    priority: 'High',
+    evidence: [reason],
+    wording: 'GitHub repository is unavailable. Reward is hidden until the issue URL resolves.',
+  };
+}
+
+function renderReport(findings) {
+  const date = new Date().toISOString().slice(0, 10);
+  const highRisk = findings.filter((finding) => finding.priority === 'High').length;
+  const reconfirm = findings.filter((finding) => finding.classification === 'needs-reconfirmation').length;
+
+  const lines = [
+    '# Bounty Board Audit',
+    '',
+    `Date: ${date}`,
+    '',
+    '## Executive Summary',
+    '',
+    `Audited ${findings.length} GitHub issue listing${findings.length === 1 ? '' : 's'}. ${highRisk} high-priority listing${highRisk === 1 ? '' : 's'} should be hidden, corrected, or reconfirmed before contributors start work.`,
+  ];
+
+  if (reconfirm) {
+    lines.push(`${reconfirm} listing${reconfirm === 1 ? '' : 's'} used offline mode and need primary-source confirmation.`);
+  }
+
+  lines.push(
+    '',
+    '## Findings Table',
+    '',
+    '| Listing | GitHub State | Classification | Priority |',
+    '|---------|--------------|----------------|----------|',
+  );
+
+  for (const finding of findings) {
+    lines.push(`| [${finding.key}](${finding.url}) | ${finding.githubState} | ${finding.classification} | ${finding.priority} |`);
+  }
+
+  lines.push('', '## Findings', '');
+  findings.forEach((finding, index) => {
+    lines.push(
+      `### Finding ${index + 1}: ${finding.key} Is ${finding.classification}`,
+      '',
+      'Surface:',
+      '',
+      `- GitHub: \`${finding.url}\``,
+      '',
+      'Evidence:',
+      '',
+      ...finding.evidence.map((item) => `- ${item}`),
+      '',
+      'Recommended action:',
+      '',
+      finding.wording,
+      '',
+    );
+  });
+
+  lines.push('## Next Action', '', 'Send the board operator exact stale listings, GitHub evidence, and recommended public wording.');
+  return `${lines.join('\n')}\n`;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const input = await fs.readFile(args.input, 'utf8');
+  const refs = extractIssueRefs(input);
+
+  if (!refs.length) {
+    throw new Error('No GitHub issue URLs found in input.');
+  }
+
+  const findings = [];
+  for (const ref of refs) {
+    findings.push(await auditRef(ref, args));
+  }
+
+  const report = renderReport(findings);
+  if (args.output) {
+    await fs.writeFile(args.output, report, 'utf8');
+  } else {
+    process.stdout.write(report);
+  }
+}
+
+main().catch((error) => {
+  console.error(`bounty-board-auditor: ${error.message}`);
+  process.exit(1);
+});

--- a/skills/capabilities/bounty-board-auditor/scripts/test_audit_bounty_board.mjs
+++ b/skills/capabilities/bounty-board-auditor/scripts/test_audit_bounty_board.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const skillDir = path.resolve(scriptDir, '..');
+const scriptPath = path.join(scriptDir, 'audit_bounty_board.mjs');
+const samplePath = path.join(skillDir, 'examples', 'sample-listings.md');
+
+const output = execFileSync(
+  process.execPath,
+  [scriptPath, '--input', samplePath, '--offline'],
+  { encoding: 'utf8' },
+);
+const selfTestOutput = execFileSync(
+  process.execPath,
+  [scriptPath, '--input', samplePath, '--self-test'],
+  { encoding: 'utf8' },
+);
+
+assert.match(output, /^# Bounty Board Audit/m);
+assert.match(output, /Audited 4 GitHub issue listings\./);
+assert.match(output, /storybookjs\/storybook#12641/);
+assert.match(output, /rodrigompy\/bugb#1/);
+assert.match(output, /jaseg\/python-mpv#61/);
+assert.match(output, /jbilcke-hf\/clapper#5/);
+assert.equal((output.match(/needs-reconfirmation/g) || []).length, 8);
+assert.doesNotMatch(output, /closed-on-github|repo-archived|withdrawn|active/);
+assert.match(selfTestOutput, /classification self-test passed/);
+
+console.log('bounty-board-auditor offline smoke test passed');

--- a/skills/capabilities/bounty-board-auditor/skill.meta.json
+++ b/skills/capabilities/bounty-board-auditor/skill.meta.json
@@ -1,0 +1,18 @@
+{
+  "slug": "bounty-board-auditor",
+  "category": "capabilities",
+  "tags": [
+    "research",
+    "competitive-intel",
+    "lead-generation",
+    "monitoring"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install bounty-board-auditor",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  }
+}


### PR DESCRIPTION
# Add bounty-board-auditor capability

## Summary

Adds `bounty-board-auditor`, a capability skill for auditing public bounty/reward boards against GitHub source-of-truth issue and repository state.

The skill guides an agent through:

- normalizing public bounty listings;
- validating GitHub issue/repo state;
- detecting closed, archived, unavailable, withdrawn, reserved, crowded, and underspecified listings;
- producing a maintainer/platform-facing cleanup report with exact status wording;
- deciding whether a contributor should attempt a bounty or ask for confirmation first;
- running a dependency-free script against Markdown/CSV issue lists for a deterministic audit report.

## Why This Fits

Gooseworks skills focus on practical GTM, research, competitive intelligence, and lead-generation workflows. This skill supports marketplace operators, OSS maintainers, and contributors by turning messy public bounty surfaces into an evidence-backed trust/audit report.

It is especially useful for AI-assisted agents because bounty boards often contain stale or crowded listings where a naive agent would submit duplicate work.

## Files

- `skills/capabilities/bounty-board-auditor/SKILL.md`
- `skills/capabilities/bounty-board-auditor/README.md`
- `skills/capabilities/bounty-board-auditor/skill.meta.json`
- `skills/capabilities/bounty-board-auditor/scripts/audit_bounty_board.mjs`
- `skills/capabilities/bounty-board-auditor/scripts/test_audit_bounty_board.mjs`
- `skills/capabilities/bounty-board-auditor/examples/sample-listings.md`
- `skills/capabilities/bounty-board-auditor/examples/sample-report.md`

## Validation

Target-repo validation passed locally after applying this in a real clone:

- `npm run build:index`
- `npm run validate:skills`
- `npm test`
- `npm run ci`
- `git diff --check`
- `node skills/capabilities/bounty-board-auditor/scripts/test_audit_bounty_board.mjs`

Submission-specific checks:

- Frontmatter included in `SKILL.md`.
- Metadata follows existing capability skill shape.
- Example input and output included.
- Offline script smoke test supported.
- Self-test included for the offline script path.
- No external credentials or API keys required for offline validation.

Local Windows integration note:

- A narrow path-normalization fix in `scripts/build-index.js` and `scripts/validate-skills.js` made `npm run validate:skills`, `npm test`, and `npm run ci` pass locally after adding this skill.

## Reviewer Checklist

- Confirm the skill belongs under `skills/capabilities/bounty-board-auditor/`.
- Confirm the generated `skills-index.json` entry is present.
- Confirm the script path is dependency-free and offline-testable.
- Confirm the report examples show evidence-backed status recommendations rather than encouraging noisy bounty claims.
- Confirm the path-normalization changes are acceptable for Windows-safe index generation and validation.

## Privacy Boundary

This PR should only contain public skill and repo-tooling files. User-specific application or account details should stay outside the public PR.
