### PR TITLE
Add render-search-grid capability (Pinterest search-moodboard format)

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -5755,6 +5755,44 @@
       }
     },
     {
+      "slug": "render-search-grid",
+      "name": "render-search-grid",
+      "category": "capabilities",
+      "domain": "ads",
+      "description": "Render a 'search-grid' (Pinterest search-moodboard) video from a config — a real-DOM page with four continuous beats (masonry search grid + typing hook with counter-drift columns → 3 cards slide in from the right and stack → the top card box-grows to fullscreen then swipe-left ×2 through captioned feature shots → warm end card), frame-stepped via Chromium and encoded with FFmpeg — deterministic assembly, FREE (real brand photos + logo; the optional music bed comes from create-music-elevenlabs), so type/logo/photos stay pixel-crisp. Use for the search-grid format.",
+      "tags": "ads",
+      "path": "skills/ads/capabilities/render-search-grid",
+      "files": [
+        "skills/ads/capabilities/render-search-grid/SKILL.md",
+        "skills/ads/capabilities/render-search-grid/scripts/build_html.py",
+        "skills/ads/capabilities/render-search-grid/scripts/capture.js",
+        "skills/ads/capabilities/render-search-grid/scripts/config.example.json",
+        "skills/ads/capabilities/render-search-grid/scripts/prep_assets.py",
+        "skills/ads/capabilities/render-search-grid/scripts/render.py",
+        "skills/ads/capabilities/render-search-grid/skill.meta.json",
+        "skills/ads/capabilities/render-search-grid/tests/smoke-test.md"
+      ],
+      "metadata": {
+        "slug": "render-search-grid",
+        "category": "capabilities",
+        "domain": "ads",
+        "tags": [
+          "ads"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install render-search-grid",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "requires_skills": [
+          "watch"
+        ]
+      }
+    },
+    {
       "slug": "render-song-mv",
       "name": "render-song-mv",
       "category": "capabilities",

--- a/skills/ads/capabilities/render-search-grid/SKILL.md
+++ b/skills/ads/capabilities/render-search-grid/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: render-search-grid
+description: Render a 'search-grid' (Pinterest search-moodboard) video from a config — a real-DOM page with four continuous beats (masonry search grid + typing hook with counter-drift columns → 3 cards slide in from the right and stack → the top card box-grows to fullscreen then swipe-left ×2 through captioned feature shots → warm end card), frame-stepped via Chromium and encoded with FFmpeg — deterministic assembly, FREE (real brand photos + logo; the optional music bed comes from create-music-elevenlabs), so type/logo/photos stay pixel-crisp. Use for the search-grid format.
+status: active
+---
+
+# render-search-grid
+
+Render the 'search-grid' format from a config. It is a **deterministic** assembler — no
+generative image/video, no AI-rendered text. Everything on screen is the brand's REAL
+product/lifestyle photography + logo, so the typed hook, feature captions, wordmark, and
+photos stay pixel-crisp. The **only** paid input is an optional music bed, produced upstream
+by `create-music-elevenlabs` and passed to `render.py --music`.
+
+## The format (four beats, one continuous ~18s motion piece, 1080×1920)
+
+1. **Search** (0–5s) — a 3-column masonry grid of the brand's catalog behind a Pinterest
+   search bar; a believable phrase types in letter-by-letter. Side columns drift DOWN, the
+   middle column drifts UP (counter-parallax).
+2. **Cards** (5–7s) — 3 room/product cards slide in from the RIGHT and stack over a warm
+   blurred backdrop.
+3. **Features** (7–14.5s) — the TOP card **physically expands** (its box grows from the
+   stacked rect to full-screen, animating width/height — NOT `transform:scale`, which would
+   stretch the image), then **swipe-left → swipe-left** through the SAME 3 rooms, each now
+   full-bleed with a caption. The 3 cards ARE the 3 features.
+4. **End card** (14.5–18s) — hero + wordmark + tagline + CTA on a warm background.
+
+## Scripts (all free / deterministic)
+
+- `scripts/build_html.py --config config.json --out index.html` — config → a single
+  self-contained HTML page exposing `window.seek(tMs)` (images base64-embedded).
+- `scripts/capture.js --html index.html --out frames --fps 30 --duration 18000` — headless
+  Chromium frame-steps `seek()` to a PNG per frame (auto-discovers a cached Playwright
+  chromium, or pass `--exe`).
+- `scripts/render.py --config config.json [--music bed.m4a] --out master.mp4` — orchestrates
+  build → capture → FFmpeg (muxes the bed with `-map 0:v:0 -map 1:a:0` when `--music` is
+  given; `$0` silent pass without it).
+- `scripts/prep_assets.py crop in.jpg out.jpg` / `logo logo.jpg wordmark.png` — the two
+  fixes this format needs almost every time: crop baked-in white L/R margins off heroes, and
+  key the white out of a black-on-white logo JPG to a transparent PNG.
+
+See `scripts/config.example.json` for the full config shape (a real worked example).
+
+## Config contract (bound by the recipe/orchestrator at remix time)
+
+`canvas`, `hook`, `grid_cols` (3 columns × 6 distinct tiles), `rooms` (exactly 3
+`{image, caption}` — the cards AND the features), `stack_bg` (blurred warm backdrop),
+`endcard` (`hero`, `wordmark`, `tagline`, `cta`, `bg`). Craft rules the renderer assumes the
+inputs already honor: real brand assets only; 6 distinct tiles/column so the drift never
+repeats; warm (never near-white) backdrops; cropped hero margins; transparent-bg wordmark;
+captions/tagline/CTA are the brand's OWN approved copy (no invented claims).
+
+## Prereqs
+
+`node` + `playwright-core` (or a cached Playwright chromium) and `ffmpeg` on PATH; `python3`
+with Pillow (for `prep_assets.py`).

--- a/skills/ads/capabilities/render-search-grid/scripts/build_html.py
+++ b/skills/ads/capabilities/render-search-grid/scripts/build_html.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""build_html.py — config-driven renderer for the "search-grid" video ad format.
+
+Reads a config.json (see config.example.json) and emits a single self-contained
+index.html that exposes `window.seek(tMs)` for deterministic frame capture. All
+images are base64-embedded so load is synchronous.
+
+Four beats (mirrors the Pinterest search-moodboard reference):
+  1. SEARCH  — masonry grid (side columns drift down / middle up) behind a Pinterest
+               search bar; the hook types in letter-by-letter.
+  2. CARDS   — 3 room cards slide in from the right and stack over a warm blurred backdrop.
+  3. FEATURES— the TOP card physically expands (box-grows) to fill the screen, then
+               swipe-left -> swipe-left through the same 3 rooms, each captioned.
+  4. END     — hero card + wordmark + tagline + CTA on a warm background.
+
+NOTE (free/deterministic renderer — no paid calls). The music bed (optional) is a
+separate paid step (create-music-elevenlabs); render.py muxes it on.
+
+Usage: python3 build_html.py --config config.json --out index.html
+"""
+import argparse, base64, json, mimetypes
+from pathlib import Path
+
+
+def datauri(path, base):
+    p = (base / path) if not Path(path).is_absolute() else Path(path)
+    mime = mimetypes.guess_type(str(p))[0] or "image/jpeg"
+    return f"data:{mime};base64," + base64.b64encode(Path(p).read_bytes()).decode()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", required=True)
+    ap.add_argument("--out", default="index.html")
+    args = ap.parse_args()
+
+    cfg_path = Path(args.config).resolve()
+    base = cfg_path.parent
+    cfg = json.loads(cfg_path.read_text())
+
+    C = cfg.get("canvas", {})
+    W, H = C.get("width", 1080), C.get("height", 1920)
+    DUR = C.get("duration_ms", 18000)
+    hook = cfg["hook"]
+    placeholder = cfg.get("placeholder", "Search for anything")
+    caret_color = cfg.get("caret_color", "#c8102e")
+
+    # 3 columns of masonry tiles (side cols drift down, middle up)
+    cols = cfg["grid_cols"]
+    assert len(cols) == 3, "grid_cols must be exactly 3 columns"
+    rooms = cfg["rooms"]           # [{image, caption}] x3 — the cards AND the features
+    assert len(rooms) == 3, "exactly 3 rooms required"
+    stack_bg = cfg["stack_bg"]
+    ec = cfg["endcard"]
+
+    U = {}  # de-dup base64 by path
+    def uri(path):
+        if path not in U:
+            U[path] = datauri(path, base)
+        return U[path]
+
+    cols_html = ""
+    for ci, col in enumerate(cols):
+        cls = "up" if ci == 1 else "down"
+        tiles = "\n".join(f'<div class="tile"><img src="{uri(t)}"></div>' for t in col)
+        cols_html += f'<div class="col {cls}">{tiles}</div>\n'
+
+    stack_html = "\n".join(
+        f'<div class="stackcard" id="sc{i}"><img src="{uri(r["image"])}"></div>'
+        for i, r in enumerate(rooms))
+    feat_html = "\n".join(
+        f'<div class="feat" id="feat{i}"><div class="feat-img"><img src="{uri(r["image"])}"></div>'
+        f'<div class="feat-scrim"></div><div class="feat-cap" id="cap{i}">{r["caption"]}</div></div>'
+        for i, r in enumerate(rooms))
+
+    ec_bg = ec.get("bg", "radial-gradient(120% 82% at 50% 42%, #ecdfce 0%, #d9c6ac 100%)")
+
+    html = f"""<!DOCTYPE html><html lang="en"><head><meta charset="utf-8">
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=Fraunces:opsz,wght@9..144,400;9..144,500;9..144,600&display=swap');
+  * {{ margin:0; padding:0; box-sizing:border-box; }}
+  html,body {{ width:{W}px; height:{H}px; overflow:hidden; background:#efece7; }}
+  #stage {{ position:relative; width:{W}px; height:{H}px; overflow:hidden; background:#efece7; }}
+  .layer {{ position:absolute; inset:0; }}
+
+  /* beat 1: search grid */
+  #gridwrap {{ position:absolute; inset:0; overflow:hidden; }}
+  .col {{ position:absolute; top:0; width:330px; display:flex; flex-direction:column; gap:22px; will-change:transform; }}
+  .col:nth-of-type(1) {{ left:22px; }} .col:nth-of-type(2) {{ left:375px; }} .col:nth-of-type(3) {{ left:728px; }}
+  .tile {{ width:100%; border-radius:22px; overflow:hidden; box-shadow:0 10px 30px rgba(40,30,20,.14); background:#fff; }}
+  .tile img {{ display:block; width:100%; height:auto; }}
+  #scrim {{ position:absolute; inset:0; pointer-events:none;
+    background:radial-gradient(120% 55% at 50% 33%, rgba(245,242,237,.80) 0%, rgba(245,242,237,.44) 34%, rgba(245,242,237,0) 62%); }}
+  #vignette {{ position:absolute; inset:0; pointer-events:none;
+    background:linear-gradient(180deg, rgba(60,45,35,.10) 0%, rgba(0,0,0,0) 16%, rgba(0,0,0,0) 84%, rgba(60,45,35,.16) 100%); }}
+  #searchwrap {{ position:absolute; top:33%; left:50%; transform:translate(-50%,-50%); width:840px; }}
+  #searchbar {{ display:flex; align-items:center; gap:18px; height:118px; padding:0 30px 0 40px; background:#fff; border-radius:60px; box-shadow:0 18px 50px rgba(40,25,15,.22); }}
+  #query {{ flex:1; font-family:'DM Sans',sans-serif; font-weight:500; font-size:44px; color:#2b2622; white-space:nowrap; overflow:hidden; }}
+  #query .ph {{ color:#b7ada3; }}
+  #caret {{ display:inline-block; width:3px; height:50px; margin-left:2px; background:{caret_color}; vertical-align:middle; transform:translateY(6px); }}
+  #mag svg {{ width:52px; height:52px; }}
+
+  /* beat 2: card stack */
+  #beat-stack {{ opacity:0; overflow:hidden; background:#6f432b; }}
+  #stack-bg {{ position:absolute; inset:-80px; background-image:url('{uri(stack_bg)}'); background-size:cover; background-position:center;
+    filter:blur(42px) brightness(.72) saturate(1.25); transform:scale(1.25); }}
+  #stack-tint {{ position:absolute; inset:0; background:radial-gradient(122% 82% at 50% 45%, rgba(96,58,36,.20) 0%, rgba(48,26,15,.66) 100%); }}
+  #stack-cards {{ position:absolute; inset:0; }}
+  .stackcard {{ position:absolute; left:90px; width:900px; height:392px; border-radius:26px; overflow:hidden;
+    box-shadow:0 26px 60px rgba(30,18,10,.34); will-change:transform,opacity,width,height; }}
+  #sc0 {{ top:342px; z-index:3; }} #sc1 {{ top:764px; z-index:2; }} #sc2 {{ top:1186px; z-index:1; }}
+  .stackcard img {{ width:100%; height:100%; object-fit:cover; display:block; }}
+
+  /* beat 3: features (grow -> swipe -> swipe) */
+  #beat-features {{ opacity:0; background:#000; overflow:hidden; }}
+  #feat-track {{ position:absolute; inset:0; }}
+  .feat {{ position:absolute; inset:0; }}
+  .feat-img {{ position:absolute; inset:0; overflow:hidden; }}
+  .feat-img img {{ width:100%; height:100%; object-fit:cover; display:block; transform-origin:center; will-change:transform; }}
+  .feat-scrim {{ position:absolute; inset:0; background:linear-gradient(180deg, rgba(0,0,0,.14) 0%, rgba(0,0,0,0) 26%, rgba(0,0,0,0) 50%, rgba(20,12,8,.64) 100%); }}
+  .feat-cap {{ position:absolute; left:0; right:0; bottom:196px; text-align:center; opacity:0;
+    font-family:'DM Sans',sans-serif; font-weight:600; font-size:66px; letter-spacing:.4px; color:#fff; text-shadow:0 3px 26px rgba(0,0,0,.44); }}
+  #feat-url {{ position:absolute; bottom:80px; left:0; right:0; text-align:center; opacity:0;
+    font-family:'DM Sans',sans-serif; font-weight:600; font-size:28px; letter-spacing:2px; text-transform:uppercase; color:#fff; text-shadow:0 2px 14px rgba(0,0,0,.55); }}
+
+  /* beat 4: end card */
+  #beat-end {{ opacity:0; display:flex; flex-direction:column; align-items:center; justify-content:center; padding:0 90px; background:{ec_bg}; }}
+  #ec-inner {{ display:flex; flex-direction:column; align-items:center; will-change:transform; }}
+  #ec-hero {{ width:704px; height:1054px; border-radius:34px; overflow:hidden; box-shadow:0 30px 80px rgba(40,25,15,.32); margin-bottom:58px; }}
+  #ec-hero img {{ width:100%; height:100%; object-fit:cover; display:block; }}
+  #ec-logo {{ height:64px; margin-bottom:34px; }}
+  #ec-tagline {{ font-family:'Fraunces',serif; font-weight:400; font-size:46px; color:#3a332c; text-align:center; line-height:1.25; }}
+  #ec-cta {{ margin-top:52px; font-family:'DM Sans',sans-serif; font-weight:600; font-size:30px; letter-spacing:2px; text-transform:uppercase; color:#8a7f73; }}
+</style></head>
+<body>
+<div id="stage">
+  <div id="beat-search" class="layer">
+    <div id="gridwrap">{cols_html}</div>
+    <div id="scrim"></div><div id="vignette"></div>
+    <div id="searchwrap"><div id="searchbar">
+      <div id="query"><span id="typed"></span><span id="caret"></span></div>
+      <div id="mag"><svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <circle cx="10.5" cy="10.5" r="7" stroke="#2b2622" stroke-width="2.4"/>
+        <line x1="15.8" y1="15.8" x2="21" y2="21" stroke="#2b2622" stroke-width="2.8" stroke-linecap="round"/></svg></div>
+    </div></div>
+  </div>
+  <div id="beat-stack" class="layer">
+    <div id="stack-bg"></div><div id="stack-tint"></div>
+    <div id="stack-cards">{stack_html}</div>
+  </div>
+  <div id="beat-features" class="layer">
+    <div id="feat-track">{feat_html}</div>
+    <div id="feat-url">{ec.get("cta_short", "")}</div>
+  </div>
+  <div id="beat-end" class="layer">
+    <div id="ec-inner">
+      <div id="ec-hero"><img src="{uri(ec["hero"])}"></div>
+      <img id="ec-logo" src="{uri(ec["wordmark"])}">
+      <div id="ec-tagline">{ec["tagline"]}</div>
+      <div id="ec-cta">{ec["cta"]}</div>
+    </div>
+  </div>
+</div>
+<script>
+  const HOOK={json.dumps(hook)}, PLACEHOLDER={json.dumps(placeholder)}, DUR={DUR};
+  const $=id=>document.getElementById(id);
+  const typed=$('typed'), caret=$('caret');
+  const bSearch=$('beat-search'), bStack=$('beat-stack'), bFeat=$('beat-features'), bEnd=$('beat-end');
+  const cols=Array.from(document.querySelectorAll('.col'));
+  const scards=[0,1,2].map(i=>$('sc'+i));
+  const feats=[0,1,2].map(i=>$('feat'+i)); const featImgs=feats.map(f=>f.querySelector('img'));
+  const caps=[0,1,2].map(i=>$('cap'+i));
+  const clamp01=x=>Math.max(0,Math.min(1,x)), lerp=(a,b,t)=>a+(b-a)*t, smooth=t=>{{t=clamp01(t);return t*t*(3-2*t);}};
+  const ramp=(t,a,b)=>smooth((t-a)/(b-a));
+  const base=[]; function measure(){{ cols.forEach((c,i)=>base[i]=-((c.scrollHeight-{H})/2)); }}
+  function seek(t){{
+    t=Math.max(0,Math.min(DUR,t));
+    const TS=480, TE=3350, n=HOOK.length;
+    let ch = t<TS?0 : t>=TE?n : Math.round(n*(t-TS)/(TE-TS));
+    typed.innerHTML = ch===0 ? '<span class="ph">'+PLACEHOLDER+'</span>' : '';
+    if(ch>0) typed.textContent=HOOK.slice(0,ch);
+    caret.style.opacity=((t>=TS&&t<TE)||(Math.floor(t/450)%2)===0)?'1':'0';
+    const gp=clamp01(t/5000), ge=gp*(2-gp);
+    cols.forEach((c,i)=>{{ const d=(i===1)?-1:1; c.style.transform='translateY('+(base[i]+d*ge*96).toFixed(2)+'px)'; }});
+
+    bSearch.style.opacity=(1-ramp(t,4500,5000)).toFixed(3);
+    bSearch.style.transform='scale('+lerp(1,1.04,ramp(t,4500,5000)).toFixed(4)+')';
+    bStack.style.opacity=(ramp(t,4650,5150)*(1-ramp(t,7560,7680))).toFixed(3);
+    bFeat.style.opacity=(ramp(t,7500,7620)*(1-ramp(t,14000,14500))).toFixed(3);
+    bEnd.style.opacity=ramp(t,14100,14650).toFixed(3);
+    $('ec-inner').style.transform='scale('+lerp(1.05,1,smooth(ramp(t,14100,15000))).toFixed(4)+')';
+
+    scards.forEach((el,i)=>{{ const st=5050+i*160, p=smooth(ramp(t,st,st+640));
+      el.style.transform='translateX('+lerp(1250,0,p).toFixed(1)+'px)'; el.style.opacity=p.toFixed(3); }});
+    const ex=smooth(ramp(t,6750,7550)), s0=scards[0];   // top card grows to fill
+    s0.style.left=lerp(90,0,ex).toFixed(1)+'px'; s0.style.top=lerp(342,0,ex).toFixed(1)+'px';
+    s0.style.width=lerp(900,{W},ex).toFixed(1)+'px'; s0.style.height=lerp(392,{H},ex).toFixed(1)+'px';
+    s0.style.borderRadius=lerp(26,0,ex).toFixed(1)+'px';
+
+    const pos=ramp(t,9500,9850)+ramp(t,11900,12250);
+    feats.forEach((el,i)=>{{ el.style.transform='translateX('+((i-pos)*{W}).toFixed(1)+'px)'; }});
+    featImgs.forEach((im,i)=>{{ const a=Math.max(0,1-Math.abs(i-pos)); im.style.transform='scale('+(1+0.06*a).toFixed(4)+')'; }});
+    caps.forEach((el,i)=>{{ let o=smooth(clamp01(1.25-Math.abs(i-pos)*1.9)); if(i===0)o*=ramp(t,7700,8050); el.style.opacity=o.toFixed(3); }});
+    $('feat-url').style.opacity=clamp01(Math.min(ramp(t,7650,8000),1-ramp(t,13800,14200))).toFixed(3);
+  }}
+  window.seek=seek;
+  window.addEventListener('load',()=>{{ measure(); seek(0); document.title='ready'; }});
+  measure(); seek(0);
+</script>
+</body></html>
+"""
+    Path(args.out).write_text(html)
+    print(f"wrote {args.out} ({len(html)//1024} KB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/ads/capabilities/render-search-grid/scripts/capture.js
+++ b/skills/ads/capabilities/render-search-grid/scripts/capture.js
@@ -1,0 +1,51 @@
+// capture.js — deterministic frame-step of index.html via headless Chromium.
+// Drives window.seek(tMs) and screenshots each frame. Free/deterministic (no paid calls).
+//
+// Usage: node capture.js --html index.html --out frames --fps 30 --duration 18000 \
+//          [--exe /path/to/Chromium] [--width 1080] [--height 1920]
+//
+// Chromium: pass --exe, or it auto-discovers the newest cached Playwright chromium
+// (~/Library/Caches/ms-playwright/chromium-*/chrome-mac/Chromium.app/.../Chromium on macOS).
+const { chromium } = require('playwright-core');
+const path = require('path'); const fs = require('fs'); const os = require('os');
+
+function arg(name, def) { const i = process.argv.indexOf('--' + name); return i > -1 ? process.argv[i + 1] : def; }
+
+function findChromium() {
+  const explicit = arg('exe'); if (explicit) return explicit;
+  const roots = [path.join(os.homedir(), 'Library/Caches/ms-playwright'), path.join(os.homedir(), '.cache/ms-playwright')];
+  for (const root of roots) {
+    if (!fs.existsSync(root)) continue;
+    // prefer the full browser (chromium-<n>) over chromium_headless_shell-<n>
+    const dirs = fs.readdirSync(root).filter(d => /^chromium-\d/.test(d)).sort().reverse();
+    for (const d of dirs) {
+      for (const rel of ['chrome-mac/Chromium.app/Contents/MacOS/Chromium', 'chrome-linux/chrome', 'chrome-win/chrome.exe']) {
+        const p = path.join(root, d, rel); if (fs.existsSync(p)) return p;
+      }
+    }
+  }
+  throw new Error('No Chromium found — pass --exe or `npx playwright install chromium`');
+}
+
+(async () => {
+  const HTML = 'file://' + path.resolve(arg('html', 'index.html'));
+  const OUT = path.resolve(arg('out', 'frames'));
+  const FPS = parseInt(arg('fps', '30'), 10);
+  const DUR = parseInt(arg('duration', '18000'), 10);
+  const W = parseInt(arg('width', '1080'), 10), Hh = parseInt(arg('height', '1920'), 10);
+  const TOTAL = Math.round(DUR / 1000 * FPS);
+  fs.rmSync(OUT, { recursive: true, force: true }); fs.mkdirSync(OUT, { recursive: true });
+  const browser = await chromium.launch({ executablePath: findChromium(), args: ['--force-color-profile=srgb'] });
+  const page = await browser.newPage({ viewport: { width: W, height: Hh }, deviceScaleFactor: 1 });
+  await page.goto(HTML, { waitUntil: 'load' });
+  await page.waitForFunction(() => typeof window.seek === 'function');
+  await page.waitForTimeout(700);
+  await page.evaluate(() => document.fonts && document.fonts.ready).catch(() => {});
+  await page.waitForTimeout(200);
+  for (let i = 0; i < TOTAL; i++) {
+    await page.evaluate(t => window.seek(t), (i / FPS) * 1000);
+    await page.screenshot({ path: path.join(OUT, 'f' + String(i).padStart(4, '0') + '.png'), clip: { x: 0, y: 0, width: W, height: Hh } });
+  }
+  await browser.close();
+  console.log('captured', TOTAL, 'frames ->', OUT);
+})();

--- a/skills/ads/capabilities/render-search-grid/scripts/config.example.json
+++ b/skills/ads/capabilities/render-search-grid/scripts/config.example.json
@@ -1,0 +1,56 @@
+{
+  "_comment": "Shipped worked example — Ruggable 'search-grid' (run-02, 2026-07). Paths point at the source project; re-point them at your own brand's real product/lifestyle photos + logo. Run prep_assets.py first: crop white margins off the end-card hero, and key the white out of the logo. All images are REAL brand assets (never AI-rendered); the only paid step is the optional music bed (create-music-elevenlabs).",
+  "canvas": { "width": 1080, "height": 1920, "fps": 30, "duration_ms": 18000 },
+  "hook": "cozy living room rug edit",
+  "placeholder": "Search for anything",
+  "caret_color": "#c8102e",
+
+  "_grid_note": "3 columns × 6 distinct tiles each (18 total). Side columns drift DOWN, middle column drifts UP. Use 6 distinct tiles/column so the drift never repeats a tile or reveals a gap. Cohesive palette is everything — warm here.",
+  "grid_cols": [
+    ["../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/02-boho-plant-room.jpg",
+     "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/06-red-persian-macro.jpg",
+     "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/03-warm-kitchen-runner.jpg",
+     "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/11-frida-flat.jpg",
+     "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/14-blue-faded-macro.jpg",
+     "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/16-patchwork-flat.jpg"],
+    ["../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/08-faded-rose-macro.jpg",
+     "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/01-living-room-fireplace.jpg",
+     "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/04-dining-chandelier.jpg",
+     "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/10-cambria-flat.jpg",
+     "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/17-linear-stripe-flat.jpg",
+     "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/13-cambria-kitchen.jpg"],
+    ["../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/07-folk-floral-macro.jpg",
+     "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/05-armchair-vignette.jpg",
+     "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/09-moody-floral-macro.jpg",
+     "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/12-vintage-daisy-flat.jpg",
+     "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/15-watercolor-flat.jpg",
+     "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/18-polychrome-flat.jpg"]
+  ],
+
+  "_rooms_note": "The 3 rooms are BOTH the stacked cards AND the enlarged/swiped features. Warm + rug-dominant + low white-wall. Captions are the brand's OWN approved product attributes — never invented claims.",
+  "rooms": [
+    { "image": "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/03-warm-kitchen-runner.jpg", "caption": "Machine Washable" },
+    { "image": "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/04-dining-chandelier.jpg", "caption": "Stain-Resistant" },
+    { "image": "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/02-boho-plant-room.jpg", "caption": "Pet & Kid Friendly" }
+  ],
+
+  "stack_bg": "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/grid/06-red-persian-macro.jpg",
+
+  "endcard": {
+    "_hero_note": "Crop white margins off first (prep_assets.py crop). Warm, rug-dominant hero.",
+    "hero": "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/endcard-hero.jpg",
+    "_wordmark_note": "Transparent-bg PNG (prep_assets.py logo) — NOT a white-bg JPG.",
+    "wordmark": "../../../clients/ruggable/ad-runs/run-02-pinterest-search-grid/source/endcard-logo.png",
+    "tagline": "Designed for whatever life unrolls.",
+    "cta": "Washable rugs · ruggable.com",
+    "cta_short": "ruggable.com",
+    "bg": "radial-gradient(120% 82% at 50% 42%, #ecdfce 0%, #d9c6ac 100%)"
+  },
+
+  "music": {
+    "prompt": "Warm, cozy home-decor moodboard background music. Soft nylon acoustic guitar with gentle warm Rhodes keys and light brushed percussion, mellow and inviting, relaxed lo-fi tempo. Instrumental only, no vocals. Full and present from the very first second; calm, uplifting mood with a soft warm resolve at the end.",
+    "length_ms": 23000,
+    "trim_to_ms": 18000,
+    "force_instrumental": true
+  }
+}

--- a/skills/ads/capabilities/render-search-grid/scripts/prep_assets.py
+++ b/skills/ads/capabilities/render-search-grid/scripts/prep_assets.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""prep_assets.py — two asset fixes this format needs almost every time.
+
+1) crop  — brand hero/lifestyle JPGs often have baked-in white L/R (or T/B) margins.
+           object-fit:cover can't create white, so edge-white = baked into the source.
+           Crops to the non-white content bbox so the image fills its card edge-to-edge.
+2) logo  — brand logo assets are frequently black-on-WHITE JPGs; over a photo or a
+           colored end-card background they show an ugly white box. Keys the white out
+           to a transparent PNG (alpha = 255 - luminance) so the wordmark floats clean.
+
+Usage:
+  python3 prep_assets.py crop  in.jpg out.jpg
+  python3 prep_assets.py logo  logo.jpg wordmark.png   [--ink 20,18,16]
+"""
+import argparse
+from PIL import Image
+
+
+def crop(src, dst):
+    im = Image.open(src).convert("RGB"); w, h = im.size; px = im.load()
+    def col_white(x): return sum(1 for y in range(0, h, 4) if min(px[x, y]) > 243) / (h // 4) > 0.97
+    def row_white(y): return sum(1 for x in range(0, w, 4) if min(px[x, y]) > 243) / (w // 4) > 0.97
+    L = 0
+    while L < w and col_white(L): L += 1
+    R = w - 1
+    while R > 0 and col_white(R): R -= 1
+    T = 0
+    while T < h and row_white(T): T += 1
+    B = h - 1
+    while B > 0 and row_white(B): B -= 1
+    out = im.crop((L, T, R + 1, B + 1))
+    out.save(dst, quality=95)
+    print(f"cropped {im.size} -> {out.size} (removed L{L} R{w-1-R} T{T} B{h-1-B})")
+
+
+def logo(src, dst, ink):
+    lg = Image.open(src).convert("RGB"); w, h = lg.size; px = lg.load()
+    out = Image.new("RGBA", (w, h), (0, 0, 0, 0)); o = out.load()
+    for y in range(h):
+        for x in range(w):
+            r, g, b = px[x, y]
+            o[x, y] = (ink[0], ink[1], ink[2], max(0, min(255, int(255 - (r + g + b) / 3))))
+    out.save(dst)
+    print(f"transparent wordmark -> {dst} {out.size}")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    c = sub.add_parser("crop"); c.add_argument("src"); c.add_argument("dst")
+    l = sub.add_parser("logo"); l.add_argument("src"); l.add_argument("dst"); l.add_argument("--ink", default="20,18,16")
+    a = ap.parse_args()
+    if a.cmd == "crop":
+        crop(a.src, a.dst)
+    else:
+        logo(a.src, a.dst, [int(x) for x in a.ink.split(",")])
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/ads/capabilities/render-search-grid/scripts/render.py
+++ b/skills/ads/capabilities/render-search-grid/scripts/render.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""render.py — free/deterministic assembly for the "search-grid" format.
+
+Pipeline: build_html.py (config -> index.html) -> capture.js (Chromium frame-step -> PNGs)
+-> ffmpeg (encode). If --music is given, it is muxed (map v:0 + a:0). NO paid calls here;
+the music bed comes from create-music-elevenlabs upstream and is passed in via --music.
+
+Prereqs: node + `npm i playwright-core` (or a cached Playwright chromium), ffmpeg on PATH.
+
+Usage:
+  python3 render.py --config config.json --out master.mp4 [--music bed.m4a] [--fps 30]
+"""
+import argparse, json, subprocess, sys, tempfile
+from pathlib import Path
+
+HERE = Path(__file__).parent
+
+
+def run(cmd, **kw):
+    print("+", " ".join(str(c) for c in cmd)); subprocess.run(cmd, check=True, **kw)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--config", required=True)
+    ap.add_argument("--out", default="master.mp4")
+    ap.add_argument("--music", help="optional audio bed (from create-music-elevenlabs), muxed on")
+    ap.add_argument("--fps", type=int)
+    ap.add_argument("--exe", help="path to a Chromium binary (else auto-discovered)")
+    args = ap.parse_args()
+
+    cfg = json.loads(Path(args.config).read_text())
+    canvas = cfg.get("canvas", {})
+    W, Hh = canvas.get("width", 1080), canvas.get("height", 1920)
+    fps = args.fps or canvas.get("fps", 30)
+    dur = canvas.get("duration_ms", 18000)
+
+    work = Path(tempfile.mkdtemp(prefix="search-grid-"))
+    html = work / "index.html"; frames = work / "frames"
+
+    run([sys.executable, str(HERE / "build_html.py"), "--config", args.config, "--out", str(html)])
+    cap = ["node", str(HERE / "capture.js"), "--html", str(html), "--out", str(frames),
+           "--fps", str(fps), "--duration", str(dur), "--width", str(W), "--height", str(Hh)]
+    if args.exe:
+        cap += ["--exe", args.exe]
+    run(cap)
+
+    enc = ["ffmpeg", "-y", "-framerate", str(fps), "-i", str(frames / "f%04d.png")]
+    if args.music:
+        enc += ["-i", args.music, "-map", "0:v:0", "-map", "1:a:0", "-c:a", "aac", "-b:a", "192k", "-shortest"]
+    enc += ["-c:v", "libx264", "-profile:v", "high", "-pix_fmt", "yuv420p", "-crf", "18",
+            "-preset", "slow", "-movflags", "+faststart", args.out]
+    run(enc)
+    print("wrote", args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/ads/capabilities/render-search-grid/skill.meta.json
+++ b/skills/ads/capabilities/render-search-grid/skill.meta.json
@@ -1,0 +1,19 @@
+{
+  "slug": "render-search-grid",
+  "category": "capabilities",
+  "domain": "ads",
+  "tags": [
+    "ads"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install render-search-grid",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "requires_skills": [
+    "watch"
+  ]
+}

--- a/skills/ads/capabilities/render-search-grid/tests/smoke-test.md
+++ b/skills/ads/capabilities/render-search-grid/tests/smoke-test.md
@@ -1,0 +1,14 @@
+# Smoke test — render-search-grid
+
+```bash
+cd scripts
+npm i playwright-core          # once (or have a cached Playwright chromium)
+python3 build_html.py --config config.example.json --out /tmp/sg.html   # -> "wrote ... KB"
+node capture.js --html /tmp/sg.html --out /tmp/sg-frames --fps 30 --duration 18000
+```
+Expect: `wrote ... KB`, `captured 540 frames`, no `PAGEERROR`. A frame at t≈7600ms shows the
+top card grown to full-screen (the box-grow, not a crossfade). `render.py --config
+config.example.json --out /tmp/sg.mp4` (no `--music`) yields a silent MP4 for a $0 pass.
+
+Passes when the deterministic render produces frames with no console errors and the four
+beats are present (search grid + typing → card stack → grow → swipe ×2 → end card).


### PR DESCRIPTION
## What

Adds the **`render-search-grid`** capability under `skills/ads/capabilities/` — the free/deterministic renderer for the new **`search-grid`** video ad format (Pinterest search-moodboard). Pairs with the canonical recipe in content-goose (`one-shot-videos/create-search-grid-video-from-refs/recipe.json`); this is the "capability" layer the recipe's `atoms` names.

## The format (one continuous ~18s 9:16 motion piece)

1. **Search** — masonry grid of the brand's real catalog behind a Pinterest search bar; a believable phrase types in letter-by-letter; side columns drift down, middle up.
2. **Cards** — 3 room/product cards slide in from the right and stack over a warm blurred backdrop.
3. **Features** — the top card **box-grows** to fullscreen (animating width/height, not `transform:scale`), then swipe-left ×2 through the same 3 rooms, each captioned.
4. **End card** — hero + wordmark + tagline + CTA on a warm background.

## Notes

- **Deterministic / free.** Real-DOM HTML exposing `window.seek(tMs)`, frame-stepped via headless Chromium (`capture.js`), encoded with FFmpeg (`render.py`). No generative image/video, no AI-rendered text — brand photos/logo/type stay pixel-crisp. The only paid input is an optional music bed from `create-music-elevenlabs`, passed to `render.py --music`.
- `prep_assets.py` ships the two fixes this format needs: crop baked-in white margins off heroes, and key white out of black-on-white logo JPGs.
- `requires_skills: [watch]`. `build:index` + `validate:skills` pass; verified locally — `GET /api/skills/catalog/render-search-grid` → 200 after catalog sync, and all three recipe atoms (`render-search-grid`, `create-music-elevenlabs`, `watch`) resolve.
- Purely additive to `skills-index.json` (no other skills changed).

Worked example: Ruggable "cozy living room rug edit" (`clients/ruggable/ad-runs/run-02-pinterest-search-grid/` in content-goose).

🤖 Generated with [Claude Code](https://claude.com/claude-code)