### PR TITLE
[FLIP DAY] New MCP tool names — goose-skills entry skills (GOOSE-3185)

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.3.0",
-  "generated": "2026-08-14",
+  "generated": "2026-09-01",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -1921,7 +1921,7 @@
       "name": "create-video-fal",
       "category": "capabilities",
       "domain": "ads",
-      "description": "Image-to-video (or text-to-video) via any FAL video model (Kling, Seedance, Veo), ROUTED THROUGH THE GooseWorks fal-proxy so the call bills the Ads agent. The template recipe names the model + params; image_url inputs must be public URLs (the orchestrator hosts local frames via MCP get_upload_url -> get_download_url). Returns the result video URL and downloads it. Use for the generative base clip of any video-ad format.",
+      "description": "Image-to-video (or text-to-video) via any FAL video model (Kling, Seedance, Veo), ROUTED THROUGH THE GooseWorks fal-proxy so the call bills the Ads agent. The template recipe names the model + params; image_url inputs must be public URLs (the orchestrator hosts local frames via MCP file_url mode upload -> mode download). Returns the result video URL and downloads it. Use for the generative base clip of any video-ad format.",
       "tags": "ads",
       "path": "skills/ads/capabilities/create-video-fal",
       "files": [

--- a/skills/ads/capabilities/create-image-fal/scripts/media_proxy.py
+++ b/skills/ads/capabilities/create-image-fal/scripts/media_proxy.py
@@ -19,7 +19,7 @@ local skill run isn't a black box. Import `gw_log(...)` to log your own steps/is
 and `run_id()` to read the current run id. Best-effort; never breaks a render.
 
 FAL inputs that are local files (a product image, an audio track) must be a PUBLIC
-URL — the orchestrator hosts them via the MCP `get_upload_url` → `get_download_url`
+URL — the orchestrator hosts them via the MCP `file_url` (mode `upload` → mode `download`)
 presigned URL and passes that URL in; this module does NOT do MCP uploads.
 """
 import json
@@ -281,7 +281,7 @@ def fal_whisper(audio_url, language="en", **kw):
     """fal-ai/whisper (word-level) through the proxy → [{text, start, end}, ...].
 
     `audio_url` MUST be a PUBLIC url (this module does not upload) — the orchestrator
-    hosts the local VO via MCP `get_upload_url` → `get_download_url` and passes that
+    hosts the local VO via MCP `file_url` (mode `upload` → mode `download`) and passes that
     presigned url in. Proxy-routed, so it bills the Ads agent (never a raw FAL_KEY)."""
     r = _fal_run("fal-ai/whisper", {"audio_url": audio_url, "task": "transcribe",
                                     "language": language, "chunk_level": "word"}, **kw)

--- a/skills/ads/capabilities/create-image-gpt-image-fal/SKILL.md
+++ b/skills/ads/capabilities/create-image-gpt-image-fal/SKILL.md
@@ -35,7 +35,7 @@ Optional:
 - `--aspect-ratio` — `9:16` (default), `16:9`, `1:1`, `2:3`, `3:2`. gpt-image-2 also accepts `3:4`, `4:3`, `4:5`. Used when `--image-size` is not given.
 - `--image-size` — explicit `WIDTHxHEIGHT` (e.g. `1728x2304`). **gpt-image-2 only** — values are rounded to multiples of 16 and capped at 3840px. On `gpt-image-1` a custom size is ignored with a warning and the aspect-ratio mapping is used instead.
 - `--quality` — `low | medium | high` (default `medium`).
-- `--ref-image` / `--ref-url` — a **PUBLIC image URL** for the `/edit` variant. **Repeatable** — pass it twice to send multiple refs (e.g. identity + style). The proxy does **not** upload local files, so a **local path is rejected** — host the image first (MCP `get_upload_url` → `get_download_url`, or any public URL) and pass that URL. When present, routes to the model's `/edit` variant so the model can match the references. Order matters: pass identity (character) first, then style refs.
+- `--ref-image` / `--ref-url` — a **PUBLIC image URL** for the `/edit` variant. **Repeatable** — pass it twice to send multiple refs (e.g. identity + style). The proxy does **not** upload local files, so a **local path is rejected** — host the image first (MCP `file_url` (mode `upload` → mode `download`), or any public URL) and pass that URL. When present, routes to the model's `/edit` variant so the model can match the references. Order matters: pass identity (character) first, then style refs.
 - `--with-logs` — stream fal queue logs.
 
 Credentials (proxy-routed — NOT a raw FAL key):
@@ -102,7 +102,7 @@ The script:
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `401 Unauthorized` from fal | Calling fal directly with an agent token, or polling `queue.fal.run` instead of the proxy | This atom is **proxy-routed** — it uses the `~/.gooseworks/credentials.json` agent token via `media_proxy.py`, never a raw `FAL_API_KEY`. Run `gooseworks login` if the credentials file is missing. |
-| `ERROR: ref images must be PUBLIC URLs` | Passed a **local path** to `--ref-image` / `--ref-url` | The proxy does not upload local files. Host it (MCP `get_upload_url` → `get_download_url`) and pass the resulting public URL. |
+| `ERROR: ref images must be PUBLIC URLs` | Passed a **local path** to `--ref-image` / `--ref-url` | The proxy does not upload local files. Host it (MCP `file_url` (mode `upload` → mode `download`)) and pass the resulting public URL. |
 | `429 Too Many Requests` | RPS limit | Drop concurrency to 2-3. |
 | Custom size ignored | `--image-size` passed with `--model gpt-image-1` | gpt-image-1 only supports fixed sizes; use `--model gpt-image-2` for custom sizes. |
 | Aspect-ratio drift (gpt-image-1) | gpt-image-1 only supports 1024x1024, 1024x1536, 1536x1024 | The script maps aspect ratios to these internally. |

--- a/skills/ads/capabilities/create-image-gpt-image-fal/scripts/generate.py
+++ b/skills/ads/capabilities/create-image-gpt-image-fal/scripts/generate.py
@@ -90,8 +90,8 @@ def main() -> int:
     ap.add_argument("--quality", default="medium", choices=["low", "medium", "high"])
     ap.add_argument("--ref-url", "--ref-image", action="append", dest="ref_urls", default=[],
                     help="PUBLIC reference image URL for the edit variant (repeatable). The proxy "
-                         "does not upload local files — host them via MCP get_upload_url -> "
-                         "get_download_url and pass the URL. Identity ref first, then style refs.")
+                         "does not upload local files — host them via the MCP file_url tool "
+                         "(mode upload -> mode download) and pass the URL. Identity ref first, then style refs.")
     args = ap.parse_args()
 
     cfg = MODELS[args.model]
@@ -129,7 +129,7 @@ def main() -> int:
         local = [u for u in args.ref_urls if not (u.startswith("http://") or u.startswith("https://"))]
         if local:
             sys.exit("ERROR: ref images must be PUBLIC URLs (the proxy does not upload local files). "
-                     "Host each via MCP get_upload_url -> get_download_url and pass the URL. "
+                     "Host each via the MCP file_url tool (mode upload -> mode download) and pass the URL. "
                      f"Got local path(s): {local}")
         payload["image_urls"] = args.ref_urls
         model = cfg["edit"]

--- a/skills/ads/capabilities/create-image-gpt-image-fal/scripts/media_proxy.py
+++ b/skills/ads/capabilities/create-image-gpt-image-fal/scripts/media_proxy.py
@@ -19,7 +19,7 @@ local skill run isn't a black box. Import `gw_log(...)` to log your own steps/is
 and `run_id()` to read the current run id. Best-effort; never breaks a render.
 
 FAL inputs that are local files (a product image, an audio track) must be a PUBLIC
-URL — the orchestrator hosts them via the MCP `get_upload_url` → `get_download_url`
+URL — the orchestrator hosts them via the MCP `file_url` (mode `upload` → mode `download`)
 presigned URL and passes that URL in; this module does NOT do MCP uploads.
 """
 import json
@@ -281,7 +281,7 @@ def fal_whisper(audio_url, language="en", **kw):
     """fal-ai/whisper (word-level) through the proxy → [{text, start, end}, ...].
 
     `audio_url` MUST be a PUBLIC url (this module does not upload) — the orchestrator
-    hosts the local VO via MCP `get_upload_url` → `get_download_url` and passes that
+    hosts the local VO via MCP `file_url` (mode `upload` → mode `download`) and passes that
     presigned url in. Proxy-routed, so it bills the Ads agent (never a raw FAL_KEY)."""
     r = _fal_run("fal-ai/whisper", {"audio_url": audio_url, "task": "transcribe",
                                     "language": language, "chunk_level": "word"}, **kw)

--- a/skills/ads/capabilities/create-music-elevenlabs/scripts/media_proxy.py
+++ b/skills/ads/capabilities/create-music-elevenlabs/scripts/media_proxy.py
@@ -19,7 +19,7 @@ local skill run isn't a black box. Import `gw_log(...)` to log your own steps/is
 and `run_id()` to read the current run id. Best-effort; never breaks a render.
 
 FAL inputs that are local files (a product image, an audio track) must be a PUBLIC
-URL — the orchestrator hosts them via the MCP `get_upload_url` → `get_download_url`
+URL — the orchestrator hosts them via the MCP `file_url` (mode `upload` → mode `download`)
 presigned URL and passes that URL in; this module does NOT do MCP uploads.
 """
 import json
@@ -281,7 +281,7 @@ def fal_whisper(audio_url, language="en", **kw):
     """fal-ai/whisper (word-level) through the proxy → [{text, start, end}, ...].
 
     `audio_url` MUST be a PUBLIC url (this module does not upload) — the orchestrator
-    hosts the local VO via MCP `get_upload_url` → `get_download_url` and passes that
+    hosts the local VO via MCP `file_url` (mode `upload` → mode `download`) and passes that
     presigned url in. Proxy-routed, so it bills the Ads agent (never a raw FAL_KEY)."""
     r = _fal_run("fal-ai/whisper", {"audio_url": audio_url, "task": "transcribe",
                                     "language": language, "chunk_level": "word"}, **kw)

--- a/skills/ads/capabilities/create-video-fal/SKILL.md
+++ b/skills/ads/capabilities/create-video-fal/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: create-video-fal
-description: Image-to-video (or text-to-video) via any FAL video model (Kling, Seedance, Veo), ROUTED THROUGH THE GooseWorks fal-proxy so the call bills the Ads agent. The template recipe names the model + params; image_url inputs must be public URLs (the orchestrator hosts local frames via MCP get_upload_url -> get_download_url). Returns the result video URL and downloads it. Use for the generative base clip of any video-ad format.
+description: Image-to-video (or text-to-video) via any FAL video model (Kling, Seedance, Veo), ROUTED THROUGH THE GooseWorks fal-proxy so the call bills the Ads agent. The template recipe names the model + params; image_url inputs must be public URLs (the orchestrator hosts local frames via MCP file_url mode upload -> mode download). Returns the result video URL and downloads it. Use for the generative base clip of any video-ad format.
 status: active
 ---
 
 # create-video-fal
 
-Image-to-video (or text-to-video) via any FAL video model (Kling, Seedance, Veo), ROUTED THROUGH THE GooseWorks fal-proxy so the call bills the Ads agent. The template recipe names the model + params; image_url inputs must be public URLs (the orchestrator hosts local frames via MCP get_upload_url -> get_download_url). Returns the result video URL and downloads it. Use for the generative base clip of any video-ad format.
+Image-to-video (or text-to-video) via any FAL video model (Kling, Seedance, Veo), ROUTED THROUGH THE GooseWorks fal-proxy so the call bills the Ads agent. The template recipe names the model + params; image_url inputs must be public URLs (the orchestrator hosts local frames via MCP file_url mode upload -> mode download). Returns the result video URL and downloads it. Use for the generative base clip of any video-ad format.
 
 ## Run
 gen_video.py --model fal-ai/kling-video/v2.1/standard/image-to-video --payload '{...}' --out clip.mp4 — bills the agent; host-swaps the FAL queue URLs; downloads the result.

--- a/skills/ads/capabilities/create-video-fal/scripts/gen_video.py
+++ b/skills/ads/capabilities/create-video-fal/scripts/gen_video.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Image-to-video (or t2v) via any FAL video model, ROUTED THROUGH THE PROXY (bills the
 Ads agent). image_url must be a PUBLIC url (orchestrator hosts local frames via MCP
-get_upload_url -> get_download_url). Model + params come from the template recipe.
+file_url mode upload -> mode download). Model + params come from the template recipe.
 
   gen_video.py --model fal-ai/kling-video/v2.1/standard/image-to-video \
       --payload '{"prompt":"...","image_url":"https://...","duration":"10","cfg_scale":0.5}' \

--- a/skills/ads/capabilities/create-video-fal/scripts/media_proxy.py
+++ b/skills/ads/capabilities/create-video-fal/scripts/media_proxy.py
@@ -19,7 +19,7 @@ local skill run isn't a black box. Import `gw_log(...)` to log your own steps/is
 and `run_id()` to read the current run id. Best-effort; never breaks a render.
 
 FAL inputs that are local files (a product image, an audio track) must be a PUBLIC
-URL — the orchestrator hosts them via the MCP `get_upload_url` → `get_download_url`
+URL — the orchestrator hosts them via the MCP `file_url` (mode `upload` → mode `download`)
 presigned URL and passes that URL in; this module does NOT do MCP uploads.
 """
 import json
@@ -281,7 +281,7 @@ def fal_whisper(audio_url, language="en", **kw):
     """fal-ai/whisper (word-level) through the proxy → [{text, start, end}, ...].
 
     `audio_url` MUST be a PUBLIC url (this module does not upload) — the orchestrator
-    hosts the local VO via MCP `get_upload_url` → `get_download_url` and passes that
+    hosts the local VO via MCP `file_url` (mode `upload` → mode `download`) and passes that
     presigned url in. Proxy-routed, so it bills the Ads agent (never a raw FAL_KEY)."""
     r = _fal_run("fal-ai/whisper", {"audio_url": audio_url, "task": "transcribe",
                                     "language": language, "chunk_level": "word"}, **kw)

--- a/skills/ads/capabilities/create-vo-elevenlabs/scripts/media_proxy.py
+++ b/skills/ads/capabilities/create-vo-elevenlabs/scripts/media_proxy.py
@@ -19,7 +19,7 @@ local skill run isn't a black box. Import `gw_log(...)` to log your own steps/is
 and `run_id()` to read the current run id. Best-effort; never breaks a render.
 
 FAL inputs that are local files (a product image, an audio track) must be a PUBLIC
-URL — the orchestrator hosts them via the MCP `get_upload_url` → `get_download_url`
+URL — the orchestrator hosts them via the MCP `file_url` (mode `upload` → mode `download`)
 presigned URL and passes that URL in; this module does NOT do MCP uploads.
 """
 import json
@@ -281,7 +281,7 @@ def fal_whisper(audio_url, language="en", **kw):
     """fal-ai/whisper (word-level) through the proxy → [{text, start, end}, ...].
 
     `audio_url` MUST be a PUBLIC url (this module does not upload) — the orchestrator
-    hosts the local VO via MCP `get_upload_url` → `get_download_url` and passes that
+    hosts the local VO via MCP `file_url` (mode `upload` → mode `download`) and passes that
     presigned url in. Proxy-routed, so it bills the Ads agent (never a raw FAL_KEY)."""
     r = _fal_run("fal-ai/whisper", {"audio_url": audio_url, "task": "transcribe",
                                     "language": language, "chunk_level": "word"}, **kw)

--- a/skills/ads/capabilities/media-proxy/SKILL.md
+++ b/skills/ads/capabilities/media-proxy/SKILL.md
@@ -51,7 +51,7 @@ eleven_music(prompt, 10500, "music.mp3", force_instrumental=True)
   `queue.fal.run`; the helper rewrites them to the proxy base (keeps the path). Never
   poll `queue.fal.run` directly (401 + burns credits).
 - **FAL inputs that are local files must be PUBLIC urls.** The orchestrator hosts a
-  local image/audio via the MCP `get_upload_url` → `get_download_url` presigned URL and
+  local image/audio via the MCP `file_url` (mode `upload` → mode `download`) presigned URL and
   passes THAT url in. This module does not do MCP uploads (prefer the presigned url;
   `fal-storage-proxy` may 404).
 - **Only the final `*.fal.media` url is a real public URL** — everything else is behind

--- a/skills/ads/capabilities/media-proxy/scripts/media_proxy.py
+++ b/skills/ads/capabilities/media-proxy/scripts/media_proxy.py
@@ -19,7 +19,7 @@ local skill run isn't a black box. Import `gw_log(...)` to log your own steps/is
 and `run_id()` to read the current run id. Best-effort; never breaks a render.
 
 FAL inputs that are local files (a product image, an audio track) must be a PUBLIC
-URL — the orchestrator hosts them via the MCP `get_upload_url` → `get_download_url`
+URL — the orchestrator hosts them via the MCP `file_url` (mode `upload` → mode `download`)
 presigned URL and passes that URL in; this module does NOT do MCP uploads.
 """
 import json
@@ -281,7 +281,7 @@ def fal_whisper(audio_url, language="en", **kw):
     """fal-ai/whisper (word-level) through the proxy → [{text, start, end}, ...].
 
     `audio_url` MUST be a PUBLIC url (this module does not upload) — the orchestrator
-    hosts the local VO via MCP `get_upload_url` → `get_download_url` and passes that
+    hosts the local VO via MCP `file_url` (mode `upload` → mode `download`) and passes that
     presigned url in. Proxy-routed, so it bills the Ads agent (never a raw FAL_KEY)."""
     r = _fal_run("fal-ai/whisper", {"audio_url": audio_url, "task": "transcribe",
                                     "language": language, "chunk_level": "word"}, **kw)

--- a/skills/ads/capabilities/render-3d-product-showcase/scripts/PIPELINE.md
+++ b/skills/ads/capabilities/render-3d-product-showcase/scripts/PIPELINE.md
@@ -15,7 +15,7 @@ seeded on the styled hero → extract Beat 1 last frame → Veo3 Beat 3 reveal s
 
 | config field | source step | phase | what it does | paid? |
 |---|---|---|---|---|
-| `product.hero_png`, `product_identity.*`, `studio_look.*` | `create-image-fal` (`fal-ai/nano-banana/edit`) | Hero | Restyle the brand's REAL product photo onto the seamless brand-color studio set → `hero_styled.png`; host it (MCP get_upload_url → get_download_url) so i2v can seed off a public url. Locks the product's real geometry — no Marketing Studio, no PDP import. | **PAID** (cheap, ~1 image) |
+| `product.hero_png`, `product_identity.*`, `studio_look.*` | `create-image-fal` (`fal-ai/nano-banana/edit`) | Hero | Restyle the brand's REAL product photo onto the seamless brand-color studio set → `hero_styled.png`; host it (MCP file_url mode upload → mode download) so i2v can seed off a public url. Locks the product's real geometry — no Marketing Studio, no PDP import. | **PAID** (cheap, ~1 image) |
 | `beats[0].prompt`, `beats[0].model`, `beats[0].start_image`, `beats[0].duration_sec` | `create-video-fal` i2v (`beats[].model` — Seedance Lite default) | Beat 1 | i2v hero rotation seeded on `hero_styled.png`. A single i2v is a partial arc, not a literal 360. Result mp4 → `working/clips/beat1.mp4`. | **PAID** |
 | `beats[1].prompt`, `beats[1].model`, `beats[1].start_image` | `create-video-fal` i2v (same model) | Beat 2 | i2v macro push-in seeded on the SAME `hero_styled.png` so the product reads identical. → `working/clips/beat2.mp4`. | **PAID** |
 | `beats[0].produces_anchor` | `ffmpeg -sseof -0.1 -i beat1.mp4 -frames:v 1 beat1_last_frame.png` | Beat 1→3 | Extract Beat 1's **last frame** — the shared anchor: Veo3 Beat-3 seed AND the Beat-4 hyperframe background. | free |

--- a/skills/ads/capabilities/render-3d-product-showcase/scripts/config.example.json
+++ b/skills/ads/capabilities/render-3d-product-showcase/scripts/config.example.json
@@ -31,7 +31,7 @@
   "product_identity": {
     "_note": "identity lock — the analog of a character lock. Run BEFORE any i2v clip call. NO Marketing Studio.",
     "step_1": "create-image-fal (fal-ai/nano-banana/edit) — restyle the real product photo onto the seamless brand-color set (centered ~50-55% frame height, warm rim light upper-right, warm bokeh, 9:16, geometry IDENTICAL to the reference, no people/hands/text) -> hero_styled.png",
-    "step_2": "host hero_styled.png via MCP get_upload_url -> get_download_url so create-video-fal can seed the beats off a PUBLIC url",
+    "step_2": "host hero_styled.png via MCP file_url mode upload -> mode download so create-video-fal can seed the beats off a PUBLIC url",
     "hard_rule": "the product geometry ALWAYS comes from the real product photo via the create-image-fal restyle — never a text-only AI invention. A lifestyle photo works too; the restyle isolates the product onto the studio set."
   },
 

--- a/skills/ads/capabilities/render-cartoon-music-video/scripts/README.md
+++ b/skills/ads/capabilities/render-cartoon-music-video/scripts/README.md
@@ -63,5 +63,5 @@ watch misses in a ~55s master:
 
 Extract a **2 fps** contact sheet across the whole master + a per-bar **FACE** crop and **HAND**
 crop (across each clip's full duration); audit ALL bars at head-crop resolution to find the true
-drift boundary; then re-extract frames from the **served** bytes (`get_download_url`), not the local
+drift boundary; then re-extract frames from the **served** bytes (`file_url` mode `download`), not the local
 file, after publish. (cartoon-music-video, Figma run 2026-07-18.)

--- a/skills/ads/capabilities/render-myth-vs-fact/scripts/beat_snap.py
+++ b/skills/ads/capabilities/render-myth-vs-fact/scripts/beat_snap.py
@@ -11,7 +11,7 @@ Two outputs, written into the work dir:
 
 Whisper word-timestamps come from fal-ai/whisper (chunk_level=word). Prefer the
 PROXY-ROUTED path so the call bills the Ads agent (never a raw FAL_KEY): the orchestrator
-hosts the rendered VO via MCP `get_upload_url` → `get_download_url` and passes the presigned
+hosts the rendered VO via MCP `file_url` (mode `upload` → mode `download`) and passes the presigned
 url as `--vo-url` (transcribed through `media_proxy.fal_whisper`). Already have the words?
 pass `--words-file words.json` and beat_snap skips transcription entirely. Legacy: a raw
 `FAL_KEY` in the env still works via `fal_client`. Fully offline: `--no-whisper` keeps the

--- a/skills/ads/composites/animate-image/SKILL.md
+++ b/skills/ads/composites/animate-image/SKILL.md
@@ -19,9 +19,9 @@ This workflow requires the GooseWorks MCP tools. If the animate-image tools are 
    - source image as the end frame;
    - source plus a separate end-frame image.
 3. Write a motion prompt describing camera movement, subject movement, environment movement, pacing, and what must remain unchanged. Do not redesign the product or add unsupported claims.
-4. Call `estimate_animate_image` and confirm the quoted credits before generation.
-5. Call `submit_animate_image` once. Save the returned job ID.
-6. Poll `get_animate_image` until it completes or fails. Never re-submit a running job.
+4. Call `ads_creative_edit` with `action: "animate", dry_run: true` and confirm the quoted credits (`estimate`) before generation.
+5. Call `ads_creative_edit` with `action: "animate"` (source render or `animate.source_image_url`, `animate.prompt`, `animate.duration_seconds`) once. Save the returned job ID.
+6. Poll `job_get { job_id, kind: "animate" }` until it completes or fails. Never re-submit a running job.
 7. Return the finished video URL and the source image used. If it fails, report the backend reason before proposing a retry.
 
 ## Rules

--- a/skills/ads/composites/product-photoshoot/SKILL.md
+++ b/skills/ads/composites/product-photoshoot/SKILL.md
@@ -13,19 +13,19 @@ This workflow requires the GooseWorks MCP tools. If they are unavailable, tell t
 
 ## Workflow
 
-1. Resolve the brand with `list_ad_brands` and the product with `list_brand_products`.
-2. If the product is missing, use `import_product` with a product URL, Shopify store, or public image URL. Poll `get_product_import`; do not re-submit an in-progress import.
+1. Resolve the brand with `brand_list` and the product with `brand_get_context { brand_id, sections: ["products"] }` (read `products.items`; `products_query` filters by name).
+2. If the product is missing, import it with `brand_update { brand_id, patch: { products: [{ import_kind, import_url, name? }] } }` — `import_kind` is `product_url`, `shopify_store`, or `image_url` (a public image URL; requires `name`). Poll the returned job with `job_get { job_id, kind: "product_import" }`; do not re-submit an in-progress import.
 3. Clarify the intended image: studio, lifestyle, on-model, close-up, setting, aspect, and count. Do not invent product attributes.
-4. Call `estimate_product_photos` and show the user the credit estimate. Confirm count and quality before spending.
-5. Call `generate_product_photos` with the chosen product, category, controls, count, quality, and optional prompt. Human model imagery requires the user's rights attestation.
-6. Poll `get_product_photo_generation` until `complete`, `partial_failure`, or `failed`. Do not submit a duplicate while it is running.
-7. Show every result and status. Let the user choose the keepers; use `approve_product_photo` only for selected results and `archive_product_photo` for rejected ones.
+4. Call `photos_generate` with `dry_run: true` and show the user the credit estimate. Confirm count and quality before spending.
+5. Call `photos_generate` with the chosen brand, product, category, controls, count, quality, and optional prompt. Human model imagery requires the user's rights attestation (`attestation_accepted: true`).
+6. Poll `photos_get { brand_id, generation_id }` until `complete`, `partial_failure`, or `failed`. Do not submit a duplicate while it is running.
+7. Show every result and status. Let the user choose the keepers; use `photos_update` with `action: "approve"` only for selected results and `action: "archive"` for rejected ones.
 
 ## Tool map
 
-- Brand and catalog: `list_ad_brands`, `list_brand_products`, `import_product`, `get_product_import`
-- Cost and generation: `estimate_product_photos`, `generate_product_photos`, `get_product_photo_generation`
-- Results: `list_product_photos`, `approve_product_photo`, `archive_product_photo`
+- Brand and catalog: `brand_list`, `brand_get_context` (`products` section), `brand_update` (product import via `patch.products`), `job_get` (`kind: "product_import"`)
+- Cost and generation: `photos_generate` (`dry_run: true` for the quote), `photos_get`
+- Results: `photos_list`, `photos_update` (`action: "approve"` / `"archive"`)
 
 ## Rules
 

--- a/skills/ads/composites/remix-graphic-ad-from-reference/SKILL.md
+++ b/skills/ads/composites/remix-graphic-ad-from-reference/SKILL.md
@@ -29,7 +29,7 @@ the reference, then recreates it with GPT Image 2:
 | `reference_image` | yes | The ad to recreate (local path or URL). One image. |
 | `product` | yes | Target product: a clean product render/photo (PNG/webp). Pull the **real** brand asset; grounding/swapping on it is what keeps the label correct. **If the brand asset is a multi-product lineup, crop to the ONE relevant product first** — the remix grounds on a single clean product per `product_slot` (use `product_images_needed` from the slot map for how many distinct products the layout needs). |
 | `copy_changes` | optional | If omitted, **the agent auto-writes it** from the brand pack mapped to the template's `slot_map` (see Phase 0.5). New headline, benefit callouts, social-proof line, discount/badge text. Keep the reference's *structure* (same zones), swap the words. |
-| `brand` | recommended | Palette (hex), font, logo/wordmark, voice — from `get_brand_kit` / a `brand-research` pack. |
+| `brand` | recommended | Palette (hex), font, logo/wordmark, voice — from `brand_get_context` (the `kit` section) / a `brand-research` pack. |
 | `style_source` | optional | **`template` (DEFAULT)** keeps the reference ad's palette/theme; **`brand`** recolours to the brand kit's documented palette. See "Brand grounding" below. The caller sets it (e.g. the user asks to "match my brand colours" → `brand`); absent → `template`. |
 | `route_hint` | optional | Engine override. Default is **always `gpt_image_2`**; `html` is only a text-overlay finishing step, never the generator. |
 | `aspect` | optional | Inherit from the reference; map to the renderer canvas. Default 4:5 / 1080×1350. |
@@ -39,7 +39,7 @@ the reference, then recreates it with GPT Image 2:
 
 ## Brand grounding — read the kit, never improvise (do this before generating)
 
-The brand context comes from `get_brand_kit` (structured): `colors` (palette hex), `typography`,
+The brand context comes from `brand_get_context`'s `kit` section (structured): `colors` (palette hex), `typography`,
 `products[]` (with `imageUrls` + `name`/`description`), `screenshotUrls`, and `referenceImages[]`
 (each tagged with `productName` + `kind: "product" | "website_screenshot"`). **Read the full kit, not
 a preview.**

--- a/skills/ads/packs/ugc-video-formats/create-video-seedance-2-fal/SKILL.md
+++ b/skills/ads/packs/ugc-video-formats/create-video-seedance-2-fal/SKILL.md
@@ -36,7 +36,7 @@ Use this atom when:
 Required:
 - `--prompt` — structured prompt block (see "Prompt template" below). Long, multi-block. Reference run example: `beauty-by-earth/video-01-three-product-grwm/working/fire_seedance_facewash.py`.
 - `--output` — local MP4 destination.
-- `--image-url` (alias `--image-ref`) — at least one **PUBLIC** reference image URL (repeatable), passed as `image_urls`. Order matters — first = `@Image1` in prompt addressing. The proxy does NOT upload local files: host local refs via MCP `get_upload_url` → `get_download_url` and pass the URL (identical to `create-video-fal`).
+- `--image-url` (alias `--image-ref`) — at least one **PUBLIC** reference image URL (repeatable), passed as `image_urls`. Order matters — first = `@Image1` in prompt addressing. The proxy does NOT upload local files: host local refs via MCP `file_url` (mode `upload` → mode `download`) and pass the URL (identical to `create-video-fal`).
 
 Optional:
 - `--resolution` — `480p` | `720p` | `1080p` (default). 1080p meaningfully better for product label fidelity.

--- a/skills/ads/packs/ugc-video-formats/create-video-seedance-2-fal/scripts/generate.py
+++ b/skills/ads/packs/ugc-video-formats/create-video-seedance-2-fal/scripts/generate.py
@@ -16,7 +16,7 @@ Hard rules:
 - NSFW / partner-validation reject → surface and exit; do NOT auto-retry
 - duration must be an INT for bytedance/seedance-2.0/reference-to-video (enum {auto,4..15}); a string 400s (invalid_request)
 - image refs must be PUBLIC URLs — the proxy does not upload local files. The
-  orchestrator hosts local refs via MCP get_upload_url -> get_download_url and passes
+  orchestrator hosts local refs via MCP file_url mode upload -> mode download and passes
   the URL here (identical to create-video-fal).
 
 Usage:
@@ -69,7 +69,7 @@ def main() -> int:
     local = [u for u in args.image_urls if not _looks_like_url(u)]
     if local:
         sys.exit("ERROR: image refs must be PUBLIC URLs (the proxy does not upload local files). "
-                 "Host each local ref via MCP get_upload_url -> get_download_url and pass the URL. "
+                 "Host each local ref via MCP file_url mode upload -> mode download and pass the URL. "
                  f"Got local path(s): {local}")
 
     payload: dict = {

--- a/skills/ads/packs/ugc-video-formats/create-video-seedance-2-fal/scripts/media_proxy.py
+++ b/skills/ads/packs/ugc-video-formats/create-video-seedance-2-fal/scripts/media_proxy.py
@@ -19,7 +19,7 @@ local skill run isn't a black box. Import `gw_log(...)` to log your own steps/is
 and `run_id()` to read the current run id. Best-effort; never breaks a render.
 
 FAL inputs that are local files (a product image, an audio track) must be a PUBLIC
-URL — the orchestrator hosts them via the MCP `get_upload_url` → `get_download_url`
+URL — the orchestrator hosts them via the MCP `file_url` (mode `upload` → mode `download`)
 presigned URL and passes that URL in; this module does NOT do MCP uploads.
 """
 import json
@@ -281,7 +281,7 @@ def fal_whisper(audio_url, language="en", **kw):
     """fal-ai/whisper (word-level) through the proxy → [{text, start, end}, ...].
 
     `audio_url` MUST be a PUBLIC url (this module does not upload) — the orchestrator
-    hosts the local VO via MCP `get_upload_url` → `get_download_url` and passes that
+    hosts the local VO via MCP `file_url` (mode `upload` → mode `download`) and passes that
     presigned url in. Proxy-routed, so it bills the Ads agent (never a raw FAL_KEY)."""
     r = _fal_run("fal-ai/whisper", {"audio_url": audio_url, "task": "transcribe",
                                     "language": language, "chunk_level": "word"}, **kw)


### PR DESCRIPTION
Stages the flip-day rewrite of the public goose-skills files from the old aliased gooseworks MCP tool names to the new 62-tool catalog (WS3-14). **Do not merge until flip day.**

Mapping sources, in priority order: goose-lab `plan/2026-08-28-master-refactor/16-alias-table.json`, the flip-day 62-name catalog list, and the implemented alias defs in `gooseworks-app/backend/src/app-mcp-server/mcp-tools/aliases/defs/*.ts` (code wins over the table). The plan estimated ~7 files; the grep found 22 (the `media_proxy.py` module is vendored into 7 capability skills, and several docs/scripts repeat the same host-a-file instruction).

## Per-file rename counts (old-name occurrences removed)

| File | Renames |
|---|---|
| `skills/ads/composites/product-photoshoot/SKILL.md` | 19 |
| `skills/ads/composites/animate-image/SKILL.md` | 3 |
| `skills/ads/composites/remix-graphic-ad-from-reference/SKILL.md` | 2 |
| `skills/ads/capabilities/{create-image-fal,create-image-gpt-image-fal,create-music-elevenlabs,create-vo-elevenlabs,create-video-fal,media-proxy}/scripts/media_proxy.py` + `packs/ugc-video-formats/create-video-seedance-2-fal/scripts/media_proxy.py` | 4 each (7 copies) |
| `create-image-gpt-image-fal/SKILL.md` / `scripts/generate.py` | 4 / 4 |
| `create-video-fal/SKILL.md` / `scripts/gen_video.py` | 4 / 2 |
| `create-video-seedance-2-fal/SKILL.md` / `scripts/generate.py` | 2 / 4 |
| `media-proxy/SKILL.md` | 2 |
| `render-myth-vs-fact/scripts/beat_snap.py` | 2 |
| `render-3d-product-showcase/scripts/PIPELINE.md` + `config.example.json` | 2 + 2 |
| `render-cartoon-music-video/scripts/README.md` | 1 |
| `skills-index.json` | regenerated via `npm run build:index` (date + 1 description) |

## What changed beyond the names

- product-photoshoot now walks the new contract: `brand_list` → `brand_get_context` (`products` section, `products_query`) → import via `brand_update` `patch.products` (`import_kind`/`import_url`) polled with `job_get { kind: "product_import" }` → `photos_generate` (`dry_run: true` for the quote) → `photos_get` → `photos_update` (`action: "approve" | "archive"`).
- animate-image: `ads_creative_edit` with `action: "animate"` (`dry_run: true` for the estimate) + `job_get { kind: "animate" }`.
- remix-graphic-ad-from-reference reads the kit via `brand_get_context`'s `kit` section.
- Every host-a-local-file instruction (`get_upload_url` → `get_download_url`) now names the `file_url` tool (mode `upload` → mode `download`).

## Deliberately UNCHANGED (transitional / long-window old names)

- `set_final_render` — review-ugc-render SKILL.md + `review_render.py` + its index descriptions (live old handler until WS2-8).
- `call_data_provider` — content-repurposing, gtm-enrichment-smart, find-twitter-influencers, scrapecreators-api, social-listening (kept long per the alias table).
- No skill references the 7 removed sharebank tools — nothing to flag.

## Verification

- Grep sweep vs the 113 alias-def old names: zero occurrences repo-wide outside the kept names above.
- Every MCP tool name introduced is in the flip-day 62-name catalog: ads_creative_edit, brand_get_context, brand_list, brand_update, file_url, job_get, photos_generate, photos_get, photos_list, photos_update.
- `npm test`: 26/26 passing. `npm run validate:skills` fails on clean main too (pre-existing: unknown domain folders `skills/composites`, `skills/packs`) — verified via `git stash`; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)