### PR TITLE
docs(render-imessage-cascade): flag example brand fields as replace-per-brand

### DIFF
--- a/skills/ads/capabilities/render-imessage-cascade/scripts/config.example.json
+++ b/skills/ads/capabilities/render-imessage-cascade/scripts/config.example.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Illustrative example (the source Gooseworks 'inbound leads' remix). The recipe binds a NEW brand's own values here at remix time — EVERY brand-specific field is a placeholder to REPLACE, including end_card.accent (do NOT ship the Gooseworks orange #f05f22 for another brand; set the remixed brand's own accent).",
   "title": "Gooseworks — Notification Cascade (inbound leads)",
   "plate": "/abs/path/plate-phone-desk.png",
   "plate_ref": "/abs/path/source-frame-with-a-notification.jpg",


### PR DESCRIPTION
## Context

Follow-up to #103 (merged) and the companion goose-lab recipe PR. Greptile flagged (P1) that the neutral **recipe** template kept the Gooseworks orange `accent` (`#f05f22`) while every other brand field was blanked — a remix would silently inherit it. That's fixed in goose-lab by blanking `accent`.

The same inheritance risk exists in this capability's `config.example.json`, which ships the Gooseworks brand values (accent included).

## Fix

This file is a **coherent, labelled example** (the source "Gooseworks — inbound leads" remix — same convention as the `render-imessage-chat` sample, which ships a full "Wonderbly" example). Blanking one field would make it a worse example, so instead add a `_comment` (matching the sibling's convention) that makes explicit: **every brand-specific field — `end_card.accent` included — is a placeholder to override per brand**, so no remix inherits the Gooseworks color.

Keeps the example runnable (the smoke test uses it) while closing the same gap greptile raised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)