### PR TITLE
fix(ads-capabilities): proxy Whisper + audio-pad + offer-ad fetched-layout & SaaS

### DIFF
--- a/skills/ads/capabilities/media-proxy/scripts/media_proxy.py
+++ b/skills/ads/capabilities/media-proxy/scripts/media_proxy.py
@@ -79,6 +79,21 @@ def fal_generate_video(model_path, payload, **kw):
     return (r.get("video") or {}).get("url") or r["videos"][0]["url"]
 
 
+def fal_whisper(audio_url, language="en", **kw):
+    """fal-ai/whisper (word-level) through the proxy → [{text, start, end}, ...].
+
+    `audio_url` MUST be a PUBLIC url (this module does not upload) — the orchestrator
+    hosts the local VO via MCP `get_upload_url` → `get_download_url` and passes that
+    presigned url in. Proxy-routed, so it bills the Ads agent (never a raw FAL_KEY)."""
+    r = _fal_run("fal-ai/whisper", {"audio_url": audio_url, "task": "transcribe",
+                                    "language": language, "chunk_level": "word"}, **kw)
+    words = []
+    for ch in r.get("chunks", []):
+        ts = ch.get("timestamp") or [None, None]
+        words.append({"text": (ch.get("text") or "").strip(), "start": ts[0], "end": ts[1]})
+    return words
+
+
 def eleven_music(prompt, music_length_ms, out_path, force_instrumental=True, timeout_s=180):
     """ElevenLabs Music through the proxy → writes the mp3 to out_path, returns it."""
     api_base, tok, agent = _cfg()

