### PR TITLE
fix(chat-recorders): page.waitForFunction options silently ignored (passed in the arg slot)

### DIFF
--- a/skills/ads/capabilities/render-chatgpt-chat/scripts/record-chat.js
+++ b/skills/ads/capabilities/render-chatgpt-chat/scripts/record-chat.js
@@ -345,7 +345,7 @@ window.__START_DRIVER__ = function () { ${driverFn} };
   await page.evaluate(() => window.__START_DRIVER__ && window.__START_DRIVER__());
 
   // 5) Wait for the driver to flag done, then flush the recording.
-  await page.waitForFunction(() => window.__DONE__ === true, { timeout: totalDurMs + 5000, polling: 100 });
+  await page.waitForFunction(() => window.__DONE__ === true, undefined, { timeout: totalDurMs + 5000, polling: 100 });
   const video = page.video();
   await page.close();
   await ctx.close();

--- a/skills/ads/capabilities/render-chatgpt-chat/scripts/render-end-card.js
+++ b/skills/ads/capabilities/render-chatgpt-chat/scripts/render-end-card.js
@@ -116,7 +116,7 @@ function main() {
     const ctx = await browser.newContext({ viewport: { width: 1080, height: 1920 }, deviceScaleFactor: 1 });
     const page = await ctx.newPage();
     await page.goto('file://' + htmlPath, { waitUntil: 'load' });
-    await page.waitForFunction(() => document.body.dataset.ready === 'true', { timeout: 5000 });
+    await page.waitForFunction(() => document.body.dataset.ready === 'true', undefined, { timeout: 5000 });
     await page.waitForTimeout(400);
     await page.screenshot({ path: outPng });
     await browser.close();

--- a/skills/ads/capabilities/render-imessage-chat/scripts/record-chat.js
+++ b/skills/ads/capabilities/render-imessage-chat/scripts/record-chat.js
@@ -367,7 +367,7 @@ async function main() {
   });
   const page = await ctx.newPage();
   await page.setContent(html, { waitUntil: 'load' });
-  await page.waitForFunction(() => window.__driverReady === true, { timeout: 5000 });
+  await page.waitForFunction(() => window.__driverReady === true, undefined, { timeout: 5000 });
   const paintOffsetSec = (Date.now() - ctxCreateTime) / 1000;
   await page.evaluate(() => window.__startDriver());
   await page.waitForTimeout(total * 1000);

--- a/skills/ads/capabilities/render-imessage-chat/scripts/render-end-card.js
+++ b/skills/ads/capabilities/render-imessage-chat/scripts/render-end-card.js
@@ -116,7 +116,7 @@ function main() {
     const ctx = await browser.newContext({ viewport: { width: 1080, height: 1920 }, deviceScaleFactor: 1 });
     const page = await ctx.newPage();
     await page.goto('file://' + htmlPath, { waitUntil: 'load' });
-    await page.waitForFunction(() => document.body.dataset.ready === 'true', { timeout: 5000 });
+    await page.waitForFunction(() => document.body.dataset.ready === 'true', undefined, { timeout: 5000 });
     await page.waitForTimeout(400);
     await page.screenshot({ path: outPng });
     await browser.close();


### PR DESCRIPTION
## Problem
Playwright for Node's signature is `page.waitForFunction(pageFunction[, arg, options])`. All four call sites in the two chat recorders pass the options object as the **second** parameter:

```js
await page.waitForFunction(() => window.__driverReady === true, { timeout: 5000 });
```

That object is serialized into the page as `arg` (unused by the predicates) and the options are **silently ignored** — the waits run with Playwright's 30 s default instead of the intended 5 s / recording-length timeouts. Not fatal on the happy path, which is why it went unnoticed, but a hung page waits 30 s (or the chatgpt recorder's driver wait loses its `polling: 100`).

## Fix
Pass `undefined` for `arg` so options land in the options slot:

```js
await page.waitForFunction(() => window.__driverReady === true, undefined, { timeout: 5000 });
```

4 sites (record-chat.js + render-end-card.js in both skills). `node --check` clean; verified by running both recorders end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)