### PR TITLE
Add webinar content engine skill

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2.0",
-  "generated": "2026-07-15",
+  "generated": "2026-07-16",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -7784,6 +7784,36 @@
             "codex"
           ]
         }
+      }
+    },
+    {
+      "slug": "webinar-content-engine",
+      "name": "webinar-content-engine",
+      "category": "composites",
+      "domain": "content",
+      "description": "Turn a webinar recording, transcript, notes, or slide deck into a factual multichannel content campaign with a long-form article, newsletter, social posts, short-video clip plan, sales follow-up, quote bank, and publishing calendar. Use when a marketing team needs to repurpose one webinar or virtual event into channel-ready assets without inventing claims or losing speaker attribution.",
+      "tags": "content",
+      "path": "skills/content/composites/webinar-content-engine",
+      "files": [
+        "skills/content/composites/webinar-content-engine/SKILL.md",
+        "skills/content/composites/webinar-content-engine/skill.meta.json"
+      ],
+      "metadata": {
+        "slug": "webinar-content-engine",
+        "category": "composites",
+        "description": "Turn one webinar into a factual multichannel campaign with an article, newsletter, social posts, clip plan, sales follow-up, quote bank, and publishing calendar.",
+        "tags": [
+          "content"
+        ],
+        "installation": {
+          "base_command": "npx goose-skills install webinar-content-engine",
+          "supports": [
+            "claude",
+            "cursor",
+            "codex"
+          ]
+        },
+        "example_prompt": "Turn this webinar transcript into a two-week content campaign with a blog post, newsletter, social posts, and timestamped clip plan."
       }
     },
     {

--- a/skills/content/composites/webinar-content-engine/SKILL.md
+++ b/skills/content/composites/webinar-content-engine/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: webinar-content-engine
+description: Turn a webinar recording, transcript, notes, or slide deck into a factual multichannel content campaign with a long-form article, newsletter, social posts, short-video clip plan, sales follow-up, quote bank, and publishing calendar. Use when a marketing team needs to repurpose one webinar or virtual event into channel-ready assets without inventing claims or losing speaker attribution.
+---
+
+# Webinar Content Engine
+
+Repurpose one webinar into a coherent campaign while preserving factual accuracy, speaker intent, and channel fit.
+
+## Intake
+
+Collect the transcript or recording, event title, speaker names and roles, audience, primary offer, desired call to action, brand voice, publishing channels, and campaign window. Ask only for information that materially changes the output. If timestamps are unavailable, mark every clip boundary as approximate.
+
+Distinguish three source states:
+
+- Full transcript: generate all assets and exact clip timestamps when timestamps exist.
+- Partial transcript or detailed notes: generate text assets, label unsupported sections, and provide approximate clip candidates.
+- Recording only: transcribe with an available tool before continuing. Do not infer dialogue from slides or visuals.
+
+## Build the evidence ledger
+
+Read the source once for structure and again for evidence. Create a compact ledger containing:
+
+- Verbatim claims with speaker and timestamp
+- Quotable lines with speaker and timestamp
+- Examples, stories, frameworks, and objections
+- Numbers, dates, product statements, and customer outcomes
+- Unclear wording or claims that require verification
+
+Never strengthen a claim beyond the source. Never turn a speaker opinion into a company fact. Paraphrase freely only when meaning and attribution remain intact. Keep direct quotes exact apart from removing filler words that do not change meaning, and disclose meaningful edits.
+
+## Choose the campaign spine
+
+Identify one core promise, three supporting ideas, one distinctive proof point, and one next action. Use this spine across every asset so the campaign feels coordinated rather than repetitive.
+
+Select assets by source strength:
+
+- Use the strongest teaching framework for the article.
+- Use the clearest practical takeaway for the newsletter.
+- Use surprising, specific, or contrarian moments for social posts.
+- Use self-contained, emotionally or intellectually complete moments for video clips.
+- Use objections, buying triggers, and implementation advice for sales follow-up.
+
+## Generate the asset pack
+
+### Executive brief
+
+Provide the audience, campaign spine, supporting ideas, proof point, call to action, and any verification warnings. List omitted topics when the source does not support them.
+
+### Long-form article
+
+Create a useful standalone article, not a transcript summary. Include a clear promise, a short context-setting introduction, three to five sections, source-backed examples, practical takeaways, and a natural call to action. Attribute speaker-specific ideas on first use.
+
+### Newsletter
+
+Write three subject lines, preview text, and a concise email. Lead with the reader problem, teach one valuable idea, link it to the webinar, and end with one call to action.
+
+### LinkedIn posts
+
+Create three distinct posts:
+
+- Insight post: one counterintuitive lesson and why it matters
+- Framework post: a usable sequence, checklist, or model from the session
+- Story post: a concrete example or turning point with a clear takeaway
+
+Avoid reusing the same opening, structure, or call to action.
+
+### X campaign
+
+Create one short thread and five standalone posts. Keep each standalone post independently useful. Prefer specific ideas and examples over teaser copy.
+
+### Short-video clip plan
+
+Select five to eight clips. For each clip provide start and end timestamps, speaker, hook, central idea, suggested on-screen title, caption, and why it can stand alone. Favor clips between twenty and ninety seconds unless the source requires more context. Never fabricate timestamps.
+
+### Sales follow-up
+
+Write one attendee email and one no-show email. Summarize the most relevant outcome, reference one source-backed insight, and offer one clear next step. Do not imply attendance, engagement, or intent that is not known.
+
+### Quote bank
+
+Provide ten to twenty direct quotes with speaker names and timestamps. Flag any quote that needs approval because it contains a customer claim, sensitive statement, or uncertain transcription.
+
+### Publishing calendar
+
+Arrange assets across two to four weeks. Sequence them from broad awareness to practical education to conversion. Include channel, asset, angle, call to action, dependency, and owner placeholder.
+
+## Quality gate
+
+Before delivery, verify:
+
+- Every number, date, outcome, and product claim appears in the evidence ledger.
+- Every direct quote has an attribution and timestamp when available.
+- Clip boundaries contain a complete thought.
+- Each asset has one primary purpose and one call to action.
+- Channel variants add a new angle instead of repeating the same copy.
+- Unverified claims and approximate timestamps are visibly labeled.
+- The final assets match the requested brand voice without imitating a living person.
+
+If a check fails, revise the asset or remove the unsupported material.
+
+## Deliverable order
+
+Return the work in this order: executive brief, evidence ledger, article, newsletter, LinkedIn posts, X campaign, clip plan, sales follow-up, quote bank, publishing calendar, and verification notes.

--- a/skills/content/composites/webinar-content-engine/skill.meta.json
+++ b/skills/content/composites/webinar-content-engine/skill.meta.json
@@ -13,5 +13,6 @@
       "codex"
     ]
   },
