### PR TITLE
Add Greptile code-review context (.greptile config tree)

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,8 @@
+{
+  "strictness": 2,
+  "instructions": "PUBLIC open-source library of growth skills — mostly markdown SKILL.md files plus JSON metadata, validated by scripts/validate-skills.js against schemas/*.schema.json. Because the repo is public, the top priority is zero leakage: no secrets, internal hostnames/URLs, customer or employee data, or absolute filesystem paths anywhere. Skill bodies are agent-facing prose, not build code.",
+  "rules": [
+    {"id":"public-no-leakage","severity":"high","scope":["**/*"],"rule":"This repo is PUBLIC. Flag any API key, token, credential, internal hostname/URL, customer data, or employee/local absolute filesystem path. Nothing secret or internal-only may be committed."},
+    {"id":"tooling-hygiene","severity":"medium","scope":["bin/**","scripts/**","tools/**"],"rule":"JS/Python tooling must validate inputs and contain no secrets. Scrapers/connectors (for example tools/apify_guard.py) must guard external input."}
+  ]
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,7 @@
+{
+  "files": [
+    {"path":"CONTRIBUTING.md","description":"SKILL.md authoring rules, including WAF-safe prose constraints.","scope":["skills/**"]},
+    {"path":"schemas/skill-meta.schema.json","description":"Required schema for skill metadata.","scope":["skills/**"]},
+    {"path":"schemas/pack-meta.schema.json","description":"Required schema for skill-pack metadata.","scope":["skills/**","packs/**"]}
+  ]
+}

--- a/skills/.greptile/rules.md
+++ b/skills/.greptile/rules.md
@@ -1,0 +1,19 @@
+# Skill authoring review rules (skills/)
+
+These enforce the conventions in `CONTRIBUTING.md` and the metadata schemas.
+
+## WAF-safe SKILL.md prose (high severity)
+The body of every `SKILL.md` is fetched at runtime and replayed verbatim into the next LLM API call, passing through an upstream WAF that blocks common RCE/RFI patterns. To avoid 403s, the prose body must NOT contain:
+- shell-variable forms (dollar-prefixed names, brace-expansion),
+- literal absolute filesystem paths,
+- backtick-wrapped shell-ish tokens,
+- dependency-folder names commonly used in exploits,
+- install-command keywords,
+- code-host URLs.
+
+Concrete paths and commands belong in the install template, tool wrappers, or scripts — not the SKILL.md body. Refer to locations descriptively instead.
+
+## Metadata + description
+- `skill-meta` / `pack-meta` must conform to `schemas/*.schema.json` so `scripts/validate-skills.js` passes.
+- The `description` field must lead with what the skill does and when to use it — it is the agent's matching signal.
+- Prefer plain prose over code blocks in the body; keep tool plumbing in scripts, not the prose.


### PR DESCRIPTION
## What

Adds a version-controlled `.greptile/` config tree so the Greptile code-review agent reviews this **public** repo with a leakage-first lens.

## Config (cascading `.greptile/` folders)

| Path | Purpose |
|---|---|
| `.greptile/` | Public-repo guardrails: **no secrets / internal URLs / customer data / absolute paths** anywhere; `bin`/`scripts`/`tools` hygiene. `files.json` → `CONTRIBUTING.md` + metadata schemas |
| `skills/.greptile/` | WAF-safe `SKILL.md` prose constraints (the body is replayed through a WAF — no shell-var forms, absolute paths, backtick tokens, install commands, or code-host URLs → avoids 403s) + metadata-schema conformance + `description`-as-matching-signal |

## Activation

Greptile reads config from the repo, so this takes effect once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)