### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #107)

### DIFF
--- a/skills/design/packs/video-production/product-reel-generator/SKILL.md
+++ b/skills/design/packs/video-production/product-reel-generator/SKILL.md
@@ -3,7 +3,7 @@ name: product-reel-generator
 description: Generates Instagram-ready product reels from any e-commerce product page URL. Scrapes product images, classifies by type, generates AI-animated clips via Higgsfield API, creates text overlays with style presets, and composes a 15-20 second reel with music. Supports model-based and product-only reels.
 user-invocable: true
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebSearch
-argument-hint: [product-page-url]
+argument-hint: "[product-page-url]"
 ---
 
 # Product Reel Generator

--- a/skills/design/packs/video-production/talking-head-video/SKILL.md
+++ b/skills/design/packs/video-production/talking-head-video/SKILL.md
@@ -3,7 +3,7 @@ name: talking-head-video
 description: Creates talking head videos from any source material (docs, changelogs, blog posts, notes, transcripts). Produces multi-scene videos with avatar narration over screenshots/images using HeyGen v2 API. Supports Quick Shot and Full Producer modes.
 user-invocable: true
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
-argument-hint: [source-content-path]
+argument-hint: "[source-content-path]"
 ---
 
 # Talking Head Video Skill

--- a/skills/design/packs/video-production/video-clipper/SKILL.md
+++ b/skills/design/packs/video-production/video-clipper/SKILL.md
@@ -3,7 +3,7 @@ name: video-clipper
 description: Repurposes long-form video (podcasts, interviews, talks) into short-form vertical clips for Instagram Reels, TikTok, and YouTube Shorts. Handles transcription, moment selection, clip extraction, speaker-tracked reframing (16:9 to 9:16), and animated captions.
 user-invocable: true
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebSearch, WebFetch
-argument-hint: [video-file-path-or-url]
+argument-hint: "[video-file-path-or-url]"
 ---
 
 # Video Clipper

--- a/skills/design/packs/video-production/video-polish/SKILL.md
+++ b/skills/design/packs/video-production/video-polish/SKILL.md
@@ -3,7 +3,7 @@ name: video-polish
 description: Takes an existing screen recording or demo video and adds professional zoom/pan effects synchronized to the narration. Uses transcript-driven zoom targeting and Remotion for rendering. Optionally replaces audio with a soundtrack.
 user-invocable: true
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebSearch
-argument-hint: [video-file-path]
+argument-hint: "[video-file-path]"
 ---
 
 # Video Polish Skill

--- a/skills/lead-generation/packs/lead-gen-devtools/community-signals/SKILL.md
+++ b/skills/lead-generation/packs/lead-gen-devtools/community-signals/SKILL.md
@@ -3,7 +3,7 @@ name: community-signals
 description: Extract leads from developer forums (Hacker News, Reddit) by detecting intent signals — alternative seeking, competitor pain, scaling challenges, DIY solutions, and migration intent. Scores users by intent strength and cross-platform presence.
 user-invocable: true
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebSearch
-argument-hint: [queries-json-path]
+argument-hint: "[queries-json-path]"
 ---
 
 # Community Signals

--- a/skills/lead-generation/packs/lead-gen-devtools/competitor-signals/SKILL.md
+++ b/skills/lead-generation/packs/lead-gen-devtools/competitor-signals/SKILL.md
@@ -3,7 +3,7 @@ name: competitor-signals
 description: Extract leads from competitor product activity — Product Hunt commenters/upvoters, HN posts about competitors, case studies, testimonials, tech press, and switching signals. Detects people actively switching from competitors as highest-priority leads.
 user-invocable: true
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch, WebSearch
-argument-hint: [config-json-path]
+argument-hint: "[config-json-path]"
 ---
 
 # Competitor Signals

--- a/skills/lead-generation/packs/lead-gen-devtools/demo-builder/SKILL.md
+++ b/skills/lead-generation/packs/lead-gen-devtools/demo-builder/SKILL.md
@@ -4,7 +4,7 @@ description: Builds personalized demo assets for top prospects using the founder
 disable-model-invocation: true
 user-invocable: true
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch, WebSearch
-argument-hint: [prospect-company-name]
+argument-hint: "[prospect-company-name]"
 ---
 
 # Demo Builder

--- a/skills/lead-generation/packs/lead-gen-devtools/event-signals/SKILL.md
+++ b/skills/lead-generation/packs/lead-gen-devtools/event-signals/SKILL.md
@@ -3,7 +3,7 @@ name: event-signals
 description: Extract leads from conferences, meetups, hackathons, and podcasts by analyzing speaker lists, sponsor lists, hackathon entries, and podcast guests. Discovers events via Sessionize, Confs.tech, Meetup, Luma, ListenNotes, and Devpost. Looks back 90 days and forward 180 days.
 user-invocable: true
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch, WebSearch
-argument-hint: [config-json-path]
+argument-hint: "[config-json-path]"
 ---
 
 # Event Signals

--- a/skills/lead-generation/packs/lead-gen-devtools/lead-discovery/SKILL.md
+++ b/skills/lead-generation/packs/lead-gen-devtools/lead-discovery/SKILL.md
@@ -3,7 +3,7 @@ name: lead-discovery
 description: Orchestrator that runs first for lead generation requests. Gathers business context via website analysis or questions, identifies competitors, builds ICP, and routes to signal skills with pre-filled inputs.
 user-invocable: true
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch, WebSearch
-argument-hint: [website-url]
+argument-hint: "[website-url]"
 ---
 
 # Lead Discovery — Orchestrator

--- a/skills/social/capabilities/tiktok-influencer-finder/SKILL.md
+++ b/skills/social/capabilities/tiktok-influencer-finder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: tiktok-influencer-finder
 description: Find TikTok influencers using Apify's Influencer Discovery Agent. Use when the user wants to discover TikTok creators or influencers in any niche.
-argument-hint: [niche/description]
+argument-hint: "[niche/description]"
 ---
 
 # TikTok Influencer Finder


### PR DESCRIPTION
Closes #107.

## Summary

Purely mechanical single-character transform to 10 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (10)

- `skills/social/capabilities/tiktok-influencer-finder/SKILL.md`
- `skills/design/packs/video-production/video-clipper/SKILL.md`
- `skills/design/packs/video-production/video-polish/SKILL.md`
- `skills/design/packs/video-production/product-reel-generator/SKILL.md`
- `skills/lead-generation/packs/lead-gen-devtools/lead-discovery/SKILL.md`
- `skills/design/packs/video-production/talking-head-video/SKILL.md`
- `skills/lead-generation/packs/lead-gen-devtools/event-signals/SKILL.md`
- `skills/lead-generation/packs/lead-gen-devtools/demo-builder/SKILL.md`
- `skills/lead-generation/packs/lead-gen-devtools/competitor-signals/SKILL.md`
- `skills/lead-generation/packs/lead-gen-devtools/community-signals/SKILL.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
