### PR TITLE
Add render-brand-identity-reveal capability

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -5131,6 +5131,47 @@
       }
     },
     {
+      "slug": "render-brand-identity-reveal",
+      "name": "render-brand-identity-reveal",
+      "category": "capabilities",
+      "domain": "ads",
+      "description": "Render a 'brand identity reveal' video from a config — a single poster frame in a real, softly-lit space (real wall, soft-focus plant in the corner, dappled leaf shadow, illuminated poster) whose artwork HARD-CUTS through ~10 on-brand poster mockups (hero product, IG post, hanging banners, sticker sheet, logo lockup, poster, two lifestyle stills, packaging, big icon) then holds on a brand end card. The environment plate is one create-image-fal generation; the mockups are real-DOM HTML frame-stepped via Playwright, perspective-composited into the detected frame quad with the plate's real leaf-shadow multiplied back onto each poster (reads as behind glass), sequenced by FFmpeg. Deterministic assembly, FREE (the plate comes from create-image-fal, the bed from create-music-elevenlabs), music bed only and approved brand copy only. Use for the brand-identity-reveal format.",
+      "tags": "ads",
+      "path": "skills/ads/capabilities/render-brand-identity-reveal",
+      "files": [
+        "skills/ads/capabilities/render-brand-identity-reveal/SKILL.md",
+        "skills/ads/capabilities/render-brand-identity-reveal/scripts/PIPELINE.md",
+        "skills/ads/capabilities/render-brand-identity-reveal/scripts/build_video.sh",
+        "skills/ads/capabilities/render-brand-identity-reveal/scripts/composite.py",
+        "skills/ads/capabilities/render-brand-identity-reveal/scripts/config.example.json",
+        "skills/ads/capabilities/render-brand-identity-reveal/scripts/measure_frame.py",
+        "skills/ads/capabilities/render-brand-identity-reveal/scripts/recrop.py",
+        "skills/ads/capabilities/render-brand-identity-reveal/scripts/render_art.py",
+        "skills/ads/capabilities/render-brand-identity-reveal/scripts/scene.html",
+        "skills/ads/capabilities/render-brand-identity-reveal/skill.meta.json",
+        "skills/ads/capabilities/render-brand-identity-reveal/tests/smoke-test.md"
+      ],
+      "metadata": {
+        "slug": "render-brand-identity-reveal",
+        "category": "capabilities",
+        "domain": "ads",
+        "tags": [
+          "ads"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install render-brand-identity-reveal",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "requires_skills": [
+          "watch"
+        ]
+      }
+    },
+    {
       "slug": "render-cgi-sizzle",
       "name": "render-cgi-sizzle",
       "category": "capabilities",

--- a/skills/ads/capabilities/render-brand-identity-reveal/SKILL.md
+++ b/skills/ads/capabilities/render-brand-identity-reveal/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: render-brand-identity-reveal
+description: Render a 'brand identity reveal' video from a config — a single poster frame in a real, softly-lit space (real wall, soft-focus plant in the corner, dappled leaf shadow, illuminated poster) whose artwork HARD-CUTS through ~10 on-brand poster mockups (hero product, IG post, hanging banners, sticker sheet, logo lockup, poster, two lifestyle stills, packaging, big icon) then holds on a brand end card. The environment plate is one create-image-fal generation; the mockups are real-DOM HTML frame-stepped via Playwright, perspective-composited into the detected frame quad with the plate's real leaf-shadow multiplied back onto each poster (reads as behind glass), sequenced by FFmpeg. Deterministic assembly, FREE (the plate comes from create-image-fal, the bed from create-music-elevenlabs), music bed only and approved brand copy only. Use for the brand-identity-reveal format.
+status: active
+---
+
+# render-brand-identity-reveal
+
+Render the 'brand identity reveal' format from a config. The signature is a single fixed
+poster frame in a REAL, softly-lit space (the illuminated poster-frame look of a
+boutique/cinema): a real wall, a real soft-focus plant in the lower-left corner, dappled
+leaf shadow. The artwork INSIDE the frame HARD-CUTS (no crossfade) through 11 beats — 10
+on-brand poster mockups + a brand END CARD held ~3s. Music bed only, NO voiceover; copy is
+baked into each mockup, never overlaid as captions.
+
+This capability is the **FREE** assembly only. The paid parts are separate generic
+capabilities the recipe names — `create-image-fal` (the one-shot environment plate) and
+`create-music-elevenlabs` (the bed). Never re-implement them here.
+
+## Three layers
+
+1. **Environment plate** (PAID, `create-image-fal`, flux-pro ultra, 9:16) — an *empty* lit
+   poster frame in a real space, high-res so the camera can be pushed closer by cropping.
+   Pick a wall color that makes the brand's poster colors POP (complement of the dominant hue).
+2. **Mockups** (FREE) — real-DOM HTML/CSS (`scene.html`), one poster per beat, built from the
+   brand's real assets + approved copy, frame-stepped via Playwright (`render_art.py`, bare
+   mode, device_scale_factor 2).
+3. **Composite** (FREE) — `measure_frame.py` detects the blank poster interior quad;
+   `composite.py` perspective-warps each poster into it AND multiplies the plate's real
+   leaf-shadow/light back onto the poster (so it reads as behind glass) + a glass sheen;
+   `build_video.sh` sequences the frames with the music bed.
+
+## Inputs
+
+- `config.json` — copy `scripts/config.example.json` and edit (canvas, plate prompt +
+  wall_style, camera crop, per-beat durations, end-card copy). Schema + per-file working-dir
+  layout are documented in `scripts/PIPELINE.md`.
+- The brand's REAL product/packaging/lifestyle stills, wordmark, and icon (recreate the icon
+  as an SVG `<mask>` if the only source has an occluding element). Approved copy only.
+
+## Workflow (free assembly)
+
+```bash
+CAP=skills/ads/capabilities/render-brand-identity-reveal
+RUN=<project>/working    # holds scene.html + assets/ + the create-image-fal plate in bg/
+
+python3 $CAP/scripts/recrop.py 0.72 0.13      # camera distance (bigger frac = bigger frame)
+python3 $CAP/scripts/measure_frame.py         # detect the blank poster interior quad
+python3 $CAP/scripts/render_art.py            # render each poster standalone (Playwright, dsf 2)
+python3 $CAP/scripts/composite.py             # warp into frame + shadow multiply + sheen
+bash    $CAP/scripts/build_video.sh $RUN/concat.txt $RUN/music.mp3 out.mp4 13.05 1.0
+```
+
+Then `watch` the master (music-only, every poster legible, shadow falls across the art, end
+card holds). See `scripts/PIPELINE.md` for adapting `scene.html` per brand.
+
+## Rules
+
+- Approved brand copy ONLY — never invent claims, customers, results, or testimonials.
+- Toggle beats with OPACITY, not `display` (a per-state `display:flex` silently overrides a
+  `display:none` toggle and paints one state over all others).
+- Camera distance = re-crop the high-res plate (`recrop.py`), don't regenerate.
+- The realism trick = MULTIPLY the plate's real shadow/light back onto each composited poster.
+- Music bed only, no VO. Close on the brand end card.
+
+## Failure Modes
+
+- Every rendered frame identical → a per-beat `display:` rule beat the visibility toggle; use
+  opacity.
+- Playwright `evaluate(fn, arg)` didn't switch state in a loop → bake the beat index into the
+  JS string and return the applied state to assert it.
+- Composited poster looks pasted-on → you skipped the shadow multiply (shadow_strength ~0.85).
+- Studio product won't cut out (white cap == seamless bg) → present as a photo-tile, don't
+  corner-flood-fill.
+- Playwright missing under node → use the python playwright + cached chromium.

