### PR TITLE
Add missing MIT LICENSE file referenced by README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 GooseWorks
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Found something that looks off? [Open an issue](https://github.com/gooseworks-ai
 
 MIT &mdash; see [LICENSE](LICENSE) for details.
 
+The skill files and CLI in this repository are MIT-licensed. The GooseWorks API they connect to is a separate paid service governed by its own [terms](https://gooseworks.ai/terms).
+
 <div align="center">
 
 **Built by [GooseWorks](https://gooseworks.sh)**


### PR DESCRIPTION
## Why

The README's License section says "MIT — see [LICENSE](LICENSE) for details", but the LICENSE file was never committed. GitHub therefore reports the repo as **unlicensed** (`licenseInfo: null`).

This blocks the directory-listing work in GOOSE-2638: several awesome-list/directory bots (e.g. awesome-claude-code) auto-detect the license via GitHub's mechanism and flag or reject unlicensed repos.

## What

- Adds the standard MIT `LICENSE` file (copyright "2026 GooseWorks" — adjust if a different legal entity name is preferred).
- Adds one clarifying line to the README License section: the skill files and CLI are MIT-licensed, while the GooseWorks API they connect to is a paid service under its own terms (links to https://gooseworks.ai/terms, verified live).

No functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)