+  "author": "Vault101dweller",
   "example_prompt": "Turn this webinar transcript into a two-week content campaign with a blog post, newsletter, social posts, and timestamped clip plan."
 }

--- a/skills/content/composites/webinar-content-engine/skill.meta.json
+++ b/skills/content/composites/webinar-content-engine/skill.meta.json
@@ -1,0 +1,17 @@
+{
+  "slug": "webinar-content-engine",
+  "category": "composites",
+  "description": "Turn one webinar into a factual multichannel campaign with an article, newsletter, social posts, clip plan, sales follow-up, quote bank, and publishing calendar.",
+  "tags": [
+    "content"
+  ],
+  "installation": {
+    "base_command": "npx goose-skills install webinar-content-engine",
+    "supports": [
+      "claude",
+      "cursor",
+      "codex"
+    ]
+  },
+  "example_prompt": "Turn this webinar transcript into a two-week content campaign with a blog post, newsletter, social posts, and timestamped clip plan."
+}


### PR DESCRIPTION
## Summary
- Adds `webinar-content-engine`, a composite skill that turns webinar transcripts, notes, recordings, or slides into a factual multichannel campaign.
- Produces an evidence ledger, article, newsletter, LinkedIn and X content, timestamped clip plan, sales follow-up, quote bank, publishing calendar, and verification notes.
- Adds the generated index entry without modifying existing skills or packs.

## Validation
- Skill Creator `quick_validate.py`: passed
- Repository skill validator: passed for 231 skills
- Target, pack, and build-index tests: 17 passed
- Index audit: existing entries unchanged; packs unchanged; version unchanged; exactly one entry added