### PR TITLE
fix(mix-master): master truncated at the last VO's end on ffmpeg 6/7 (sidechain key EOF)

### DIFF
--- a/skills/ads/packs/video-ad-formats/mix-master/scripts/mix.sh
+++ b/skills/ads/packs/video-ad-formats/mix-master/scripts/mix.sh
@@ -140,7 +140,7 @@ VO_LABELS=""
 for i in $(seq 0 $((N_VO - 1))); do
   VO_LABELS+="[vo${i}]"
 done
-CHAIN+="${VO_LABELS}amix=inputs=${N_VO}:duration=longest,volume=${VO_MIX_VOLUME}[vo_pre];"$'\n'
+CHAIN+="${VO_LABELS}amix=inputs=${N_VO}:duration=longest,volume=${VO_MIX_VOLUME},apad=whole_dur=${TOTAL}[vo_pre];"$'\n'
 CHAIN+="[vo_pre]asplit=2[vo_final][vo_sc];"$'\n'
 
 # Music: pad, trim, fade out


### PR DESCRIPTION
## Problem
On current ffmpeg (verified on 7.0), `mix.sh` produces a master that ends at the **last VO clip's end** instead of `--total-duration` — the music tail after the final spoken word is gone (repro below: 8.0 s requested → 5.0 s produced; some configurations collapse much further).

Root cause: modern ffmpeg ends `sidechaincompress` when its **sidechain** input EOFs. The VO key bus `[vo_sc]` ends at the last VO, so `[music_ducked]` is truncated there, and the final `amix duration=longest` can't recover the tail (both inputs now end at the same point).

## Repro
```bash
ffmpeg -f lavfi -i color=c=blue:s=320x240:d=8:r=30 -c:v libx264 video.mp4
ffmpeg -f lavfi -i sine=frequency=440:duration=2 -ac 2 vo1.wav
ffmpeg -f lavfi -i sine=frequency=880:duration=2 -ac 2 vo2.wav
ffmpeg -f lavfi -i sine=frequency=220:duration=10 -ac 2 music.wav
bash mix.sh --video video.mp4 --vo vo1.wav,vo2.wav --vo-starts 0,3000   --music music.wav --output out.mp4 --total-duration 8.0
ffprobe out.mp4   # duration 5.0, not 8.0
```

## Fix
`apad=whole_dur=${TOTAL}` on the VO bus **before** the `asplit`, so the sidechain key spans the full timeline (silence past the last VO ⇒ compressor naturally releases; `[vo_final]` gains only trailing silence).

Verified: output = exactly `--total-duration`, the ducked music tail is present, and the VO-region loudness is unchanged (volumedetect mean identical to the unpatched run over the first 5 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)