### PR TITLE
fix(myth-vs-fact): compose.py is a SyntaxError on Python 3.11 (PEP 701 nested f-string)

### DIFF
--- a/skills/ads/capabilities/render-myth-vs-fact/scripts/compose.py
+++ b/skills/ads/capabilities/render-myth-vs-fact/scripts/compose.py
@@ -42,8 +42,9 @@ def ffprobe_dur(path):
 
 def concat_silent(beats, frames_dir, work, fps):
     lst = work / "concat.txt"
-    lst.write_text("\n".join(f"file '{(frames_dir / f'beat-{b['n']}.mp4').resolve()}'"
-                             for b in beats) + "\n")
+    lst.write_text("\n".join(
+        "file '{}'".format((frames_dir / "beat-{}.mp4".format(b["n"])).resolve())
+        for b in beats) + "\n")
     out = work / "master-silent.mp4"
     run(["ffmpeg", "-y", "-loglevel", "error", "-f", "concat", "-safe", "0",
          "-i", str(lst), "-c", "copy", str(out)])


### PR DESCRIPTION
## Problem
`concat_silent()` nests an f-string that reuses the enclosing quote character:

```python
f"file '{(frames_dir / f'beat-{b['n']}.mp4').resolve()}'"
```

`b['n']` inside the single-quoted inner f-string is PEP 701 syntax — legal only on **Python 3.12+**. On 3.11 (the default python3 on plenty of systems today) the module doesn't parse:

```
SyntaxError: f-string: unmatched '['
```

so the whole myth-vs-fact compose step is unusable regardless of inputs.

## Fix
`str.format` for the nested piece — no behavior change, output byte-identical. Compile-verified on 3.11 and 3.12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)