### PR TITLE
docs(imessage-cascade): PIL banner text can't render emoji — mojibake baked into the video

### DIFF
--- a/skills/ads/capabilities/render-imessage-cascade/SKILL.md
+++ b/skills/ads/capabilities/render-imessage-cascade/SKILL.md
@@ -49,6 +49,11 @@ text starts ~150px from the banner's left edge. Change one, change both.
   brand's colors — the brand lives ONLY on the handle (bottom-right) + the end card.
 - **SF Pro for all banner text** (title Semibold ~38, body Regular ~36, NOW/handle ~25).
   Never AI-render text.
+- **No emoji in notification copy.** Banner text is drawn with PIL, which cannot
+  render color emoji — a 👀 or 🔥 in a title/body comes out as mojibake
+  (`ðŸ'€`) baked into the video. Keep the texting voice with words/punctuation
+  ("where's that tee from??"); emoji are fine in the Chromium-rendered chat
+  formats (imessage-chat / chatgpt-chat), just not here.
 - 3–5 notifications (more crowds the top / clips the pill); newest enters at the BOTTOM,
   so banner 1 is the oldest and ends up on TOP.
 - ✕-clear then end card (a real hand-swipe needs a paid i2v — out of scope here).


### PR DESCRIPTION
## Problem
The cascade's notification banners are drawn with PIL, which cannot render color emoji. Texting-style copy naturally includes them — and a 👀 or 🔥 in a title/body silently renders as mojibake (`ðŸ'€`) baked into the finished video. Hit in a real render: the ad LOOKED done, the mojibake only surfaced in frame QC.

There's no code fix that makes sense here (PIL emoji support isn't realistic; the Twemoji-paste approach used elsewhere in the pack would be a bigger feature), so this documents the constraint where authors will see it.

## Fix
One craft-rule bullet in SKILL.md: no emoji in cascade notification copy; use words/punctuation — emoji remain fine in the Chromium-rendered chat formats (imessage-chat / chatgpt-chat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)