### PR TITLE
docs(proof-points): compose_master.py docstring references a one_shot.py that doesn't exist

### DIFF
--- a/skills/ads/capabilities/render-proof-points-overlay/scripts/compose_master.py
+++ b/skills/ads/capabilities/render-proof-points-overlay/scripts/compose_master.py
@@ -4,7 +4,7 @@ music bed, apply the anti-AI grain pass -> master-final.mp4. Config-driven so it
 handles any 3-4 proof-point count.
 
 Assumes overlays already built into <run>/generated/overlays by build_overlays.py
-(the one_shot.py driver runs that first). Positions + reveal times from config.layout.
+(run fetch_icons.py + build_overlays.py first). Positions + reveal times from config.layout.
 
 Cascade signature: pills alternate LEFT / RIGHT down the frame, each revealed at
 its own time via overlay enable='gte(t,T)' — eye follows L->R->L->R on the beat.


### PR DESCRIPTION
## Problem
`compose_master.py`'s docstring says overlays are built by build_overlays.py *'(the one_shot.py driver runs that first)'* — but render-proof-points-overlay ships no `one_shot.py` (that driver lives in render-airdrop-carousel). Anyone looking for the referenced driver hits a dead end.

## Fix
Docstring now points at the actual flow (`fetch_icons.py` + `build_overlays.py` invoked directly, matching the skill's smoke test). Comment-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)