### PR TITLE
Add: optional Atlas image provider

### DIFF
--- a/skills-index.json
+++ b/skills-index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.3.0",
-  "generated": "2026-09-01",
+  "generated": "2026-09-02",
   "skills": [
     {
       "slug": "ad-angle-miner",
@@ -1770,7 +1770,7 @@
       "name": "create-image-gpt-image-fal",
       "category": "capabilities",
       "domain": "ads",
-      "description": "Generate a single photoreal or designed image with OpenAI gpt-image via fal.ai. Supports gpt-image-1 (default, fixed sizes — the FAL fallback for Higgsfield's `gpt_image_2`) and gpt-image-2 (`openai/gpt-image-2`, custom output sizes up to 3840px). Routes to text-to-image or the edit variant depending on whether a reference image is provided. Use for photoreal character anchors, scene keyframes, and designed sheets (e.g. storyboards) where precise layout and legible text matter.",
+      "description": "Generate a single photoreal or designed image with OpenAI gpt-image through the GooseWorks FAL proxy or the optional Atlas Cloud provider. FAL remains the default. Supports gpt-image-1 and gpt-image-2, and routes to text-to-image or edit based on whether a reference image is provided.",
       "tags": "ads, design",
       "path": "skills/ads/capabilities/create-image-gpt-image-fal",
       "files": [

--- a/skills/ads/capabilities/create-image-gpt-image-fal/SKILL.md
+++ b/skills/ads/capabilities/create-image-gpt-image-fal/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: create-image-gpt-image-fal
-description: Generate a single photoreal or designed image with OpenAI gpt-image via fal.ai. Supports gpt-image-1 (default, fixed sizes — the FAL fallback for Higgsfield's `gpt_image_2`) and gpt-image-2 (`openai/gpt-image-2`, custom output sizes up to 3840px). Routes to text-to-image or the edit variant depending on whether a reference image is provided. Use for photoreal character anchors, scene keyframes, and designed sheets (e.g. storyboards) where precise layout and legible text matter.
+description: Generate a single photoreal or designed image with OpenAI gpt-image through the GooseWorks FAL proxy or the optional Atlas Cloud provider. FAL remains the default. Supports gpt-image-1 and gpt-image-2, and routes to text-to-image or edit based on whether a reference image is provided.
 ---
 
 # create-image-gpt-image-fal
 
 ## Purpose
 
-Generate one image via fal.ai's OpenAI gpt-image endpoints. Two model families are supported through a single `--model` flag:
+Generate one image with OpenAI gpt-image. The existing GooseWorks FAL proxy remains the default; Atlas Cloud is an explicit opt-in provider. Two model families are supported through a single `--model` flag:
 
 - **`gpt-image-1`** (default) — `fal-ai/gpt-image-1`. The FAL fallback for Higgsfield's `gpt_image_2`. Fixed output sizes only. Used by:
   - `video-orchestrator/lock-character` Phase 0 (anchor portrait) and Phase 1 (angle keyframes via `/edit`)
@@ -32,6 +32,8 @@ Required:
 
 Optional:
 - `--model` — `gpt-image-1` (default) or `gpt-image-2`.
+- `--provider` — `fal` (default) or `atlas`. Selecting Atlas does not change existing FAL callers.
+- `--yes` — confirms the billable Atlas request after the script reads the live model catalog, schema, and unit price. Atlas never submits without this flag.
 - `--aspect-ratio` — `9:16` (default), `16:9`, `1:1`, `2:3`, `3:2`. gpt-image-2 also accepts `3:4`, `4:3`, `4:5`. Used when `--image-size` is not given.
 - `--image-size` — explicit `WIDTHxHEIGHT` (e.g. `1728x2304`). **gpt-image-2 only** — values are rounded to multiples of 16 and capped at 3840px. On `gpt-image-1` a custom size is ignored with a warning and the aspect-ratio mapping is used instead.
 - `--quality` — `low | medium | high` (default `medium`).
@@ -41,6 +43,11 @@ Optional:
 Credentials (proxy-routed — NOT a raw FAL key):
 - The bundled `scripts/media_proxy.py` routes every call through the GooseWorks **fal-proxy**, which **bills the Ads agent**. It reads `~/.gooseworks/credentials.json` (`api_base`, `api_key`, `agent_id`) — written by `gooseworks login`. Do **not** set `FAL_API_KEY`: an agent (`cal_`) token is not a FAL key and 401s against fal directly.
 - Set `GW_PROJECT_ID=<ad project id>` in the env so the generation's spend attributes to that ad project (per-project cost shows in the app).
+
+Atlas credentials:
+- Set `ATLASCLOUD_API_KEY` when using `--provider atlas`.
+- The Atlas adapter resolves the matching text-to-image or edit model from the live catalog and validates the request against its current schema before submission.
+- A generation POST is made exactly once. Only result polling uses bounded retry and backoff.
 
 ## Preflight
 
@@ -74,20 +81,28 @@ python3 .../generate.py \
   --model gpt-image-2 \
   --image-size 1728x2304 \
   --quality high
+
+# Explicit Atlas Cloud provider; FAL remains the default when this flag is absent
+python3 .../generate.py \
+  --prompt "..." \
+  --output /path/to/storyboard.png \
+  --model gpt-image-2 \
+  --provider atlas \
+  --yes
 ```
 
 The script:
-1. Loads the agent credentials from `~/.gooseworks/credentials.json` via the bundled `media_proxy.py` (proxy-routed; bills the Ads agent).
-2. Resolves the model family (`--model`) and output size (`--image-size` if given and supported, else the aspect-ratio mapping).
-3. If one or more `--ref-image` / `--ref-url` flags are set, passes them as `image_urls=[url1, url2, ...]` (they must already be PUBLIC URLs) and routes to the model's `/edit` variant. Otherwise routes to the `/text-to-image` variant.
-4. Submits through the GooseWorks **fal-proxy** and polls the queue to completion — host-swapping the `queue.fal.run` status/response URLs to the proxy base (see `media_proxy.py`); never polls `queue.fal.run` directly.
+1. Resolves the model family (`--model`) and output size (`--image-size` if given and supported, else the aspect-ratio mapping).
+2. If one or more `--ref-image` / `--ref-url` flags are set, routes to the provider's edit variant. Otherwise it uses text-to-image.
+3. With the default FAL provider, loads the agent credentials from `~/.gooseworks/credentials.json`, submits through the GooseWorks fal-proxy, and polls its queue to completion.
+4. With Atlas, reads the live catalog and model schema, prints the current request plan, requires `--yes`, submits once, and polls the returned prediction with bounded GET retries.
 5. Downloads the first result image to `--output`.
-6. Writes `<output>.meta.json` with `gateway: "fal-proxy"`, model id, `model_family`, request, and cost.
+6. Writes `<output>.meta.json` with the selected gateway, model id, `model_family`, request, and cost.
 
 ## Output
 
 - `<output_path>` — PNG (≥ 1 KB).
-- `<output_path>.meta.json` — request + result metadata + cost, including `model_family` (`gpt-image-1` or `gpt-image-2`).
+- `<output_path>.meta.json` — request + result metadata, including the selected gateway, resolved model, and `model_family` (`gpt-image-1` or `gpt-image-2`). Atlas output also records the prediction id and live unit price.
 
 ## Quality Checks
 
@@ -102,6 +117,8 @@ The script:
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `401 Unauthorized` from fal | Calling fal directly with an agent token, or polling `queue.fal.run` instead of the proxy | This atom is **proxy-routed** — it uses the `~/.gooseworks/credentials.json` agent token via `media_proxy.py`, never a raw `FAL_API_KEY`. Run `gooseworks login` if the credentials file is missing. |
+| Atlas confirmation required | Atlas preflight completed but `--yes` was omitted | Review the printed live model, size, quality, and unit price, then rerun with `--yes`. |
+| Missing Atlas API key | Atlas was selected without credentials | Set `ATLASCLOUD_API_KEY`; the default FAL path does not require it. |
 | `ERROR: ref images must be PUBLIC URLs` | Passed a **local path** to `--ref-image` / `--ref-url` | The proxy does not upload local files. Host it (MCP `get_upload_url` → `get_download_url`) and pass the resulting public URL. |
 | `429 Too Many Requests` | RPS limit | Drop concurrency to 2-3. |
 | Custom size ignored | `--image-size` passed with `--model gpt-image-1` | gpt-image-1 only supports fixed sizes; use `--model gpt-image-2` for custom sizes. |

--- a/skills/ads/capabilities/create-image-gpt-image-fal/scripts/atlas_provider.py
+++ b/skills/ads/capabilities/create-image-gpt-image-fal/scripts/atlas_provider.py
@@ -1,0 +1,236 @@
+"""Atlas Cloud adapter for the gpt-image capability.
+
+Generation POSTs are deliberately single-attempt. Only prediction GETs use
+bounded retry/backoff so a transient poll failure cannot duplicate a paid job.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any, Callable
+from urllib import error as url_error
+from urllib import request as url_request
+from urllib.parse import urlparse
+
+
+API_ROOT = "https://api.atlascloud.ai"
+CATALOG_URL = f"{API_ROOT}/api/v1/models"
+SUCCESS_STATUSES = {"completed", "succeeded", "success"}
+FAILURE_STATUSES = {"failed", "canceled", "cancelled", "error"}
+
+MODELS = {
+    "gpt-image-1": {
+        "t2i": "openai/gpt-image-1/text-to-image",
+        "edit": "openai/gpt-image-1/edit",
+    },
+    "gpt-image-2": {
+        "t2i": "openai/gpt-image-2/text-to-image",
+        "edit": "openai/gpt-image-2/edit",
+    },
+}
+
+
+class ConfirmationRequired(RuntimeError):
+    """Raised after preflight when a billable submit was not confirmed."""
+
+
+def _read_json(url: str, *, api_key: str | None = None) -> dict[str, Any]:
+    headers = {"Accept": "application/json", "User-Agent": "goose-skills/atlas-provider"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    req = url_request.Request(url, headers=headers, method="GET")
+    with url_request.urlopen(req, timeout=60) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("Atlas GET returned a non-object response")
+    return payload
+
+
+def _post_json_once(url: str, *, api_key: str, payload: dict[str, Any]) -> dict[str, Any]:
+    req = url_request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+            "User-Agent": "goose-skills/atlas-provider",
+        },
+        method="POST",
+    )
+    try:
+        with url_request.urlopen(req, timeout=120) as response:
+            result = json.loads(response.read().decode("utf-8"))
+    except url_error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")[:500]
+        raise RuntimeError(f"Atlas submit failed ({exc.code}): {detail}") from exc
+    if not isinstance(result, dict):
+        raise ValueError("Atlas submit returned a non-object response")
+    return result
+
+
+def _walk(value: Any):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _walk(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk(child)
+
+
+def _find_model(catalog: dict[str, Any], model: str) -> dict[str, Any]:
+    matches = [
+        item
+        for item in _walk(catalog)
+        if item.get("model") == model and item.get("display_console") is True
+    ]
+    if len(matches) != 1:
+        raise ValueError(f"Atlas model is unavailable or ambiguous: {model}")
+    return matches[0]
+
+
+def _validate_payload(schema: dict[str, Any], payload: dict[str, Any]) -> None:
+    input_schema = schema.get("components", {}).get("schemas", {}).get("Input", {})
+    properties = input_schema.get("properties")
+    if not isinstance(properties, dict):
+        raise ValueError("Atlas model schema is missing Input.properties")
+    missing = sorted(set(input_schema.get("required", [])).difference(payload))
+    if missing:
+        raise ValueError(f"Atlas request is missing required fields: {', '.join(missing)}")
+    unknown = sorted(set(payload).difference(set(properties).union({"model"})))
+    if unknown:
+        raise ValueError(f"Atlas request contains unsupported fields: {', '.join(unknown)}")
+    for name, value in payload.items():
+        choices = properties.get(name, {}).get("enum")
+        if choices and value not in choices:
+            raise ValueError(f"Atlas {name} must be one of: {', '.join(map(str, choices))}")
+
+
+def _unwrap(payload: dict[str, Any]) -> dict[str, Any]:
+    if "code" in payload and str(payload.get("code")) != "200":
+        raise RuntimeError(
+            f"Atlas API returned code {payload.get('code')}: {payload.get('message')}"
+        )
+    data = payload.get("data", payload)
+    if not isinstance(data, dict):
+        raise ValueError("Atlas response is missing an object payload")
+    return data
+
+
+def _prediction_path(schema: dict[str, Any]) -> str:
+    for path, operation in schema.get("paths", {}).items():
+        if "{request_id}" in path and isinstance(operation, dict) and "get" in operation:
+            return path
+    return "/api/v1/model/prediction/{request_id}"
+
+
+def _unit_price(entry: dict[str, Any]) -> str:
+    actual = entry.get("price", {}).get("actual", {})
+    return str(actual.get("base_price", "unknown"))
+
+
+def generate(
+    *,
+    prompt: str,
+    model_family: str,
+    size: str,
+    quality: str,
+    ref_urls: list[str],
+    confirmed: bool,
+    poll_attempts: int = 30,
+    read_json: Callable[..., dict[str, Any]] = _read_json,
+    post_json: Callable[..., dict[str, Any]] = _post_json_once,
+    sleep_fn: Callable[[float], None] = time.sleep,
+) -> tuple[str, dict[str, Any]]:
+    """Submit once to Atlas, poll with bounded GET retries, and return one URL."""
+    api_key = os.environ.get("ATLASCLOUD_API_KEY") or os.environ.get("ATLAS_CLOUD_API_KEY")
+    if not api_key:
+        raise RuntimeError("ATLASCLOUD_API_KEY is required for the Atlas provider")
+    if model_family not in MODELS:
+        raise ValueError(f"Unsupported Atlas model family: {model_family}")
+
+    model = MODELS[model_family]["edit" if ref_urls else "t2i"]
+    catalog = read_json(CATALOG_URL, api_key=api_key)
+    entry = _find_model(catalog, model)
+    schema_url = entry.get("schema")
+    if not isinstance(schema_url, str) or urlparse(schema_url).scheme != "https":
+        raise ValueError("Atlas model catalog is missing an HTTPS schema URL")
+    schema = read_json(schema_url)
+
+    payload: dict[str, Any] = {
+        "model": model,
+        "prompt": prompt,
+        "size": size,
+        "quality": quality,
+        "output_format": "png",
+        "moderation": "low",
+    }
+    if ref_urls:
+        payload["images"] = ref_urls
+    _validate_payload(schema, payload)
+
+    print(
+        f"[gpt-image-atlas] plan model={model} size={size} "
+        f"quality={quality} unit_price={_unit_price(entry)}",
+        flush=True,
+    )
+    if not confirmed:
+        raise ConfirmationRequired(
+            "Atlas generation is billable. Review the plan and rerun with --yes."
+        )
+
+    submitted = _unwrap(
+        post_json(
+            f"{API_ROOT}/api/v1/model/generateImage",
+            api_key=api_key,
+            payload=payload,
+        )
+    )
+    prediction_id = submitted.get("id") or submitted.get("prediction_id")
+    if not isinstance(prediction_id, str) or not prediction_id:
+        raise ValueError("Atlas submit response is missing a prediction id")
+
+    result_path = _prediction_path(schema).replace("{request_id}", prediction_id)
+    result_url = f"{API_ROOT}{result_path}"
+    completed: dict[str, Any] | None = None
+    for poll_index in range(poll_attempts):
+        last_error: Exception | None = None
+        for retry_index in range(4):
+            try:
+                prediction = _unwrap(read_json(result_url, api_key=api_key))
+                last_error = None
+                break
+            except (OSError, ValueError, url_error.URLError) as exc:
+                last_error = exc
+                if retry_index < 3:
+                    sleep_fn(float(2**retry_index))
+        if last_error is not None:
+            raise RuntimeError(f"Atlas prediction GET failed after 4 attempts: {last_error}")
+        status = str(prediction.get("status", "")).lower()
+        if status in SUCCESS_STATUSES:
+            completed = prediction
+            break
+        if status in FAILURE_STATUSES:
+            raise RuntimeError(f"Atlas prediction {status}: {prediction.get('error', 'no detail')}")
+        if poll_index + 1 < poll_attempts:
+            sleep_fn(float(min(2**poll_index, 8)))
+    if completed is None:
+        raise TimeoutError(f"Atlas prediction did not finish after {poll_attempts} polls")
+
+    outputs = completed.get("outputs") or completed.get("output")
+    if isinstance(outputs, str):
+        outputs = [outputs]
+    if not isinstance(outputs, list) or not outputs or not isinstance(outputs[0], str):
+        raise ValueError("Atlas prediction completed without an output URL")
+    if urlparse(outputs[0]).scheme != "https":
+        raise ValueError("Atlas output URL must use HTTPS")
+    unit_price = _unit_price(entry)
+    return outputs[0], {
+        "gateway": "atlas-cloud",
+        "model": model,
+        "model_family": model_family,
+        "prediction_id": prediction_id,
+        "unit_price": unit_price,
+        "cost_estimate_usd": unit_price,
+    }

--- a/skills/ads/capabilities/create-image-gpt-image-fal/scripts/generate.py
+++ b/skills/ads/capabilities/create-image-gpt-image-fal/scripts/generate.py
@@ -32,6 +32,7 @@ from pathlib import Path
 # 401s with an agent/`cal_` token — that key isn't a FAL key.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from atlas_provider import ConfirmationRequired, generate as atlas_generate  # noqa: E402
 from media_proxy import fal_generate, download  # noqa: E402  (bundled)
 
 # Per-model config. `custom_size` says whether the model accepts arbitrary
@@ -83,6 +84,10 @@ def main() -> int:
     ap.add_argument("--output", required=True, type=Path)
     ap.add_argument("--model", default="gpt-image-1", choices=list(MODELS),
                     help="gpt-image-1 (default, fixed sizes) or gpt-image-2 (custom sizes).")
+    ap.add_argument("--provider", default="fal", choices=["fal", "atlas"],
+                    help="Generation provider. Defaults to the existing GooseWorks FAL proxy.")
+    ap.add_argument("--yes", action="store_true",
+                    help="Confirm the billable Atlas generation after live model preflight.")
     ap.add_argument("--aspect-ratio", default="9:16",
                     help="Used when --image-size is not given.")
     ap.add_argument("--image-size", default=None,
@@ -136,15 +141,30 @@ def main() -> int:
     else:
         model = cfg["t2i"]
 
-    print(f"[gpt-image-fal] submitting {model} via proxy ({w}x{h}, q={args.quality})...", flush=True)
-    # fal_generate routes through the proxy and (with the hardened media_proxy) surfaces
-    # FAL's real error instead of a KeyError.
-    image_url = fal_generate(model, payload)
+    provider_meta = {}
+    if args.provider == "atlas":
+        try:
+            image_url, provider_meta = atlas_generate(
+                prompt=args.prompt,
+                model_family=args.model,
+                size=f"{w}x{h}",
+                quality=args.quality,
+                ref_urls=args.ref_urls,
+                confirmed=args.yes,
+            )
+        except ConfirmationRequired as exc:
+            sys.exit(f"ERROR: {exc}")
+    else:
+        print(f"[gpt-image-fal] submitting {model} via proxy ({w}x{h}, q={args.quality})...", flush=True)
+        # fal_generate routes through the proxy and (with the hardened media_proxy) surfaces
+        # FAL's real error instead of a KeyError.
+        image_url = fal_generate(model, payload)
 
-    print(f"[gpt-image-fal] downloading to {args.output}...", flush=True)
+    provider_label = "atlas" if args.provider == "atlas" else "fal"
+    print(f"[gpt-image-{provider_label}] downloading to {args.output}...", flush=True)
     download(image_url, str(args.output))
     nbytes = args.output.stat().st_size if args.output.exists() else 0
-    print(f"[gpt-image-fal] wrote {nbytes} bytes", flush=True)
+    print(f"[gpt-image-{provider_label}] wrote {nbytes} bytes", flush=True)
 
     cost = cfg["cost_by_quality"][args.quality]
     meta = {
@@ -159,8 +179,9 @@ def main() -> int:
         "image_url": image_url,
         "cost_estimate_usd": cost,
     }
+    meta.update(provider_meta)
     Path(str(args.output) + ".meta.json").write_text(json.dumps(meta, indent=2))
-    print(f"[gpt-image-fal] est cost: ${cost:.2f}", flush=True)
+    print(f"[gpt-image-{provider_label}] est cost: ${meta['cost_estimate_usd']}", flush=True)
     return 0
 
 

--- a/skills/ads/capabilities/create-image-gpt-image-fal/tests/expected-output.md
+++ b/skills/ads/capabilities/create-image-gpt-image-fal/tests/expected-output.md
@@ -4,10 +4,12 @@ A correct run produces, per generation:
 
 - A PNG at the requested `--output` path, > 1 KB, that opens as a valid image.
 - A `<output>.meta.json` sidecar containing:
-  - `gateway: "fal"`
-  - `model` — the resolved fal endpoint (`fal-ai/gpt-image-1/text-to-image` or `openai/gpt-image-2`, plus `/edit` variants when a ref image is used)
+  - `gateway: "fal-proxy"` for the default provider or `gateway: "atlas-cloud"` when Atlas is selected
+  - `model` — the resolved provider endpoint, including an edit variant when a reference image is used
   - `model_family` — `gpt-image-1` or `gpt-image-2`
   - `image_size`, `quality`, `prompt`, `cost_estimate_usd`
+
+Atlas-specific output also includes the prediction id and unit price read from the live catalog. Omitting `--yes` must stop after preflight without submitting a generation.
 
 Model-specific:
 - **gpt-image-1** — output is one of its fixed sizes (1024×1024, 1024×1536, 1536×1024); a custom `--image-size` is ignored with a warning.

--- a/skills/ads/capabilities/create-image-gpt-image-fal/tests/smoke-test.md
+++ b/skills/ads/capabilities/create-image-gpt-image-fal/tests/smoke-test.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Prove the atom can generate an image via fal.ai for both model families — `gpt-image-1` (default) and `gpt-image-2` (custom size).
+Prove the atom can generate an image through the default FAL route or the opt-in Atlas route without changing provider defaults.
 
 ## Input
 
@@ -10,7 +10,7 @@ The prompt in `sample-input.md`.
 
 ## Steps
 
-1. Confirm `FAL_API_KEY` (or `FAL_KEY`) is in `.env`. If absent, mark the run `blocked` and stop.
+1. Confirm GooseWorks credentials exist for FAL, or set `ATLASCLOUD_API_KEY` for Atlas. If neither is available, mark the run `blocked` and stop.
 2. Create `RUN=skills/test-runs/$(date +%Y%m%dT%H%M%SZ)/create-image-gpt-image-fal && mkdir -p "$RUN"`.
 3. Default model (gpt-image-1), cheapest tier:
    ```bash
@@ -23,17 +23,19 @@ The prompt in `sample-input.md`.
    python3 .../generate.py --prompt "..." --output "$RUN/g2.png" \
      --model gpt-image-2 --image-size 1024x1536 --quality low
    ```
+5. To smoke-test Atlas instead of spending through FAL, add `--provider atlas --yes` to one command. Run a single billable generation; do not retry its POST.
 
 ## Expected output shape
 
 - `$RUN/g1.png` exists, > 1 KB; `g1.png.meta.json` has `model_family: "gpt-image-1"`.
 - `$RUN/g2.png` exists, > 1 KB, dimensions 1024×1536; `g2.png.meta.json` has `model_family: "gpt-image-2"`.
+- An Atlas run reports `gateway: "atlas-cloud"`, the resolved Atlas model, and a prediction id.
 
 ## Pass / fail
 
 - **Pass:** both PNGs exist and open; meta files report the correct `model_family`.
 - **Fail:** a generation errors, or gpt-image-2 ignores the custom size.
-- **Blocked:** no `FAL_API_KEY`.
+- **Blocked:** no credentials for the selected provider.
 
 ## Notes
 

--- a/skills/ads/capabilities/create-image-gpt-image-fal/tests/test_atlas_provider.py
+++ b/skills/ads/capabilities/create-image-gpt-image-fal/tests/test_atlas_provider.py
@@ -1,0 +1,186 @@
+import importlib.util
+import os
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "atlas_provider.py"
+SPEC = importlib.util.spec_from_file_location("atlas_provider", SCRIPT)
+assert SPEC and SPEC.loader
+atlas = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(atlas)
+
+MODEL = "openai/gpt-image-2/text-to-image"
+EDIT_MODEL = "openai/gpt-image-2/edit"
+SCHEMA_URL = "https://static.example.test/schema.json"
+
+
+def catalog(*models):
+    return {
+        "code": "200",
+        "data": {
+            "groups": [
+                {
+                    "models": [
+                        {
+                            "model": model,
+                            "display_console": True,
+                            "schema": SCHEMA_URL,
+                            "price": {"actual": {"base_price": "0.009"}},
+                        }
+                        for model in models
+                    ]
+                }
+            ]
+        },
+    }
+
+
+def schema(*, edit=False):
+    properties = {
+        "prompt": {"type": "string"},
+        "size": {"enum": ["1024x1024"]},
+        "quality": {"enum": ["medium", "high"]},
+        "output_format": {"enum": ["png", "jpeg"]},
+        "moderation": {"type": "string"},
+    }
+    required = ["model", "prompt"]
+    if edit:
+        properties["images"] = {"type": "array"}
+        required.append("images")
+    return {
+        "paths": {"/api/v1/model/result/{request_id}": {"get": {}}},
+        "components": {
+            "schemas": {"Input": {"properties": properties, "required": required}}
+        },
+    }
+
+
+class AtlasProviderTests(unittest.TestCase):
+    def test_finds_one_exact_console_visible_model(self):
+        entry = atlas._find_model(catalog(MODEL), MODEL)
+        self.assertEqual(entry["model"], MODEL)
+        self.assertEqual(atlas._unit_price(entry), "0.009")
+
+    def test_schema_rejects_an_unsupported_size(self):
+        payload = {
+            "model": MODEL,
+            "prompt": "test",
+            "size": "2048x2048",
+            "quality": "medium",
+            "output_format": "png",
+            "moderation": "low",
+        }
+        with self.assertRaisesRegex(ValueError, "Atlas size must be one of"):
+            atlas._validate_payload(schema(), payload)
+
+    @mock.patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "test-key"}, clear=True)
+    def test_unconfirmed_preflight_never_posts(self):
+        post_calls = []
+
+        def read_json(url, **_kwargs):
+            return schema() if url == SCHEMA_URL else catalog(MODEL)
+
+        def post_json(*args, **kwargs):
+            post_calls.append((args, kwargs))
+            raise AssertionError("unconfirmed generation must not POST")
+
+        with self.assertRaises(atlas.ConfirmationRequired):
+            atlas.generate(
+                prompt="test",
+                model_family="gpt-image-2",
+                size="1024x1024",
+                quality="medium",
+                ref_urls=[],
+                confirmed=False,
+                read_json=read_json,
+                post_json=post_json,
+            )
+        self.assertEqual(post_calls, [])
+
+    @mock.patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "test-key"}, clear=True)
+    def test_confirmed_generation_posts_once_then_polls_result_path(self):
+        posts = []
+        predictions = iter(
+            [
+                {"code": 200, "data": {"status": "processing"}},
+                {
+                    "code": 200,
+                    "data": {
+                        "status": "completed",
+                        "outputs": ["https://cdn.example.test/result.png"],
+                    },
+                },
+            ]
+        )
+
+        def read_json(url, **_kwargs):
+            if url == atlas.CATALOG_URL:
+                return catalog(MODEL)
+            if url == SCHEMA_URL:
+                return schema()
+            self.assertEqual(url, f"{atlas.API_ROOT}/api/v1/model/result/prediction-1")
+            return next(predictions)
+
+        def post_json(url, **kwargs):
+            posts.append((url, kwargs["payload"]))
+            return {"code": 200, "data": {"id": "prediction-1"}}
+
+        url, metadata = atlas.generate(
+            prompt="test",
+            model_family="gpt-image-2",
+            size="1024x1024",
+            quality="medium",
+            ref_urls=[],
+            confirmed=True,
+            read_json=read_json,
+            post_json=post_json,
+            sleep_fn=lambda _: None,
+        )
+
+        self.assertEqual(url, "https://cdn.example.test/result.png")
+        self.assertEqual(metadata["gateway"], "atlas-cloud")
+        self.assertEqual(len(posts), 1)
+        self.assertEqual(posts[0][1]["model"], MODEL)
+
+    @mock.patch.dict(os.environ, {"ATLASCLOUD_API_KEY": "test-key"}, clear=True)
+    def test_reference_images_select_the_edit_model_and_payload(self):
+        submitted = []
+
+        def read_json(url, **_kwargs):
+            if url == atlas.CATALOG_URL:
+                return catalog(EDIT_MODEL)
+            if url == SCHEMA_URL:
+                return schema(edit=True)
+            return {
+                "code": 200,
+                "data": {
+                    "status": "completed",
+                    "outputs": ["https://cdn.example.test/edit.png"],
+                },
+            }
+
+        def post_json(_url, **kwargs):
+            submitted.append(kwargs["payload"])
+            return {"code": 200, "data": {"id": "prediction-edit"}}
+
+        atlas.generate(
+            prompt="edit",
+            model_family="gpt-image-2",
+            size="1024x1024",
+            quality="high",
+            ref_urls=["https://example.test/ref.png"],
+            confirmed=True,
+            read_json=read_json,
+            post_json=post_json,
+            sleep_fn=lambda _: None,
+        )
+
+        self.assertEqual(len(submitted), 1)
+        self.assertEqual(submitted[0]["model"], EDIT_MODEL)
+        self.assertEqual(submitted[0]["images"], ["https://example.test/ref.png"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add Atlas Cloud as an explicit opt-in provider for the existing gpt-image capability while keeping the GooseWorks FAL proxy as the default
- resolve the selected Atlas text-to-image or edit model from the live catalog, validate its current schema, require billable confirmation, submit once, and use bounded result polling
- preserve reference-image routing and write provider-specific metadata; update the generated skill index and smoke-test documentation

## Validation

- `python3 -m unittest discover -s skills/ads/capabilities/create-image-gpt-image-fal/tests -p 'test_*.py' -v` (5 passed)
- `python3 -m py_compile` for the changed generator, Atlas adapter, and focused tests
- `npm run ci` (257 skills validated; generated index verified; 32 tests passed)
- one live low-quality Atlas `openai/gpt-image-2/text-to-image` smoke test (single POST, 1024x1024 PNG)
- `git diff --check`
