### PR TITLE
fix(compose): caption burn fails on Windows — ass= filter path escaping (myth-vs-fact, 3d-character, absurdist)

### DIFF
--- a/skills/ads/capabilities/render-3d-character-explainer/scripts/compose.py
+++ b/skills/ads/capabilities/render-3d-character-explainer/scripts/compose.py
@@ -218,8 +218,11 @@ def main():
 
 
 def _ass_escape(path):
-    # ffmpeg filtergraph escaping for a filename inside ass=...
-    return path.replace("\\", "\\\\").replace(":", "\\:").replace("'", "\\'")
+    # ffmpeg filtergraph escaping for a filename inside ass='...': use FORWARD
+    # slashes — doubled backslashes break the ass filter's filename parse on
+    # Windows — and escape the drive colon, which otherwise terminates the
+    # option value.
+    return path.replace("\\", "/").replace(":", "\\:").replace("'", "\\'")
 
 
 if __name__ == "__main__":

--- a/skills/ads/capabilities/render-absurdist-explainer/scripts/compose.py
+++ b/skills/ads/capabilities/render-absurdist-explainer/scripts/compose.py
@@ -214,8 +214,11 @@ def main():
 
 
 def _ass_escape(path):
-    # ffmpeg filtergraph escaping for a filename inside ass=...
-    return path.replace("\\", "\\\\").replace(":", "\\:").replace("'", "\\'")
+    # ffmpeg filtergraph escaping for a filename inside ass='...': use FORWARD
+    # slashes — doubled backslashes break the ass filter's filename parse on
+    # Windows — and escape the drive colon, which otherwise terminates the
+    # option value.
+    return path.replace("\\", "/").replace(":", "\\:").replace("'", "\\'")
 
 
 if __name__ == "__main__":

--- a/skills/ads/capabilities/render-myth-vs-fact/scripts/compose.py
+++ b/skills/ads/capabilities/render-myth-vs-fact/scripts/compose.py
@@ -85,7 +85,11 @@ def mix_audio(vo, music, work, music_db, tail_fade, video_dur=None):
 def burn(silent, audio, captions, out):
     ass = str(Path(captions).resolve()) if captions and os.path.exists(captions) else None
     if ass:
-        vf = f"[0:v]ass='{ass}'[v]"
+        # Escape for the filtergraph: FORWARD slashes (doubled backslashes break
+        # the ass filter's filename parse on Windows) and escape the drive
+        # colon, which otherwise terminates the option value.
+        ass_esc = ass.replace("\\", "/").replace(":", "\\:").replace("'", "\\'")
+        vf = f"[0:v]ass='{ass_esc}'[v]"
         run(["ffmpeg", "-y", "-loglevel", "error",
              "-i", str(silent), "-i", str(audio),
              "-filter_complex", vf, "-map", "[v]", "-map", "1:a:0",


### PR DESCRIPTION
## Problem
The subtitle-burn step fails on Windows in three compose scripts:

- **render-myth-vs-fact** `burn()` interpolates the resolved `.ass` path raw into `ass='{path}'` — the drive colon (`C:`) terminates the filter option value: `Unable to parse option value ... as image size`.
- **render-3d-character-explainer** / **render-absurdist-explainer** `_ass_escape()` doubles backslashes (`\`) — the ass filter's filename parser rejects that form on Windows too.

Validated empirically on ffmpeg 7.0 / Windows 11: both forms fail; the burn step dies.

## Fix
Normalize to **forward slashes** (ffmpeg accepts them on Windows) and escape the colon (`\:`) inside the quoted value — the one form that parses on both platforms. POSIX paths contain no backslash/colon, so behavior there is unchanged.

Verified by burning real karaoke captions in all three pipelines on Windows with this change (caption visible in output frames).

🤖 Generated with [Claude Code](https://claude.com/claude-code)