--- a/skills/ads/capabilities/render-myth-vs-fact/scripts/beat_snap.py
+++ b/skills/ads/capabilities/render-myth-vs-fact/scripts/beat_snap.py
@@ -9,21 +9,36 @@ Two outputs, written into the work dir:
   - whisper/words-flat.json : [{text, start, end}, ...] (what compose.py's captions read)
   - beat-manifest.json      : the config beats with re-snapped start/end/duration.
 
-Whisper is fetched via FAL (fal-ai/whisper, chunk_level=word). If FAL is unavailable (no
-FAL_KEY / no network), pass --no-whisper to fall back to the DURATIONS ALREADY IN CONFIG
-(cumulative, un-snapped) so the pipeline still runs end-to-end offline. On-card text is the
+Whisper word-timestamps come from fal-ai/whisper (chunk_level=word). Prefer the
+PROXY-ROUTED path so the call bills the Ads agent (never a raw FAL_KEY): the orchestrator
+hosts the rendered VO via MCP `get_upload_url` → `get_download_url` and passes the presigned
+url as `--vo-url` (transcribed through `media_proxy.fal_whisper`). Already have the words?
+pass `--words-file words.json` and beat_snap skips transcription entirely. Legacy: a raw
+`FAL_KEY` in the env still works via `fal_client`. Fully offline: `--no-whisper` keeps the
+config durations un-snapped (NOTE: no words ⇒ no karaoke captions). On-card text is the
 source of truth, so brand-name homophones in the transcript are fine.
 
 Usage:
-  beat_snap.py --config config.json --work-dir /path/to/work [--vo vo.mp3] [--no-whisper]
+  beat_snap.py --config config.json --work-dir DIR --vo-url <presigned-url>   # proxy (preferred)
+  beat_snap.py --config config.json --work-dir DIR --words-file words.json    # pre-fetched
+  beat_snap.py --config config.json --work-dir DIR --vo vo.mp3                 # legacy FAL_KEY
+  beat_snap.py --config config.json --work-dir DIR --no-whisper               # offline
 
-ENV: FAL_KEY (alias FAL_API_KEY) when Whisper is used.
+ENV: GW_PROJECT_ID (attributes proxy spend to the ad project); FAL_KEY only for the legacy path.
 """
 import argparse, json, os
 from pathlib import Path
 
 
+def transcribe_proxy(vo_url):
+    """Proxy-routed Whisper (bills the Ads agent). Needs media_proxy.py on sys.path —
+    the orchestrator fetches it with the create-vo-elevenlabs / media-proxy capability."""
+    from media_proxy import fal_whisper
+    return fal_whisper(vo_url)
+
+
 def transcribe_fal(vo_path):
+    """Legacy: a raw FAL_KEY in the env (NOT proxy-routed — does not bill the Ads agent)."""
     import fal_client
     if "FAL_KEY" not in os.environ and "FAL_API_KEY" in os.environ:
         os.environ["FAL_KEY"] = os.environ["FAL_API_KEY"]
@@ -60,9 +75,11 @@ def main():
     ap = argparse.ArgumentParser(description="Snap beats to VO word onsets.")
     ap.add_argument("--config", required=True)
     ap.add_argument("--work-dir", required=True)
-    ap.add_argument("--vo", help="VO mp3 (defaults to config.vo)")
+    ap.add_argument("--vo", help="VO mp3 (defaults to config.vo) — legacy raw-FAL_KEY path")
+    ap.add_argument("--vo-url", help="presigned PUBLIC url of the rendered VO → proxy Whisper (preferred)")
+    ap.add_argument("--words-file", help="pre-fetched words-flat.json → skip transcription")
     ap.add_argument("--no-whisper", action="store_true",
-                    help="skip FAL; keep config durations (offline fallback)")
+                    help="skip transcription; keep config durations (offline; NO captions)")
     a = ap.parse_args()
 
     cfg = json.load(open(a.config))
@@ -72,12 +89,21 @@ def main():
     vo = a.vo or cfg.get("vo")
 
     words = []
-    if not a.no_whisper and vo and os.path.exists(vo):
-        print(f"[whisper] transcribing {vo}")
+    if a.words_file:
+        words = json.load(open(a.words_file))
+        print(f"[whisper] loaded {len(words)} words from {a.words_file}")
+    elif a.no_whisper:
+        print("[whisper] skipped — using config beat durations un-snapped")
+    elif a.vo_url:
+        print("[whisper] transcribing via proxy (bills the Ads agent)")
+        words = transcribe_proxy(a.vo_url)
+        print(f"[whisper] {len(words)} words: " + " ".join(w["text"] for w in words)[:200])
+    elif vo and os.path.exists(vo) and ("FAL_KEY" in os.environ or "FAL_API_KEY" in os.environ):
+        print(f"[whisper] transcribing {vo} via legacy FAL_KEY (not proxy-billed)")
         words = transcribe_fal(vo)
         print(f"[whisper] {len(words)} words: " + " ".join(w["text"] for w in words)[:200])
     else:
-        print("[whisper] skipped — using config beat durations un-snapped")
+        print("[whisper] no --vo-url / --words-file / FAL_KEY — durations un-snapped, no captions")
 
     (work / "whisper" / "words-flat.json").write_text(json.dumps(words, indent=2))
 

--- a/skills/ads/capabilities/render-myth-vs-fact/scripts/compose.py
+++ b/skills/ads/capabilities/render-myth-vs-fact/scripts/compose.py
@@ -55,21 +55,30 @@ def concat_silent(beats, frames_dir, work, fps):
     return out
 
 
-def mix_audio(vo, music, work, music_db, tail_fade):
+def mix_audio(vo, music, work, music_db, tail_fade, video_dur=None):
+    """Mix VO (+ optional music) → an m4a as long as the VIDEO. The final `burn` uses
+    -shortest, so if the audio is shorter than the video (the normal case — the end card
+    holds a beat past the last spoken word) the end-card hold gets silently truncated.
+    Pad the audio to `video_dur` so the hold survives. `apad` runs BEFORE amix's
+    duration=first collapses length, so the padded VO drives the output length."""
     out = work / "mixed-audio.m4a"
+    # apad the VO bus to the full video length (harmless no-op when video_dur is None).
+    pad = f",apad=whole_dur={video_dur:.3f}" if video_dur else ""
     if music and os.path.exists(music):
         vo_dur = ffprobe_dur(vo)
-        fc = (f"[1:a]volume={music_db}dB,"
-              f"afade=t=out:st={max(0, vo_dur - tail_fade):.2f}:d={tail_fade}[m];"
-              f"[0:a][m]amix=inputs=2:duration=first:normalize=0[a]")
+        fc = (f"[0:a]apad=whole_dur={video_dur:.3f}[vo];" if video_dur else "[0:a]anull[vo];")
+        fc += (f"[1:a]volume={music_db}dB,"
+               f"afade=t=out:st={max(0, (video_dur or vo_dur) - tail_fade):.2f}:d={tail_fade}[m];"
+               f"[vo][m]amix=inputs=2:duration=first:normalize=0[a]")
         run(["ffmpeg", "-y", "-loglevel", "error", "-i", str(vo), "-i", str(music),
              "-filter_complex", fc, "-map", "[a]",
              "-c:a", "aac", "-b:a", "192k", "-ar", "44100", str(out)])
-        print(f"[mix] {out} (VO + music@{music_db}dB)")
+        print(f"[mix] {out} (VO + music@{music_db}dB, padded to {video_dur or vo_dur:.2f}s)")
     else:
         run(["ffmpeg", "-y", "-loglevel", "error", "-i", str(vo),
-             "-c:a", "aac", "-b:a", "192k", "-ar", "44100", str(out)])
-        print(f"[mix] {out} (VO only)")
+             "-af", f"anull{pad}", "-c:a", "aac", "-b:a", "192k", "-ar", "44100", str(out)])
+        print(f"[mix] {out} (VO only, padded to {video_dur:.2f}s)" if video_dur
+              else f"[mix] {out} (VO only)")
     return out
 
 
@@ -123,7 +132,8 @@ def main():
     tail_fade = mix_cfg.get("tail_fade", 0.8)
 
     silent = concat_silent(beats, frames_dir, work, fps)
-    audio = mix_audio(vo, music, work, music_db, tail_fade)
+    # Pad audio to the silent video's real length so -shortest keeps the full end-card hold.
+    audio = mix_audio(vo, music, work, music_db, tail_fade, video_dur=ffprobe_dur(silent))
     final = burn(silent, audio, captions, a.out)
 
     md = ffprobe_dur(final)

--- a/skills/ads/capabilities/render-offer-ad/scripts/config.example.json
+++ b/skills/ads/capabilities/render-offer-ad/scripts/config.example.json
@@ -1,5 +1,11 @@
 {
   "_comment": "Illustrative worked example — brand-neutralised from the validated 'drinkable collagen' offer-ad run. The recipe binds a NEW brand's own product photo / palette / copy / music here. Replace every /abs/or/working/... path with a REAL absolute path or a runtime working/ path. ALL text is typeset in the engine (never AI-rendered). The ONLY composited bitmap is the REAL product photo (objectFit:contain, never stretched) — an AI-rendered packshot is an instant fail.",
+  "_notes": {
+    "cta_label": "Do NOT end cta_label with an arrow — Scene04 appends its own '→' (render.py also strips a stray trailing arrow, but keep the source clean).",
+    "mechanism_prop": "One of TWO engine presets only: 'spoon' (drinkable/liquid) or 'accent' (neutral bar; use for SaaS/software & anything non-CPG). Not arbitrary SVG.",
+    "product_format": "Optional. Physical: liquid/powder/capsule/gummy/cream/serum. Digital: software/saas/app. Omit for a product that fits none → the claim-matches-format gate skips.",
+    "saas": "For a SaaS/software product: product_hero_image = a REAL app UI screenshot (keeps its own bg — fine), product_format = 'saas', mechanism_prop = 'accent'."
+  },
 
   "product_hero_image": "/abs/or/working/raw-materials/product-hero.webp",
   "product_format": "liquid",

--- a/skills/ads/capabilities/render-offer-ad/scripts/render.py
+++ b/skills/ads/capabilities/render-offer-ad/scripts/render.py
@@ -32,8 +32,31 @@ import subprocess
 import sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-CAP_DIR = os.path.dirname(HERE)
-PROJECT_DIR = os.path.join(CAP_DIR, "project")
+
+
+def _resolve_project_dir() -> str:
+    """Locate the bundled Remotion project/ dir robustly.
+
+    Works whether render.py runs from the REPO layout (capability/scripts/render.py
+    → ../project) OR from a FETCHED layout: `gooseworks fetch` flattens the scripts/
+    prefix, so render.py lands at the capability root and project/ is a sibling
+    (→ ./project). Try both, then a short upward walk; match on package.json.
+    """
+    candidates = [
+        os.path.join(HERE, "project"),                    # fetched: render.py at cap root
+        os.path.join(os.path.dirname(HERE), "project"),   # repo: render.py in scripts/
+    ]
+    d = HERE
+    for _ in range(4):
+        d = os.path.dirname(d)
+        candidates.append(os.path.join(d, "project"))
+    for c in candidates:
+        if os.path.isfile(os.path.join(c, "package.json")):
+            return c
+    return os.path.join(os.path.dirname(HERE), "project")  # repo-layout default
+
+
+PROJECT_DIR = _resolve_project_dir()
 COMPOSITION_ID = "offer-ad"
 
 # ---- physical-format → allowed claim vocabulary (gating check a) -----------
@@ -44,6 +67,11 @@ FORMAT_VOCAB = {
     "gummy": {"chew", "gummy", "gummies", "bite"},
     "cream": {"apply", "rub", "spread", "dab", "massage"},
     "serum": {"drop", "apply", "dropper", "absorb"},
+    # digital products (SaaS / software / app) — the mechanism is the workflow, not a
+    # physical action. Recognized so the gate doesn't WARN "unknown"; no forbidden set.
+    "software": {"search", "prompt", "click", "type", "sync", "one"},
+    "saas": {"search", "prompt", "click", "type", "sync", "one"},
+    "app": {"search", "prompt", "click", "tap", "type", "sync"},
 }
 # vocab that belongs to a DIFFERENT format and must NOT appear (mismatch flag)
 FORMAT_FORBIDDEN = {
@@ -53,6 +81,10 @@ FORMAT_FORBIDDEN = {
     "gummy": {"scoop", "sip", "swallow"},
     "cream": {"drink", "sip", "chew", "swallow"},
     "serum": {"drink", "chew", "swallow"},
+    # digital products have no physical-format vocabulary to collide with.
+    "software": set(),
+    "saas": set(),
+    "app": set(),
 }
 
 
@@ -101,6 +133,18 @@ def gate_mechanism_prop(cfg: dict) -> None:
             "static. Got: "
             + repr(cfg.get("mechanism_prop"))
         )
+
+
+def clean_cta_label(label: str) -> str:
+    """Scene04 ALWAYS appends its own '→' arrow. Strip a trailing arrow (and
+    whitespace) the operator may have typed into cta_label so it never renders a
+    double arrow ('Try it → →')."""
+    s = str(label).rstrip()
+    for arrow in ("→", "->", "➔", "➜", "»", "▶", "➡"):
+        if s.endswith(arrow):
+            s = s[: -len(arrow)].rstrip()
+            break
+    return s
 
 
 def stage_asset(src: str, public_dir: str, dest_name: str) -> str:
@@ -155,7 +199,7 @@ def build_props(cfg: dict, public_dir: str) -> dict:
             "subline": copy.get("subline", ""),
             "motif_chip": copy.get("motif_chip", ""),
             "claim_lines": copy["claim_lines"],
-            "cta_label": copy["cta_label"],
+            "cta_label": clean_cta_label(copy["cta_label"]),
             "cta_url": copy["cta_url"],
             "wordmark": copy["wordmark"],
         },


### PR DESCRIPTION
Skill fixes for the newly-published `myth-vs-fact` and `offer-ad` video formats (plus a shared media-proxy helper).

## render-myth-vs-fact
- **beat_snap.py** — prefer **proxy-routed Whisper** (`--vo-url`) so transcription bills the Ads agent (not a raw `FAL_KEY`); add `--words-file` to skip transcription when words are pre-fetched; keep legacy `FAL_KEY` and offline `--no-whisper` paths.
- **compose.py** — pad the audio bus to the silent video's real length so the final `-shortest` mux no longer **truncates the end-card hold**.

## media-proxy
- add `fal_whisper()` (`fal-ai/whisper`, `chunk_level=word`) → `[{text,start,end}]`, routed through the proxy.

## render-offer-ad
- **render.py** — resolve the bundled Remotion `project/` robustly for both the repo layout and the `gooseworks fetch` flattened layout (match on `package.json`); recognize `software`/`saas`/`app` product formats in the claim-vocabulary gate; strip an operator-typed trailing arrow so Scene04's own `→` never doubles.
- **config.example.json** — document `cta_label` / `mechanism_prop` / `product_format` + the SaaS recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)