### PR TITLE
fix(fonts): silent tiny-text degradation off-macOS (proof-points, absurdist end card)

### DIFF
--- a/skills/ads/capabilities/render-absurdist-explainer/scripts/build_endcard.py
+++ b/skills/ads/capabilities/render-absurdist-explainer/scripts/build_endcard.py
@@ -18,23 +18,25 @@ Layout (top -> bottom):
 
 Reads a config.json; writes endcard.png into --out (or the config's end_card.image).
 """
-import argparse, json, os
+import argparse, json, os, sys
 from PIL import Image, ImageDraw, ImageFont
 
 W, H = 1080, 1920
 
 # Portable font fallback chain: DejaVu (ships with Pillow / most Linux), then macOS
-# Arial, then Pillow's built-in. Bold + regular variants each.
+# Arial, then Windows Arial, then Pillow's built-in. Bold + regular variants each.
 _BOLD_CANDS = [
     "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
     "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
     "/Library/Fonts/Arial Bold.ttf",
+    "C:/Windows/Fonts/arialbd.ttf",
     "DejaVuSans-Bold.ttf",
 ]
 _REG_CANDS = [
     "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
     "/System/Library/Fonts/Supplemental/Arial.ttf",
     "/Library/Fonts/Arial.ttf",
+    "C:/Windows/Fonts/arial.ttf",
     "DejaVuSans.ttf",
 ]
 

--- a/skills/ads/capabilities/render-proof-points-overlay/scripts/build_overlays.py
+++ b/skills/ads/capabilities/render-proof-points-overlay/scripts/build_overlays.py
@@ -15,15 +15,23 @@ Usage:  build_overlays.py --config config.json --out-dir <run>/generated/overlay
 import argparse
 import json
 import pathlib
+import sys
 from PIL import Image, ImageDraw, ImageFont
 
 # ---- font resolution (bold is load-bearing: regular reads as a generic UI card) ----
 FONT_CANDIDATES = [
+    # macOS
     "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
     "/System/Library/Fonts/Supplemental/Arial Rounded Bold.ttf",
     "/System/Library/Fonts/HelveticaNeue.ttc",
     "/System/Library/Fonts/SFNS.ttf",
     "/System/Library/Fonts/Supplemental/Arial.ttf",
+    # Windows
+    "C:/Windows/Fonts/arialbd.ttf",
+    "C:/Windows/Fonts/arial.ttf",
+    # Linux
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf",
 ]
 
 


### PR DESCRIPTION
## Problem
`render-proof-points-overlay/build_overlays.py`'s `FONT_CANDIDATES` are macOS-only, and `render-absurdist-explainer/build_endcard.py`'s candidates lack Windows paths. Off those platforms the loop falls through to `ImageFont.load_default()` — PIL's bitmap font, which **ignores the requested size**.

The failure mode is nasty: the script **exits 0** and writes PNGs that look plausible in a file listing, but the pills / end-card copy render at ~10px — a broken ad that passes silently. Hit in a real render on Windows 11 (validated: the overlays came out with tiny text and no warning).

## Fix
Add Windows (`arialbd.ttf`/`arial.ttf`) and Linux (DejaVu/Liberation) candidates — macOS order preserved, behavior there unchanged.