--- a/skills/ads/capabilities/render-brand-identity-reveal/scripts/PIPELINE.md
+++ b/skills/ads/capabilities/render-brand-identity-reveal/scripts/PIPELINE.md
@@ -1,0 +1,54 @@
+# PIPELINE — brand-identity-reveal free assembly
+
+The free renderer is **documentation-grade**: `scene.html` is brand-specific (the shipped
+reference is the Touchland instance), and the Python scripts drive Playwright + PIL + FFmpeg
+around it. Adapt `scene.html` per brand; the scripts are generic.
+
+## Working-dir layout (per project)
+
+```
+working/
+  scene.html            # 11 poster modules; one active via `.on` class (toggle by OPACITY)
+  assets/products/*     # the brand's real product / lifestyle stills
+  assets/brand/*        # wordmark png, brand-icon svg
+  bg/plate_sage_1.png   # PAID: create-image-fal environment plate (high-res, empty frame)
+  bg/plate_final.png    # recrop.py output (camera distance)
+  bg/corners.txt        # measure_frame.py output (the frame interior quad)
+  art/art_std_01..11.png# render_art.py output (standalone posters, bare mode, 2x)
+  frames_v2/frame_01..11.png  # composite.py output (posters warped into the lit frame)
+  concat.txt            # ffmpeg concat list (frames + per-beat durations)
+  music.mp3             # PAID: create-music-elevenlabs bed
+```
+
+## Steps (script → output)
+
+1. **Plate [PAID]** — `create-image-fal` (flux-pro ultra, 9:16) → `bg/plate_sage_1.png`.
+   `gen_plate.py` is the reference wrapper (loads FAL_KEY, prompt in `config.plate`). Pick a
+   `wall_style` color that complements the brand's dominant hue so the posters pop.
+2. **Camera** — `recrop.py <interior_width_frac> <top_frac>` → `bg/plate_final.png`. The plate
+   is high-res, so cropping closer costs no quality. `0.72 0.13` = frame ~72% of width.
+3. **Detect frame** — `measure_frame.py` → `bg/corners.txt` (bright + low-sat + near-neutral
+   mask → largest component → 4 corners).
+4. **Mockups** — author `scene.html` (11 modules from the brand's assets + approved copy), then
+   `render_art.py` → `art/art_std_01..11.png` (Playwright bare mode: `body.bare` hides the CSS
+   room and the frame fills the viewport; `device_scale_factor=2`).
+5. **Composite** — `composite.py`: perspective-warp each poster into the quad, **multiply the
+   plate's interior luma back onto it** (`shadow_strength`), glass sheen → `frames_v2/*`.
+6. **Sequence** — write `concat.txt` (frames + `duration` lines per `config.beats[].seconds`,
+   repeat the last frame line), then `build_video.sh concat.txt music.mp3 out.mp4 <total_s>`.
+
+## Adapting `scene.html` per brand
+
+- Keep the 11 module ids (`.a1`..`.a11`, `data-i`), the `#thand` icon symbol pattern, and the
+  bare-mode CSS. Swap: product image paths, wordmark/icon, palette CSS vars, and the baked
+  copy (approved only). Recreate the brand icon as an SVG `<mask>` if the only source has an
+  occluding element.
+- Beats are opaque full-bleed; **toggle with opacity, not display** (a per-state `display:flex`
+  silently overrides a `display:none` toggle).
+
+## Split (per adding-and-testing-a-video-format.md)
+
+- **Paid** (already generic caps): `create-image-fal` (plate), `create-music-elevenlabs` (bed).
+- **Free renderer** (`render-brand-identity-reveal`): `scene.html`, `render_art.py`,
+  `recrop.py`, `measure_frame.py`, `composite.py`, `build_video.sh`. (`gen_plate.py` is a
+  convenience wrapper around the paid `create-image-fal` step — not part of the free cap.)

--- a/skills/ads/capabilities/render-brand-identity-reveal/scripts/build_video.sh
+++ b/skills/ads/capabilities/render-brand-identity-reveal/scripts/build_video.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Free assembly step: sequence the composited poster frames + a music bed into the master.
+# Inputs: a concat list (frames + per-beat durations) and a music file. No paid calls.
+#
+#   ./build_video.sh <concat.txt> <music.mp3> <out.mp4> <total_seconds> [music_start]
+#
+# concat.txt is an ffmpeg concat-demuxer list of the composited frames (frames_v2/frame_NN.png)
+# with `duration <s>` lines (variable, non-uniform rhythm); repeat the last frame line once so
+# its duration is honored. See config.example.json -> beats[].seconds for the pacing.
+set -euo pipefail
+CONCAT="${1:?concat list}"; MUSIC="${2:?music}"; OUT="${3:?out.mp4}"
+DUR="${4:?total seconds}"; MSTART="${5:-1.0}"
+FADE=$(python3 -c "print(max(0, ${DUR} - 0.35))")
+
+ffmpeg -y -hide_banner -loglevel error \
+  -f concat -safe 0 -i "$CONCAT" \
+  -ss "$MSTART" -i "$MUSIC" \
+  -filter_complex "[0:v]fps=30,scale=1080:1920:force_original_aspect_ratio=increase,crop=1080:1920,setsar=1,format=yuv420p[v];\
+[1:a]atrim=0:${DUR},asetpts=PTS-STARTPTS,afade=t=out:st=${FADE}:d=0.35,loudnorm=I=-14:TP=-1.5:LRA=11[a]" \
+  -map "[v]" -map "[a]" -t "$DUR" \
+  -c:v libx264 -crf 20 -preset medium -pix_fmt yuv420p \
+  -c:a aac -b:a 192k -movflags +faststart \
+  "$OUT"
+echo "wrote $OUT (${DUR}s)"

--- a/skills/ads/capabilities/render-brand-identity-reveal/scripts/composite.py
+++ b/skills/ads/capabilities/render-brand-identity-reveal/scripts/composite.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Composite each standalone artwork into the lit poster frame of the photoreal plate.
+Reintroduces the plate's real leaf-shadow/lighting onto the poster + adds glass sheen."""
+import os, ast
+import numpy as np
+from PIL import Image, ImageDraw, ImageFilter
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PLATE = Image.open(os.path.join(HERE, "bg/plate_final.png")).convert("RGB")
+W, H = PLATE.size
+c = ast.literal_eval(open(os.path.join(HERE, "bg/corners.txt")).read())
+# inset 4px so artwork never bleeds onto the wood frame
+def inset(p, dx, dy): return (p[0] + dx, p[1] + dy)
+TL = inset(c["tl"], 4, 4); TR = inset(c["tr"], -4, 4)
+BR = inset(c["br"], -4, -4); BL = inset(c["bl"], 4, -4)
+QUAD = [TL, TR, BR, BL]
+
+OUT = os.path.join(HERE, "frames_v2"); os.makedirs(OUT, exist_ok=True)
+
+def find_coeffs(output_pts, input_pts):
+    A = []
+    for (xo, yo), (xi, yi) in zip(output_pts, input_pts):
+        A.append([xo, yo, 1, 0, 0, 0, -xi * xo, -xi * yo])
+        A.append([0, 0, 0, xo, yo, 1, -yi * xo, -yi * yo])
+    A = np.array(A, dtype=np.float64)
+    B = np.array(input_pts, dtype=np.float64).reshape(8)
+    return np.linalg.solve(A, B)
+
+# --- shadow/light map from the empty plate interior (canvas space) ---
+plate_np = np.asarray(PLATE).astype(np.float32)
+luma = 0.2126 * plate_np[..., 0] + 0.7152 * plate_np[..., 1] + 0.0722 * plate_np[..., 2]
+# reference "fully-lit" white = high percentile inside the quad bbox
+xs = [p[0] for p in QUAD]; ys = [p[1] for p in QUAD]
+sub = luma[min(ys):max(ys), min(xs):max(xs)]
+ref = np.percentile(sub, 97)
+mapf = np.clip(luma / max(ref, 1.0), 0.25, 1.0)
+mapf = 1.0 - (1.0 - mapf) * 0.85          # 0.85 = shadow strength
+mapf = np.stack([mapf] * 3, axis=-1)       # HxWx3
+
+# glass sheen (soft diagonal highlight) + edge inner shadow, built once in quad space
+sheen = Image.new("L", (W, H), 0)
+sd = ImageDraw.Draw(sheen)
+sd.polygon(QUAD, fill=0)
+# a bright band across the upper-left of the poster
+band = Image.new("L", (W, H), 0)
+bd = ImageDraw.Draw(band)
+bx0, by0 = TL; bx1 = TR[0]
+bd.polygon([(bx0, by0), (bx0 + (bx1 - bx0) * 0.55, by0),
+            (bx0, by0 + (BL[1] - by0) * 0.62)], fill=42)
+band = band.filter(ImageFilter.GaussianBlur(70))
+sheen_np = np.asarray(band).astype(np.float32)[..., None]
+
+def coeffs_for():
+    inp = [(0, 0), (1480 - 1, 0), (1480 - 1, 2136 - 1), (0, 2136 - 1)]
+    return find_coeffs(QUAD, inp)
+
+COEFFS = coeffs_for()
+
+for i in range(1, 12):
+    art = Image.open(os.path.join(HERE, f"art/art_std_{i:02d}.png")).convert("RGBA")
+    warped = art.transform((W, H), Image.PERSPECTIVE, COEFFS, Image.BICUBIC, fillcolor=(0, 0, 0, 0))
+    wnp = np.asarray(warped).astype(np.float32)
+    rgb = wnp[..., :3]; alpha = wnp[..., 3:4] / 255.0
+    rgb = rgb * mapf                       # bake real leaf-shadow onto poster
+    rgb = np.clip(rgb + sheen_np, 0, 255)  # glass sheen highlight
+    out = plate_np.copy()
+    out = out * (1 - alpha) + rgb * alpha  # alpha composite over plate
+    Image.fromarray(out.astype(np.uint8)).save(os.path.join(OUT, f"frame_{i:02d}.png"))
+    print("wrote", f"frame_{i:02d}.png")

--- a/skills/ads/capabilities/render-brand-identity-reveal/scripts/config.example.json
+++ b/skills/ads/capabilities/render-brand-identity-reveal/scripts/config.example.json
@@ -1,0 +1,51 @@
+{
+  "canvas": { "width": 1080, "height": 1920, "fps": 30 },
+
+  "plate": {
+    "_comment": "PAID: generated once via create-image-fal (fal-ai/flux-pro/v1.1-ultra). Empty lit poster frame in a real space. Pick a wall color that makes the brand's poster colors POP (complement of the dominant brand hue).",
+    "model": "fal-ai/flux-pro/v1.1-ultra",
+    "aspect_ratio": "9:16",
+    "wall_style": "soft sage-green glossy subway tiles with fine grout lines",
+    "prompt": "Photorealistic vertical 9:16 photograph, cinematic soft light, shallow depth of field. A single empty poster frame mounted flat on a wall, viewed nearly straight-on with only slight perspective. Slim brushed/wood snap poster frame with a thin bevel and soft drop shadow. The poster panel inside is a BLANK plain matte off-white surface, evenly and brightly lit like an illuminated lightbox, completely empty with NO text/logo/image. Lower-left foreground: a real potted plant with green leaves thrown heavily out of focus (creamy bokeh), leaves rising to about the bottom edge of the frame. Gentle dappled leaf shadows on the wall upper area. Premium boutique interior, warm inviting light, subtle vignette. {wall_style}."
+  },
+
+  "camera": {
+    "_comment": "Frame size in the composition. recrop.py <interior_width_frac> <top_frac>. Larger frac = closer camera / bigger frame. 0.72 = frame fills ~72% of width.",
+    "interior_width_frac": 0.72,
+    "top_frac": 0.13
+  },
+
+  "composite": {
+    "_comment": "composite.py: perspective-warp each mockup into the detected frame quad, MULTIPLY the plate's real leaf-shadow/light back onto the poster (shadow_strength), add glass sheen.",
+    "shadow_strength": 0.85,
+    "sheen": true
+  },
+
+  "beats": [
+    { "id": 1,  "kind": "hero-product",        "seconds": 1.05, "note": "real product on brand-color bg + ghosted brand icon" },
+    { "id": 2,  "kind": "social-post",         "seconds": 0.95, "note": "IG-post mockup: product/lifestyle image + approved caption" },
+    { "id": 3,  "kind": "hanging-banners",     "seconds": 0.95, "note": "two banners: wordmark + product + 3-word descriptor" },
+    { "id": 4,  "kind": "sticker-sheet",       "seconds": 1.05, "note": "repeating brand-icon badge grid + one peel sticker" },
+    { "id": 5,  "kind": "logo-lockup",         "seconds": 1.00, "note": "icon + wordmark + tagline" },
+    { "id": 6,  "kind": "poster",              "seconds": 1.05, "note": "editorial hero still + approved headline + URL" },
+    { "id": 7,  "kind": "lifestyle-a",         "seconds": 0.95, "note": "real lifestyle still, full-bleed" },
+    { "id": 8,  "kind": "packaging",           "seconds": 0.95, "note": "real packaging hero + short label" },
+    { "id": 9,  "kind": "lifestyle-b",         "seconds": 1.00, "note": "second real lifestyle still, full-bleed" },
+    { "id": 10, "kind": "big-icon",            "seconds": 1.10, "note": "large brand icon sign-off on brand color" },
+    { "id": 11, "kind": "end-card",            "seconds": 3.00, "note": "BRAND END CARD: icon + wordmark + tagline + what the brand makes + Shop Now + URL. Held long." }
+  ],
+
+  "music": {
+    "_comment": "PAID (optional, default ON): create-music-elevenlabs, instrumental. Reference is music-bed-only, NO VO.",
+    "direction": "upbeat playful pop / soft house, 90-120 BPM, instrumental, beauty-brand Reels energy",
+    "start_offset_s": 1.0
+  },
+
+  "end_card": {
+    "tagline": "<brand tagline>",
+    "descriptor": "<one approved descriptor line>",
+    "product_lines": "<what the brand makes, e.g. 'hand mist · body & hair mist · glow essence'>",
+    "cta": "Shop Now",
+    "url": "<brand.com>"
+  }
+}

--- a/skills/ads/capabilities/render-brand-identity-reveal/scripts/measure_frame.py
+++ b/skills/ads/capabilities/render-brand-identity-reveal/scripts/measure_frame.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Detect the bright blank poster interior in the plate and report its 4 corners."""
+import numpy as np
+from PIL import Image, ImageDraw
+
+im = Image.open("bg/plate_final.png").convert("RGB")
+a = np.asarray(im).astype(np.int32)
+R, G, B = a[..., 0], a[..., 1], a[..., 2]
+mx = a.max(2); mn = a.min(2)
+val = mx
+sat = np.where(mx > 0, (mx - mn) / np.maximum(mx, 1), 0)
+# poster interior: bright, low saturation, near-neutral (not green wall, not tan frame)
+mask = (val > 150) & (sat < 0.16) & (np.abs(R - G) < 26) & (np.abs(G - B) < 26)
+
+# keep the largest connected component via simple flood using scipy if present, else bbox of mask
+try:
+    from scipy import ndimage
+    lbl, n = ndimage.label(mask)
+    if n:
+        sizes = ndimage.sum(np.ones_like(lbl), lbl, range(1, n + 1))
+        biggest = int(np.argmax(sizes)) + 1
+        mask = lbl == biggest
+except Exception as e:
+    print("no scipy, using raw mask:", e)
+
+ys, xs = np.where(mask)
+s = xs + ys
+d = xs - ys
+tl = (xs[np.argmin(s)], ys[np.argmin(s)])
+br = (xs[np.argmax(s)], ys[np.argmax(s)])
+tr = (xs[np.argmax(d)], ys[np.argmax(d)])
+bl = (xs[np.argmin(d)], ys[np.argmin(d)])
+print("bbox:", xs.min(), ys.min(), xs.max(), ys.max())
+print("TL", tl, "TR", tr, "BR", br, "BL", bl)
+
+# draw for verification
+g = im.copy(); dr = ImageDraw.Draw(g)
+for p, c in [(tl, (255, 0, 0)), (tr, (0, 120, 255)), (br, (255, 0, 255)), (bl, (0, 200, 0))]:
+    dr.ellipse([p[0]-10, p[1]-10, p[0]+10, p[1]+10], fill=c)
+dr.line([tl, tr, br, bl, tl], fill=(255, 0, 0), width=3)
+g.save("bg/plate_corners.png")
+with open("bg/corners.txt", "w") as f:
+    f.write(repr({"tl": tl, "tr": tr, "br": br, "bl": bl}))
+print("saved plate_corners.png")

--- a/skills/ads/capabilities/render-brand-identity-reveal/scripts/recrop.py
+++ b/skills/ads/capabilities/render-brand-identity-reveal/scripts/recrop.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Re-crop the high-res plate tighter (closer camera) so the frame is bigger.
+Detects the poster interior in the original, then crops a 9:16 window that puts the
+interior at a target width fraction, keeping wall above and the plant in the corner."""
+import sys, numpy as np
+from PIL import Image
+from scipy import ndimage
+
+SRC = "bg/plate_sage_1.png"
+FRAC = float(sys.argv[1]) if len(sys.argv) > 1 else 0.72   # interior width / output width
+TOP_FRAC = float(sys.argv[2]) if len(sys.argv) > 2 else 0.13  # interior top as frac of output H
+
+im = Image.open(SRC).convert("RGB")
+W0, H0 = im.size
+a = np.asarray(im).astype(np.int32)
+R, G, B = a[..., 0], a[..., 1], a[..., 2]
+mx = a.max(2); mn = a.min(2)
+val = mx; sat = np.where(mx > 0, (mx - mn) / np.maximum(mx, 1), 0)
+mask = (val > 150) & (sat < 0.16) & (np.abs(R - G) < 26) & (np.abs(G - B) < 26)
+lbl, n = ndimage.label(mask)
+sizes = ndimage.sum(np.ones_like(lbl), lbl, range(1, n + 1))
+mask = lbl == (int(np.argmax(sizes)) + 1)
+ys, xs = np.where(mask)
+ix0, iy0, ix1, iy1 = xs.min(), ys.min(), xs.max(), ys.max()
+iw, ih = ix1 - ix0, iy1 - iy0
+icx = (ix0 + ix1) / 2
+print("interior in original:", ix0, iy0, ix1, iy1, "w,h", iw, ih)
+
+# crop width so interior spans FRAC of output width
+CW = iw / FRAC
+CH = CW * 1920 / 1080
+scale = 1080 / CW
+# horizontal: center on interior center
+cx0 = icx - CW / 2
+# vertical: interior top at TOP_FRAC of output
+cy0 = iy0 - (TOP_FRAC * 1920) / scale
+# clamp inside original
+cx0 = max(0, min(cx0, W0 - CW))
+cy0 = max(0, min(cy0, H0 - CH))
+box = (int(round(cx0)), int(round(cy0)), int(round(cx0 + CW)), int(round(cy0 + CH)))
+print("crop box:", box, "-> scale", round(scale, 3))
+crop = im.crop(box).resize((1080, 1920), Image.LANCZOS)
+crop.save("bg/plate_final.png")
+print("saved bg/plate_final.png")

--- a/skills/ads/capabilities/render-brand-identity-reveal/scripts/render_art.py
+++ b/skills/ads/capabilities/render-brand-identity-reveal/scripts/render_art.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Render each artwork standalone (bare mode) at the frame-interior aspect, 2x for crispness."""
+import os, sys
+from playwright.sync_api import sync_playwright
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCENE = f"file://{HERE}/scene.html"
+OUT = os.path.join(HERE, "art"); os.makedirs(OUT, exist_ok=True)
+IW, IH = 740, 1068  # matches original frame-interior design; dsf=2 -> 1480x2136
+
+states = sys.argv[1:] or [str(i) for i in range(1, 11)]
+with sync_playwright() as p:
+    b = p.chromium.launch()
+    pg = b.new_page(viewport={"width": IW, "height": IH}, device_scale_factor=2)
+    pg.goto(SCENE); pg.wait_for_timeout(500)
+    pg.evaluate("document.body.classList.add('bare')")
+    for i in states:
+        js = ("() => { document.querySelectorAll('.art').forEach(e=>e.classList.remove('on'));"
+              "var el=document.querySelector('.art[data-i=\"%s\"]'); if(el)el.classList.add('on');"
+              "return document.querySelector('.art.on')?document.querySelector('.art.on').dataset.i:'NONE'; }") % i
+        on = pg.evaluate(js)
+        pg.wait_for_timeout(500)
+        out = os.path.join(OUT, f"art_std_{int(i):02d}.png")
+        pg.screenshot(path=out, clip={"x": 0, "y": 0, "width": IW, "height": IH})
+        print(f"wrote {out} (on={on})")
+    b.close()

--- a/skills/ads/capabilities/render-brand-identity-reveal/scripts/scene.html
+++ b/skills/ads/capabilities/render-brand-identity-reveal/scripts/scene.html
@@ -1,0 +1,374 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>touchland — brand identity reveal</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --pink:#FF9DB6; --pink-deep:#FF6F8A; --coral:#FF8A7A;
+    --lav:#C7B4F0; --lav-deep:#A98FE6; --mint:#9FE0C6; --mint-deep:#6FD0AC;
+    --lemon:#F3E483; --bone:#F7F0E4; --cream:#F3E8D8; --ink:#2A2A2E; --ink-soft:#6b6b70;
+  }
+  *{box-sizing:border-box; margin:0; padding:0;}
+  html,body{width:1080px; height:1920px; overflow:hidden; font-family:'Inter',sans-serif; background:#ded6cb;}
+
+  /* ============ WALL ============ */
+  .wall{position:absolute; inset:0;
+    background:
+      radial-gradient(120% 90% at 50% 22%, #efe8dd 0%, #e6ded2 42%, #d9d0c3 78%, #cabfb0 100%);
+  }
+  .wall::after{ /* vignette */
+    content:""; position:absolute; inset:0;
+    background:radial-gradient(130% 100% at 50% 42%, rgba(0,0,0,0) 55%, rgba(60,45,40,.16) 100%);
+  }
+  .grain{position:absolute; inset:0; opacity:.05; mix-blend-mode:multiply; pointer-events:none;}
+  /* soft leaf shadow cast on wall (upper area, like the reference) */
+  .leafshadow{position:absolute; top:-140px; right:-120px; width:900px; height:1000px;
+    opacity:.07; filter:blur(12px); mix-blend-mode:multiply; transform:rotate(8deg);}
+  .leafshadow svg{width:100%;height:100%;}
+
+  /* ============ FRAME ============ */
+  .frame{position:absolute; left:144px; top:352px; width:792px; height:1128px;
+    border:24px solid #f6f1ea;
+    border-radius:4px;
+    box-shadow:
+      0 2px 0 2px #cdbfae inset,          /* inner molding shade */
+      0 0 0 2px #b7a892,                  /* outer edge */
+      -26px 34px 60px rgba(40,28,22,.34), /* drop shadow */
+      10px 10px 24px rgba(40,28,22,.12);
+    background:#ffffff;
+    overflow:hidden;
+    z-index:5;
+  }
+  .frame::after{ /* subtle glass sheen across the artwork */
+    content:""; position:absolute; inset:0; z-index:40; pointer-events:none;
+    background:linear-gradient(128deg, rgba(255,255,255,.22) 0%, rgba(255,255,255,0) 26%, rgba(255,255,255,0) 82%, rgba(255,255,255,.10) 100%);
+  }
+  .art{position:absolute; inset:0; opacity:0; overflow:hidden;}
+  .art.on{opacity:1;}
+
+  /* bare mode: render only the artwork (for compositing into a real photo plate) */
+  body.bare .wall, body.bare .leafshadow, body.bare .plant, body.bare .pot{display:none !important;}
+  body.bare .frame{left:0 !important; top:0 !important; width:100vw !important; height:100vh !important;
+    border:0 !important; border-radius:0 !important; box-shadow:none !important; background:#fff;}
+  body.bare .frame::after{display:none !important;}
+  .cover{position:absolute; inset:0; width:100%; height:100%; object-fit:cover;}
+
+  /* ============ FOREGROUND PLANT ============ */
+  .plant{position:absolute; left:-70px; bottom:-40px; width:640px; height:660px;
+    z-index:20; filter:blur(14px); opacity:.97;}
+  .plant svg{width:100%; height:100%;}
+  .pot{position:absolute; left:70px; bottom:-60px; width:300px; height:300px; z-index:19;
+    filter:blur(13px);
+    background:radial-gradient(60% 70% at 50% 30%, #d8b48f 0%, #c69a72 55%, #a97e58 100%);
+    border-radius:20px 20px 40px 40px;}
+
+  /* ============ shared brand bits ============ */
+  .ic{color:#fff;}
+  .ic svg{display:block; width:100%; height:100%;}
+  .wm{height:44px;}                    /* wordmark png, dark */
+  .wm.white{filter:brightness(0) invert(1);}
+  .badge{position:absolute; display:flex; align-items:center; justify-content:center; border-radius:50%;}
+
+  /* ---------- Art 1: HERO ---------- */
+  .a1{background:radial-gradient(85% 75% at 50% 42%, #FFB3C6 0%, #FF9DB6 55%, #FF7E9E 100%);}
+  .a1 .rings{position:absolute; inset:0; display:flex; align-items:center; justify-content:center;}
+  .a1 .rings i{position:absolute; border:2px solid rgba(255,255,255,.28); border-radius:50%;}
+  .a1 .ghost{position:absolute; left:50%; top:44%; transform:translate(-50%,-50%); width:360px; height:420px; opacity:.16;}
+  .a1 .tile{position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); width:74%;
+    border-radius:26px; overflow:hidden; box-shadow:0 24px 50px rgba(120,30,50,.28); border:8px solid #fff;}
+  .a1 .tile img{width:100%; display:block;}
+  .a1 .tag{position:absolute; left:0; right:0; bottom:52px; text-align:center; color:#fff;
+    font-family:'Poppins'; font-weight:700; font-size:44px; letter-spacing:1px; text-shadow:0 2px 10px rgba(150,30,60,.3);}
+
+  /* ---------- Art 2: IG POST ---------- */
+  .a2{background:linear-gradient(160deg,#D8C6F5,#C0A9EC);}
+  .post{position:absolute; left:50%; top:50%; transform:translate(-50%,-50%); width:84%;
+    background:#fff; border-radius:22px; overflow:hidden; box-shadow:0 26px 54px rgba(70,40,110,.3);}
+  .post .hd{display:flex; align-items:center; gap:14px; padding:20px 22px;}
+  .post .av{width:56px; height:56px; border-radius:50%; background:linear-gradient(135deg,#FF9DB6,#FF7E9E);
+    display:flex; align-items:center; justify-content:center;}
+  .post .av .ic{width:30px; height:34px;}
+  .post .hn{font-family:'Poppins'; font-weight:700; font-size:30px; color:#1a1a1a;}
+  .post .dots{margin-left:auto; font-size:34px; color:#333; letter-spacing:2px; font-weight:700;}
+  .post .im{position:relative; width:100%; aspect-ratio:1/1; overflow:hidden; background:#f3eee6;}
+  .post .im img{width:100%; height:100%; object-fit:cover;}
+  .post .cap-on{position:absolute; left:26px; bottom:24px; color:#fff; font-family:'Poppins'; font-weight:800;
+    font-size:52px; line-height:.98; text-shadow:0 3px 14px rgba(0,0,0,.28);}
+  .post .im::after{content:""; position:absolute; inset:0; background:linear-gradient(0deg, rgba(30,10,30,.34) 0%, rgba(0,0,0,0) 40%);}
+  .post .row{display:flex; align-items:center; gap:24px; padding:20px 24px 6px; font-size:38px;}
+  .post .row .sp{margin-left:auto;}
+  .post .cap{padding:2px 24px 26px; font-size:26px; color:#222; line-height:1.3;}
+  .post .cap b{font-family:'Poppins'; font-weight:600;}
+
+  /* ---------- Art 3: BANNERS ---------- */
+  .a3{background:radial-gradient(90% 80% at 50% 40%, #B9EBD6 0%, #9FE0C6 60%, #7FD0AC 100%);}
+  .banner{position:absolute; top:70px; width:300px; height:830px; border-radius:12px 12px 6px 6px;
+    box-shadow:0 22px 40px rgba(20,80,60,.28); overflow:hidden; display:flex; flex-direction:column; align-items:center;}
+  .banner::before{content:""; position:absolute; top:-26px; left:50%; transform:translateX(-50%);
+    width:150px; height:16px; background:#4a4a4a; border-radius:8px;}
+  .banner::after{content:""; position:absolute; top:-30px; left:50%; transform:translateX(-50%);
+    width:8px; height:20px; background:#4a4a4a;}
+  .bL{left:74px; transform:rotate(-2.5deg); background:#F4E9DA;}
+  .bR{right:74px; top:100px; transform:rotate(2deg); background:#FBFAF6;}
+  .banner .wm{margin-top:40px; height:36px;}
+  .banner .ptile{width:180px; height:230px; margin-top:30px; border-radius:16px; overflow:hidden; box-shadow:0 10px 22px rgba(40,40,40,.16);}
+  .banner .ptile img{width:100%; height:100%; object-fit:cover;}
+  .banner h4{font-family:'Poppins'; font-weight:800; font-size:40px; color:#c65a72; margin-top:30px; text-align:center; line-height:1; padding:0 18px;}
+  .bR h4{color:#3aa07e;}
+  .banner p{font-size:22px; color:#6b6b70; margin-top:12px; letter-spacing:1px; text-transform:uppercase;}
+  .banner .mini{margin-top:auto; margin-bottom:26px; width:38px; height:44px;}
+  .bL .mini{color:#c65a72;} .bR .mini{color:#3aa07e;}
+
+  /* ---------- Art 4: STICKER SHEET ---------- */
+  .a4{background:#F4ECDD;}
+  .sheet{position:absolute; inset:0; display:grid; grid-template-columns:repeat(3,1fr); grid-template-rows:repeat(4,1fr);
+    place-items:center; padding:24px; opacity:.9;}
+  .stk{width:180px; height:180px; border-radius:50%; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:6px;
+    box-shadow:0 6px 14px rgba(0,0,0,.08);}
+  .stk .ic{width:70px; height:80px;}
+  .stk small{font-family:'Poppins'; font-weight:700; font-size:19px; color:#fff; letter-spacing:.5px;}
+  .peel{position:absolute; left:50%; top:50%; transform:translate(-50%,-52%) rotate(-6deg); width:320px; height:320px; border-radius:50%;
+    display:flex; flex-direction:column; align-items:center; justify-content:center; gap:12px;
+    box-shadow:0 30px 50px rgba(0,0,0,.28), 0 0 0 10px rgba(255,255,255,.9);}
+  .peel .ic{width:120px; height:138px;}
+  .peel small{font-family:'Poppins'; font-weight:800; font-size:34px; color:#fff; letter-spacing:1px;}
+  .peel .curl{position:absolute; right:-6px; bottom:-6px; width:120px; height:120px; border-radius:50%;
+    background:linear-gradient(135deg, rgba(255,255,255,0), rgba(0,0,0,.18)); filter:blur(4px);}
+
+  /* ---------- Art 5: LOGO LOCKUP ---------- */
+  .a5{background:linear-gradient(180deg,#FBF4E9,#F3E8D6); display:flex; flex-direction:column; align-items:center; justify-content:center;}
+  .a5 .ic{width:150px; height:172px; color:#FF7E9E; margin-bottom:8px;}
+  .a5 .wm{height:78px;}
+  .a5 .tl{margin-top:26px; font-family:'Poppins'; font-weight:600; letter-spacing:8px; text-transform:uppercase; font-size:26px; color:#8a8088;}
+  .a5 .rule{width:70px; height:4px; background:#FF7E9E; border-radius:2px; margin-top:30px;}
+
+  /* ---------- Art 6: POSTER (rose editorial) ---------- */
+  .a6 .cover{object-position:50% 20%;}
+  .a6 .scrim{position:absolute; inset:0; background:linear-gradient(0deg, rgba(48,14,26,.82) 0%, rgba(48,14,26,.55) 24%, rgba(48,14,26,0) 50%);}
+  .a6 .badge{top:34px; right:34px; width:118px; height:118px; background:rgba(255,255,255,.16); border:2px solid rgba(255,255,255,.7);}
+  .a6 .badge .ic{width:60px; height:70px; color:#fff;}
+  .a6 .cta{position:absolute; left:44px; right:44px; bottom:200px; color:#fff;}
+  .a6 .cta h2{font-family:'Poppins'; font-weight:800; font-size:64px; line-height:1.0; text-shadow:0 3px 14px rgba(0,0,0,.35);}
+  .a6 .cta .url{margin-top:20px; font-family:'Poppins'; font-weight:600; letter-spacing:4px; text-transform:uppercase; font-size:25px; opacity:.92;}
+
+  /* ---------- Art 7 & 9: full-bleed lifestyle ---------- */
+  .a7 .wmk,.a9 .wmk{position:absolute; right:40px; bottom:40px; height:38px; z-index:5; filter:brightness(0) invert(1); opacity:.95;}
+
+  /* ---------- Art 8: PACKAGING ---------- */
+  .a8{background:radial-gradient(85% 75% at 50% 42%, #BFE7FF 0%, #A6D8FA 55%, #86C4F0 100%);}
+  .a8 .tile{position:absolute; left:50%; top:46%; transform:translate(-50%,-50%); width:80%;
+    border-radius:24px; overflow:hidden; box-shadow:0 26px 52px rgba(20,60,110,.3); border:8px solid #fff;}
+  .a8 .tile img{width:100%; display:block;}
+  .a8 .badge{top:34px; right:34px; width:104px; height:104px; background:#fff; box-shadow:0 8px 18px rgba(20,60,110,.2);}
+  .a8 .badge .ic{width:52px; height:60px; color:#5AA6E0;}
+  .a8 .lab{position:absolute; left:0; right:0; bottom:150px; text-align:center;}
+  .a8 .lab h3{font-family:'Poppins'; font-weight:800; font-size:52px; color:#fff; letter-spacing:1px; text-shadow:0 2px 10px rgba(20,60,110,.3);}
+  .a8 .lab p{margin-top:8px; font-family:'Poppins'; font-weight:500; letter-spacing:4px; text-transform:uppercase; font-size:24px; color:rgba(255,255,255,.92);}
+
+  /* ---------- Art 11: END CARD ---------- */
+  .a11{background:linear-gradient(165deg,#FCEFEA 0%,#F8DEE3 58%,#F3CDD7 100%);
+    display:flex; flex-direction:column; align-items:center; justify-content:center; text-align:center; padding:0 56px;}
+  .a11 .ic{width:118px; height:136px; color:#FF6F8A; margin-bottom:6px;}
+  .a11 .wm{height:66px;}
+  .a11 .tl{margin-top:18px; font-family:'Poppins'; font-weight:600; letter-spacing:7px; text-transform:uppercase; font-size:23px; color:#E1607E;}
+  .a11 .rule{width:62px; height:4px; background:#FF6F8A; border-radius:2px; margin:28px 0;}
+  .a11 .desc{font-family:'Poppins'; font-weight:800; font-size:44px; line-height:1.04; color:#2A2A2E;}
+  .a11 .cats{margin-top:16px; font-family:'Inter'; font-weight:500; font-size:21px; letter-spacing:.5px; color:#8a7c7f;}
+  .a11 .shop{margin-top:44px; display:flex; flex-direction:column; align-items:center; gap:16px;}
+  .a11 .pill{background:#2A2A2E; color:#fff; font-family:'Poppins'; font-weight:600; font-size:27px; padding:17px 42px; border-radius:44px;}
+  .a11 .url{font-family:'Poppins'; font-weight:600; letter-spacing:3px; font-size:22px; color:#2A2A2E; text-transform:uppercase;}
+
+  /* ---------- Art 10: BIG ICON ---------- */
+  .a10{background:radial-gradient(80% 70% at 50% 42%, #FF9DB6 0%, #FF7E9E 60%, #FF6486 100%); display:flex; align-items:center; justify-content:center;}
+  .a10 .rings{position:absolute; inset:0; display:flex; align-items:center; justify-content:center;}
+  .a10 .rings i{position:absolute; border:2px solid rgba(255,255,255,.22); border-radius:50%;}
+  .a10 .ic{width:360px; height:420px; color:#fff; z-index:2; filter:drop-shadow(0 10px 24px rgba(150,30,60,.28));}
+</style>
+</head>
+<body>
+  <!-- reusable icon symbol -->
+  <svg width="0" height="0" style="position:absolute">
+    <symbol id="thand" viewBox="0 0 120 140">
+      <mask id="hm">
+        <rect x="0" y="0" width="120" height="140" fill="black"/>
+        <g fill="white">
+          <rect x="26" y="52" width="70" height="66" rx="30" ry="32"/>
+          <rect x="31" y="34" width="15" height="44" rx="7.5"/>
+          <rect x="48" y="20" width="15" height="60" rx="7.5"/>
+          <rect x="64" y="24" width="15" height="56" rx="7.5"/>
+          <rect x="80" y="36" width="15" height="46" rx="7.5"/>
+          <rect x="12" y="60" width="15" height="38" rx="7.5" transform="rotate(38 19.5 79)"/>
+        </g>
+        <path d="M 46 90 Q 61 106 76 90" stroke="black" stroke-width="8" stroke-linecap="round" fill="none"/>
+      </mask>
+      <rect x="0" y="0" width="120" height="140" fill="currentColor" mask="url(#hm)"/>
+    </symbol>
+  </svg>
+
+  <div class="wall"></div>
+  <div class="leafshadow">
+    <svg viewBox="0 0 200 220">
+      <g fill="#2a2018">
+        <path d="M100 10 C60 60 55 140 100 210 C145 140 140 60 100 10 Z"/>
+        <path d="M100 40 C70 70 40 90 20 120 M100 70 C130 95 165 105 185 130 M100 110 C72 130 50 160 40 190 M100 130 C132 150 150 175 160 200" stroke="#2a2018" stroke-width="6" fill="none"/>
+      </g>
+    </svg>
+  </div>
+
+  <div class="frame">
+    <!-- ART 1: HERO -->
+    <div class="art a1" data-i="1">
+      <div class="rings"><i style="width:300px;height:300px"></i><i style="width:440px;height:440px"></i><i style="width:600px;height:600px"></i></div>
+      <div class="ghost ic"><svg><use href="#thand"/></svg></div>
+      <div class="tile"><img src="../assets/products/mist_watermelon.jpg"></div>
+    </div>
+
+    <!-- ART 2: IG POST -->
+    <div class="art a2" data-i="2">
+      <div class="post">
+        <div class="hd">
+          <div class="av"><div class="ic"><svg><use href="#thand"/></svg></div></div>
+          <div class="hn">touchland</div>
+          <div class="dots">•••</div>
+        </div>
+        <div class="im">
+          <img src="../assets/products/cases_overview.jpg">
+          <div class="cap-on">move<br>your mood</div>
+        </div>
+        <div class="row"><span>♥</span><span>💬</span><span>➦</span><span class="sp">🔖</span></div>
+        <div class="cap"><b>touchland</b> &nbsp;sensorial essentials for everyday joy 💕</div>
+      </div>
+    </div>
+
+    <!-- ART 3: BANNERS -->
+    <div class="art a3" data-i="3">
+      <div class="banner bL">
+        <img class="wm" src="../assets/products/../brand/touchland_wordmark.png">
+        <div class="ptile"><img src="../assets/products/case_pink.jpg"></div>
+        <h4>a purse<br>essential</h4>
+        <p>everyday carry</p>
+        <div class="mini ic"><svg><use href="#thand"/></svg></div>
+      </div>
+      <div class="banner bR">
+        <img class="wm" src="../assets/brand/touchland_wordmark.png">
+        <div class="ptile"><img src="../assets/products/mist_mint.jpg"></div>
+        <h4>move<br>your mood</h4>
+        <p>power mist</p>
+        <div class="mini ic"><svg><use href="#thand"/></svg></div>
+      </div>
+    </div>
+
+    <!-- ART 4: STICKER SHEET -->
+    <div class="art a4" data-i="4">
+      <div class="sheet" id="sheet"></div>
+      <div class="peel" style="background:linear-gradient(135deg,#FF9DB6,#FF6F8A)">
+        <div class="ic"><svg><use href="#thand"/></svg></div>
+        <small>move your mood</small>
+        <div class="curl"></div>
+      </div>
+    </div>
+
+    <!-- ART 5: LOGO LOCKUP -->
+    <div class="art a5" data-i="5">
+      <div class="ic"><svg><use href="#thand"/></svg></div>
+      <img class="wm" src="../assets/brand/touchland_wordmark.png">
+      <div class="tl">move your mood</div>
+      <div class="rule"></div>
+    </div>
+
+    <!-- ART 6: POSTER -->
+    <div class="art a6" data-i="6">
+      <img class="cover" src="../assets/products/blushrose_hero_rose.png">
+      <div class="scrim"></div>
+      <div class="badge"><div class="ic"><svg><use href="#thand"/></svg></div></div>
+      <div class="cta">
+        <h2>sensorial essentials<br>for everyday joy</h2>
+        <div class="url">touchland.com</div>
+      </div>
+    </div>
+
+    <!-- ART 7: LIFESTYLE spritz -->
+    <div class="art a7" data-i="7">
+      <img class="cover" src="../assets/products/life_spritz.png">
+      <img class="wmk" src="../assets/brand/touchland_wordmark.png" style="filter:brightness(0) invert(1)">
+    </div>
+
+    <!-- ART 8: PACKAGING -->
+    <div class="art a8" data-i="8">
+      <div class="badge"><div class="ic"><svg><use href="#thand"/></svg></div></div>
+      <div class="tile"><img src="../assets/products/case_pink.jpg"></div>
+      <div class="lab"><h3>the mist case</h3><p>carry it everywhere</p></div>
+    </div>
+
+    <!-- ART 9: LIFESTYLE model -->
+    <div class="art a9" data-i="9">
+      <img class="cover" src="../assets/products/life_model.png">
+      <img class="wmk" src="../assets/brand/touchland_wordmark.png" style="filter:brightness(0) invert(1)">
+    </div>
+
+    <!-- ART 10: BIG ICON -->
+    <div class="art a10" data-i="10">
+      <div class="rings"><i style="width:520px;height:520px"></i><i style="width:680px;height:680px"></i></div>
+      <div class="ic"><svg><use href="#thand"/></svg></div>
+    </div>
+
+    <!-- ART 11: END CARD -->
+    <div class="art a11" data-i="11">
+      <div class="ic"><svg><use href="#thand"/></svg></div>
+      <img class="wm" src="../assets/brand/touchland_wordmark.png">
+      <div class="tl">move your mood</div>
+      <div class="rule"></div>
+      <div class="desc">sensorial essentials<br>for everyday joy</div>
+      <div class="cats">hand mist &middot; body &amp; hair mist &middot; glow essence</div>
+      <div class="shop">
+        <div class="pill">Shop Now</div>
+        <div class="url">touchland.com</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="pot"></div>
+  <div class="plant">
+    <svg viewBox="0 0 200 210">
+      <defs>
+        <linearGradient id="lg" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stop-color="#63bd7e"/><stop offset="1" stop-color="#2f7d4a"/></linearGradient>
+        <linearGradient id="lg2" x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stop-color="#7cc98f"/><stop offset="1" stop-color="#3f9159"/></linearGradient>
+      </defs>
+      <g fill="url(#lg2)">
+        <ellipse cx="46" cy="60" rx="40" ry="86" transform="rotate(-34 46 60)"/>
+        <ellipse cx="135" cy="50" rx="38" ry="88" transform="rotate(26 135 50)"/>
+        <ellipse cx="170" cy="120" rx="36" ry="72" transform="rotate(52 170 120)"/>
+        <ellipse cx="24" cy="140" rx="34" ry="70" transform="rotate(-58 24 140)"/>
+      </g>
+      <g fill="url(#lg)">
+        <ellipse cx="72" cy="66" rx="44" ry="82" transform="rotate(-22 72 66)"/>
+        <ellipse cx="118" cy="58" rx="42" ry="84" transform="rotate(16 118 58)"/>
+        <ellipse cx="95" cy="38" rx="40" ry="78" transform="rotate(-4 95 38)"/>
+        <ellipse cx="150" cy="112" rx="40" ry="70" transform="rotate(40 150 112)"/>
+        <ellipse cx="44" cy="128" rx="38" ry="66" transform="rotate(-48 44 128)"/>
+        <ellipse cx="105" cy="120" rx="46" ry="66" transform="rotate(6 105 120)"/>
+      </g>
+    </svg>
+  </div>
+
+<script>
+  // build sticker grid
+  const cols=['#FF9DB6','#9FE0C6','#C7B4F0','#F3E483','#FF8A7A','#86C4F0','#FF9DB6','#9FE0C6','#C7B4F0','#F3E483','#FF8A7A','#86C4F0'];
+  const sheet=document.getElementById('sheet');
+  for(let k=0;k<12;k++){
+    const d=document.createElement('div'); d.className='stk'; d.style.background=cols[k];
+    d.innerHTML='<div class="ic"><svg><use href="#thand"/></svg></div><small>touchland</small>';
+    sheet.appendChild(d);
+  }
+  // show requested state
+  const i = new URLSearchParams(location.search).get('i') || '1';
+  const el = document.querySelector('.art[data-i="'+i+'"]');
+  if(el) el.classList.add('on');
+</script>
+</body>
+</html>

--- a/skills/ads/capabilities/render-brand-identity-reveal/skill.meta.json
+++ b/skills/ads/capabilities/render-brand-identity-reveal/skill.meta.json
@@ -1,0 +1,19 @@
+{
+  "slug": "render-brand-identity-reveal",
+  "category": "capabilities",
+  "domain": "ads",
+  "tags": [
+    "ads"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install render-brand-identity-reveal",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "requires_skills": [
+    "watch"
+  ]
+}

--- a/skills/ads/capabilities/render-brand-identity-reveal/tests/smoke-test.md
+++ b/skills/ads/capabilities/render-brand-identity-reveal/tests/smoke-test.md
@@ -1,0 +1,20 @@
+# Smoke test — brand-identity-reveal
+
+Fast structural checks (no paid calls).
+
+1. **Recipe is valid + within cap**
+   ```bash
+   python3 -c "import json; r=json.load(open('one-shot-videos/create-brand-identity-reveal-video-from-refs/recipe.json')); \
+   assert r['format']=='brand-identity-reveal'; assert 'render-brand-identity-reveal' in r['atoms']; \
+   assert len(json.dumps({'recipe':r}))<65536; print('recipe OK')"
+   ```
+2. **Scripts present**: `scene.html`, `render_art.py`, `measure_frame.py`, `recrop.py`,
+   `composite.py`, `build_video.sh`, `config.example.json`, `PIPELINE.md` all exist under `scripts/`.
+3. **Renderer runs on the reference** (free, needs python playwright + a plate):
+   - `render_art.py` produces 11 `art/art_std_NN.png` at the frame-interior aspect.
+   - `measure_frame.py` prints 4 corners + writes `bg/corners.txt`.
+   - `composite.py` produces 11 `frames_v2/frame_NN.png` at 1080x1920.
+4. **Assembly**: `build_video.sh` produces an mp4 whose `ffprobe` duration ≈ sum(beats.seconds)
+   and whose audio stream is present (music) with no speech (Whisper via `watch`).
+
+PASS = all four; no invented copy in any rendered poster.


### PR DESCRIPTION
## What

Adds the **`render-brand-identity-reveal`** free-renderer capability for the new
`brand-identity-reveal` video format — a poster in a real, softly-lit frame whose artwork
hard-cuts through ~10 on-brand poster mockups + a brand end card.

## How it fits the format (templates-as-data)

- **Paid, generic caps** (unchanged): `create-image-fal` (the one-shot environment plate),
  `create-music-elevenlabs` (bed).
- **This capability** = the FREE assembly only: Playwright mockup render → PIL
  perspective-composite into the detected frame quad (the plate's real leaf-shadow is
  multiplied back onto each poster so it reads as behind glass) → FFmpeg sequence.
- Canonical recipe lives in content-goose
  (`one-shot-videos/create-brand-identity-reveal-video-from-refs/recipe.json`); worked
  example: the Touchland run.

## Contents

`SKILL.md` (single-line description), `skill.meta.json`, `tests/smoke-test.md`, and
`scripts/` (scene.html, render_art/measure_frame/recrop/composite, build_video.sh,
config.example.json, PIPELINE.md). No paid calls in the renderer.

Verified locally: `build:index` + `validate:skills` pass; catalog sync resolves
`GET /api/skills/catalog/render-brand-identity-reveal` → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)