### PR TITLE
Add airdrop-notification-carousel-video skill

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-06-30",
+  "generated": "2026-07-06",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -208,6 +208,40 @@
             "codex"
           ]
         }
+      }
+    },
+    {
+      "slug": "airdrop-notification-carousel-video",
+      "name": "airdrop-notification-carousel-video",
+      "category": "composites",
+      "domain": "ads",
+      "description": ">-",
+      "tags": "ads, content, social, design",
+      "path": "skills/ads/composites/airdrop-notification-carousel-video",
+      "files": [],
+      "metadata": {
+        "slug": "airdrop-notification-carousel-video",
+        "category": "composites",
+        "tags": [
+          "ads",
+          "content",
+          "social",
+          "design"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install airdrop-notification-carousel-video",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "domain": "ads",
+        "requires_tools": [
+          "ffmpeg",
+          "python3 (numpy, Pillow)",
+          "headless Chrome (Playwright)"
+        ]
       }
     },
     {

--- a/skills/ads/composites/airdrop-notification-carousel-video/SKILL.md
+++ b/skills/ads/composites/airdrop-notification-carousel-video/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: airdrop-notification-carousel-video
+description: >-
+  Produce a single vertical "AirDrop" share-sheet notification ad (about 6-8s,
+  9:16) from a brand's real product photos — the viral iOS AirDrop trend ("Brand
+  would like to share a ___ - Decline / Accept"), remixed for any brand. The
+  native AirDrop card springs up and its preview window cycles through a carousel
+  of real product images, landing on a range/lineup payoff with an Accept tap; a
+  notification chime plus soft ticks track the swaps. The engine is deterministic
+  — an HTML card (real DOM text) rendered to PNG, chroma-keyed, its preview window
+  filled per-product in Pillow, then animated and audio-synthed with FFmpeg. No
+  generative video, so the UI text and wordmark stay pixel-crisp and every product
+  on screen is a real brand photo. Use when someone references the "AirDrop
+  notification" / "would like to share" trend, wants a scroll-stopping product-
+  carousel spot, or has a brand with product photography. Not for talking-head UGC
+  video, and not for a static single-image ad (drop the carousel and export one
+  frame). Needs python3 (numpy, Pillow), ffmpeg, and a headless Chrome (Playwright).
+tags: [ads, content, social, design]
+---
+
+# airdrop-notification-carousel-video
+
+## What it does
+
+Recreates the viral **iOS "AirDrop" notification ad** — a native share-sheet card
+("**Brand** would like to share a *doughnut* · Decline / Accept") with a product
+photo in the preview — as a **product carousel** for any brand: the preview window
+flips through many real product images and lands on a range/lineup payoff.
+
+The reusable core is a **deterministic composite engine**: a real-DOM AirDrop card
+is rendered once, chroma-keyed, and its preview window refilled per product, then
+animated. This is deliberately **not** generative video — the whole point of the
+format is crisp system-UI text and **real** product photography, both of which a
+video model would smear. Nothing here calls a paid model; it runs entirely on
+Playwright + Pillow + FFmpeg.
+
+Default output is about **6-8s** (`first_hold + N·per + final_hold`), 1080×1920,
+h264 + aac.
+
+## Inputs
+
+Required:
+- **Brand line** — sender name (bold, e.g. `acme.`) + message (`would like to share
+  a candle`). Mirror the trend's noun-product joke.
+- **Product images** — 6-16 ordered **real** product photos (the carousel). Clean
+  on-white PDP hero shots work best; a lifestyle shot or two adds variety.
+- **Final / payoff image** — the shot held at the end (a lineup / family / "whole
+  range" image reads as "the entire collection").
+
+Optional:
+- **Wordmark** — a brand logo SVG (inlined into the band) or a text fallback.
+- **Tagline** — the band line under the wordmark (e.g. a real proof point like
+  `100k+ sold` — use only true claims the brand actually makes).
+- **Accent** — the Accept-button / brand color (default rose `#d98695`); **band
+  color** (default cream `#f5e9da`).
+- **Timing** — `per` (seconds per image, default 0.34), `first_hold` (1.0),
+  `final_hold` (2.1), `slide` (0.72). Lower `per` = more frenetic.
+
+## Engine (scripts/)
+
+| Script | Does |
+|---|---|
+| `build_card.py` | Brand params → `chrome.html` + `chrome-pressed.html`: the AirDrop card on a **green page** (`#00e000`) with a **magenta preview window** (`#ff00ff`) and a solid brand band. Text is real DOM — never AI-rendered. |
+| `one_shot.py` | Glue: `build_card` → headless-Chrome screenshot of both card states (Playwright) → `compose_carousel`. One JSON config, one MP4. |
+| `compose_carousel.py` | The render engine: green-key the card → detect the magenta window → fill it with each product (cover-crop) → blurred per-product backdrop with a slow push-in → card spring-up + carousel + Accept tap → synth audio (whoosh / chime / ticks / pop) → encode h264 + aac. |
+
+**Chroma contract (load-bearing):** `#00e000` green = page background (keyed to the
+card's alpha), `#ff00ff` magenta = preview window (replaced per product). Neither
+color may appear in the card art or the product photos.
+
+Install deps: `pip install numpy Pillow playwright && playwright install chromium`,
+and have `ffmpeg` on `PATH`.
+
+## Workflow
+
+### 1 — Gather real assets
+Collect the brand line, a wordmark (SVG or text), the accent color, 8-14 ordered
+product photos, and a payoff image. Pull product photos from the brand's site or
+your own library — **use real photos**, never AI-generated products, and never
+invent proof claims (a `100k+ sold` band must be the brand's own figure). If your
+product files are git-LFS pointers, materialize them before rendering.
+
+### 2 — Build the card
+```
+python3 scripts/build_card.py --brand "acme." --message "would like to share a candle" \
+  --tagline "The best-selling scent - 100k+ sold" \
+  --wordmark-svg logo.svg --accent "#d98695" --out-dir work/
+```
+
+### 3 — Screenshot both card states
+Render `work/chrome.html` and `work/chrome-pressed.html` to PNG with a headless
+Chrome (fullPage) → `chrome-green.png` / `chrome-green-pressed.png`. `one_shot.py`
+does this with Playwright; any headless Chrome (Puppeteer, etc.) works. A dpr-2
+screenshot (2160×3840) is fine — the engine rescales.
+
+### 4 — Compose
+```
+python3 scripts/compose_carousel.py \
+  --chrome work/chrome-green.png --chrome-pressed work/chrome-green-pressed.png \
+  --images "p1.png,p2.png,p3.png,..." --final-image lineup.jpg --out ad.mp4
+```
+Or do steps 2-4 in one call from a JSON config:
+```
+python3 scripts/one_shot.py --config config.json --out ad.mp4
+```
+
+### 5 — Watch / QC
+Extract a frame strip across the timeline; confirm every product **fully fills**
+the window (no magenta), the card text + wordmark are crisp, the carousel reads, it
+lands on the payoff + Accept tap, and audio ticks track the swaps. Fix, re-compose,
+re-watch.
+
+## Config schema (one_shot.py)
+
+```json
+{
+  "brand": "acme.",
+  "message": "would like to share a candle",
+  "tagline": "The best-selling scent - 100k+ sold",
+  "wordmark_svg": "logo.svg",
+  "accent": "#d98695",
+  "band_color": "#f5e9da",
+  "images": ["p1.png", "p2.png", "p3.png"],
+  "final_image": "lineup.jpg",
+  "timing": {"per": 0.34, "first_hold": 1.0, "final_hold": 2.1, "slide": 0.72}
+}
+```
+
+## Decision rules
+
+- **Real product photos only.** The format's credibility is that these look like
+  real AirDropped items. No AI-generated products in the carousel.
+- **Never AI-render text.** Card UI, wordmark, and band are DOM / SVG composited, so
+  `AirDrop`, `Decline`, `Accept`, and the brand line stay sharp. Image models
+  misspell even short known strings — keep all text in the DOM layer.
+- **Cover-crop the window.** A white-bg PDP shot reading as "product floating in a
+  white tile" is on-brand and fine; warm/lifestyle shots fill edge-to-edge.
+- **End on the range.** The payoff image should say "the whole line" (lineup /
+  family / all-variants) — the carousel builds to it.
+- **Hard cuts, on rhythm.** Trend aesthetic = snappy swaps + a tick per swap. Don't
+  crossfade.
+- **Duration is derived**, not trimmed: `first_hold + (N-1)·per + final_hold`. Add
+  images or raise `per` to lengthen; don't cut the audio short.
+
+## Output
+
+- `<name>.mp4` — 1080×1920, about 6-8s, h264 + aac (chime + per-swap ticks + Accept
+  pop).
+- A poster still (extract a payoff frame).
+
+## Quality checks
+
+- No green/magenta leaks anywhere in-frame.
+- Card title, brand line, wordmark, and buttons are crisp at 1080p.
+- 6 or more distinct real product images cycle; each fully fills the window.
+- Lands on the payoff image + a visible Accept tap-highlight.
+- Audio: chime on card-land, a tick on each swap, a pop on the tap.
+
+## Failure modes
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Tiny broken images in the window | Product files were git-LFS pointers | Materialize the real files before rendering. |
+| Green halo around the card, or magenta showing in the window | A product photo contains near-pure green/magenta, or the key thresholds are off | Swap the image, or tighten `window_mask` / `key_green` thresholds in `compose_carousel.py`. |
+| Screenshot step fails | No headless Chrome | `pip install playwright && playwright install chromium`, or screenshot with another headless Chrome and call `compose_carousel.py` directly. |
+| Baked-in text on a product shot shows in the window (e.g. `SHADE 02`) | The source photo has burned-in labels | Usually fine (reads as real PDP art); reorder or cover-crop tighter if it clashes. |

--- a/skills/ads/composites/airdrop-notification-carousel-video/requirements.txt
+++ b/skills/ads/composites/airdrop-notification-carousel-video/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+Pillow
+playwright

--- a/skills/ads/composites/airdrop-notification-carousel-video/scripts/build_card.py
+++ b/skills/ads/composites/airdrop-notification-carousel-video/scripts/build_card.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""build_card.py — generate the keyable iOS "AirDrop" share-sheet card HTML.
+
+Writes two HTML files (normal + Accept-pressed) sized to the target frame. Each
+renders a native-looking AirDrop card on a GREEN page (#00e000, keyed out in
+compose_carousel.py) with a MAGENTA preview window (#ff00ff, replaced per-product
+in compose_carousel.py) and a SOLID brand band (wordmark + tagline). Text is real
+DOM text, never AI-rendered, so it stays pixel-crisp.
+
+Render these two HTML files to PNG (fullPage) with any headless Chrome — Playwright
+(see one_shot.py) or another headless Chrome — then feed the PNGs to
+compose_carousel.py.
+
+The two chroma colors are load-bearing and must not appear in the card art:
+  GREEN  #00e000 = page background  -> keyed to transparency (the card's alpha)
+  MAGENTA #ff00ff = preview window  -> replaced by each product image
+"""
+import argparse, html, os
+
+GREEN = "#00e000"
+MAGENTA = "#ff00ff"
+
+
+def build(brand, message, tagline, wordmark_svg, wordmark_text, accent,
+          band_color, card_width, pressed):
+    accept_bg = "background:rgba(0,0,0,.06);" if pressed else ""
+    if wordmark_svg and os.path.exists(wordmark_svg):
+        wm = open(wordmark_svg).read()
+    else:
+        wm = f'<div style="font-size:56px;font-weight:800;letter-spacing:-1px;color:#1a1a1a">{html.escape(wordmark_text)}</div>'
+    tag = html.escape(tagline).replace("(R)", "&reg;").replace(" - ", " &middot; ")
+    return f"""<!doctype html><html><head><meta charset="utf-8"><style>
+*{{margin:0;padding:0;box-sizing:border-box;-webkit-font-smoothing:antialiased;}}
+html,body{{background:{GREEN};}}
+.frame{{position:relative;width:1080px;height:1920px;overflow:hidden;background:{GREEN};
+  font-family:-apple-system,"SF Pro Display","SF Pro Text","Helvetica Neue",Arial,sans-serif;}}
+.card{{position:absolute;left:50%;top:50%;transform:translate(-50%,-50%);
+  width:{card_width}px;background:#fafafa;border-radius:42px;overflow:hidden;box-shadow:none;}}
+.pad{{padding:42px 46px 10px;}}
+.title{{text-align:center;font-size:45px;font-weight:700;letter-spacing:.3px;color:#111;}}
+.sub{{text-align:center;font-size:30px;font-weight:400;color:#3a3a3c;margin-top:13px;line-height:1.35;}}
+.sub b{{font-weight:800;color:#111;letter-spacing:-.5px;}}
+.preview{{margin:30px 46px 36px;border-radius:28px;overflow:hidden;position:relative;
+  aspect-ratio:928/1010;background:{MAGENTA};}}
+.band{{position:absolute;left:0;right:0;bottom:0;padding:22px 30px 26px;
+  background:{band_color};border-top:1px solid rgba(0,0,0,.06);}}
+.wm{{display:flex;justify-content:center;align-items:center;}}
+.wm svg{{height:50px;width:auto;}}
+.tagline{{color:#1a1a1a;font-size:18px;font-weight:600;letter-spacing:2.2px;text-align:center;
+  margin-top:10px;text-transform:uppercase;opacity:.82;}}
+.btns{{display:flex;border-top:1px solid rgba(0,0,0,.12);}}
+.btn{{flex:1;text-align:center;padding:36px 0;font-size:35px;font-weight:500;}}
+.decline{{color:#8a8a8e;}}
+.accept{{color:{accent};font-weight:800;border-left:1px solid rgba(0,0,0,.12);{accept_bg}}}
+</style></head><body>
+<div class="frame"><div class="card">
+  <div class="pad"><div class="title">AirDrop</div>
+    <div class="sub"><b>{html.escape(brand)}</b> {html.escape(message)}</div></div>
+  <div class="preview"><div class="band"><div class="wm">{wm}</div>
+    <div class="tagline">{tag}</div></div></div>
+  <div class="btns"><div class="btn decline">Decline</div><div class="btn accept">Accept</div></div>
+</div></div></body></html>"""
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Generate keyable AirDrop card HTML (normal + pressed).")
+    ap.add_argument("--brand", required=True, help='sender name, bold in the line, e.g. "dibs."')
+    ap.add_argument("--message", required=True, help='rest of the line, e.g. "would like to share a blush"')
+    ap.add_argument("--tagline", default="", help='band tagline, e.g. "The viral Desert Island Duo - 1M+ sold"')
+    ap.add_argument("--wordmark-svg", default="", help="path to brand wordmark SVG (inlined); falls back to --wordmark-text")
+    ap.add_argument("--wordmark-text", default="", help="text wordmark when no SVG (defaults to --brand)")
+    ap.add_argument("--accent", default="#d98695", help="Accept-button color (brand accent)")
+    ap.add_argument("--band-color", default="#f5e9da", help="brand band background color")
+    ap.add_argument("--card-width", type=int, default=672)
+    ap.add_argument("--out-dir", required=True)
+    a = ap.parse_args()
+    os.makedirs(a.out_dir, exist_ok=True)
+    wt = a.wordmark_text or a.brand
+    for pressed, name in ((False, "chrome.html"), (True, "chrome-pressed.html")):
+        htmlstr = build(a.brand, a.message, a.tagline, a.wordmark_svg, wt, a.accent,
+                        a.band_color, a.card_width, pressed)
+        open(os.path.join(a.out_dir, name), "w").write(htmlstr)
+    print(f"wrote {a.out_dir}/chrome.html + chrome-pressed.html")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/ads/composites/airdrop-notification-carousel-video/scripts/compose_carousel.py
+++ b/skills/ads/composites/airdrop-notification-carousel-video/scripts/compose_carousel.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""compose_carousel.py — the AirDrop product-carousel render engine.
+
+Takes the two rendered card PNGs (green page + magenta preview window, from
+build_card.py + a headless-Chrome screenshot) and a list of product images, and
+produces the finished vertical video:
+
+  * green-key the card  -> the card's alpha (drop shadow synthesized in PIL)
+  * detect the magenta window -> fill it with each product (cover), in sequence
+  * blurred, darkened per-product backdrop with a slow push-in
+  * card springs up (iOS ease-out-back), holds; preview cycles the products;
+    lands on --final-image with an Accept tap-highlight
+  * synth audio: whoosh on entry, chime on land, soft tick per swap, tap pop
+  * encode h264 + aac via ffmpeg
+
+Deterministic — no generative video, so the UI text stays crisp. Requires
+numpy, Pillow, and ffmpeg on PATH.
+
+Example:
+  python3 compose_carousel.py \
+    --chrome chrome-green.png --chrome-pressed chrome-green-pressed.png \
+    --images "a.png,b.png,c.png" --final-image lineup.jpg \
+    --out out.mp4
+"""
+import argparse, os, shutil, subprocess, sys, wave
+import numpy as np
+from PIL import Image, ImageFilter, ImageEnhance
+
+
+def key_green(path, W, H):
+    """Green screen (#00e000) -> alpha. Returns HxWx4 uint8; magenta window stays opaque."""
+    im = np.asarray(Image.open(path).convert("RGB").resize((W, H), Image.LANCZOS)).astype(np.int16)
+    r, g, b = im[..., 0], im[..., 1], im[..., 2]
+    greenness = g - np.maximum(r, b)
+    alpha = np.clip((120 - greenness) / 60.0, 0, 1)
+    alpha = (alpha * 255).astype(np.uint8)
+    rgb = im.copy()                       # green despill on partially-keyed edge pixels
+    spill = (greenness > 0) & (alpha < 255)
+    rgb[..., 1] = np.where(spill, np.minimum(g, np.maximum(r, b)), g)
+    return np.dstack([rgb.astype(np.uint8), alpha])
+
+
+def window_mask(chrome):
+    """Magenta (#ff00ff) preview-window mask + its bounding box."""
+    r, g, b, a = (chrome[..., i].astype(int) for i in range(4))
+    mag = (r > 165) & (g < 115) & (b > 165) & (a > 128)
+    ys, xs = np.where(mag)
+    if len(xs) == 0:
+        sys.exit("ERROR: no magenta preview window found in the card PNG.")
+    return mag, (xs.min(), ys.min(), xs.max(), ys.max())
+
+
+def fill_card(chrome, mask, bbox, prod_path):
+    """Copy of the card with the magenta window filled by the product (cover-crop)."""
+    x0, y0, x1, y1 = bbox
+    ww, wh = x1 - x0 + 1, y1 - y0 + 1
+    card = chrome.copy()
+    p = Image.open(prod_path).convert("RGB")
+    sc = max(ww / p.width, wh / p.height)
+    p2 = p.resize((int(p.width * sc) + 1, int(p.height * sc) + 1), Image.LANCZOS)
+    cx, cy = (p2.width - ww) // 2, (p2.height - wh) // 2
+    crop = np.asarray(p2.crop((cx, cy, cx + ww, cy + wh)))
+    region = card[y0:y1 + 1, x0:x1 + 1, :3]
+    m = mask[y0:y1 + 1, x0:x1 + 1]
+    region[m] = crop[m]
+    card[y0:y1 + 1, x0:x1 + 1, :3] = region
+    return card
+
+
+def make_bg(path, BW, BH):
+    im = Image.open(path).convert("RGB")
+    sc = max(BW / im.width, BH / im.height)
+    im2 = im.resize((int(im.width * sc) + 1, int(im.height * sc) + 1), Image.LANCZOS)
+    l, t = (im2.width - BW) // 2, (im2.height - BH) // 2
+    bg = im2.crop((l, t, l + BW, t + BH)).filter(ImageFilter.GaussianBlur(26))
+    bg = ImageEnhance.Brightness(bg).enhance(0.5)
+    return ImageEnhance.Color(bg).enhance(1.08)
+
+
+def ease_out_back(x):
+    c1 = 1.70158; c3 = c1 + 1
+    return 1 + c3 * ((x - 1) ** 3) + c1 * ((x - 1) ** 2)
+
+
+def synth_audio(path, dur, swaps, tap_t, sr=44100):
+    n = int(dur * sr); buf = np.zeros(n)
+    def tone(freq, t0, d, amp, decay):
+        i0 = int(t0 * sr); L = int(d * sr); tt = np.arange(L) / sr
+        seg = amp * np.sin(2 * np.pi * freq * tt) * np.exp(-tt / decay)
+        e = min(i0 + L, n); buf[i0:e] += seg[:e - i0]
+    def whoosh(t0, d, amp):
+        i0 = int(t0 * sr); L = int(d * sr); tt = np.arange(L) / sr
+        env = np.sin(np.pi * np.clip(tt / d, 0, 1)) ** 2
+        seg = amp * np.random.RandomState(1).randn(L) * env
+        seg = np.convolve(seg, np.ones(80) / 80, mode="same")
+        e = min(i0 + L, n); buf[i0:e] += seg[:e - i0]
+    whoosh(0.05, 0.55, 0.10)
+    tone(1319, 0.70, 0.7, 0.34, 0.34); tone(1976, 0.70, 0.6, 0.16, 0.28); tone(2637, 0.70, 0.4, 0.07, 0.2)
+    for st in swaps:
+        tone(2650, st, 0.05, 0.14, 0.02); tone(3500, st, 0.035, 0.06, 0.015)
+    if tap_t is not None:
+        tone(2400, tap_t, 0.05, 0.16, 0.02); tone(760, tap_t + 0.02, 0.16, 0.12, 0.09); tone(1140, tap_t + 0.02, 0.16, 0.07, 0.09)
+    buf = buf / (np.max(np.abs(buf)) or 1.0) * 0.85
+    st = np.clip(np.stack([buf, buf], 1), -1, 1)
+    with wave.open(path, "wb") as w:
+        w.setnchannels(2); w.setsampwidth(2); w.setframerate(sr)
+        w.writeframes((st * 32767).astype("<i2").tobytes())
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--chrome", required=True)
+    ap.add_argument("--chrome-pressed", default="")
+    ap.add_argument("--images", default="", help="comma-separated ordered product image paths")
+    ap.add_argument("--images-dir", default="", help="dir of product images (sorted) if --images omitted")
+    ap.add_argument("--final-image", required=True, help="the payoff image held at the end")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--per", type=float, default=0.34, help="seconds per carousel image")
+    ap.add_argument("--first-hold", type=float, default=1.00, help="first image hold (covers slide-in)")
+    ap.add_argument("--final-hold", type=float, default=2.10)
+    ap.add_argument("--slide", type=float, default=0.72)
+    ap.add_argument("--fps", type=int, default=30)
+    ap.add_argument("--width", type=int, default=1080)
+    ap.add_argument("--height", type=int, default=1920)
+    ap.add_argument("--no-audio", action="store_true")
+    a = ap.parse_args()
+    W, H, FPS = a.width, a.height, a.fps
+
+    imgs = [s for s in a.images.split(",") if s] if a.images else \
+        sorted(os.path.join(a.images_dir, f) for f in os.listdir(a.images_dir)
+               if f.lower().endswith((".png", ".jpg", ".jpeg", ".webp")))
+    if not imgs:
+        sys.exit("ERROR: no product images (pass --images or --images-dir).")
+    seq = [(imgs[0], a.first_hold)] + [(p, a.per) for p in imgs[1:]] + [(a.final_image, a.final_hold)]
+
+    dur = sum(s for _, s in seq); N = int(round(dur * FPS))
+    bounds, acc = [], 0.0
+    for _, s in seq:
+        bounds.append((acc, acc + s)); acc += s
+    swaps = [b[0] for b in bounds[1:]]
+
+    chrome = key_green(a.chrome, W, H)
+    chrome_p = key_green(a.chrome_pressed, W, H) if a.chrome_pressed else chrome
+    mask, bbox = window_mask(chrome)
+    variants = [fill_card(chrome, mask, bbox, p) for p, _ in seq]
+    if a.chrome_pressed:
+        mask_p, bbox_p = window_mask(chrome_p)
+        final_pressed = fill_card(chrome_p, mask_p, bbox_p, a.final_image)
+    else:
+        final_pressed = variants[-1]
+    BW, BH = int(W * 1.1), int(H * 1.1)
+    bgs = [make_bg(p, BW, BH) for p, _ in seq]
+
+    al = chrome[..., 3]
+    sh = np.zeros((H, W, 4), np.uint8); sh[..., 3] = (al * 0.5).astype(np.uint8)
+    shadow = Image.fromarray(sh, "RGBA").filter(ImageFilter.GaussianBlur(38))
+
+    frames = os.path.join(os.path.dirname(a.out) or ".", ".carousel_frames")
+    if os.path.exists(frames):
+        shutil.rmtree(frames)
+    os.makedirs(frames)
+
+    tap_a, tap_b = dur - 0.92, dur - 0.60
+    def img_at(t):
+        for i, (lo, hi) in enumerate(bounds):
+            if lo <= t < hi:
+                return i
+        return len(seq) - 1
+    for f in range(N):
+        t = f / FPS; idx = img_at(t)
+        k = 1.0 + 0.05 * (t / dur); zw, zh = int(BW * k), int(BH * k)
+        fr = bgs[idx].resize((zw, zh), Image.LANCZOS)
+        cxx, cyy = (zw - W) // 2, (zh - H) // 2
+        fr = fr.crop((cxx, cyy, cxx + W, cyy + H)).convert("RGBA")
+        p = ease_out_back(t / a.slide) if t < a.slide else 1.0
+        yoff = int(round((1.0 - p) * H))
+        tap = a.chrome_pressed and idx == len(seq) - 1 and tap_a <= t <= tap_b
+        dy = 3 if tap else 0
+        arr = final_pressed if tap else variants[idx]
+        a_mul = min(t / 0.33, 1.0)
+        shp = shadow
+        if a_mul < 1.0:
+            sa = np.asarray(shadow).copy(); sa[..., 3] = (sa[..., 3] * a_mul).astype(np.uint8)
+            shp = Image.fromarray(sa, "RGBA")
+        fr.alpha_composite(shp, (0, yoff + 22 + dy))
+        lay = arr
+        if a_mul < 1.0:
+            lay = arr.copy(); lay[..., 3] = (lay[..., 3] * a_mul).astype(np.uint8)
+        fr.alpha_composite(Image.fromarray(lay, "RGBA"), (0, yoff + dy))
+        fr.convert("RGB").save(f"{frames}/f{f:04d}.png")
+
+    silent = a.out + ".silent.mp4"
+    subprocess.run(["ffmpeg", "-y", "-loglevel", "error", "-framerate", str(FPS),
+                    "-i", f"{frames}/f%04d.png", "-c:v", "libx264", "-pix_fmt", "yuv420p",
+                    "-crf", "18", "-movflags", "+faststart", silent], check=True)
+    if a.no_audio:
+        shutil.move(silent, a.out)
+    else:
+        aud = a.out + ".aud.wav"
+        synth_audio(aud, dur, swaps, (tap_a + 0.05) if a.chrome_pressed else None)
+        subprocess.run(["ffmpeg", "-y", "-loglevel", "error", "-i", silent, "-i", aud,
+                        "-map", "0:v:0", "-map", "1:a:0", "-c:v", "copy", "-c:a", "aac",
+                        "-b:a", "192k", "-shortest", a.out], check=True)
+        os.remove(silent); os.remove(aud)
+    shutil.rmtree(frames)
+    print(f"wrote {a.out}  ({dur:.2f}s, {N} frames, {len(imgs)} images + final)")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/ads/composites/airdrop-notification-carousel-video/scripts/one_shot.py
+++ b/skills/ads/composites/airdrop-notification-carousel-video/scripts/one_shot.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""one_shot.py — end-to-end AirDrop product-carousel ad from a single config.
+
+Reads a JSON config, then: build_card.py -> headless-Chrome screenshot of both
+card states -> compose_carousel.py. One call, one MP4.
+
+Config schema (see demo/working/config.json):
+{
+  "brand": "dibs.",
+  "message": "would like to share a blush",
+  "tagline": "The viral Desert Island Duo - 1M+ sold",
+  "wordmark_svg": "/abs/path/logo.svg",     # optional; else text wordmark = brand
+  "accent": "#d98695",                       # Accept-button / brand accent
+  "band_color": "#f5e9da",
+  "images": ["/abs/p1.png", "/abs/p2.png", ...],   # ordered carousel (real product photos)
+  "final_image": "/abs/lineup.jpg",          # payoff held at the end
+  "timing": {"per": 0.34, "first_hold": 1.0, "final_hold": 2.1, "slide": 0.72}
+}
+
+The screenshot step uses Playwright if installed (`pip install playwright &&
+playwright install chromium`). If Playwright is unavailable, run build_card.py
+yourself, screenshot chrome.html / chrome-pressed.html (fullPage) to
+chrome-green.png / chrome-green-pressed.png via another headless Chrome, then call
+compose_carousel.py directly — see SKILL.md Phase 3.
+"""
+import argparse, json, os, subprocess, sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def shoot(html_path, out_png):
+    """Screenshot a card HTML (fullPage) via Playwright chromium."""
+    try:
+        from playwright.sync_api import sync_playwright
+    except ImportError:
+        sys.exit("Playwright not installed. Either `pip install playwright && playwright "
+                 "install chromium`, or screenshot the HTML via another headless Chrome "
+                 "(see SKILL.md Phase 3) and run compose_carousel.py directly.")
+    with sync_playwright() as pw:
+        b = pw.chromium.launch()
+        pg = b.new_page(viewport={"width": 1080, "height": 1920}, device_scale_factor=2)
+        pg.goto("file://" + os.path.abspath(html_path))
+        pg.wait_for_timeout(300)
+        pg.screenshot(path=out_png, full_page=True)
+        b.close()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--work-dir", default="")
+    ap.add_argument("--no-audio", action="store_true")
+    a = ap.parse_args()
+    cfg = json.load(open(a.config))
+    work = a.work_dir or os.path.join(os.path.dirname(a.out) or ".", "airdrop_work")
+    os.makedirs(work, exist_ok=True)
+
+    # 1. card HTML
+    cmd = [sys.executable, os.path.join(HERE, "build_card.py"),
+           "--brand", cfg["brand"], "--message", cfg["message"],
+           "--tagline", cfg.get("tagline", ""), "--accent", cfg.get("accent", "#d98695"),
+           "--band-color", cfg.get("band_color", "#f5e9da"), "--out-dir", work]
+    if cfg.get("wordmark_svg"):
+        cmd += ["--wordmark-svg", cfg["wordmark_svg"]]
+    subprocess.run(cmd, check=True)
+
+    # 2. screenshot both states
+    shoot(os.path.join(work, "chrome.html"), os.path.join(work, "chrome-green.png"))
+    shoot(os.path.join(work, "chrome-pressed.html"), os.path.join(work, "chrome-green-pressed.png"))
+
+    # 3. compose
+    tm = cfg.get("timing", {})
+    cmd = [sys.executable, os.path.join(HERE, "compose_carousel.py"),
+           "--chrome", os.path.join(work, "chrome-green.png"),
+           "--chrome-pressed", os.path.join(work, "chrome-green-pressed.png"),
+           "--images", ",".join(cfg["images"]), "--final-image", cfg["final_image"],
+           "--out", a.out,
+           "--per", str(tm.get("per", 0.34)), "--first-hold", str(tm.get("first_hold", 1.0)),
+           "--final-hold", str(tm.get("final_hold", 2.1)), "--slide", str(tm.get("slide", 0.72))]
+    if a.no_audio:
+        cmd.append("--no-audio")
+    subprocess.run(cmd, check=True)
+    print(f"DONE -> {a.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/ads/composites/airdrop-notification-carousel-video/skill.meta.json
+++ b/skills/ads/composites/airdrop-notification-carousel-video/skill.meta.json
@@ -1,0 +1,11 @@
+{
+  "slug": "airdrop-notification-carousel-video",
+  "category": "composites",
+  "tags": ["ads", "content", "social", "design"],
+  "installation": {
+    "base_command": "npx goose-skills install airdrop-notification-carousel-video",
+    "supports": ["claude", "cursor", "codex"]
+  },
+  "domain": "ads",
+  "requires_tools": ["ffmpeg", "python3 (numpy, Pillow)", "headless Chrome (Playwright)"]
+}


### PR DESCRIPTION
## What

Adds **`airdrop-notification-carousel-video`** under `skills/ads/composites/`.

Recreates the viral iOS **"AirDrop notification"** ad — a native share-sheet card ("**Brand** would like to share a ___ · Decline / Accept") — as a **product carousel** for any brand. The AirDrop card springs up and its preview window cycles through a set of real product photos, landing on a range/lineup payoff with an Accept tap; a notification chime + soft ticks track the swaps.

## How it works

Deterministic composite — **no generative video**, so the system-UI text and wordmark stay pixel-crisp and every product on screen is a real brand photo:

- `build_card.py` — brand params → a real-DOM AirDrop card HTML on a green page (`#00e000`, keyed to the card's alpha) with a magenta preview window (`#ff00ff`, refilled per product).
- `one_shot.py` — build card → headless-Chrome (Playwright) screenshot of both states → compose.
- `compose_carousel.py` — green-key the card, fill the window with each product, blurred per-product backdrop + push-in, card spring-up + carousel + Accept tap, synth audio, encode h264+aac.

Stack: python3 (numpy, Pillow) + Playwright + FFmpeg. No paid model calls, no MCP, no proxies.

## Checks
- `publish.py lint` → OK (no app/proxy/internal coupling)
- `validate-skills.js` → passed
- `build-index.js` → regenerated `skills-index.json` (skill present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)