### PR TITLE
fix(stitch): GNU-compatible mktemp (Linux/Git Bash breakage)

### DIFF
--- a/skills/ads/capabilities/render-chatgpt-chat/scripts/stitch.sh
+++ b/skills/ads/capabilities/render-chatgpt-chat/scripts/stitch.sh
@@ -73,14 +73,14 @@ END_DUR=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$END")
 XFADE=0.30
 TOTAL=$(python3 -c "print($CHAT_DUR + $END_DUR - $XFADE)")
 XSTART=$(python3 -c "print($CHAT_DUR - $XFADE)")
-TMP_VIDEO=$(mktemp -t gpt-stitch).mp4
+TMP_VIDEO=$(mktemp "${TMPDIR:-/tmp}/gpt-stitch.XXXXXX").mp4
 ffmpeg -y -i "$CHAT" -i "$END" \
   -filter_complex "[1:v]scale=${CW}:${CH}:force_original_aspect_ratio=decrease,pad=${CW}:${CH}:-1:-1:color=${PAD_COLOR},setsar=1[end];[0:v][end]xfade=transition=fade:duration=${XFADE}:offset=${XSTART}[v]" \
   -map "[v]" -an -c:v libx264 -pix_fmt yuv420p -movflags +faststart "$TMP_VIDEO" >/dev/null 2>&1
 echo "  video stitched, ${TOTAL}s (${CW}x${CH})"
 
 # 2) Build the audio mix (subliminal ChatGPT SFX cues [+ optional ducked bed]).
-TMP_AUDIO=$(mktemp -t gpt-audio).m4a
+TMP_AUDIO=$(mktemp "${TMPDIR:-/tmp}/gpt-audio.XXXXXX").m4a
 MUSIC_ARG="${MUSIC:-NONE}"
 python3 - "$SFX_JSON" "$SFX_DIR" "$MUSIC_ARG" "$TOTAL" "$TMP_AUDIO" <<'PY'
 import json, sys, subprocess

--- a/skills/ads/capabilities/render-imessage-chat/scripts/stitch.sh
+++ b/skills/ads/capabilities/render-imessage-chat/scripts/stitch.sh
@@ -46,14 +46,14 @@ END_DUR=$(ffprobe -v error -show_entries format=duration -of csv=p=0 "$END")
 XFADE=0.30
 TOTAL=$(python3 -c "print($CHAT_DUR + $END_DUR - $XFADE)")
 XSTART=$(python3 -c "print($CHAT_DUR - $XFADE)")
-TMP_VIDEO=$(mktemp -t imsg-stitch).mp4
+TMP_VIDEO=$(mktemp "${TMPDIR:-/tmp}/imsg-stitch.XXXXXX").mp4
 ffmpeg -y -i "$CHAT" -i "$END" \
   -filter_complex "[0:v][1:v]xfade=transition=fade:duration=${XFADE}:offset=${XSTART}[v]" \
   -map "[v]" -an -c:v libx264 -pix_fmt yuv420p -movflags +faststart "$TMP_VIDEO" >/dev/null 2>&1
 echo "  video stitched, ${TOTAL}s"
 
 # 2) Build the audio mix (deterministic SFX cues [+ optional ducked music bed]).
-TMP_AUDIO=$(mktemp -t imsg-audio).m4a
+TMP_AUDIO=$(mktemp "${TMPDIR:-/tmp}/imsg-audio.XXXXXX").m4a
 MUSIC_ARG="${MUSIC:-NONE}"
 python3 - "$SFX_JSON" "$SFX_DIR" "$MUSIC_ARG" "$TOTAL" "$TMP_AUDIO" <<'PY'
 import json, sys, subprocess


### PR DESCRIPTION
## Problem
`stitch.sh` in **render-imessage-chat** and **render-chatgpt-chat** uses `mktemp -t <prefix>`. That's BSD (macOS) syntax — GNU mktemp (all Linux distros, Git Bash on Windows) fails with:

```
mktemp: too few X's in template 'imsg-stitch'
```

so the stitch step dies before producing the master. Hit in a real render on Windows/Git Bash; reproducible on any Linux.

## Fix
Explicit template under `${TMPDIR:-/tmp}`, valid on both BSD and GNU:

```bash
TMP_VIDEO=$(mktemp "${TMPDIR:-/tmp}/imsg-stitch.XXXXXX").mp4
```

4 sites across the two scripts. `bash -n` clean; verified by running the full imessage-chat pipeline end-to-end with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)