### PR TITLE
fix(offer-ad): render.py fails on Windows — npx/npm .cmd shims (WinError 2)

### DIFF
--- a/skills/ads/capabilities/render-offer-ad/scripts/render.py
+++ b/skills/ads/capabilities/render-offer-ad/scripts/render.py
@@ -221,7 +221,10 @@ def build_props(cfg: dict, public_dir: str) -> dict:
 
 def run(cmd, cwd=None):
     print("[render-offer-ad] $", " ".join(cmd))
-    subprocess.run(cmd, cwd=cwd, check=True)
+    # Resolve the executable so this works on Windows too, where npx/npm are
+    # .cmd shims that bare subprocess.run (no shell) cannot find (WinError 2).
+    exe = shutil.which(cmd[0]) or cmd[0]
+    subprocess.run([exe] + list(cmd[1:]), cwd=cwd, check=True)
 
 
 def main() -> None:


### PR DESCRIPTION
## Problem
`render.py`'s `run()` calls `subprocess.run(["npx", "remotion", ...])` / `["npm", "install"]` with bare list args. On Windows, `npx`/`npm` are `.cmd` shims, which `CreateProcess` doesn't resolve without a shell:

```
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

The driver dies before Remotion ever starts. Hit in a real offer-ad render on Windows 11.

## Fix
Resolve the executable via `shutil.which(cmd[0])` (returns `npx.cmd` on Windows, the plain path elsewhere) before `subprocess.run`. `shutil` is already imported; behavior on macOS/Linux is unchanged.

Verified by rendering the offer-ad composition end-to-end on Windows with this patch (master + 1:1 crop produced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)